### PR TITLE
fix matchtp variables

### DIFF
--- a/L1Trigger/TrackFindingTracklet/test/BuildFile.xml
+++ b/L1Trigger/TrackFindingTracklet/test/BuildFile.xml
@@ -18,6 +18,8 @@
     <use   name="Geometry/CommonDetUnit"/>
     <use   name="Geometry/Records"/>
     <use   name="Geometry/TrackerGeometryBuilder"/>
+    <use   name="MagneticField/Engine"/>
+    <use   name="MagneticField/Records"/>
     <use   name="SimTracker/TrackTriggerAssociation"/>
     <use   name="SimDataFormats/TrackingHit"/>
     <use   name="SimDataFormats/TrackingAnalysis"/>

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1036,7 +1036,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 	tmp_matchtp_d0 = tmp_matchtp_d0 * (-1);  //fix d0 sign
 
-	static double pi = 4.0 * atan(1.0);
+	static double pi = M_PI;
 	float delphi = tmp_matchtp_phi - atan2(-r2_inv * tmp_matchtp_x0p, r2_inv * tmp_matchtp_y0p);
 	if (delphi < -pi)
 	  delphi += 2.0 * pi;
@@ -1162,7 +1162,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
 
     tmp_tp_d0 = tmp_tp_d0 * (-1);  //fix d0 sign
 
-    static double pi = 4.0 * atan(1.0);
+    static double pi = M_PI;
     float delphi = tmp_tp_phi - atan2(-r2_inv * tmp_tp_x0p, r2_inv * tmp_tp_y0p);
     if (delphi < -pi)
       delphi += 2.0 * pi;

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1026,10 +1026,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
 
 	float tmp_matchtp_charge = my_tp->charge();
 	float K = Kmagnitude * tmp_matchtp_charge;
-	float d = 0;
 
-	float tmp_matchtp_x0p = delx - (d + 1. / (2. * K) * sin(tmp_matchtp_phi));
-	float tmp_matchtp_y0p = dely + (d + 1. / (2. * K) * cos(tmp_matchtp_phi));
+	float tmp_matchtp_x0p = delx - (1. / (2. * K) * sin(tmp_matchtp_phi));
+	float tmp_matchtp_y0p = dely + (1. / (2. * K) * cos(tmp_matchtp_phi));
 	float tmp_matchtp_rp = sqrt(tmp_matchtp_x0p * tmp_matchtp_x0p + tmp_matchtp_y0p * tmp_matchtp_y0p);
 	tmp_matchtp_d0 = tmp_matchtp_charge * tmp_matchtp_rp - (1. / (2. * K));
 
@@ -1154,10 +1153,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
 
     float tmp_tp_charge = tp_ptr->charge();
     float K = Kmagnitude * tmp_tp_charge;
-    float d = 0;
 
-    float tmp_tp_x0p = delx - (d + 1. / (2. * K) * sin(tmp_tp_phi));
-    float tmp_tp_y0p = dely + (d + 1. / (2. * K) * cos(tmp_tp_phi));
+    float tmp_tp_x0p = delx - (1. / (2. * K) * sin(tmp_tp_phi));
+    float tmp_tp_y0p = dely + (1. / (2. * K) * cos(tmp_tp_phi));
     float tmp_tp_rp = sqrt(tmp_tp_x0p * tmp_tp_x0p + tmp_tp_y0p * tmp_tp_y0p);
     float tmp_tp_d0 = tmp_tp_charge * tmp_tp_rp - (1. / (2. * K));
 

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -869,7 +869,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       if (L1Tk_nPar == 5) {
         float tmp_trk_x0 = iterL1Track->POCA().x();
         float tmp_trk_y0 = iterL1Track->POCA().y();
-        tmp_trk_d0 = -tmp_trk_x0 * sin(tmp_trk_phi) + tmp_trk_y0 * cos(tmp_trk_phi);
+        tmp_trk_d0 = tmp_trk_x0 * sin(tmp_trk_phi) - tmp_trk_y0 * cos(tmp_trk_phi);
       }
 
       float tmp_trk_chi2 = iterL1Track->chi2();
@@ -1385,7 +1385,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       if (L1Tk_nPar == 5) {
         float tmp_matchtrk_x0 = matchedTracks.at(i_track)->POCA().x();
         float tmp_matchtrk_y0 = matchedTracks.at(i_track)->POCA().y();
-        tmp_matchtrk_d0 = -tmp_matchtrk_x0 * sin(tmp_matchtrk_phi) + tmp_matchtrk_y0 * cos(tmp_matchtrk_phi);
+        tmp_matchtrk_d0 = tmp_matchtrk_x0 * sin(tmp_matchtrk_phi) - tmp_matchtrk_y0 * cos(tmp_matchtrk_phi);
       }
 
       tmp_matchtrk_chi2 = matchedTracks.at(i_track)->chi2();

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1130,18 +1130,6 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float tmp_tp_z0_prod = tmp_tp_vz;
     float tmp_tp_d0_prod = tmp_tp_vx * sin(tmp_tp_phi) - tmp_tp_vy * cos(tmp_tp_phi);
 
-    if (MyProcess == 13 && abs(tmp_tp_pdgid) != 13)
-      continue;
-    if (MyProcess == 11 && abs(tmp_tp_pdgid) != 11)
-      continue;
-    if ((MyProcess == 6 || MyProcess == 15 || MyProcess == 211) && abs(tmp_tp_pdgid) != 211)
-      continue;
-
-    if (tmp_tp_pt < TP_minPt)
-      continue;
-    if (std::abs(tmp_tp_eta) > TP_maxEta)
-      continue;
-
     // ----------------------------------------------------------------------------------------------
     // get d0/z0 propagated back to the IP
 
@@ -1171,6 +1159,17 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float tmp_tp_z0 = tmp_tp_vz + tmp_tp_t * delphi / (2.0 * r2_inv);
     // ----------------------------------------------------------------------------------------------
 
+    if (MyProcess == 13 && abs(tmp_tp_pdgid) != 13)
+      continue;
+    if (MyProcess == 11 && abs(tmp_tp_pdgid) != 11)
+      continue;
+    if ((MyProcess == 6 || MyProcess == 15 || MyProcess == 211) && abs(tmp_tp_pdgid) != 211)
+      continue;
+
+    if (tmp_tp_pt < TP_minPt)
+      continue;
+    if (std::abs(tmp_tp_eta) > TP_maxEta)
+      continue;
     if (std::abs(tmp_tp_z0) > TP_maxZ0)
       continue;
 

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1034,8 +1034,6 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
 	float tmp_matchtp_rp = sqrt(tmp_matchtp_x0p * tmp_matchtp_x0p + tmp_matchtp_y0p * tmp_matchtp_y0p);
 	tmp_matchtp_d0 = my_tp->charge() * tmp_matchtp_rp - (1. / (2. * r2_inv));
 
-	tmp_matchtp_d0 = tmp_matchtp_d0 * (-1);  //fix d0 sign
-
 	static double pi = M_PI;
 	float delphi = tmp_matchtp_phi - atan2(-r2_inv * tmp_matchtp_x0p, r2_inv * tmp_matchtp_y0p);
 	if (delphi < -pi)
@@ -1147,8 +1145,6 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float tmp_tp_y0p = dely + (1. / (2. * r2_inv) * cos(tmp_tp_phi));
     float tmp_tp_rp = sqrt(tmp_tp_x0p * tmp_tp_x0p + tmp_tp_y0p * tmp_tp_y0p);
     float tmp_tp_d0 = tmp_tp_charge * tmp_tp_rp - (1. / (2. * r2_inv));
-
-    tmp_tp_d0 = tmp_tp_d0 * (-1);  //fix d0 sign
 
     static double pi = M_PI;
     float delphi = tmp_tp_phi - atan2(-r2_inv * tmp_tp_x0p, r2_inv * tmp_tp_y0p);


### PR DESCRIPTION
PR description:
The trk_matchtp_{} variables in the standard ntuple maker had some issues. First, the trk_matchtp_z0 was incorrect. It was actually the vz, not z0. Next, trk_matchtp_d0 was not included in the collection but is an important variable to have for studying displaced tracks. Lastly, many of the calls to get the variables, such as the tp phi, were outdated although it still worked.

I made all these fixes by followiing exactly what was done in the regular tp collection to get/calculate all of the variables.

PR validation:
Here are the distributions of the trk_matchtp_z0 and trk_matchtp_d0 to show that they are calculated correctly. The rest of the matchtp variables did not change.
<img width="658" alt="Screen Shot 2021-03-08 at 7 56 33 PM" src="https://user-images.githubusercontent.com/15660721/110413219-b8206c80-804a-11eb-823d-504c3a56a21d.png">
<img width="668" alt="Screen Shot 2021-03-08 at 7 58 49 PM" src="https://user-images.githubusercontent.com/15660721/110413220-b8b90300-804a-11eb-8509-7b055def59ce.png">
