### PR TITLE
Corrections to fix updates to new LUTs that broke the displaced tracking

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEngineUnit.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEngineUnit.h
@@ -34,8 +34,8 @@ namespace trklet {
                        unsigned int iSeed,
                        unsigned int nbitsfinephiediff,
                        unsigned int iAllStub,
-                       const TrackletLUT& pttableinnernew,
-                       const TrackletLUT& pttableouternew,
+                       const TrackletLUT* pttableinnernew,
+                       const TrackletLUT* pttableouternew,
                        VMStubsTEMemory* outervmstubs);
 
     ~TrackletEngineUnit() = default;
@@ -83,8 +83,8 @@ namespace trklet {
 
     bool idle_;
 
-    const TrackletLUT& pttableinnernew_;
-    const TrackletLUT& pttableouternew_;
+    const TrackletLUT* pttableinnernew_;
+    const TrackletLUT* pttableouternew_;
 
     std::pair<const Stub*, const Stub*> candpair_, candpair__;
     bool goodpair_, goodpair__;

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
@@ -59,6 +59,8 @@ namespace trklet {
     
     int lookup(unsigned int index) const;
 
+    unsigned int size() const { return table_.size(); }
+
   private:
 
     int getphiCorrValue(unsigned int layerdisk, unsigned int ibend, unsigned int irbin,

--- a/L1Trigger/TrackFindingTracklet/interface/Util.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Util.h
@@ -138,7 +138,7 @@ namespace trklet {
   //Open file - create directory if not existent.
   inline std::ofstream openfile(const std::string& dir, const std::string& fname, const char* file, int line) {
     if (dirExists(dir) != 1) {
-      std::cout << "Creating directory : " << dir << std::endl;
+      edm::LogVerbatim("Tracklet")  << "Creating directory : " << dir;
       int fail = system((std::string("mkdir -p ") + dir).c_str());
       if (fail) {
         throw cms::Exception("BadDir") << file << " " << line << " could not create directory " << dir;
@@ -159,7 +159,7 @@ namespace trklet {
   inline void openfile(
       std::ofstream& out, bool first, const std::string& dir, const std::string& fname, const char* file, int line) {
     if (dirExists(dir) != 1) {
-      std::cout << "Creating directory : " << dir << std::endl;
+      edm::LogVerbatim("Tracklet") << "Creating directory : " << dir;
       int fail = system((std::string("mkdir -p ") + dir).c_str());
       if (fail) {
         throw cms::Exception("BadDir") << file << " " << line << " could not create directory " << dir;

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngineUnit.cc
@@ -12,8 +12,8 @@ TrackletEngineUnit::TrackletEngineUnit(const Settings* const settings,
                                        unsigned int iSeed,
                                        unsigned int nbitsfinephidiff,
                                        unsigned int iAllStub,
-				       const TrackletLUT& pttableinnernew,
-				       const TrackletLUT& pttableouternew,
+				       const TrackletLUT* pttableinnernew,
+				       const TrackletLUT* pttableouternew,
                                        VMStubsTEMemory* outervmstubs)
 : settings_(settings), pttableinnernew_(pttableinnernew), pttableouternew_(pttableouternew), candpairs_(3) {
   idle_ = true;
@@ -101,7 +101,7 @@ void TrackletEngineUnit::step(bool, int, int) {
     int ptinnerindex = (idphi << tedata_.innerbend_.nbits()) + tedata_.innerbend_.value();
     int ptouterindex = (idphi << outerbend.nbits()) + outerbend.value();
     
-    if (!(inrange && pttableinnernew_.lookup(ptinnerindex) && pttableouternew_.lookup(ptouterindex))) {
+    if (!(inrange && pttableinnernew_->lookup(ptinnerindex) && pttableouternew_->lookup(ptouterindex))) {
       if (settings_->debugTracklet()) {
         edm::LogVerbatim("Tracklet") << " Stub pair rejected because of stub pt cut bends : "
                                      << settings_->benddecode(

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -598,7 +598,7 @@ void TrackletLUT::initVMRTable(unsigned int layerdisk, VMRTableType type, int re
 	  table_.push_back(getVMRLookup(layerdisk + 1, z, r, dz, dr));
 	}
 	if (layerdisk == LayerDisk::L2) {
-	  table_.push_back(getVMRLookup(layerdisk + 1, z, r, dz, dr, 1));
+	  table_.push_back(getVMRLookup(layerdisk + 1, z, r, dz, dr, Seed::L2L3));
 	}
       }
 
@@ -611,27 +611,22 @@ void TrackletLUT::initVMRTable(unsigned int layerdisk, VMRTableType type, int re
       
       if (type == VMRTableType::innerthird ) {
 	if (layerdisk == LayerDisk::L2) {  //projection from L2 to D1 for L2L3D1 seeding
-	  table_.push_back(getVMRLookup(6, z, r, dz, dr, 10));
+	  table_.push_back(getVMRLookup(LayerDisk::D1, z, r, dz, dr, Seed::L2L3D1));
 	}
 	
 	if (layerdisk == LayerDisk::L5) {  //projection from L5 to L4 for L5L6L4 seeding
-	  table_.push_back(getVMRLookup(3, z, r, dz, dr));
+	  table_.push_back(getVMRLookup(LayerDisk::L4, z, r, dz, dr));
 	}
 	
 	if (layerdisk == LayerDisk::L3) {  //projection from L3 to L5 for L3L4L2 seeding
-	  table_.push_back(getVMRLookup(1, z, r, dz, dr));
+	  table_.push_back(getVMRLookup(LayerDisk::L2, z, r, dz, dr));
 	}
 	
 	if (layerdisk == LayerDisk::D1) {  //projection from D1 to L2 for D1D2L2 seeding
-	  table_.push_back(getVMRLookup(1, z, r, dz, dr));
+	  table_.push_back(getVMRLookup(LayerDisk::L2, z, r, dz, dr));
 	}
       }
 
-      if (type == VMRTableType::innerthird ) {
-	if (layerdisk == LayerDisk::L1 || layerdisk == 1) {
-	  table_.push_back(getVMRLookup(N_LAYER, z, r, dz, dr, layerdisk + N_LAYER));
-	}
-      }
     }
   }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -71,16 +71,16 @@ void TrackletLUT::initTPlut(bool fillInner, unsigned int iSeed, unsigned int lay
       settings_.nallstubs(layerdisk2) * settings_.nvmte(1, iSeed) * (1 << settings_.nfinephi(1, iSeed));
   double dfinephi = settings_.dphisectorHG() / nfinephibins;
 
-  double rmin = -1.0;
-  double rmax = -1.0;
+  //double rmin = -1.0;
+  //double rmax = -1.0;
 
   int outerrbits = 3;
 
   if (iSeed == Seed::L1L2 || iSeed == Seed::L2L3 ||iSeed == Seed::L3L4 || iSeed == Seed::L5L6 ) {
     outerrbits = 0;
-    rmin = settings_.rmean(layerdisk1);
-    rmax = settings_.rmean(layerdisk2);
-  } else {
+    //rmin = settings_.rmean(layerdisk1);
+    //rmax = settings_.rmean(layerdisk2);
+  } /*else {
     if (iSeed == Seed::L1D1) {
       rmax = settings_.rmaxdiskl1overlapvm();
       rmin = settings_.rmean(layerdisk1);
@@ -91,7 +91,7 @@ void TrackletLUT::initTPlut(bool fillInner, unsigned int iSeed, unsigned int lay
       rmax = settings_.rmaxdiskvm();
       rmin = rmax * settings_.zmean(layerdisk2 - N_LAYER - 1) / settings_.zmean(layerdisk2 - N_LAYER);
     }
-  }
+    }*/
 
   int outerrbins = (1 << outerrbits);
 
@@ -209,12 +209,13 @@ void TrackletLUT::initTPregionlut(unsigned int iSeed, unsigned int layerdisk1, u
   }
 
   unsigned int nbendbitsinner = 3;
-  unsigned int nbendbitsouter = 3;
-  if (iSeed == Seed::L3L4) {
-    nbendbitsouter = 4;
-  } else if (iSeed == Seed::L5L6) {
+  //unsigned int nbendbitsouter = 3;
+  //if (iSeed == Seed::L3L4) {
+  //  nbendbitsouter = 4;
+  // } else 
+  if (iSeed == Seed::L5L6) {
     nbendbitsinner = 4;
-    nbendbitsouter = 4;
+    // nbendbitsouter = 4;
   }
 
   for (int innerfinephi = 0; innerfinephi < (1 << nbitsfinephi); innerfinephi++) {

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -39,7 +39,7 @@ void TrackletLUT::initmatchcut(unsigned int layerdisk, MatchType type, unsigned 
 
   if (type==barrelphi) {
     name_ += TrackletConfigBuilder::LayerName(layerdisk)+"PHI"+cregion+"_phicut.tab";
-  }
+      }
   if (type==barrelz) {    
     name_ += TrackletConfigBuilder::LayerName(layerdisk)+"PHI"+cregion+"_zcut.tab";
   }
@@ -71,28 +71,12 @@ void TrackletLUT::initTPlut(bool fillInner, unsigned int iSeed, unsigned int lay
       settings_.nallstubs(layerdisk2) * settings_.nvmte(1, iSeed) * (1 << settings_.nfinephi(1, iSeed));
   double dfinephi = settings_.dphisectorHG() / nfinephibins;
 
-  //double rmin = -1.0;
-  //double rmax = -1.0;
-
   int outerrbits = 3;
 
   if (iSeed == Seed::L1L2 || iSeed == Seed::L2L3 ||iSeed == Seed::L3L4 || iSeed == Seed::L5L6 ) {
     outerrbits = 0;
-    //rmin = settings_.rmean(layerdisk1);
-    //rmax = settings_.rmean(layerdisk2);
-  } /*else {
-    if (iSeed == Seed::L1D1) {
-      rmax = settings_.rmaxdiskl1overlapvm();
-      rmin = settings_.rmean(layerdisk1);
-    } else if (iSeed == Seed::L2D1) {
-      rmax = settings_.rmaxdiskvm();
-      rmin = settings_.rmean(layerdisk1);
-    } else {
-      rmax = settings_.rmaxdiskvm();
-      rmin = rmax * settings_.zmean(layerdisk2 - N_LAYER - 1) / settings_.zmean(layerdisk2 - N_LAYER);
-    }
-    }*/
-
+  }
+  
   int outerrbins = (1 << outerrbits);
 
   double dphi[2];
@@ -209,13 +193,9 @@ void TrackletLUT::initTPregionlut(unsigned int iSeed, unsigned int layerdisk1, u
   }
 
   unsigned int nbendbitsinner = 3;
-  //unsigned int nbendbitsouter = 3;
-  //if (iSeed == Seed::L3L4) {
-  //  nbendbitsouter = 4;
-  // } else 
+
   if (iSeed == Seed::L5L6) {
     nbendbitsinner = 4;
-    // nbendbitsouter = 4;
   }
 
   for (int innerfinephi = 0; innerfinephi < (1 << nbitsfinephi); innerfinephi++) {

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
@@ -187,8 +187,8 @@ void TrackletProcessor::addInput(MemoryBase* memory, string input) {
                               iSeed_,
                               nbitsfinephidiff_,
                               iAllStub_,
-                              pttableinner_,
-                              pttableouter_,
+                              &pttableinner_,
+                              &pttableouter_,
                               outervmstubs_);
 
     teunits_.resize(settings_.teunits(iSeed_), teunit);
@@ -299,14 +299,10 @@ void TrackletProcessor::execute(unsigned int iSector, double phimin, double phim
 
     TrackletEngineUnit* teunitptr = nullptr;
 
-    int iTE = 0;
-    int icount = -1;
     for (auto& teunit : teunits_) {
       teunit.setNearFull();
-      icount++;
       if (!teunit.empty()) {
         teunitptr = &teunit;
-        iTE = icount;
       }
     }
 

--- a/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
@@ -110,7 +110,7 @@ void VMRouter::addOutput(MemoryBase* memory, string output) {
       } else if (seedtype < 'o' && seedtype >= 'a') {
         if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3)
           iseed = Seed::L2L3D1;
-        if (layerdisk_ == LayerDisk::L1)
+        if (layerdisk_ == LayerDisk::L2)
           inner = 0;
       } else if (seedtype > 'o' && seedtype <= 'z') {
         if (layerdisk_ == LayerDisk::L2)
@@ -185,7 +185,7 @@ void VMRouter::execute() {
     for (unsigned int i = 0; i < stubinput->nStubs(); i++) {
       if (allStubCounter >= settings_.maxStep("VMR"))
         continue;
-      if (allStubCounter > 127)
+      if (allStubCounter >= (1<<N_BITSMEMADDRESS))
         continue;
       Stub* stub = stubinput->getStub(i);
 
@@ -194,7 +194,7 @@ void VMRouter::execute() {
 
       //use &127 to make sure we fit into the number of bits -
       //though we should have protected against overflows above
-      FPGAWord allStubIndex(allStubCounter & 127, 7, true, __LINE__, __FILE__);
+      FPGAWord allStubIndex(allStubCounter & ((1<<N_BITSMEMADDRESS)-1),  N_BITSMEMADDRESS, true, __LINE__, __FILE__);
 
       //TODO - should not be needed - but need to migrate some other pieces of code before removing
       stub->setAllStubIndex(allStubCounter);
@@ -287,7 +287,7 @@ void VMRouter::execute() {
       for (auto& ivmstubTEPHI : vmstubsTEPHI_) {
         unsigned int iseed = ivmstubTEPHI.seednumber;
         unsigned int inner = ivmstubTEPHI.stubposition;
-        if ((iseed == 4 || iseed == 5 || iseed == 6 || iseed == 7) && (!stub->isPSmodule()))
+        if ((iseed == Seed::D1D2 || iseed == Seed::D3D4 || iseed == Seed::L1D1 || iseed == Seed::L2D1) && (!stub->isPSmodule()))
           continue;
 
         unsigned int lutwidth = settings_.lutwidthtab(inner, iseed);
@@ -301,7 +301,7 @@ void VMRouter::execute() {
           if (layerdisk_ < N_LAYER) {
             lutval = melut;
           } else {
-            if (inner == 2 && iseed == 10) {
+            if (inner == 2 && iseed == Seed::L2L3D1) {
               lutval = 0;
               if (stub->r().value() < 10) {
                 lutval = 8 * (1 + (stub->r().value() >> 2));
@@ -317,14 +317,14 @@ void VMRouter::execute() {
           if (lutval == -1)
             continue;
         } else {
-          if (iseed < 6 || iseed > 7) {
+          if (iseed < Seed::L1D1 || iseed > Seed::L2D1) {
 	    lutval = innerTable_.lookup((indexz<<nbitsrfinebintable_)+indexr);
           } else {
 	    lutval = innerOverlapTable_.lookup((indexz<<nbitsrfinebintable_)+indexr);
           }
           if (lutval == -1)
             continue;
-          if (settings_.extended() && (iseed == 2 || iseed == 3 || iseed == 10 || iseed == 4)) {
+          if (settings_.extended() && (iseed == 2 || iseed == 3 || iseed == 4 || iseed == 10)) {
 	    int lutval2 = innerThirdTable_.lookup((indexz<<nbitsrfinebintable_)+indexr);
             if (lutval2 == -1)
               continue;

--- a/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
@@ -324,7 +324,7 @@ void VMRouter::execute() {
           }
           if (lutval == -1)
             continue;
-          if (settings_.extended() && (iseed == 2 || iseed == 3 || iseed == 4 || iseed == 10)) {
+          if (settings_.extended() && (iseed == Seed::L3L4 || iseed == Seed::L5L6 || iseed == Seed::D1D2 || iseed == Seed::L2L3D1)) {
 	    int lutval2 = innerThirdTable_.lookup((indexz<<nbitsrfinebintable_)+indexr);
             if (lutval2 == -1)
               continue;

--- a/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc
@@ -70,8 +70,13 @@ bool VMStubsTEMemory::addVMStub(VMStubTE vmstub, int bin) {
     return true;
   }
 
-  bool pass = bendtable_.lookup(vmstub.bend().value());
-
+  bool pass = false;
+  if (settings_.extended()&&bendtable_.size()==0) {
+    pass = true ;
+  } else {
+    pass = bendtable_.lookup(vmstub.bend().value());
+  }
+  
   if (!pass) {
     if (settings_.debugTracklet())
       edm::LogVerbatim("Tracklet") << getName() << " Stub failed bend cut. bend = "
@@ -132,8 +137,14 @@ bool VMStubsTEMemory::addVMStub(VMStubTE vmstub) {
 
   //If the pt of the stub is consistent with the allowed pt of tracklets
   //in that can be formed in this VM and the other VM used in the TE.
-  bool pass = bendtable_.lookup(vmstub.bend().value());
 
+  bool pass = false;
+  if (settings_.extended()&&bendtable_.size()==0) {
+    pass = true ;
+  } else {
+    pass = bendtable_.lookup(vmstub.bend().value());
+  }
+    
   if (!pass) {
     if (settings_.debugTracklet())
       edm::LogVerbatim("Tracklet") << getName() << " Stub failed bend cut. bend = "


### PR DESCRIPTION
#### PR description:

Corrections to fix updates to new LUTs that broke the displaced tracking

#### PR validation:

 Checked that this changes restored the tracking efficiency for the affected seeding (L2L3D1)

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
