### PR TITLE
add dphi cuts in MatchEnginge to reduce combinatoric

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/MatchEngine.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MatchEngine.h
@@ -33,6 +33,10 @@ namespace trklet {
     int layer_;
     int disk_;
 
+    bool barrel_;
+    int nvm_;
+    int nvmbits_;
+
     //used in the layers
     std::vector<bool> table_;
 

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngine.cc
@@ -26,6 +26,16 @@ MatchEngine::MatchEngine(string name, Settings const& settings, Globals* global,
     throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " " << name << " subname = " << subname << " "
                                       << layer_ << " " << disk_;
 
+  barrel_ = layer_ > 0;
+
+  nvm_ = barrel_ ? settings_.nvmme(layer_ - 1) * settings_.nallstubs(layer_ - 1)
+                 : settings_.nvmme(disk_ + N_LAYER - 1) * settings_.nallstubs(disk_ + N_LAYER - 1);
+
+  if (nvm_ == 32)
+    nvmbits_ = 5;
+  if (nvm_ == 16)
+    nvmbits_ = 4;
+
   if (layer_ > 0) {
     unsigned int nbits = 3;
     if (layer_ >= 4)
@@ -115,8 +125,6 @@ void MatchEngine::addInput(MemoryBase* memory, string input) {
 }
 
 void MatchEngine::execute() {
-  bool barrel = layer_ > 0;
-
   unsigned int countall = 0;
   unsigned int countpass = 0;
 
@@ -135,6 +143,7 @@ void MatchEngine::execute() {
   int rzbin = 0;
   int projfinerz = 0;
   int projfinerzadj = 0;
+  unsigned int projfinephi = 0;
 
   int projindex = 0;
   int projrinv = 0;
@@ -173,9 +182,9 @@ void MatchEngine::execute() {
       iproj++;
       moreproj = iproj < nproj;
 
-      unsigned int rzfirst = barrel ? proj->zbin1projvm(layer_) : proj->rbin1projvm(disk_);
+      unsigned int rzfirst = barrel_ ? proj->zbin1projvm(layer_) : proj->rbin1projvm(disk_);
       unsigned int rzlast = rzfirst;
-      bool second = (barrel ? proj->zbin2projvm(layer_) : proj->rbin2projvm(disk_)) == 1;
+      bool second = (barrel_ ? proj->zbin2projvm(layer_) : proj->rbin2projvm(disk_)) == 1;
       if (second)
         rzlast += 1;
 
@@ -225,12 +234,15 @@ void MatchEngine::execute() {
 
         Tracklet* proj = vmprojs_->getTracklet(projindex);
 
+        FPGAWord fpgaphi = barrel_ ? proj->fpgaphiproj(layer_) : proj->fpgaphiprojdisk(disk_);
+        projfinephi = (fpgaphi.value() >> (fpgaphi.nbits() - (nvmbits_ + 3))) & 7;
+
         nstubs = vmstubs_->nStubsBin(rzbin);
 
-        projfinerz = barrel ? proj->finezvm(layer_) : proj->finervm(disk_);
+        projfinerz = barrel_ ? proj->finezvm(layer_) : proj->finervm(disk_);
 
         projrinv =
-            barrel
+            barrel_
                 ? (16 + (((-2) * proj->fpgaphiprojder(layer_).value()) >> (proj->fpgaphiprojder(layer_).nbits() - 4)))
                 : proj->getBendIndex(disk_).value();
         assert(projrinv >= 0);
@@ -275,31 +287,33 @@ void MatchEngine::execute() {
 
       int nbits = isPSmodule ? 3 : 4;
 
-      //TODO - should use finephi information to reduce combinatorics
+      int deltaphi = projfinephi - vmstub.finephi().value();
+
+      bool passphi = (abs(deltaphi) < 3) || (abs(deltaphi) > 5);
 
       unsigned int index = (projrinv << nbits) + vmstub.bend().value();
 
       //Check if stub z position consistent
       int idrz = stubfinerz - projfinerzadj;
-      bool pass;
+      bool passz;
 
-      if (barrel) {
+      if (barrel_) {
         if (isPSseed) {
-          pass = idrz >= -2 && idrz <= 2;
+          passz = idrz >= -2 && idrz <= 2;
         } else {
-          pass = idrz >= -5 && idrz <= 5;
+          passz = idrz >= -5 && idrz <= 5;
         }
       } else {
         if (isPSmodule) {
-          pass = idrz >= -1 && idrz <= 1;
+          passz = idrz >= -1 && idrz <= 1;
         } else {
-          pass = idrz >= -5 && idrz <= 5;
+          passz = idrz >= -5 && idrz <= 5;
         }
       }
 
       //Check if stub bend and proj rinv consistent
-      if (pass) {
-        if (barrel ? table_[index] : (isPSmodule ? tablePS_[index] : table2S_[index])) {
+      if (passz && passphi) {
+        if (barrel_ ? table_[index] : (isPSmodule ? tablePS_[index] : table2S_[index])) {
           Tracklet* proj = vmprojs_->getTracklet(projindex);
           std::pair<Tracklet*, int> tmp(proj, vmprojs_->getAllProjIndex(projindex));
           if (settings_.writeMonitorData("Seeds")) {


### PR DESCRIPTION
This adds phi cuts (obo Anders Ryd) in the match engine to reduce combinatorics, and in turn reduce impact of truncation, as shown in the presentation from Cara Pesciotta (https://indico.cern.ch/event/965564/#25-update-on-truncation-effect). 

KNOWN ISSUES: The match engine needs to be cleaned up to remove hard-coded bit assignments and other hard-coded constants. I.e. the "problem" extends beyond what is in this particular PR and this part of the code needs to be cleaned up thoroughly before PR'ing to central CMSSW. 