### PR TITLE
Fixing the disp tracking bug

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -294,23 +294,23 @@ void MatchCalculator::execute() {
         edm::LogProblem("Tracklet") << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox
                                     << endl;
       }
-      assert(std::abs(dphi) < 0.2);
-      assert(std::abs(dphiapprox) < 0.2);
 
-      if (settings_.writeMonitorData("Residuals")) {
-        double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
+      bool imatch = false;
+      if(std::abs(dphi) < 0.2 && std::abs(dphiapprox) < 0.2){ //Changed the Asserts into if statements
+        if (settings_.writeMonitorData("Residuals")) {
+          double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
 
-        globals_->ofstream("layerresiduals.txt")
-            << layerdisk_ + 1 << " " << seedindex << " " << pt << " "
-            << ideltaphi * settings_.kphi1() * settings_.rmean(layerdisk_) << " "
-            << dphiapprox * settings_.rmean(layerdisk_) << " "
-            << phimatchcut_[seedindex] * settings_.kphi1() * settings_.rmean(layerdisk_) << "   "
-            << ideltaz * fact_ * settings_.kz() << " " << dz << " " << zmatchcut_[seedindex] * settings_.kz() << endl;
+          globals_->ofstream("layerresiduals.txt")
+              << layerdisk_ + 1 << " " << seedindex << " " << pt << " "
+              << ideltaphi * settings_.kphi1() * settings_.rmean(layerdisk_) << " "
+              << dphiapprox * settings_.rmean(layerdisk_) << " "
+              << phimatchcut_[seedindex] * settings_.kphi1() * settings_.rmean(layerdisk_) << "   "
+              << ideltaz * fact_ * settings_.kz() << " " << dz << " " << zmatchcut_[seedindex] * settings_.kz() << endl;
+        }
+
+       imatch = (std::abs(ideltaphi) <= (int)phimatchcut_[seedindex]) &&
+                      (std::abs(ideltaz * fact_) <= (int)zmatchcut_[seedindex]);
       }
-
-      bool imatch = (std::abs(ideltaphi) <= (int)phimatchcut_[seedindex]) &&
-                    (std::abs(ideltaz * fact_) <= (int)zmatchcut_[seedindex]);
-
       if (settings_.debugTracklet()) {
         edm::LogVerbatim("Tracklet") << getName() << " imatch = " << imatch << " ideltaphi cut " << ideltaphi << " "
                                      << phimatchcut_[seedindex] << " ideltaz*fact cut " << ideltaz * fact_ << " "
@@ -454,19 +454,25 @@ void MatchCalculator::execute() {
       double drphicut = idrphicut * settings_.kphi() * settings_.kr();
       double drcut = idrcut * settings_.krprojshiftdisk();
 
-      if (settings_.writeMonitorData("Residuals")) {
-        double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
+      bool match, imatch;
+      if(std::abs(dphi) < 0.25 && std::abs(dphiapprox) < 0.25){ //Changed the Asserts into if statements
+        if (settings_.writeMonitorData("Residuals")) {
+          double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
 
-        globals_->ofstream("diskresiduals.txt")
-            << disk << " " << stub->isPSmodule() << " " << tracklet->layer() << " " << abs(tracklet->disk()) << " "
-            << pt << " " << ideltaphi * settings_.kphi() * stub->r() << " " << drphiapprox << " " << drphicut << " "
-            << ideltar * settings_.krprojshiftdisk() << " " << deltar << " " << drcut << " " << endl;
+          globals_->ofstream("diskresiduals.txt")
+              << disk << " " << stub->isPSmodule() << " " << tracklet->layer() << " " << abs(tracklet->disk()) << " "
+              << pt << " " << ideltaphi * settings_.kphi() * stub->r() << " " << drphiapprox << " " << drphicut << " "
+              << ideltar * settings_.krprojshiftdisk() << " " << deltar << " " << drcut << " " << endl;
+        }
+
+        match = (std::abs(drphi) < drphicut) && (std::abs(deltar) < drcut);
+
+        imatch = (std::abs(ideltaphi * irstub) < idrphicut) && (std::abs(ideltar) < idrcut);
       }
-
-      bool match = (std::abs(drphi) < drphicut) && (std::abs(deltar) < drcut);
-
-      bool imatch = (std::abs(ideltaphi * irstub) < idrphicut) && (std::abs(ideltar) < idrcut);
-
+      else{
+        edm::LogProblem("Tracklet") << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox
+                                    << "dphi " << dphi << " Seed / ISeed " << tracklet->getISeed()<< endl;
+      }
       if (settings_.debugTracklet()) {
         edm::LogVerbatim("Tracklet") << "imatch match disk: " << imatch << " " << match << " " << std::abs(ideltaphi)
                                      << " " << drphicut / (settings_.kphi() * stub->r()) << " " << std::abs(ideltar)
@@ -479,12 +485,6 @@ void MatchCalculator::execute() {
         if (settings_.debugTracklet()) {
           edm::LogVerbatim("Tracklet") << "MatchCalculator found match in disk " << getName();
         }
-
-        if (std::abs(dphi) >= 0.25) {
-          edm::LogVerbatim("Tracklet") << "dphi " << dphi << " Seed / ISeed " << tracklet->getISeed();
-        }
-        assert(std::abs(dphi) < 0.25);
-        assert(std::abs(dphiapprox) < 0.25);
 
         tracklet->addMatchDisk(disk,
                                ideltaphi,

--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -472,6 +472,8 @@ void MatchCalculator::execute() {
       else{
         edm::LogProblem("Tracklet") << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox
                                     << "dphi " << dphi << " Seed / ISeed " << tracklet->getISeed()<< endl;
+        match = false;
+        imatch = false;
       }
       if (settings_.debugTracklet()) {
         edm::LogVerbatim("Tracklet") << "imatch match disk: " << imatch << " " << match << " " << std::abs(ideltaphi)

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -454,7 +454,8 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
   double phiderdiskapprox[N_DISK], rderdiskapprox[N_DISK];
 
   //TODO: implement the actual integer calculation
-  approxtracklet(r1,
+  if(settings_.useapprox()){
+    approxtracklet(r1,
                  z1,
                  phi1,
                  r2,
@@ -478,6 +479,28 @@ bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
                  rprojdiskapprox,
                  phiderdiskapprox,
                  rderdiskapprox);
+  }
+  else{
+    rinvapprox = rinv;
+    phi0approx = phi0;
+    d0approx = d0;
+    tapprox = t;
+    z0approx = z0;
+
+    for (unsigned int i = 0; i < toR_.size(); ++i) {
+      phiprojapprox[i] = phiproj[i];
+      zprojapprox[i] = zproj[i];
+      phiderapprox[i] = phider[i];
+      zderapprox[i] = zder[i];
+    }
+
+    for (unsigned int i = 0; i < toZ_.size(); ++i) {
+      phiprojdiskapprox[i] = phiprojdisk[i];
+      rprojdiskapprox[i] = rprojdisk[i];
+      phiderdiskapprox[i] = phiderdisk[i];
+      rderdiskapprox[i] = rderdisk[i];
+    }
+  }
 
   //store the approcximate results
 
@@ -848,7 +871,8 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
   double phiderdiskapprox[N_DISK], rderdiskapprox[N_DISK];
 
   //TODO: implement the actual integer calculation
-  approxtracklet(r1,
+  if(settings_.useapprox()){
+    approxtracklet(r1,
                  z1,
                  phi1,
                  r2,
@@ -872,6 +896,28 @@ bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
                  rprojdiskapprox,
                  phiderdiskapprox,
                  rderdiskapprox);
+  }
+  else{
+    rinvapprox = rinv;
+    phi0approx = phi0;
+    d0approx = d0;
+    tapprox = t;
+    z0approx = z0;
+
+    for (unsigned int i = 0; i < toR_.size(); ++i) {
+      phiprojapprox[i] = phiproj[i];
+      zprojapprox[i] = zproj[i];
+      phiderapprox[i] = phider[i];
+      zderapprox[i] = zder[i];
+    }
+
+    for (unsigned int i = 0; i < toZ_.size(); ++i) {
+      phiprojdiskapprox[i] = phiprojdisk[i];
+      rprojdiskapprox[i] = rprojdisk[i];
+      phiderdiskapprox[i] = phiderdisk[i];
+      rderdiskapprox[i] = rderdisk[i];
+    }
+  }
 
   //store the approcximate results
   if (settings_.debugTracklet()) {
@@ -1226,7 +1272,8 @@ bool TrackletCalculatorDisplaced::LLDSeeding(const Stub* innerFPGAStub,
   double phiderdiskapprox[N_DISK], rderdiskapprox[N_DISK];
 
   //TODO: implement the actual integer calculation
-  approxtracklet(r1,
+  if(settings_.useapprox()){
+    approxtracklet(r1,
                  z1,
                  phi1,
                  r2,
@@ -1250,6 +1297,28 @@ bool TrackletCalculatorDisplaced::LLDSeeding(const Stub* innerFPGAStub,
                  rprojdiskapprox,
                  phiderdiskapprox,
                  rderdiskapprox);
+  }
+  else{
+    rinvapprox = rinv;
+    phi0approx = phi0;
+    d0approx = d0;
+    tapprox = t;
+    z0approx = z0;
+
+    for (unsigned int i = 0; i < toR_.size(); ++i) {
+      phiprojapprox[i] = phiproj[i];
+      zprojapprox[i] = zproj[i];
+      phiderapprox[i] = phider[i];
+      zderapprox[i] = zder[i];
+    }
+
+    for (unsigned int i = 0; i < toZ_.size(); ++i) {
+      phiprojdiskapprox[i] = phiprojdisk[i];
+      rprojdiskapprox[i] = rprojdisk[i];
+      phiderdiskapprox[i] = phiderdisk[i];
+      rderdiskapprox[i] = rderdisk[i];
+    }
+  }
 
   //store the approcximate results
   if (settings_.debugTracklet()) {


### PR DESCRIPTION
Changed a couple of asserts into if statements

#### PR description:

This is to fix the bug when using displaced tracking. The problem is coming from a couple of "pile-up" tracks, reconstructed using displaced seed. There is a slight discrepancy arising from the approx projection.

To rectify this, I have turned a couple of asserts in the match calculator to if statements. This way, the function of asserts is served when we have this discrepancy, that if conditions will do the job, without breaking the program.

#### PR validation:

The fix is run over ttbar+200 PU for validation.

