### PR TITLE
Bug Fix in Stub.cc

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/Stub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Stub.cc
@@ -211,6 +211,12 @@ double Stub::rapprox() const {
     int lr = 1 << (8 - settings_.nrbitsstub(layer_.value()));
     return r_.value() * settings_.kr() * lr + settings_.rmean(layer_.value());
   }
+  if( !l1tstub_->isPSmodule()){
+  if(abs(disk_.value())<=2)
+      return settings_.rDSSinner(r_.value());
+  else
+      return settings_.rDSSouter(r_.value());
+  }
   return r_.value() * settings_.kr();
 }
 


### PR DESCRIPTION
There is a problem with the rapprox implementation.
Values for Stub->rapprox(); and Stub->r(); are 70cms apart for Disk 2S.

The bug fix above will prevent this from happening.

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
