### PR TITLE
L1 tk dev 11 1 0 pre8 vm router table fix

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/VMRouterTable.h
+++ b/L1Trigger/TrackFindingTracklet/interface/VMRouterTable.h
@@ -16,11 +16,11 @@ namespace trklet {
   class VMRouterTable {
   public:
     VMRouterTable(Settings const& settings);
-    VMRouterTable(Settings const& settings, unsigned int layerdisk, std::string name);
+    VMRouterTable(Settings const& settings, unsigned int layerdisk, std::string const& name);
 
     ~VMRouterTable() = default;
 
-    void init(unsigned int layerdisk, std::string name);
+    void init(unsigned int layerdisk, std::string const& name);
 
     // negative return means that seed can not be formed
     int getLookup(unsigned int layerdisk, double z, double r, int iseed = -1);
@@ -30,7 +30,7 @@ namespace trklet {
     int lookupinner(int zbin, int rbin);
     int lookupinneroverlap(int zbin, int rbin);
     int lookupinnerThird(int zbin, int rbin);
-    void writeVMTable(std::string name, std::vector<int>& table);
+    void writeVMTable(std::string const& name, std::vector<int> const& table);
 
   private:
     Settings const& settings_;

--- a/L1Trigger/TrackFindingTracklet/interface/VMRouterTable.h
+++ b/L1Trigger/TrackFindingTracklet/interface/VMRouterTable.h
@@ -30,7 +30,7 @@ namespace trklet {
     int lookupinner(int zbin, int rbin);
     int lookupinneroverlap(int zbin, int rbin);
     int lookupinnerThird(int zbin, int rbin);
-    void writeVMTable(std::string name);
+    void writeVMTable(std::string name, std::vector<int>& table);
 
   private:
     Settings const& settings_;

--- a/L1Trigger/TrackFindingTracklet/interface/VMRouterTable.h
+++ b/L1Trigger/TrackFindingTracklet/interface/VMRouterTable.h
@@ -30,6 +30,7 @@ namespace trklet {
     int lookupinner(int zbin, int rbin);
     int lookupinneroverlap(int zbin, int rbin);
     int lookupinnerThird(int zbin, int rbin);
+    void writeVMTable(std::string name);
 
   private:
     Settings const& settings_;

--- a/L1Trigger/TrackFindingTracklet/interface/VMRouterTable.h
+++ b/L1Trigger/TrackFindingTracklet/interface/VMRouterTable.h
@@ -16,11 +16,11 @@ namespace trklet {
   class VMRouterTable {
   public:
     VMRouterTable(Settings const& settings);
-    VMRouterTable(Settings const& settings, unsigned int layerdisk);
+    VMRouterTable(Settings const& settings, unsigned int layerdisk, std::string name);
 
     ~VMRouterTable() = default;
 
-    void init(unsigned int layerdisk);
+    void init(unsigned int layerdisk, std::string name);
 
     // negative return means that seed can not be formed
     int getLookup(unsigned int layerdisk, double z, double r, int iseed = -1);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -307,13 +307,6 @@ void TrackletEventProcessor::event(SLHCEvent& ev) {
     }
   }
 
-  if (settings_->writeMem()) {
-    for (unsigned int k = 0; k < N_SECTOR; k++) {
-      if (k == settings_->writememsect())
-        sectors_[k]->writeInputStubs(first);
-    }
-  }
-
   addStubTimer_.stop();
 
   // ----------------------------------------------------------------------------------------

--- a/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
@@ -22,7 +22,7 @@ VMRouter::VMRouter(string name, Settings const& settings, Globals* global, unsig
   overlapbits_ = 7;
   nextrabits_ = overlapbits_ - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_));
 
-  vmrtable_.init(layerdisk_);
+  vmrtable_.init(layerdisk_, getName());
 
   nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk_);
   nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk_);

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
@@ -9,11 +9,11 @@ using namespace trklet;
 
 VMRouterTable::VMRouterTable(Settings const& settings) : settings_(settings) {}
 
-VMRouterTable::VMRouterTable(Settings const& settings, unsigned int layerdisk) : settings_(settings) {
-  init(layerdisk);
+VMRouterTable::VMRouterTable(Settings const& settings, unsigned int layerdisk, std::string name) : settings_(settings) {
+  init(layerdisk, name);
 }
 
-void VMRouterTable::init(unsigned int layerdisk) {
+void VMRouterTable::init(unsigned int layerdisk, std::string name) {
   zbits_ = settings_.vmrlutzbits(layerdisk);
   rbits_ = settings_.vmrlutrbits(layerdisk);
 
@@ -99,14 +99,7 @@ void VMRouterTable::init(unsigned int layerdisk) {
     }
   }
   if (settings_.writeTable()) {
-    int ldnumber = layerdisk;
-    char ldchar = 'L';
-    if (ldnumber >= N_LAYER) {
-      ldnumber -= N_LAYER;
-      ldchar = 'D';
-    }
-    ldnumber ++;
-    writeVMTable(settings_.tablePath()+"VMR_"+ldchar+to_string(ldnumber)+"_finebin.tab");
+    writeVMTable(settings_.tablePath()+name+"_finebin.tab");
   }
 }
 

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
@@ -98,8 +98,30 @@ void VMRouterTable::init(unsigned int layerdisk, std::string name) {
       }
     }
   }
+
   if (settings_.writeTable()) {
-    writeVMTable(settings_.tablePath()+name+"_finebin.tab");
+    // write finebin tables
+    writeVMTable(settings_.tablePath()+name+"_finebin.tab",vmrtable_);
+    // write barrel seed teinner tables
+    if (layerdisk == 0 || layerdisk == 1 || layerdisk == 2 || layerdisk == 4) {
+      writeVMTable(settings_.tablePath()+"VMTableInnerL"+to_string(layerdisk+1)+"L"+std::to_string(layerdisk+2)+".tab",vmrtableteinner_);
+    }
+    // write disk seed teinner tables
+    if (layerdisk == 6 || layerdisk == 8) {
+      writeVMTable(settings_.tablePath()+"VMTableInnerD"+to_string(layerdisk-5)+"D"+std::to_string(layerdisk-4)+".tab",vmrtableteinner_);
+    }
+    // write overlap seed teinner tables
+    if (layerdisk == 0 || layerdisk == 1) {
+      writeVMTable(settings_.tablePath()+"VMTableInnerL"+to_string(layerdisk+1)+"D1.tab",vmrtableteinneroverlap_);
+    }
+    // write barrel teouter tables (same as finebin tables)
+    if (layerdisk == 1 || layerdisk == 2 || layerdisk == 3 || layerdisk == 5) {
+      writeVMTable(settings_.tablePath()+"VMTableOuterL"+to_string(layerdisk+1)+".tab",vmrtable_);
+    }
+    // write disk teouter tables
+    if (layerdisk == 6 || layerdisk == 7 || layerdisk == 9) {
+      writeVMTable(settings_.tablePath()+"VMTableOuterD"+to_string(layerdisk-5)+".tab",vmrtabletedisk_);
+    }
   }
 }
 
@@ -290,15 +312,15 @@ int VMRouterTable::lookupinnerThird(int zbin, int rbin) {
   return vmrtableteinnerThird_[index];
 }
 
-void VMRouterTable::writeVMTable(std::string name) {
+void VMRouterTable::writeVMTable(std::string name, std::vector<int>& table) {
   ofstream out;
   out.open(name.c_str());
   out << "{" << endl;
-  for (unsigned int i = 0; i < vmrtable_.size(); i++) {
+  for (unsigned int i = 0; i < table.size(); i++) {
     if (i != 0) {
       out << "," << endl;
     }
-    int itable = vmrtable_[i];
+    int itable = table[i];
     out << itable;
   }
   out << endl << "};" << endl;

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
@@ -9,11 +9,11 @@ using namespace trklet;
 
 VMRouterTable::VMRouterTable(Settings const& settings) : settings_(settings) {}
 
-VMRouterTable::VMRouterTable(Settings const& settings, unsigned int layerdisk, std::string name) : settings_(settings) {
+VMRouterTable::VMRouterTable(Settings const& settings, unsigned int layerdisk, std::string const& name) : settings_(settings) {
   init(layerdisk, name);
 }
 
-void VMRouterTable::init(unsigned int layerdisk, std::string name) {
+void VMRouterTable::init(unsigned int layerdisk, std::string const& name) {
   zbits_ = settings_.vmrlutzbits(layerdisk);
   rbits_ = settings_.vmrlutrbits(layerdisk);
 
@@ -312,7 +312,7 @@ int VMRouterTable::lookupinnerThird(int zbin, int rbin) {
   return vmrtableteinnerThird_[index];
 }
 
-void VMRouterTable::writeVMTable(std::string name, std::vector<int>& table) {
+void VMRouterTable::writeVMTable(std::string const& name, std::vector<int> const& table) {
   ofstream out;
   out.open(name.c_str());
   out << "{" << endl;

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
@@ -98,6 +98,16 @@ void VMRouterTable::init(unsigned int layerdisk) {
       }
     }
   }
+  if (settings_.writeTable()) {
+    int ldnumber = layerdisk;
+    char ldchar = 'L';
+    if (ldnumber >= N_LAYER) {
+      ldnumber -= N_LAYER;
+      ldchar = 'D';
+    }
+    ldnumber ++;
+    writeVMTable(settings_.tablePath()+"VMR_"+ldchar+to_string(ldnumber)+"_finebin.tab");
+  }
 }
 
 int VMRouterTable::getLookup(unsigned int layerdisk, double z, double r, int iseed) {
@@ -285,4 +295,19 @@ int VMRouterTable::lookupinnerThird(int zbin, int rbin) {
   int index = zbin * rbins_ + rbin;
   assert(index >= 0 && index < (int)vmrtableteinnerThird_.size());
   return vmrtableteinnerThird_[index];
+}
+
+void VMRouterTable::writeVMTable(std::string name) {
+  ofstream out;
+  out.open(name.c_str());
+  out << "{" << endl;
+  for (unsigned int i = 0; i < vmrtable_.size(); i++) {
+    if (i != 0) {
+      out << "," << endl;
+    }
+    int itable = vmrtable_[i];
+    out << itable;
+  }
+  out << endl << "};" << endl;
+  out.close();
 }


### PR DESCRIPTION
#### PR description:

Fixes VMRouter HLS LUTs printing, and duplicate event printing in InputStubs
@aehart @skinnari

#### PR validation:

Tested with VMRouter on fw_sync branch of firmware-hls. Passes for 100 ttbar PU200 events.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
