### PR TITLE
Add beam constraint to extended tracking

### DIFF
--- a/L1Trigger/TrackFindingTMTT/interface/KFTrackletTrack.h
+++ b/L1Trigger/TrackFindingTMTT/interface/KFTrackletTrack.h
@@ -75,14 +75,6 @@ namespace tmtt {
           numIterations_(0),
           accepted_(accepted) {}
 
-    //--- Optionally std::set track helix params & chi2 if beam-spot constraint is used (for 5-parameter fit).
-    void setBeamConstr(float qOverPt_bcon, float phi0_bcon, float chi2rphi_bcon) {
-      done_bcon_ = true;
-      qOverPt_bcon_ = qOverPt_bcon;
-      d0_bcon_ = 0.0, phi0_bcon_ = phi0_bcon;
-      chi2rphi_bcon_ = chi2rphi_bcon;
-    }
-
     //--- Set/get additional info about fitted track that is specific to individual track fit algorithms (KF, LR, chi2)
     //--- and is used for debugging/histogramming purposes.
 

--- a/L1Trigger/TrackFindingTMTT/interface/KFTrackletTrack.h
+++ b/L1Trigger/TrackFindingTMTT/interface/KFTrackletTrack.h
@@ -45,7 +45,12 @@ namespace tmtt {
                     unsigned int nHelixParam,
                     unsigned int iPhiSec,
                     unsigned int iEtaReg,
-                    bool accepted = true)
+                    bool accepted = true,
+		    bool done_bcon = false,
+		    float qOverPt_bcon = 0.,
+		    float d0_bcon = 0.,
+		    float phi0_bcon = 0.,
+		    float chi2rphi_bcon = 0.)
         : l1track3D_(l1track3D),
           stubs_(stubs),
           hitPattern_(hitPattern),
@@ -56,11 +61,11 @@ namespace tmtt {
           tanLambda_(tanLambda),
           chi2rphi_(chi2rphi),
           chi2rz_(chi2rz),
-          done_bcon_(false),
-          qOverPt_bcon_(qOverPt),
-          d0_bcon_(d0),
-          phi0_bcon_(phi0),
-          chi2rphi_bcon_(chi2rphi),
+          done_bcon_(done_bcon),
+          qOverPt_bcon_(qOverPt_bcon),
+          d0_bcon_(d0_bcon),
+          phi0_bcon_(phi0_bcon),
+          chi2rphi_bcon_(chi2rphi_bcon),
           nHelixParam_(nHelixParam),
           iPhiSec_(iPhiSec),
           iEtaReg_(iEtaReg),
@@ -131,6 +136,7 @@ namespace tmtt {
     float invPt_bcon() const { return std::abs(qOverPt_bcon_); }
     float pt_bcon() const { return 1. / (1.0e-6 + this->invPt_bcon()); }
     float phi0_bcon() const { return phi0_bcon_; }
+    float d0_bcon() const { return d0_bcon_; }
 
     // Phi and z coordinates at which track crosses "chosenR" values used by r-phi HT and rapidity sectors respectively.
     // (Optionally with beam-spot constraint applied).

--- a/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
+++ b/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
@@ -161,7 +161,12 @@ namespace tmtt {
                            nHelixParam(),
                            iPhiSec(),
                            iEtaReg(),
-                           accepted());
+                           accepted(),
+			   done_bcon(),
+			   qOverPt_bcon(),
+			   d0_bcon(),
+			   phi0_bcon(),
+			   chi2rphi_bcon());
       return trk_;
     }
 
@@ -247,6 +252,7 @@ namespace tmtt {
       return 1. / (small + this->invPt_bcon());
     }
     float phi0_bcon() const { return phi0_bcon_; }
+    float d0_bcon() const { return d0_bcon_; }
 
     // Phi and z coordinates at which track crosses "chosenR" values used by r-phi HT and rapidity sectors respectively.
     // (Optionally with beam-spot constraint applied).

--- a/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
+++ b/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
@@ -111,11 +111,12 @@ namespace tmtt {
     ~L1fittedTrack() override = default;
 
     //--- Optionally std::set track helix params & chi2 if beam-spot constraint is used (for 5-parameter fit).
-    void setBeamConstr(float qOverPt_bcon, float phi0_bcon, float chi2rphi_bcon) {
+    void setBeamConstr(float qOverPt_bcon, float phi0_bcon, float chi2rphi_bcon, bool accepted) {
       done_bcon_ = true;
       qOverPt_bcon_ = qOverPt_bcon;
       d0_bcon_ = 0.0, phi0_bcon_ = phi0_bcon;
       chi2rphi_bcon_ = chi2rphi_bcon;
+      accepted_ = accepted;
     }
 
     //--- Set/get additional info about fitted track that is specific to individual track fit algorithms (KF, LR, chi2)

--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -102,7 +102,15 @@ namespace tmtt {
         if (nHelixPar_ == 5) {
           double chi2rphi_bcon = 0.;
           TVectorD trackPars_bcon = trackParams_BeamConstr(cand, chi2rphi_bcon);
-          fitTrk.setBeamConstr(trackPars_bcon[QOVERPT], trackPars_bcon[PHI0], chi2rphi_bcon);
+
+	  // Check scaled chi2 cut
+	  vector<double> kfLayerVsChiSqCut = settings_->kfLayerVsChiSq5();
+	  double chi2scaled = chi2rphi_bcon / settings_->kalmanChi2RphiScale() + fitTrk.chi2rz();
+	  bool accepted = true;
+	  if (chi2scaled > kfLayerVsChiSqCut[cand->nStubLayers()])
+	    accepted = false;
+
+          fitTrk.setBeamConstr(trackPars_bcon[QOVERPT], trackPars_bcon[PHI0], chi2rphi_bcon, accepted);
         }
       }
 

--- a/L1Trigger/TrackFindingTMTT/src/Settings.cc
+++ b/L1Trigger/TrackFindingTMTT/src/Settings.cc
@@ -42,6 +42,7 @@ namespace tmtt {
         //kalmanDebugLevel_(2), // Good for debugging
         kalmanMinNumStubs_(4),
         kalmanMaxNumStubs_(6),
+        kalmanAddBeamConstr_(false),
         kalmanRemove2PScut_(true),
         kalmanMaxSkipLayersHard_(1),  // On "hard" input tracks
         kalmanMaxSkipLayersEasy_(2),  // On "easy" input tracks

--- a/L1Trigger/TrackFindingTMTT/src/Settings.cc
+++ b/L1Trigger/TrackFindingTMTT/src/Settings.cc
@@ -42,7 +42,7 @@ namespace tmtt {
         //kalmanDebugLevel_(2), // Good for debugging
         kalmanMinNumStubs_(4),
         kalmanMaxNumStubs_(6),
-        kalmanAddBeamConstr_(false),
+        kalmanAddBeamConstr_(false), // Apply post-fit beam-spot constraint to 5-param fit
         kalmanRemove2PScut_(true),
         kalmanMaxSkipLayersHard_(1),  // On "hard" input tracks
         kalmanMaxSkipLayersEasy_(2),  // On "easy" input tracks

--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -195,108 +195,66 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
                                   << ", phi0 = " << trk.phi0() << ", eta = " << trk.eta() << ", z0 = " << trk.z0()
                                   << ", chi2 = " << trk.chi2() << ", accepted = " << trk.accepted();
 
+    double phi0fit,rinvfit = -999;
+    double d0,chi2rphi = -999;
     if (trk.done_bcon()) {
+
+      d0 = trk.d0_bcon();
+      chi2rphi = trk.chi2rphi_bcon();
+
       // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
-      double phi0fit = reco::reduceRange(trk.phi0_bcon() - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
+      phi0fit = reco::reduceRange(trk.phi0_bcon() - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
+      rinvfit = 0.01 * settings_.c() * settings_.bfield() * trk.qOverPt_bcon();
 
-      double rinvfit = 0.01 * settings_.c() * settings_.bfield() * trk.qOverPt_bcon();
-
-      int irinvfit = rinvfit / settings_.krinvpars();
-      int iphi0fit = phi0fit / settings_.kphi0pars();
-      int itanlfit = trk.tanLambda() / settings_.ktpars();
-      int iz0fit = trk.z0() / settings_.kz0pars();
-      int id0fit = trk.d0_bcon() / settings_.kd0pars();
-      int ichi2rphifit = trk.chi2rphi_bcon() / 16;
-      int ichi2rzfit = trk.chi2rz() / 16;
-
-      const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
-      vector<const L1TStub*> l1stubsFromFit;
-      for (const tmtt::Stub* s : stubsFromFit) {
-	unsigned int IDf = s->index();
-	const L1TStub* l1s = L1StubIndices.at(IDf);
-	l1stubsFromFit.push_back(l1s);
-      }
-
-      if (settings_.printDebugKF()) {
-	edm::LogVerbatim("L1track") << "#stubs before/after KF fit = " << TMTTstubs.size() << "/"
-				    << l1stubsFromFit.size();
-      }
-
-      tracklet->setFitPars(rinvfit,
-			   phi0fit,
-			   trk.d0_bcon(),
-			   trk.tanLambda(),
-			   trk.z0(),
-			   trk.chi2rphi_bcon(),
-			   trk.chi2rz(),
-			   rinvfit,
-			   phi0fit,
-			   trk.d0_bcon(),
-			   trk.tanLambda(),
-			   trk.z0(),
-			   trk.chi2rphi_bcon(),
-			   trk.chi2rz(),
-			   irinvfit,
-			   iphi0fit,
-			   id0fit,
-			   itanlfit,
-			   iz0fit,
-			   ichi2rphifit,
-			   ichi2rzfit,
-			   trk.hitPattern(),
-			   l1stubsFromFit);
     } else if (!trk.done_bcon()) {
 
+      d0 = trk.d0();
+      chi2rphi = trk.chi2rphi();
+
       // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
-      double phi0fit = reco::reduceRange(trk.phi0() - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
-
-      double rinvfit = 0.01 * settings_.c() * settings_.bfield() * trk.qOverPt();
-
-      int irinvfit = rinvfit / settings_.krinvpars();
-      int iphi0fit = phi0fit / settings_.kphi0pars();
-      int itanlfit = trk.tanLambda() / settings_.ktpars();
-      int iz0fit = trk.z0() / settings_.kz0pars();
-      int id0fit = trk.d0() / settings_.kd0pars();
-      int ichi2rphifit = trk.chi2rphi() / 16;
-      int ichi2rzfit = trk.chi2rz() / 16;
-
-      const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
-      vector<const L1TStub*> l1stubsFromFit;
-      for (const tmtt::Stub* s : stubsFromFit) {
-	unsigned int IDf = s->index();
-	const L1TStub* l1s = L1StubIndices.at(IDf);
-	l1stubsFromFit.push_back(l1s);
-      }
-
-      if (settings_.printDebugKF()) {
-	edm::LogVerbatim("L1track") << "#stubs before/after KF fit = " << TMTTstubs.size() << "/"
-				    << l1stubsFromFit.size();
-      }
-
-      tracklet->setFitPars(rinvfit,
-			   phi0fit,
-			   trk.d0(),
-			   trk.tanLambda(),
-			   trk.z0(),
-			   trk.chi2rphi(),
-			   trk.chi2rz(),
-			   rinvfit,
-			   phi0fit,
-			   trk.d0(),
-			   trk.tanLambda(),
-			   trk.z0(),
-			   trk.chi2rphi(),
-			   trk.chi2rz(),
-			   irinvfit,
-			   iphi0fit,
-			   id0fit,
-			   itanlfit,
-			   iz0fit,
-			   ichi2rphifit,
-			   ichi2rzfit,
-			   trk.hitPattern(),
-			   l1stubsFromFit);
+      phi0fit = reco::reduceRange(trk.phi0() - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
+      rinvfit = 0.01 * settings_.c() * settings_.bfield() * trk.qOverPt();
     }
+
+    int irinvfit = rinvfit / settings_.krinvpars();
+    int iphi0fit = phi0fit / settings_.kphi0pars();
+    int itanlfit = trk.tanLambda() / settings_.ktpars();
+    int iz0fit = trk.z0() / settings_.kz0pars();
+    int id0fit = d0 / settings_.kd0pars();
+    int ichi2rphifit = chi2rphi / 16;
+    int ichi2rzfit = trk.chi2rz() / 16;
+
+    const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
+    vector<const L1TStub*> l1stubsFromFit;
+    for (const tmtt::Stub* s : stubsFromFit) {
+      unsigned int IDf = s->index();
+      const L1TStub* l1s = L1StubIndices.at(IDf);
+      l1stubsFromFit.push_back(l1s);
+    }
+
+    tracklet->setFitPars(rinvfit,
+			 phi0fit,
+			 d0,
+			 trk.tanLambda(),
+			 trk.z0(),
+			 chi2rphi,
+			 trk.chi2rz(),
+			 rinvfit,
+			 phi0fit,
+			 d0,
+			 trk.tanLambda(),
+			 trk.z0(),
+			 chi2rphi,
+			 trk.chi2rz(),
+			 irinvfit,
+			 iphi0fit,
+			 id0fit,
+			 itanlfit,
+			 iz0fit,
+			 ichi2rphifit,
+			 ichi2rzfit,
+			 trk.hitPattern(),
+			 l1stubsFromFit);
   } else {
     if (settings_.printDebugKF()) {
       edm::LogVerbatim("L1track") << "FitTrack:KF rejected track";

--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -195,55 +195,108 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
                                   << ", phi0 = " << trk.phi0() << ", eta = " << trk.eta() << ", z0 = " << trk.z0()
                                   << ", chi2 = " << trk.chi2() << ", accepted = " << trk.accepted();
 
-    // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
-    double phi0fit = reco::reduceRange(trk.phi0() - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
+    if (trk.done_bcon()) {
+      // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
+      double phi0fit = reco::reduceRange(trk.phi0_bcon() - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
 
-    double rinvfit = 0.01 * settings_.c() * settings_.bfield() * trk.qOverPt();
+      double rinvfit = 0.01 * settings_.c() * settings_.bfield() * trk.qOverPt_bcon();
 
-    int irinvfit = rinvfit / settings_.krinvpars();
-    int iphi0fit = phi0fit / settings_.kphi0pars();
-    int itanlfit = trk.tanLambda() / settings_.ktpars();
-    int iz0fit = trk.z0() / settings_.kz0pars();
-    int id0fit = trk.d0() / settings_.kd0pars();
-    int ichi2rphifit = trk.chi2rphi() / 16;
-    int ichi2rzfit = trk.chi2rz() / 16;
+      int irinvfit = rinvfit / settings_.krinvpars();
+      int iphi0fit = phi0fit / settings_.kphi0pars();
+      int itanlfit = trk.tanLambda() / settings_.ktpars();
+      int iz0fit = trk.z0() / settings_.kz0pars();
+      int id0fit = trk.d0_bcon() / settings_.kd0pars();
+      int ichi2rphifit = trk.chi2rphi_bcon() / 16;
+      int ichi2rzfit = trk.chi2rz() / 16;
 
-    const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
-    vector<const L1TStub*> l1stubsFromFit;
-    for (const tmtt::Stub* s : stubsFromFit) {
-      unsigned int IDf = s->index();
-      const L1TStub* l1s = L1StubIndices.at(IDf);
-      l1stubsFromFit.push_back(l1s);
+      const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
+      vector<const L1TStub*> l1stubsFromFit;
+      for (const tmtt::Stub* s : stubsFromFit) {
+	unsigned int IDf = s->index();
+	const L1TStub* l1s = L1StubIndices.at(IDf);
+	l1stubsFromFit.push_back(l1s);
+      }
+
+      if (settings_.printDebugKF()) {
+	edm::LogVerbatim("L1track") << "#stubs before/after KF fit = " << TMTTstubs.size() << "/"
+				    << l1stubsFromFit.size();
+      }
+
+      tracklet->setFitPars(rinvfit,
+			   phi0fit,
+			   trk.d0_bcon(),
+			   trk.tanLambda(),
+			   trk.z0(),
+			   trk.chi2rphi_bcon(),
+			   trk.chi2rz(),
+			   rinvfit,
+			   phi0fit,
+			   trk.d0_bcon(),
+			   trk.tanLambda(),
+			   trk.z0(),
+			   trk.chi2rphi_bcon(),
+			   trk.chi2rz(),
+			   irinvfit,
+			   iphi0fit,
+			   id0fit,
+			   itanlfit,
+			   iz0fit,
+			   ichi2rphifit,
+			   ichi2rzfit,
+			   trk.hitPattern(),
+			   l1stubsFromFit);
+    } else if (!trk.done_bcon()) {
+
+      // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
+      double phi0fit = reco::reduceRange(trk.phi0() - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
+
+      double rinvfit = 0.01 * settings_.c() * settings_.bfield() * trk.qOverPt();
+
+      int irinvfit = rinvfit / settings_.krinvpars();
+      int iphi0fit = phi0fit / settings_.kphi0pars();
+      int itanlfit = trk.tanLambda() / settings_.ktpars();
+      int iz0fit = trk.z0() / settings_.kz0pars();
+      int id0fit = trk.d0() / settings_.kd0pars();
+      int ichi2rphifit = trk.chi2rphi() / 16;
+      int ichi2rzfit = trk.chi2rz() / 16;
+
+      const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
+      vector<const L1TStub*> l1stubsFromFit;
+      for (const tmtt::Stub* s : stubsFromFit) {
+	unsigned int IDf = s->index();
+	const L1TStub* l1s = L1StubIndices.at(IDf);
+	l1stubsFromFit.push_back(l1s);
+      }
+
+      if (settings_.printDebugKF()) {
+	edm::LogVerbatim("L1track") << "#stubs before/after KF fit = " << TMTTstubs.size() << "/"
+				    << l1stubsFromFit.size();
+      }
+
+      tracklet->setFitPars(rinvfit,
+			   phi0fit,
+			   trk.d0(),
+			   trk.tanLambda(),
+			   trk.z0(),
+			   trk.chi2rphi(),
+			   trk.chi2rz(),
+			   rinvfit,
+			   phi0fit,
+			   trk.d0(),
+			   trk.tanLambda(),
+			   trk.z0(),
+			   trk.chi2rphi(),
+			   trk.chi2rz(),
+			   irinvfit,
+			   iphi0fit,
+			   id0fit,
+			   itanlfit,
+			   iz0fit,
+			   ichi2rphifit,
+			   ichi2rzfit,
+			   trk.hitPattern(),
+			   l1stubsFromFit);
     }
-
-    if (settings_.printDebugKF()) {
-      edm::LogVerbatim("L1track") << "#stubs before/after KF fit = " << TMTTstubs.size() << "/"
-                                  << l1stubsFromFit.size();
-    }
-
-    tracklet->setFitPars(rinvfit,
-                         phi0fit,
-                         trk.d0(),
-                         trk.tanLambda(),
-                         trk.z0(),
-                         trk.chi2rphi(),
-                         trk.chi2rz(),
-                         rinvfit,
-                         phi0fit,
-                         trk.d0(),
-                         trk.tanLambda(),
-                         trk.z0(),
-                         trk.chi2rphi(),
-                         trk.chi2rz(),
-                         irinvfit,
-                         iphi0fit,
-                         id0fit,
-                         itanlfit,
-                         iz0fit,
-                         ichi2rphifit,
-                         ichi2rzfit,
-                         trk.hitPattern(),
-                         l1stubsFromFit);
   } else {
     if (settings_.printDebugKF()) {
       edm::LogVerbatim("L1track") << "FitTrack:KF rejected track";

--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -195,26 +195,22 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
                                   << ", phi0 = " << trk.phi0() << ", eta = " << trk.eta() << ", z0 = " << trk.z0()
                                   << ", chi2 = " << trk.chi2() << ", accepted = " << trk.accepted();
 
-    double phi0fit,rinvfit = -999;
-    double d0,chi2rphi = -999;
+    double d0,chi2rphi,phi0,qoverpt = -999;
     if (trk.done_bcon()) {
-
       d0 = trk.d0_bcon();
       chi2rphi = trk.chi2rphi_bcon();
-
-      // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
-      phi0fit = reco::reduceRange(trk.phi0_bcon() - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
-      rinvfit = 0.01 * settings_.c() * settings_.bfield() * trk.qOverPt_bcon();
-
+      phi0 = trk.phi0_bcon();
+      qoverpt = trk.qOverPt_bcon();
     } else if (!trk.done_bcon()) {
-
       d0 = trk.d0();
       chi2rphi = trk.chi2rphi();
-
-      // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
-      phi0fit = reco::reduceRange(trk.phi0() - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
-      rinvfit = 0.01 * settings_.c() * settings_.bfield() * trk.qOverPt();
+      phi0 = trk.phi0();
+      qoverpt = trk.qOverPt();
     }
+
+    // Tracklet wants phi0 with respect to lower edge of sector, not global phi0. 
+    double phi0fit = reco::reduceRange(phi0 - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
+    double rinvfit = 0.01 * settings_.c() * settings_.bfield() * qoverpt;
 
     int irinvfit = rinvfit / settings_.krinvpars();
     int iphi0fit = phi0fit / settings_.kphi0pars();


### PR DESCRIPTION
#### PR description:

This addition to the code allows users to add in the beam-spot constraint on top of extended tracking based on a bool located in L1Trigger/TrackFindingTMTT/src/Settings.cc called "kalmanAddBeamConstr_". The default is false. Once true, the beam spot constraint is done and the additional bcon_ variables are saved in KFTrackletTrack.h and passed along to the TTTrack. An additional check in KFbase.cc is done after the beam spot constraint is applied to the scaled chi2 variable which ensures that the new bcon_ variables can still fit into the FPGAWord.

#### PR validation:

I have checked that the distributions of the extended tracking with the beam spot constraint returns the same resolution in pt and phi as in the hybrid prompt tracking. These results can be found [here](https://indico.cern.ch/event/1008442/contributions/4248385/attachments/2197790/3716179/L1T_2_26_21.pdf). This also produces the same results when turned the bool is turned off as before this code was implemented.
