### PR TITLE
Readded changes to enable printout of VMRouter LUTs

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -507,7 +507,7 @@ namespace trklet {
 	 {{5, 5, 5, 5, 5, 5, 5, 5, 4, 4, 4, 4}},    //outer
          {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4}}}};  //outermost (triplets only)
 
-    std::array<std::array<unsigned int, N_SEED>, 3> lutwidthtab_{{{{10, 10, 10, 10, 9, 9, 10, 10, 0, 0, 11, 0}},
+    std::array<std::array<unsigned int, N_SEED>, 3> lutwidthtab_{{{{10, 10, 10, 10, 10, 10, 10, 10, 0, 0, 11, 0}},
                                                                   {{6, 6, 6, 6, 10, 10, 10, 10, 0, 0, 6, 0}},
                                                                   {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 6}}}};
 

--- a/L1Trigger/TrackFindingTracklet/interface/VMRouterTable.h
+++ b/L1Trigger/TrackFindingTracklet/interface/VMRouterTable.h
@@ -16,11 +16,11 @@ namespace trklet {
   class VMRouterTable {
   public:
     VMRouterTable(Settings const& settings);
-    VMRouterTable(Settings const& settings, unsigned int layerdisk);
+    VMRouterTable(Settings const& settings, unsigned int layerdisk, std::string const& name);
 
     ~VMRouterTable() = default;
 
-    void init(unsigned int layerdisk);
+    void init(unsigned int layerdisk, std::string const& name);
 
     // negative return means that seed can not be formed
     int getLookup(unsigned int layerdisk, double z, double r, int iseed = -1);
@@ -30,6 +30,7 @@ namespace trklet {
     int lookupinner(int zbin, int rbin);
     int lookupinneroverlap(int zbin, int rbin);
     int lookupinnerThird(int zbin, int rbin);
+    void writeVMTable(std::string const& name, std::vector<int> const& table);
 
   private:
     Settings const& settings_;

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -307,13 +307,6 @@ void TrackletEventProcessor::event(SLHCEvent& ev) {
     }
   }
 
-  if (settings_->writeMem()) {
-    for (unsigned int k = 0; k < N_SECTOR; k++) {
-      if (k == settings_->writememsect())
-        sectors_[k]->writeInputStubs(first);
-    }
-  }
-
   addStubTimer_.stop();
 
   // ----------------------------------------------------------------------------------------

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
@@ -39,7 +39,7 @@ TrackletProcessor::TrackletProcessor(string name, Settings const& settings, Glob
   nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk1_);
   nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk1_);
 
-  vmrtable_.init(layerdisk1_);
+  vmrtable_.init(layerdisk1_, getName());
 
   nbitsrzbin_ = 3;
   if (iSeed_ == 4 || iSeed_ == 5)

--- a/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
@@ -22,7 +22,7 @@ VMRouter::VMRouter(string name, Settings const& settings, Globals* global, unsig
   overlapbits_ = 7;
   nextrabits_ = overlapbits_ - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_));
 
-  vmrtable_.init(layerdisk_);
+  vmrtable_.init(layerdisk_, getName());
 
   nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk_);
   nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk_);

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -22,7 +22,7 @@ VMRouterCM::VMRouterCM(string name, Settings const& settings, Globals* global, u
   overlapbits_ = 7;
   nextrabits_ = overlapbits_ - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_));
 
-  vmrtable_.init(layerdisk_);
+  vmrtable_.init(layerdisk_, getName());
 
   nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk_);
   nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk_);

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterTable.cc
@@ -9,11 +9,11 @@ using namespace trklet;
 
 VMRouterTable::VMRouterTable(Settings const& settings) : settings_(settings) {}
 
-VMRouterTable::VMRouterTable(Settings const& settings, unsigned int layerdisk) : settings_(settings) {
-  init(layerdisk);
+VMRouterTable::VMRouterTable(Settings const& settings, unsigned int layerdisk, std::string const& name) : settings_(settings) {
+  init(layerdisk, name);
 }
 
-void VMRouterTable::init(unsigned int layerdisk) {
+void VMRouterTable::init(unsigned int layerdisk, std::string const& name) {
   zbits_ = settings_.vmrlutzbits(layerdisk);
   rbits_ = settings_.vmrlutrbits(layerdisk);
 
@@ -96,6 +96,31 @@ void VMRouterTable::init(unsigned int layerdisk) {
       if (layerdisk == 0 || layerdisk == 1) {
         vmrtableteinneroverlap_.push_back(getLookup(6, z, r, layerdisk + 6));
       }
+    }
+  }
+
+  if (settings_.writeTable()) {
+    // write finebin tables
+    writeVMTable(settings_.tablePath()+name+"_finebin.tab",vmrtable_);
+    // write barrel seed teinner tables
+    if (layerdisk == 0 || layerdisk == 1 || layerdisk == 2 || layerdisk == 4) {
+      writeVMTable(settings_.tablePath()+"VMTableInnerL"+to_string(layerdisk+1)+"L"+std::to_string(layerdisk+2)+".tab",vmrtableteinner_);
+    }
+    // write disk seed teinner tables
+    if (layerdisk == 6 || layerdisk == 8) {
+      writeVMTable(settings_.tablePath()+"VMTableInnerD"+to_string(layerdisk-5)+"D"+std::to_string(layerdisk-4)+".tab",vmrtableteinner_);
+    }
+    // write overlap seed teinner tables
+    if (layerdisk == 0 || layerdisk == 1) {
+      writeVMTable(settings_.tablePath()+"VMTableInnerL"+to_string(layerdisk+1)+"D1.tab",vmrtableteinneroverlap_);
+    }
+    // write barrel teouter tables (same as finebin tables)
+    if (layerdisk == 1 || layerdisk == 2 || layerdisk == 3 || layerdisk == 5) {
+      writeVMTable(settings_.tablePath()+"VMTableOuterL"+to_string(layerdisk+1)+".tab",vmrtable_);
+    }
+    // write disk teouter tables
+    if (layerdisk == 6 || layerdisk == 7 || layerdisk == 9) {
+      writeVMTable(settings_.tablePath()+"VMTableOuterD"+to_string(layerdisk-5)+".tab",vmrtabletedisk_);
     }
   }
 }
@@ -286,3 +311,19 @@ int VMRouterTable::lookupinnerThird(int zbin, int rbin) {
   assert(index >= 0 && index < (int)vmrtableteinnerThird_.size());
   return vmrtableteinnerThird_[index];
 }
+
+void VMRouterTable::writeVMTable(std::string const& name, std::vector<int> const& table) {
+  ofstream out;
+  out.open(name.c_str());
+  out << "{" << endl;
+  for (unsigned int i = 0; i < table.size(); i++) {
+    if (i != 0) {
+      out << "," << endl;
+    }
+    int itable = table[i];
+    out << itable;
+  }
+  out << endl << "};" << endl;
+  out.close();
+}
+


### PR DESCRIPTION
#### PR description:

These are the same changes that were in my original PR25, but after I opened the original PR there were some changes to VMRouterCM.cc and TrackletProcessor.cc which used the pre-changed VMRouterTable init method signature. So this PR also updates those calls to VMRouterTable::init.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
