### PR TITLE
Fixed clang warnings + minor simplifications

### DIFF
--- a/L1Trigger/TrackFindingTMTT/README.md
+++ b/L1Trigger/TrackFindingTMTT/README.md
@@ -13,7 +13,9 @@ editing if necessary variables: GEOMETRY (CMS geometry version), inputMCtxt (MC 
 - Look at the performance histograms Hist.root (explained in class "Histos" below)
 
 2) cmsRun -n 4 L1TrackNtupleMaker_cfg.py 
-after editing it to change L1TRACKALGO = 'TMTT'. This writes a TTree with the fitfitted L1 tracks to file in a TTTrack collection, from which tracking performance can be studied with ROOT macro. L1TrackNtuplePlot.C.
+after editing it to change L1TRACKALGO = 'TMTT'. This writes a TTree of the fitted L1 tracks to .root file, from which tracking performance can be studied with ROOT macro L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C. Other values of L1TRACKALGO permit to run the Hybrid or Tracklet emulation, or floating point emulation.
+
+Both (1) & (2) are able to write a dataset containing the TTTrack collection of the fitted tracks.
 
 N.B. .txt files listing available MC samples can be found in https://github.com/cms-data/L1Trigger-TrackFindingTMTT .
 

--- a/L1Trigger/TrackFindingTMTT/interface/Settings.h
+++ b/L1Trigger/TrackFindingTMTT/interface/Settings.h
@@ -218,8 +218,6 @@ namespace tmtt {
     double minPtToReduceLayers() const { return minPtToReduceLayers_; }
     // Change min. number of layers cut to (MinStubLayers - 1) for tracks in these rapidity sectors.
     const std::vector<unsigned int>& etaSecsReduceLayers() const { return etaSecsReduceLayers_; }
-    // Define layers using layer ID (true) or by bins in radius of 5 cm width (false)?
-    bool useLayerID() const { return useLayerID_; }
     //Reduce this layer ID, so that it takes no more than 8 different values in any eta region (simplifies firmware)?
     bool reduceLayerID() const { return reduceLayerID_; }
 
@@ -391,16 +389,10 @@ namespace tmtt {
     double trackerOuterRadius() const { return 112.7; }  // max. occuring stub radius.
     double trackerInnerRadius() const { return 21.8; }   // min. occuring stub radius.
     double trackerHalfLength() const { return 270.; }    // half-length of tracker.
-    double layerIDfromRadiusBin() const {
-      return 6.;
-    }  // When counting stubs in layers, actually histogram stubs in distance from beam-line with this bin size.
-    double crazyStubCut() const {
-      return 0.01;
-    }  // Stubs differing from TP trajectory by more than this in phi are assumed to come from delta rays etc.
 
-    //=== Set and get B-field value in Tesla.
-    // N.B. This must bet std::set for each event, and can't be initialized at the beginning of the job.
-    void setMagneticField(float magneticField) { magneticField_ = magneticField; }
+    //=== Set and get B-field value (mutable) in Tesla.
+    // N.B. This must bet std::set for each run, and can't be initialized at the beginning of the job.
+    void setMagneticField(float magneticField) const { magneticField_ = magneticField; }
     float magneticField() const {
       if (magneticField_ == 0.)
         throw cms::Exception("LogicError") << "Settings: You attempted to access the B field before it was initialized";
@@ -410,15 +402,6 @@ namespace tmtt {
     //=== Settings used for HYBRID TRACKING code only.
     // Is hybrid tracking in use?
     bool hybrid() const { return hybrid_; }
-    // Info about geometry, needed for use of hybrid outside CMSSW.
-    double ssStripPitch() const { return ssStripPitch_; }
-    double ssNStrips() const { return ssNStrips_; }
-    double ssStripLength() const { return ssStripLength_; }
-    double psPixelPitch() const { return psPixelPitch_; }
-    double psNStrips() const { return psNStrips_; }
-    double psPixelLength() const { return psPixelLength_; }
-    // max z at which non-tilted modules are found in 3 barrel PS layers. (Element 0 not used).
-    const std::vector<float>& zMaxNonTilted() const { return zMaxNonTilted_; }
 
   private:
     // Input tags for ES & ED data.
@@ -560,7 +543,6 @@ namespace tmtt {
     unsigned int minStubLayers_;
     double minPtToReduceLayers_;
     std::vector<unsigned int> etaSecsReduceLayers_;
-    bool useLayerID_;
     bool reduceLayerID_;
 
     // Specification of algorithm to eliminate duplicate tracks
@@ -599,7 +581,6 @@ namespace tmtt {
     double residualCut_;
     //
     unsigned kalmanDebugLevel_;
-    bool kalmanFillInternalHists_;
     unsigned int kalmanMinNumStubs_;
     unsigned int kalmanMaxNumStubs_;
     bool kalmanAddBeamConstr_;
@@ -661,19 +642,10 @@ namespace tmtt {
     bool writeOutEdmFile_;
 
     // B-field in Tesla
-    std::atomic<float> magneticField_;
+    mutable std::atomic<float> magneticField_;
 
     // Hybrid tracking
     bool hybrid_;
-
-    double psPixelPitch_;
-    double psNStrips_;
-    double psPixelLength_;
-    double ssStripPitch_;
-    double ssNStrips_;
-    double ssStripLength_;
-
-    std::vector<float> zMaxNonTilted_;
   };
 
 }  // namespace tmtt

--- a/L1Trigger/TrackFindingTMTT/interface/Stub.h
+++ b/L1Trigger/TrackFindingTMTT/interface/Stub.h
@@ -42,19 +42,23 @@ namespace tmtt {
   class Stub {
   public:
     // Hybrid L1 tracking: stub constructor.
-    Stub(double phi,
-         double r,
-         double z,
-         double bend,
-         unsigned int layerId,
-         bool psModule,
-         bool barrel,
-         unsigned int iphi,
-         double alpha,
-         const Settings* settings,
-         unsigned int ID,
-         unsigned int iPhiSec);
-
+    Stub(const Settings* settings,
+             unsigned int idStub,
+	     double phi,
+             double r,
+             double z,
+             double bend,
+             unsigned int iphi,
+             double alpha,
+             unsigned int layerId,
+             unsigned int iPhiSec,
+             bool psModule,
+    	     bool barrel,
+    	     bool tiltedBarrel,
+	     float stripPitch,
+	     float stripLength,
+	     unsigned int nStrips);
+ 
     // TMTT L1 tracking: stub constructor.
     Stub(const TTStubRef& ttStubRef,
          unsigned int index_in_vStubs,

--- a/L1Trigger/TrackFindingTMTT/interface/Stub.h
+++ b/L1Trigger/TrackFindingTMTT/interface/Stub.h
@@ -182,15 +182,9 @@ namespace tmtt {
     float sigmaR() const { return (barrel() ? 0. : sigmaPar()); }
     float sigmaZ() const { return (barrel() ? sigmaPar() : 0.); }
     // Hit resolution perpendicular to strip. Measures phi.
-    float sigmaPerp() const {
-      static const float f = sqrt(1. / 12);
-      return f * stripPitch_;
-    }
+    float sigmaPerp() const {return invRoot12 * stripPitch_;}
     // Hit resolution parallel to strip. Measures r or z.
-    float sigmaPar() const {
-      static const float f = sqrt(1. / 12.);
-      return f * stripLength_;
-    }
+    float sigmaPar() const {return invRoot12 * stripLength_;}
 
     //--- These module variables could be taken directly from trackerModule_, were it not for need
     //--- to support Hybrid.
@@ -291,6 +285,8 @@ namespace tmtt {
     unsigned int nStrips_;
 
     const float rejectedStubBend_ = 99999.;  // Bend set to this if stub rejected.
+
+    const float invRoot12 = sqrt(1./12.);
   };
 
 }  // namespace tmtt

--- a/L1Trigger/TrackFindingTMTT/interface/TrackerModule.h
+++ b/L1Trigger/TrackFindingTMTT/interface/TrackerModule.h
@@ -83,15 +83,9 @@ namespace tmtt {
     // Strip length (or pixel pitch along longest axis).
     float stripLength() const { return stripLength_; }
     // Hit resolution perpendicular to strip (or to longest pixel axis). Measures phi.
-    float sigmaPerp() const {
-      static const float f = sqrt(1. / 12.);
-      return f * stripPitch_;
-    }
+    float sigmaPerp() const {return invRoot12 * stripPitch_;}
     // Hit resolution parallel to strip (or to longest pixel axis). Measures r or z.
-    float sigmaPar() const {
-      static const float f = sqrt(1. / 12.);
-      return f * stripLength_;
-    }
+    float sigmaPar() const {return invRoot12 * stripLength_;}
     // Sensor pitch over separation.
     float pitchOverSep() const { return stripPitch_ / sensorSpacing_; }
     // "B" parameter correction for module tilt.
@@ -134,6 +128,8 @@ namespace tmtt {
     unsigned int moduleTypeID_;
 
     ModuleTypeCfg moduleTypeCfg_;
+
+    const float invRoot12 = sqrt(1./12.);
   };
 
 }  // namespace tmtt

--- a/L1Trigger/TrackFindingTMTT/interface/TrackerModule.h
+++ b/L1Trigger/TrackFindingTMTT/interface/TrackerModule.h
@@ -129,7 +129,7 @@ namespace tmtt {
 
     ModuleTypeCfg moduleTypeCfg_;
 
-    const float invRoot12 = sqrt(1./12.);
+    float invRoot12 = sqrt(1./12.);
   };
 
 }  // namespace tmtt

--- a/L1Trigger/TrackFindingTMTT/plugins/TMTrackProducer.cc
+++ b/L1Trigger/TrackFindingTMTT/plugins/TMTrackProducer.cc
@@ -172,7 +172,6 @@ namespace tmtt {
     // Pointers to TTTrack collections for ED output.
     auto htTTTracksForOutput = std::make_unique<TTTrackCollection>();
     auto rzTTTracksForOutput = std::make_unique<TTTrackCollection>();
-    const unsigned int nFitAlgs = trackFitters_.size();
     map<string, unique_ptr<TTTrackCollection>> allFitTTTracksForOutput;
     for (const string& fitterName : trackFitters_) {
       auto fitTTTracksForOutput = std::make_unique<TTTrackCollection>();

--- a/L1Trigger/TrackFindingTMTT/python/TMTrackProducer_Defaults_cfi.py
+++ b/L1Trigger/TrackFindingTMTT/python/TMTrackProducer_Defaults_cfi.py
@@ -236,8 +236,6 @@ TMTrackProducer_params = cms.PSet(
      # (Histogram "AlgEffVsEtaSec" will help you identify which sectors to declare).
      #EtaSecsReduceLayers  = cms.vuint32(),
      EtaSecsReduceLayers  = cms.vuint32(5,12),
-     # Define layers using layer ID (true) or by bins in radius of 5 cm width (false).
-     UseLayerID           = cms.bool(True),
      # Reduce this layer ID, so that it takes no more than 8 different values in any eta region (simplifies firmware).
      ReducedLayerID       = cms.bool(True)
   ),

--- a/L1Trigger/TrackFindingTMTT/src/ConverterToTTTrack.cc
+++ b/L1Trigger/TrackFindingTMTT/src/ConverterToTTTrack.cc
@@ -23,7 +23,6 @@ namespace tmtt {
       hitPattern = 0;
       d0 = 0.;
       z0 = 0;
-      ;
       tanL = 0;
       chi2rphi = 0.;
       chi2rz = 0;

--- a/L1Trigger/TrackFindingTMTT/src/MiniHTstage.cc
+++ b/L1Trigger/TrackFindingTMTT/src/MiniHTstage.cc
@@ -239,7 +239,6 @@ namespace tmtt {
         numStubsPerLinkStage2[encodedLinkYZ] += numStubs;
 
     } else {
-      newerLink = newLink;
       newererLink = newLink;
     }
     unsigned int trueLinkID =

--- a/L1Trigger/TrackFindingTMTT/src/Settings.cc
+++ b/L1Trigger/TrackFindingTMTT/src/Settings.cc
@@ -10,91 +10,54 @@ namespace tmtt {
   ///=== Hybrid Tracking
   ///=== Set config params for HYBRID TRACKING via hard-wired consts to allow use outside CMSSW.
 
-  Settings::Settings() {
-    //
+Settings::Settings():
+    //--------------------------------------------------------------------------------------------------
     // TMTT related configuration parameters, including Kalman Filter.
     // Meaning of these parameters explained in TrackFindingTMTT/python/TMTrackProducer_Defaults_cfi.py
-    //
-    reduceLayerID_ = true;
-    useLayerID_ = true;
-    minFracMatchStubsOnReco_ = -99;
-    minFracMatchStubsOnTP_ = -99;
-    minNumMatchLayers_ = 4;
-    minNumMatchPSLayers_ = 0;
-    stubMatchStrict_ = false;
-    minStubLayers_ = 4;
-    minPtToReduceLayers_ = 99999.;
-    kalmanMinNumStubs_ = 4;
-    kalmanMaxNumStubs_ = 6;
-    numPhiNonants_ = 9;
-    numPhiSectors_ = 9;
-    etaRegions_ = {-2.4,
-                   -2.08,
-                   -1.68,
-                   -1.26,
-                   -0.90,
-                   -0.62,
-                   -0.41,
-                   -0.20,
-                   0.0,
-                   0.20,
-                   0.41,
-                   0.62,
-                   0.90,
-                   1.26,
-                   1.68,
-                   2.08,
-                   2.4};  // Used by KF
-    kalmanRemove2PScut_ = true;
-    killScenario_ = 0;
-    kalmanMaxSkipLayersHard_ = 1;  // On "hard" input tracks
-    kalmanMaxSkipLayersEasy_ = 2;  // On "easy" input tracks
-    kalmanMaxStubsEasy_ = 10;      // Max. #stubs an input track can have to be defined "easy"
-    kalmanMaxStubsPerLayer_ = 4;   // To save resources, consider at most this many stubs per layer per track.
-    kalmanDebugLevel_ = 0;
-    //kalmanDebugLevel_=2; // Good for debugging
-    enableDigitize_ = false;
-    houghMinPt_ = 2.0;
-    chosenRofPhi_ = 67.240;
-    chosenRofZ_ = 50.0;
-    houghNbinsPt_ = 48;  // Mini HT bins in 2 GeV HT array
-    useApproxB_ = true;
-    kalmanHOtilted_ = true;
-    kalmanHOhelixExp_ = true;
-    kalmanHOalpha_ = 1;
-    kalmanHOfw_ = false;
-    kalmanHOprojZcorr_ = 1;
-    bApprox_gradient_ = 0.886454;
-    bApprox_intercept_ = 0.504148;
-    kalmanMultiScattTerm_ = 0.00075;
-    kalmanChi2RphiScale_ = 8;
-    //
-    // Cfg params & constants required only for HYBRID tracking (as taken from DB for TMTT).
-    //
+    //--------------------------------------------------------------------------------------------------
+
+    // General cfg params
+    enableDigitize_(false),
+    useApproxB_(true),
+    bApprox_gradient_(0.886454),
+    bApprox_intercept_(0.504148),
+    numPhiNonants_(9),
+    numPhiSectors_(9),    
+    chosenRofPhi_(55.), // Hourglass radius in r-phi (tracklet)
+etaRegions_({-2.4,-2.08,-1.68,-1.26,-0.90,-0.62,-0.41,-0.20,0.0,0.20,0.41,0.62,0.90,1.26,1.68,2.08,2.4}),  
+    chosenRofZ_(50.0), // Hourglass radius in r-z (this must be tmtt)
+    houghMinPt_(2.0), // L1 track pt cut
+    minStubLayers_(4),
+    minPtToReduceLayers_(99999.),
+    reduceLayerID_(true),
+    minFracMatchStubsOnReco_(-99),
+    minFracMatchStubsOnTP_(-99),
+    minNumMatchLayers_(4),
+    minNumMatchPSLayers_(0),
+    stubMatchStrict_(false),
+
+    // Kalman filter track fit cfg
+    kalmanDebugLevel_(0),
+    //kalmanDebugLevel_(2), // Good for debugging
+    kalmanMinNumStubs_(4),
+    kalmanMaxNumStubs_(6),
+    kalmanRemove2PScut_(true),
+    kalmanMaxSkipLayersHard_(1),  // On "hard" input tracks
+    kalmanMaxSkipLayersEasy_(2),  // On "easy" input tracks
+    kalmanMaxStubsEasy_(10),      // Max. #stubs an input track can have to be defined "easy"
+    kalmanMaxStubsPerLayer_(4),   // To save resources, consider at most this many stubs per layer per track.
+    kalmanMultiScattTerm_(0.00075),
+    kalmanChi2RphiScale_(8),
+    kalmanHOtilted_(true),
+    kalmanHOhelixExp_(true),
+    kalmanHOalpha_(1),
+    kalmanHOprojZcorr_(1),
+    kalmanHOfw_(false)    
+      {
+
     hybrid_ = true;
-    psPixelPitch_ = 0.01;
-    psNStrips_ = 960;
-    psPixelLength_ = 0.1467;
-    ssStripPitch_ = 0.009;
-    ssNStrips_ = 1016;
-    ssStripLength_ = 5.0250;
-    // max z at which non-tilted modules are found in 3 barrel PS layers. (Element 0 not used).
-    zMaxNonTilted_ = {0, 15.3, 24.6, 33.9};
-
-    magneticField_ = 3.81120228767395;
-
-    // Stub digitization params for hybrid (copied from TrackFindingTMTT/interface/HLS/KFconstants.h
-    constexpr double rMult_hybrid = 1. / 0.02929688;
-    constexpr double phiSMult_hybrid = 1. / (7.828293e-6 * 8);
-    constexpr double zMult_hybrid =
-        rMult_hybrid / 2;  // In KF VHDL, z/r mult = 1/2, whereas in HLS, they are identical.
-    // Number of bits copied from TrackFindingTMTT/interface/HLS/KFstub.h (BR1, BPHI, BZ)
-    rtBits_ = 12;
-    phiSBits_ = 14;
-    zBits_ = 14;
-    rtRange_ = pow(2, rtBits_) / rMult_hybrid;
-    phiSRange_ = pow(2, phiSBits_) / phiSMult_hybrid;
-    zRange_ = pow(2, zBits_) / zMult_hybrid;
+    magneticField_ = 0.; // Value set later
+    killScenario_ = 0; // Emulation of dead modules
 
     if (hybrid_) {
       if (not useApproxB_) {
@@ -256,7 +219,6 @@ namespace tmtt {
         minStubLayers_(l1TrackDef_.getParameter<unsigned int>("MinStubLayers")),
         minPtToReduceLayers_(l1TrackDef_.getParameter<double>("MinPtToReduceLayers")),
         etaSecsReduceLayers_(l1TrackDef_.getParameter<vector<unsigned int>>("EtaSecsReduceLayers")),
-        useLayerID_(l1TrackDef_.getParameter<bool>("UseLayerID")),
         reduceLayerID_(l1TrackDef_.getParameter<bool>("ReducedLayerID")),
 
         //=== Specification of algorithm to eliminate duplicate tracks.
@@ -363,13 +325,8 @@ namespace tmtt {
         magneticField_(0.),
 
         // Hybrid tracking
-        hybrid_(iConfig.getParameter<bool>("Hybrid")),
-        psPixelPitch_(0.),
-        psNStrips_(0.),
-        psPixelLength_(0.),
-        ssStripPitch_(0.),
-        ssNStrips_(0.),
-        ssStripLength_(0.) {
+        hybrid_(iConfig.getParameter<bool>("Hybrid"))
+  {
     // If user didn't specify any PDG codes, use e,mu,pi,K,p, to avoid picking up unstable particles like Xi-.
     vector<unsigned int> genPdgIdsUnsigned(genCuts_.getParameter<vector<unsigned int>>("GenPdgIds"));
     if (genPdgIdsUnsigned.empty()) {

--- a/L1Trigger/TrackFindingTMTT/src/Stub.cc
+++ b/L1Trigger/TrackFindingTMTT/src/Stub.cc
@@ -17,19 +17,24 @@ namespace tmtt {
 
   //=== Hybrid L1 tracking: stub constructor.
 
-  Stub::Stub(double phi,
+  Stub::Stub(const Settings* settings,
+	     unsigned int idStub,
+	     double phi,
              double r,
              double z,
              double bend,
-             unsigned int layerId,
-             bool psModule,
-             bool barrel,
              unsigned int iphi,
              double alpha,
-             const Settings* settings,
-             unsigned int ID,
-             unsigned int iPhiSec)
-      : phi_(phi),
+             unsigned int layerId,
+             unsigned int iPhiSec,
+             bool psModule,
+             bool barrel,
+	     bool tiltedBarrel,
+	     float stripPitch,
+	     float stripLength,
+	     unsigned int nStrips)
+    :   index_in_vStubs_(idStub),  // A unique ID to label the stub.
+        phi_(phi),
         r_(r),
         z_(z),
         bend_(bend),
@@ -39,26 +44,12 @@ namespace tmtt {
         psModule_(psModule),
         layerId_(layerId),
         layerIdReduced_(TrackerModule::calcLayerIdReduced(layerId)),
-        barrel_(barrel) {  //work in progress on better constructor for new hybrid
-    if (psModule && barrel) {
-      // max z at which non-tilted modules are found in 3 barrel PS layers. (Element 0 not used).
-      const vector<float>& zMax = settings->zMaxNonTilted();
-      tiltedBarrel_ = (std::abs(z) > zMax[layerId]);
-    } else {
-      tiltedBarrel_ = false;
-    }
-    tiltAngle_ = 0.;  // Not used if cfg uses "ApproxB".
-    if (psModule) {
-      stripPitch_ = settings->psPixelPitch();
-      stripLength_ = settings->psPixelLength();
-      nStrips_ = settings->psNStrips();
-    } else {
-      stripPitch_ = settings->ssStripPitch();
-      stripLength_ = settings->ssStripLength();
-      nStrips_ = settings->ssNStrips();
-    }
-    index_in_vStubs_ = ID;  // A unique ID to label the stub.
-  }
+        barrel_(barrel),
+        tiltedBarrel_(tiltedBarrel),
+        stripPitch_(stripPitch),
+        stripLength_(stripLength),
+        nStrips_(nStrips)
+{}
 
   //=== TMTT L1 tracking: stub constructor.
 

--- a/L1Trigger/TrackFindingTMTT/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTMTT/test/L1TrackNtupleMaker_cfg.py
@@ -15,6 +15,7 @@ process = cms.Process("L1TrackNtuple")
 GEOMETRY = "D49"
 
 # Specify L1 tracking algo ('HYBRID', 'HYBRID_DISPLACED', 'TMTT','HYBRID_FLOAT', 'TRACKLET_FLOAT'),
+# (To run Tracklet, set L1TRKALGO='HYBRID', and set USEHYBRID in TrackFindingTracklet/interface/Settings.h)
 L1TRKALGO = 'TMTT'
 
 # Write output dataset?
@@ -31,6 +32,8 @@ if (L1TRKALGO == 'HYBRID_FLOAT'):
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.categories.append('L1track')
+process.MessageLogger.categories.append('Tracklet')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 


### PR DESCRIPTION
#### PR description:

Fixed clang warning about GlobalCacheTMTT, deleted a few unnecessary cfg parameters, and eliminated the few hard-wired geometry constants in the Stub constructor used for the Hybrid L1 tracking.

#### PR validation:

Tracking performance good with "cmsRun -n 4".
