### PR TITLE
PurgeDuplicates test-vectors (11_3_X)

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -248,6 +248,13 @@ namespace trklet {
     unsigned int nbitstrackletindex() const { return nbitstrackletindex_; }
     void setNbitstrackletindex(unsigned int nbitstrackletindex) { nbitstrackletindex_ = nbitstrackletindex; }
 
+    unsigned int nbitsitc() const { return nbitsitc_; }
+    unsigned int nbitsseed() const { return (extended_ ? nbitsseedextended_ : nbitsseed_); }
+    unsigned int nbitstcindex() const { return nbitsseed() + nbitsitc(); }
+    void setNbitsitc(unsigned int nbitsitc) { nbitsitc_ = nbitsitc; }
+    void setNbitsseed(unsigned int nbitsseed) { nbitsseed_ = nbitsseed; }
+    void setNbitsseedextended(unsigned int nbitsseed) { nbitsseedextended_ = nbitsseed; }
+
     double dphisectorHG() const {
       return 2 * M_PI / N_SECTOR +
              2 * std::max(std::abs(asin(0.5 * rinvmax() * rmean(0)) - asin(0.5 * rinvmax() * rcrit_)),
@@ -449,6 +456,12 @@ namespace trklet {
     double ptcutte_{1.8};  //Minimum pt in TE
 
     unsigned int nbitstrackletindex_{7};  //Bits used to store the tracklet index
+
+    unsigned int nbitsitc_{4};           //Bits used to store the iTC, a unique
+                                         //identifier assigned to each TC within a sector
+    unsigned int nbitsseed_{3};          //Bits used to store the seed number
+    unsigned int nbitsseedextended_{4};  //Bits used to store the seed number
+                                         //in the extended project
 
     //Bits used to store track parameter in tracklet
     int nbitsrinv_{14};

--- a/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
@@ -470,7 +470,9 @@ namespace trklet {
                     int hitpattern,
                     const std::vector<const L1TStub*>& l1stubs = std::vector<const L1TStub*>());
 
-    std::string trackfitstr();
+    const std::string layerstubstr(const unsigned layer) const;
+    const std::string diskstubstr(const unsigned disk) const;
+    std::string trackfitstr() const;
 
     Track makeTrack(const std::vector<const L1TStub*>& l1stubs);
 
@@ -499,8 +501,11 @@ namespace trklet {
 
     int TCID() const { return TCIndex_ * (1 << settings_.nbitstrackletindex()) + trackletIndex_; }
 
-    int getISeed() const;
-    int getITC() const;
+    const int getISeed() const;
+    const int getITC() const;
+
+    void setTrackIndex(int index);
+    const int trackIndex() const;
 
     unsigned int PSseed() const { return ((layer() == 1) || (layer() == 2) || (disk() != 0)) ? 1 : 0; }
 
@@ -527,6 +532,7 @@ namespace trklet {
 
     int trackletIndex_;
     int TCIndex_;
+    int trackIndex_;
 
     //Tracklet track parameters
     TrackPars<FPGAWord> fpgapars_;

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -996,6 +996,7 @@ void FitTrack::execute() {
       if (settings_.removalType() == "merge") {
         trackfit_->addStubList(trackstublist);
         trackfit_->addStubidsList(stubidslist);
+        bestTracklet->setTrackIndex(trackfit_->nTracks());
         trackfit_->addTrack(bestTracklet);
       } else if (bestTracklet->fit()) {
         assert(trackfit_ != nullptr);
@@ -1005,6 +1006,7 @@ void FitTrack::execute() {
                << endl;
           fout.close();
         }
+        bestTracklet->setTrackIndex(trackfit_->nTracks());
         trackfit_->addTrack(bestTracklet);
       }
     }

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -681,135 +681,105 @@ const std::string Tracklet::diskstubstr(const unsigned disk) const {
 }
 
 std::string Tracklet::trackfitstr() const {
-  string stub0;
-  string stub1;
-  string stub2;
-  string stub3;
-  string stub4;
-  string stub5;
-  string stub6;
-  string stub7;
-  string hitmap(24, '0');
+  const unsigned maxNHits = 8;
+  const unsigned nBitsPerHit = 3;
+  vector<string> stub(maxNHits, "0");
+  string hitmap(maxNHits * nBitsPerHit, '0');
 
-  if (isBarrel()) {
-    if (layer() == 1) {
-      stub0 = layerstubstr(2);
-      stub1 = layerstubstr(3);
-      stub2 = layerstubstr(4);
-      stub3 = layerstubstr(5);
+  // Assign stub strings for each of the possible projections for each seed.
+  // The specific layers/disks for a given seed are determined by the wiring.
+  switch (seedIndex()) {
+    case 0:                       // L1L2
+      stub[0] = layerstubstr(2);  // L3
+      stub[1] = layerstubstr(3);  // L4
+      stub[2] = layerstubstr(4);  // L5
+      stub[3] = layerstubstr(5);  // L6
 
-      stub4 = diskstubstr(0);
-      stub5 = diskstubstr(1);
-      stub6 = diskstubstr(2);
-      stub7 = diskstubstr(3);
-    }
-    if (layer() == 2) {
-      stub0 = layerstubstr(0);
-      stub1 = layerstubstr(3);
-      stub2 = layerstubstr(4);
+      stub[4] = diskstubstr(0);  // D1
+      stub[5] = diskstubstr(1);  // D2
+      stub[6] = diskstubstr(2);  // D3
+      stub[7] = diskstubstr(3);  // D4
 
-      stub3 = diskstubstr(0);
-      stub4 = diskstubstr(1);
-      stub5 = diskstubstr(2);
-      stub6 = diskstubstr(3);
+      break;
 
-      stub7 = "0";
-    }
+    case 1:                       // L2L3
+      stub[0] = layerstubstr(0);  // L1
+      stub[1] = layerstubstr(3);  // L4
+      stub[2] = layerstubstr(4);  // L5
 
-    if (layer() == 3) {
-      stub0 = layerstubstr(0);
-      stub1 = layerstubstr(1);
-      stub2 = layerstubstr(4);
-      stub3 = layerstubstr(5);
+      stub[3] = diskstubstr(0);  // D1
+      stub[4] = diskstubstr(1);  // D2
+      stub[5] = diskstubstr(2);  // D3
+      stub[6] = diskstubstr(3);  // D4
 
-      stub4 = diskstubstr(0);
-      stub5 = diskstubstr(1);
+      break;
 
-      stub6 = "0";
-      stub7 = "0";
-    }
+    case 2:                       // L3L4
+      stub[0] = layerstubstr(0);  // L1
+      stub[1] = layerstubstr(1);  // L2
+      stub[2] = layerstubstr(4);  // L5
+      stub[3] = layerstubstr(5);  // L6
 
-    if (layer() == 5) {
-      stub0 = layerstubstr(0);
-      stub1 = layerstubstr(1);
-      stub2 = layerstubstr(2);
-      stub3 = layerstubstr(3);
+      stub[4] = diskstubstr(0);  // D1
+      stub[5] = diskstubstr(1);  // D2
 
-      stub4 = "0";
-      stub5 = "0";
-      stub6 = "0";
-      stub7 = "0";
-    }
+      break;
+
+    case 3:                       // L5L6
+      stub[0] = layerstubstr(0);  // L1
+      stub[1] = layerstubstr(1);  // L2
+      stub[2] = layerstubstr(2);  // L3
+      stub[3] = layerstubstr(3);  // L4
+
+      break;
+
+    case 4:                       // D1D2
+      stub[0] = layerstubstr(0);  // L1
+      stub[1] = layerstubstr(1);  // L2
+
+      stub[2] = diskstubstr(2);  // D3
+      stub[3] = diskstubstr(3);  // D4
+      stub[4] = diskstubstr(4);  // D5
+
+      break;
+
+    case 5:                       // D3D4
+      stub[0] = layerstubstr(0);  // L1
+
+      stub[1] = diskstubstr(0);  // D1
+      stub[2] = diskstubstr(1);  // D2
+      stub[3] = diskstubstr(4);  // D5
+
+      break;
+
+    case 6:                      // L1D1
+      stub[0] = diskstubstr(1);  // D2
+      stub[1] = diskstubstr(2);  // D3
+      stub[2] = diskstubstr(3);  // D4
+      stub[3] = diskstubstr(4);  // D5
+
+      break;
+
+    case 7:                       // L2D1
+      stub[0] = layerstubstr(0);  // L1
+
+      stub[1] = diskstubstr(1);  // D2
+      stub[2] = diskstubstr(2);  // D3
+      stub[3] = diskstubstr(3);  // D4
+
+      break;
   }
 
-  if (isDisk()) {
-    if (abs(disk()) == 1) {
-      stub0 = layerstubstr(0);
-      stub1 = layerstubstr(1);
-
-      stub2 = diskstubstr(2);
-      stub3 = diskstubstr(3);
-      stub4 = diskstubstr(4);
-
-      stub5 = "0";
-      stub6 = "0";
-      stub7 = "0";
-    }
-
-    if (abs(disk()) == 3) {
-      stub0 = layerstubstr(0);
-
-      stub1 = diskstubstr(0);
-      stub2 = diskstubstr(1);
-      stub3 = diskstubstr(4);
-
-      stub4 = "0";
-      stub5 = "0";
-      stub6 = "0";
-      stub7 = "0";
-    }
-  }
-
-  if (isOverlap()) {
-    if (layer() == 1) {
-      stub0 = diskstubstr(1);
-      stub1 = diskstubstr(2);
-      stub2 = diskstubstr(3);
-      stub3 = diskstubstr(4);
-
-      stub4 = "0";
-      stub5 = "0";
-      stub6 = "0";
-      stub7 = "0";
-    }
-
-    if (layer() == 2) {
-      stub0 = layerstubstr(0);
-
-      stub1 = diskstubstr(1);
-      stub2 = diskstubstr(2);
-      stub3 = diskstubstr(3);
-
-      stub4 = "0";
-      stub5 = "0";
-      stub6 = "0";
-      stub7 = "0";
-    }
-  }
-
-  hitmap[2] = stub0[0];
-  hitmap[5] = stub1[0];
-  hitmap[8] = stub2[0];
-  hitmap[11] = stub3[0];
-  hitmap[14] = stub4[0];
-  hitmap[17] = stub5[0];
-  hitmap[20] = stub6[0];
-  hitmap[23] = stub7[0];
+  // Only one hit per layer/disk is allowed currently, so the hit map for a
+  // given layer/disk is just equal to the valid bit of the corresponding stub
+  // string, which is the first character.
+  for (unsigned i = 0; i < maxNHits; i++)
+    hitmap[i * nBitsPerHit + 2] = stub[i][0];
 
   std::string oss("");
   //Binary print out
   if (!settings_.writeoutReal()) {
-    const FPGAWord tmp(getISeed(), 3, true, __LINE__, __FILE__);
+    const FPGAWord tmp(getISeed(), settings_.nbitsseed(), true, __LINE__, __FILE__);
 
     oss += "1|";  // valid bit
     oss += tmp.str() + "|";
@@ -817,19 +787,12 @@ std::string Tracklet::trackfitstr() const {
     oss += fpgapars_.phi0().str() + "|";
     oss += fpgapars_.z0().str() + "|";
     oss += fpgapars_.t().str() + "|";
-    oss += hitmap + "|";
-    oss += stub0 + "|";
-    oss += stub1 + "|";
-    oss += stub2 + "|";
-    oss += stub3;
-    if (stub4 != "0")
-      oss += "|" + stub4;
-    if (stub5 != "0")
-      oss += "|" + stub5;
-    if (stub6 != "0")
-      oss += "|" + stub6;
-    if (stub7 != "0")
-      oss += "|" + stub7;
+    oss += hitmap;
+    for (unsigned i = 0; i < maxNHits; i++)
+      // If a valid stub string was never assigned, then that stub is not
+      // included in the output.
+      if (stub[i] != "0")
+        oss += "|" + stub[i];
   }
 
   return oss;

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -633,7 +633,7 @@ void Tracklet::setFitPars(double rinvfit,
 }
 
 const std::string Tracklet::layerstubstr(const unsigned layer) const {
-  assert(layer <= 5);
+  assert(layer < N_LAYER);
 
   std::stringstream oss("");
   if (!layerresid_[layer].valid())
@@ -643,7 +643,7 @@ const std::string Tracklet::layerstubstr(const unsigned layer) const {
       cout << "trackIndex_ = " << trackIndex_ << endl;
       assert(0);
     }
-    const FPGAWord tmp(trackIndex_, 7, true, __LINE__, __FILE__);
+    const FPGAWord tmp(trackIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
     oss << "1|";  // valid bit
     oss << tmp.str() << "|";
     oss << layerresid_[layer].fpgastubid().str() << "|";
@@ -656,17 +656,17 @@ const std::string Tracklet::layerstubstr(const unsigned layer) const {
 }
 
 const std::string Tracklet::diskstubstr(const unsigned disk) const {
-  assert(disk <= 4);
+  assert(disk < N_DISK);
 
   std::stringstream oss("");
   if (!diskresid_[disk].valid())
     oss << "0|0000000|0000000000|000000000000|000000000000|0000000";
   else {
-    if (trackIndex_ < 0 || trackIndex_ > 127) {
+    if (trackIndex_ < 0 || trackIndex_ > (int)settings_.ntrackletmax()) {
       cout << "trackIndex_ = " << trackIndex_ << endl;
       assert(0);
     }
-    const FPGAWord tmp(trackIndex_, 7, true, __LINE__, __FILE__);
+    const FPGAWord tmp(trackIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
     const FPGAWord& stubr = diskresid_[disk].stubptr()->r();
     const bool isPS = diskresid_[disk].stubptr()->isPSmodule();
     oss << "1|";  // valid bit

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -473,11 +473,9 @@ void TrackletEventProcessor::event(SLHCEvent& ev) {
   FTTimer_.start();
   for (unsigned int k = 0; k < N_SECTOR; k++) {
     sectors_[k]->executeFT();
-#ifndef USEHYBRID  //don't try to print these memories if running hybrid
     if ((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) {
       sectors_[k]->writeTF(first);
     }
-#endif
   }
   FTTimer_.stop();
 
@@ -485,12 +483,10 @@ void TrackletEventProcessor::event(SLHCEvent& ev) {
   PDTimer_.start();
   for (unsigned int k = 0; k < N_SECTOR; k++) {
     sectors_[k]->executePD(tracks_);
-#ifndef USEHYBRID  //don't try to print these memories if running hybrid
     if (((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) ||
         settings_->writeMonitorData("CT")) {
       sectors_[k]->writeCT(first);
     }
-#endif
   }
   PDTimer_.stop();
 }


### PR DESCRIPTION
@skinnari @tomalin

#### PR description:

This is a duplicate of PR #69, but rebased to L1TK-dev-11_3_0_pre3.

This PR includes various changes needed to output a first version of the test-vectors for the development of the PurgeDuplicates HLS module, including both the TrackBuilder and TrackMerger steps.

These changes involve turning on writing the TrackFitMemories and CleanTrackMemories (corresponding to the output vectors for the TrackBuilder and TrackMerger, respectively) in the TrackletEventProcessor, and adjusting the output format in Tracklet::trackfitstr(). The stub r has also been added in Tracklet::fullmatchstr() and Tracklet::fullmatchdiskstr() (input vectors for the TrackBuilder).

PR validation:
Running the code with writeMem set to true in Settings.h correctly produces the test-vectors currently in use for development of the PurgeDuplicates module. The usual code checks and format scripts have also been run.