### PR TITLE
Ian update max step

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -624,21 +624,21 @@ namespace trklet {
          {{0.0, 0.0, 0.0, 0.0, 3.6, 3.4, 3.7, 0.0, 0.0, 0.0, 0.0, 3.0}}}};  //disk 5
 
     // Offset to the maximum number of steps in each processing step:
-    // Set to 0 (default) means standard trunction
+    // Set to 0 (default) means standard truncation
     // Set to large value, e.g. 10000, to disable truncation
     unsigned int maxstepoffset_{0};
 
-    //Default number of processing steps for one event
+    //Number of processing steps for one event (108=18TM*240MHz/40MHz)
     std::unordered_map<std::string, unsigned int> maxstep_{{"Link", 108},
-                                                           {"MC", 107},
-                                                           {"ME", 101},
+	                                                   {"VMR", 108},
+                                                           {"TE", 108},
+                                                           {"TC", 108},
+                                                           {"PR", 108},
+                                                           {"ME", 108},
+                                                           {"MC", 105},
                                                            {"MP", 108},
-                                                           {"PR", 107},
-                                                           {"TC", 107},
-                                                           {"TE", 101},
                                                            {"TP", 108},
-                                                           {"TRE", 108},
-                                                           {"VMR", 101}};
+                                                           {"TRE", 108}};
 
     // If set to true this will generate debub printout in text files
     std::unordered_map<std::string, bool> writeMonitorData_{{"IL", false},

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -71,7 +71,7 @@ if GEOMETRY == "D49":
   #inputMC=getCMSdata(dataName)
 
   # Or read specified .root file:
-  inputMC = ["/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/FDFA00CE-FA93-0142-B187-99CBD4A43944.root"] 
+  inputMC = ["/store/relval/CMSSW_11_3_0_pre3/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v3_2026D49PU200-v1/00000/001edbad-174e-46af-932a-6ce8e04aee1c.root"] 
 
 else:
   print "this is not a valid geometry!!!"    


### PR DESCRIPTION
This updates the C++ map "maxSteps_" inside Settings.h, which sets the number of data samples each processing module can process within 1 time-multiplexed period. The new numbers (from Derek) correspond to what the HLS code is capable of. (Though the corresponding numbers in the HLS repo https://github.com/cms-L1TK/firmware-hls/blob/master/TrackletAlgorithm/Constants.h#L28 can't be updated until after the C++ has generated new txt files).

Also updated cfg.py to use a CMSSW 11_3_0 MC sample.