### PR TITLE
Clean up Matrix class in TMTT directory

### DIFF
--- a/L1Trigger/TrackFindingTMTT/interface/Array2D.h
+++ b/L1Trigger/TrackFindingTMTT/interface/Array2D.h
@@ -1,0 +1,34 @@
+#ifndef L1Trigger_TrackFindingTMTT_Array2D_h
+#define L1Trigger_TrackFindingTMTT_Array2D_h
+
+#include <vector>
+
+//=== Generic 2D array class.
+
+// (Replaced boost::numeric::ublas::matrix when boost library 
+//  became too big).
+
+// Author: Lucas Camolezi
+
+namespace tmtt {
+
+  template <typename T>
+  class Array2D {
+  public:
+    //for a mxn matrix - row major
+    Array2D(unsigned int m, unsigned int n) : _n{n}, _m{m} { array2D_.resize(m * n); }
+    const T& operator()(unsigned int i, unsigned int j) const { return array2D_.at(i * _n + j); }
+    T& operator()(unsigned int i, unsigned int j) {
+      if (i >= _m || j >= _n)
+        throw std::out_of_range("matrix access out of bounds");
+
+      return array2D_[i * _n + j];
+    }
+
+  private:
+    std::vector<T> array2D_;
+    unsigned int _n, _m;
+  };
+}  // namespace tmtt
+
+#endif

--- a/L1Trigger/TrackFindingTMTT/interface/HTbase.h
+++ b/L1Trigger/TrackFindingTMTT/interface/HTbase.h
@@ -1,36 +1,17 @@
-
 #ifndef L1Trigger_TrackFindingTMTT_HTbase_h
 #define L1Trigger_TrackFindingTMTT_HTbase_h
 
 #include "L1Trigger/TrackFindingTMTT/interface/HTcell.h"
 #include "L1Trigger/TrackFindingTMTT/interface/L1track2D.h"
+#include "L1Trigger/TrackFindingTMTT/interface/Array2D.h"
 
 #include <vector>
 #include <list>
 #include <utility>
 #include <memory>
 
-namespace tmtt {
-  template <typename T>
-  class matrix {
-  public:
-    //for a mxn matrix - row major
-    matrix(unsigned int m, unsigned int n) : _n{n}, _m{m} { _matrix.resize(m * n); }
-    const T& operator()(unsigned int i, unsigned int j) const { return _matrix.at(i * _n + j); }
-    T& operator()(unsigned int i, unsigned int j) {
-      if (i >= _m || j >= _n)
-        throw std::out_of_range("matrix access out of bounds");
-
-      return _matrix[i * _n + j];
-    }
-
-  private:
-    std::vector<T> _matrix;
-    unsigned int _n, _m;
-  };
-}  // namespace tmtt
-
 //=== Base class for Hough Transform array for a single (eta,phi) sector.
+
 namespace tmtt {
 
   class Settings;
@@ -61,7 +42,7 @@ namespace tmtt {
 
     // Get all the cells that make up the array, which in turn give access to the stubs inside them.
     // N.B. You can use allCells().size1() and allCells().size2() to get the dimensions ofthe array.
-    virtual const matrix<std::unique_ptr<HTcell>>& allCells() const { return htArray_; }
+    virtual const Array2D<std::unique_ptr<HTcell>>& allCells() const { return htArray_; }
 
     //=== Info about track candidates found.
 
@@ -148,7 +129,7 @@ namespace tmtt {
 
     // Hough transform array.
     // This has two dimensions, representing the two track helix parameters being varied.
-    matrix<std::unique_ptr<HTcell>> htArray_;
+    Array2D<std::unique_ptr<HTcell>> htArray_;
 
     unsigned int optoLinkID_;  // ID of opto-link from HT to Track Fitter.
 

--- a/L1Trigger/TrackFindingTMTT/interface/Histos.h
+++ b/L1Trigger/TrackFindingTMTT/interface/Histos.h
@@ -6,6 +6,7 @@
 #include "L1Trigger/TrackFindingTMTT/interface/Settings.h"
 #include "L1Trigger/TrackFindingTMTT/interface/L1track3D.h"
 #include "L1Trigger/TrackFindingTMTT/interface/TrackerModule.h"
+#include "L1Trigger/TrackFindingTMTT/interface/Array2D.h"
 
 #include <vector>
 #include <map>
@@ -41,9 +42,9 @@ namespace tmtt {
     // Book & fill all histograms.
     virtual void book();
     virtual void fill(const InputData& inputData,
-                      const matrix<std::unique_ptr<Sector>>& mSectors,
-                      const matrix<std::unique_ptr<HTrphi>>& mHtPhis,
-                      const matrix<std::unique_ptr<Make3Dtracks>>& mGet3Dtrks,
+                      const Array2D<std::unique_ptr<Sector>>& mSectors,
+                      const Array2D<std::unique_ptr<HTrphi>>& mHtPhis,
+                      const Array2D<std::unique_ptr<Make3Dtracks>>& mGet3Dtrks,
                       const std::map<std::string, std::list<const L1fittedTrack*>>& mapFinalTracks);
 
     // Print tracking performance summary & make tracking efficiency histograms.
@@ -69,11 +70,11 @@ namespace tmtt {
 
     // Fill histograms for specific topics.
     virtual void fillInputData(const InputData& inputData);
-    virtual void fillEtaPhiSectors(const InputData& inputData, const matrix<std::unique_ptr<Sector>>& mSectors);
-    virtual void fillRphiHT(const matrix<std::unique_ptr<HTrphi>>& mHtRphis);
-    virtual void fillRZfilters(const matrix<std::unique_ptr<Make3Dtracks>>& mMake3Dtrks);
+    virtual void fillEtaPhiSectors(const InputData& inputData, const Array2D<std::unique_ptr<Sector>>& mSectors);
+    virtual void fillRphiHT(const Array2D<std::unique_ptr<HTrphi>>& mHtRphis);
+    virtual void fillRZfilters(const Array2D<std::unique_ptr<Make3Dtracks>>& mMake3Dtrks);
     virtual void fillTrackCands(const InputData& inputData,
-                                const matrix<std::unique_ptr<Make3Dtracks>>& mMake3Dtrks,
+                                const Array2D<std::unique_ptr<Make3Dtracks>>& mMake3Dtrks,
                                 const std::string& tName);
     virtual void fillTrackCands(const InputData& inputData,
                                 const std::vector<L1track3D>& tracks,

--- a/L1Trigger/TrackFindingTMTT/interface/MiniHTstage.h
+++ b/L1Trigger/TrackFindingTMTT/interface/MiniHTstage.h
@@ -3,6 +3,7 @@
 
 #include "L1Trigger/TrackFindingTMTT/interface/HTrphi.h"
 #include "L1Trigger/TrackFindingTMTT/interface/MuxHToutputs.h"
+#include "L1Trigger/TrackFindingTMTT/interface/Array2D.h"
 
 #include <memory>
 
@@ -14,7 +15,7 @@ namespace tmtt {
   public:
     MiniHTstage(const Settings* settings);
 
-    void exec(matrix<std::unique_ptr<HTrphi>>& mHtRphis);
+    void exec(Array2D<std::unique_ptr<HTrphi>>& mHtRphis);
 
   private:
     // Do load balancing

--- a/L1Trigger/TrackFindingTMTT/interface/MuxHToutputs.h
+++ b/L1Trigger/TrackFindingTMTT/interface/MuxHToutputs.h
@@ -2,6 +2,7 @@
 #define L1Trigger_TrackFindingTMTT_MuxHToutputs_h
 
 #include "L1Trigger/TrackFindingTMTT/interface/HTrphi.h"
+#include "L1Trigger/TrackFindingTMTT/interface/Array2D.h"
 
 #include <vector>
 #include <memory>
@@ -34,7 +35,7 @@ namespace tmtt {
     // of multiple (eta,phi) sectors onto single links and the truncation of the tracks caused by the requirement
     // to output all the tracks within the time-multiplexed period.
     // This function replaces the 2D track collection in the r-phi HT with the subset surviving the TM cut.
-    void exec(matrix<std::unique_ptr<HTrphi>>& mHtRphis) const;
+    void exec(Array2D<std::unique_ptr<HTrphi>>& mHtRphis) const;
 
     // Determine number of optical links used to output tracks from each phi nonant
     // (where "link" refers to a pair of links in the hardware).

--- a/L1Trigger/TrackFindingTMTT/plugins/TMTrackProducer.cc
+++ b/L1Trigger/TrackFindingTMTT/plugins/TMTrackProducer.cc
@@ -10,6 +10,7 @@
 #include "L1Trigger/TrackFindingTMTT/interface/HTcell.h"
 #include "L1Trigger/TrackFindingTMTT/interface/MuxHToutputs.h"
 #include "L1Trigger/TrackFindingTMTT/interface/MiniHTstage.h"
+#include "L1Trigger/TrackFindingTMTT/interface/Array2D.h"
 #include "L1Trigger/TrackFindingTMTT/interface/PrintL1trk.h"
 
 #include "FWCore/MessageService/interface/MessageLogger.h"
@@ -170,13 +171,13 @@ namespace tmtt {
     const list<Stub*>& vStubs = inputData.stubs();
 
     // Creates matrix of Sector objects, which decide which stubs are in which (eta,phi) sector
-    matrix<unique_ptr<Sector>> mSectors(settings_.numPhiSectors(), settings_.numEtaRegions());
+    Array2D<unique_ptr<Sector>> mSectors(settings_.numPhiSectors(), settings_.numEtaRegions());
     // Create matrix of r-phi Hough-Transform arrays, with one-to-one correspondence to sectors.
-    matrix<unique_ptr<HTrphi>> mHtRphis(settings_.numPhiSectors(), settings_.numEtaRegions());
+    Array2D<unique_ptr<HTrphi>> mHtRphis(settings_.numPhiSectors(), settings_.numEtaRegions());
     // Create matrix of Make3Dtracks objects, to run optional r-z track filter, with one-to-one correspondence to sectors.
-    matrix<unique_ptr<Make3Dtracks>> mMake3Dtrks(settings_.numPhiSectors(), settings_.numEtaRegions());
+    Array2D<unique_ptr<Make3Dtracks>> mMake3Dtrks(settings_.numPhiSectors(), settings_.numEtaRegions());
     // Create matrix of tracks from each fitter in each sector
-    matrix<map<string, std::list<L1fittedTrack>>> mapmFitTrks(settings_.numPhiSectors(), settings_.numEtaRegions());
+    Array2D<map<string, std::list<L1fittedTrack>>> mapmFitTrks(settings_.numPhiSectors(), settings_.numEtaRegions());
     // Final tracks after duplicate removal from each track fitter in entire tracker.
     map<string, list<const L1fittedTrack*>> mapFinalTracks;
 

--- a/L1Trigger/TrackFindingTMTT/src/Histos.cc
+++ b/L1Trigger/TrackFindingTMTT/src/Histos.cc
@@ -81,9 +81,9 @@ namespace tmtt {
   //=== Fill all histograms
 
   void Histos::fill(const InputData& inputData,
-                    const matrix<unique_ptr<Sector>>& mSectors,
-                    const matrix<unique_ptr<HTrphi>>& mHtRphis,
-                    const matrix<unique_ptr<Make3Dtracks>>& mMake3Dtrks,
+                    const Array2D<unique_ptr<Sector>>& mSectors,
+                    const Array2D<unique_ptr<HTrphi>>& mHtRphis,
+                    const Array2D<unique_ptr<Make3Dtracks>>& mMake3Dtrks,
                     const std::map<std::string, std::list<const L1fittedTrack*>>& mapFinalTracks) {
     // Each function here protected by a mytex lock, so only one thread can run it at a time.
 
@@ -383,7 +383,7 @@ namespace tmtt {
 
   //=== Fill histograms checking if (eta,phi) sector definition choices are good.
 
-  void Histos::fillEtaPhiSectors(const InputData& inputData, const matrix<unique_ptr<Sector>>& mSectors) {
+  void Histos::fillEtaPhiSectors(const InputData& inputData, const Array2D<unique_ptr<Sector>>& mSectors) {
     // Allow only one thread to run this function at a time
     static std::mutex myMutex;
     std::lock_guard<std::mutex> myGuard(myMutex);
@@ -442,7 +442,7 @@ namespace tmtt {
 
   //=== Fill histograms checking filling of r-phi HT array.
 
-  void Histos::fillRphiHT(const matrix<unique_ptr<HTrphi>>& mHtRphis) {
+  void Histos::fillRphiHT(const Array2D<unique_ptr<HTrphi>>& mHtRphis) {
     //--- Loop over (eta,phi) sectors, counting the number of stubs in the HT array of each.
 
     // Allow only one thread to run this function at a time (UNCOMMENT IF YOU ADD HISTOS HERE)
@@ -460,7 +460,7 @@ namespace tmtt {
 
   //=== Fill histograms about r-z track filters.
 
-  void Histos::fillRZfilters(const matrix<unique_ptr<Make3Dtracks>>& mMake3Dtrks) {
+  void Histos::fillRZfilters(const Array2D<unique_ptr<Make3Dtracks>>& mMake3Dtrks) {
     // Allow only one thread to run this function at a time (UNCOMMENT IF YOU ADD HISTOS HERE)
     //static std::mutex myMutex;
     //std::lock_guard<std::mutex> myGuard(myMutex);
@@ -585,7 +585,7 @@ namespace tmtt {
   //=== Fill histograms studying track candidates found before track fit is run.
 
   void Histos::fillTrackCands(const InputData& inputData,
-                              const matrix<std::unique_ptr<Make3Dtracks>>& mMake3Dtrks,
+                              const Array2D<std::unique_ptr<Make3Dtracks>>& mMake3Dtrks,
                               const string& tName) {
     // Allow only one thread to run this function at a time
     static std::mutex myMutex;

--- a/L1Trigger/TrackFindingTMTT/src/MiniHTstage.cc
+++ b/L1Trigger/TrackFindingTMTT/src/MiniHTstage.cc
@@ -42,7 +42,7 @@ namespace tmtt {
     }
   }
 
-  void MiniHTstage::exec(matrix<unique_ptr<HTrphi>>& mHtRphis) {
+  void MiniHTstage::exec(Array2D<unique_ptr<HTrphi>>& mHtRphis) {
     for (unsigned int iPhiNon = 0; iPhiNon < numPhiNonants_; iPhiNon++) {
       // Indices are ([link ID, MHT cell], #stubs).
       map<pair<unsigned int, unsigned int>, unsigned int> numStubsPerLinkStage1;

--- a/L1Trigger/TrackFindingTMTT/src/MuxHToutputs.cc
+++ b/L1Trigger/TrackFindingTMTT/src/MuxHToutputs.cc
@@ -54,7 +54,7 @@ namespace tmtt {
   //=== to output all the tracks within the time-multiplexed period.
   //=== This function replaces the 2D track collection in the r-phi HT with the subset surviving the TM cut.
 
-  void MuxHToutputs::exec(matrix<unique_ptr<HTrphi>>& mHtRphis) const {
+  void MuxHToutputs::exec(Array2D<unique_ptr<HTrphi>>& mHtRphis) const {
     // As this loops over sectors in order of increasing sector number, this MUX algorithm always transmits tracks
     // from the lowest sector numbers on each link first. So the highest sector numbers are more likely to be
     // truncated by the TM period. The algorithm assumes that two or more m-bin ranges from the same sector will never


### PR DESCRIPTION
#### PR description:

Someone in the SW group replaced the 2D matrix class from boost by a hand-made class called "matrix" (because the boost library was too big). To make this new class adhere to CMSSW coding rules, this now:

1) Renames this class to "Array2D", so it starts with capital letter.
2) Defines it in its own header file Array2D.h.