### PR TITLE
Made stub format consistent with DTC emulation.

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -286,7 +286,7 @@ void TrackletEventProcessor::event(SLHCEvent& ev) {
         assert(layerdiskcode < 4);
         FPGAWord ldcode;
         ldcode.set(layerdiskcode, 2);
-        string dataword = "1|" + ldcode.str() + "|" + fpgastub.str();
+        string dataword = fpgastub.str() + "|" + ldcode.str() + "|1";
         if (topbit == 0) {
           (*dtcstubs[dtcbase + "A"]) << dataword << " " << trklet::hexFormat(dataword) << endl;
         } else {


### PR DESCRIPTION
#### PR description:

This PR moves the layer ID and valid bit to the end of the stub word so that it is consistent with the DTC emulation, as documented here:
https://twiki.cern.ch/twiki/bin/view/CMS/HybridDataFormat#DTC_output

This was discussed during Emyr's talk during the 7 Oct algorithm meeting here:
https://indico.cern.ch/event/957554/#22-future-l1trk-c-emulation-st

#### PR validation:

I ran the emulation with `writeMem = true`, and I now see that the stub format in the MemPrints/InputStubs/Link_*.dat files is consistent with the DTC emulation.