### PR TITLE
Allow multiple stubs per layer when turing on FakeFit

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -17,6 +17,11 @@ HybridFit::HybridFit(unsigned int iSector, Settings const& settings, Globals* gl
 
 void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist) {
   if (settings_.fakefit()) {
+    vector<const L1TStub*> l1stubsFromFitTrack;
+    for (unsigned int k = 0; k < trackstublist.size(); k++) {
+        const L1TStub* L1stub = trackstublist[k]->l1tstub();
+        l1stubsFromFitTrack.push_back(L1stub);
+    }
     tracklet->setFitPars(tracklet->rinvapprox(),
                          tracklet->phi0approx(),
                          tracklet->d0approx(),
@@ -38,7 +43,8 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
                          tracklet->fpgaz0().value(),
                          0,
                          0,
-                         0);
+                         0,
+                         l1stubsFromFitTrack);
     return;
   }
 


### PR DESCRIPTION
This change will allow multiple stubs per layer when turning on hybrid and fakefit option. Here is the debug statement when DR is turned off and fakefit is turned on. 

<img width="708" alt="debug" src="https://user-images.githubusercontent.com/43122048/93459352-e1551100-f8e1-11ea-8a75-b8066dd73d72.png">

The Tracklet and Hybrid algorithms deliver slightly different efficiency when both turning on fakefit.

![L1TK_ttbar-pu0_eff_eta](https://user-images.githubusercontent.com/43122048/93457360-26c40f00-f8df-11ea-8b8d-39b94d7b62d8.png)

Another problem I wanted to raise is the potential confusion caused by different booleans. For example, to generate the results I presented here, you may think we need to turn off "doKF" in the Settings.h and turn on "fakefit" in the same file. Actually, we need to turn on "doKF" because FitTrack.cc will not allow multiple stubs per layer unless "doKF" is turned on. Luckily, KF will never be called because that part of the code will be skipped when turning on "fakefit". 