### PR TITLE
fix bug in extended seeding

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
@@ -334,9 +334,8 @@ void VMRouter::execute() {
           if (settings_.extended() &&
               (iseed == Seed::L3L4 || iseed == Seed::L5L6 || iseed == Seed::D1D2 || iseed == Seed::L2L3D1)) {
             int lutval2 = innerThirdTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-            if (lutval2 == -1)
-              continue;
-            lutval += (lutval2 << 10);
+            if (lutval2 != -1)
+	      lutval += (lutval2 << 10);
           }
         }
 


### PR DESCRIPTION
#### PR description:

This PR makes the fix as described [here](https://indico.cern.ch/event/1033157/contributions/4352276/attachments/2241390/3800388/L1T_5_7_21.pdf). It fixes the extended tracking discarding prompt seeds. As a consequence of this fix, the efficiency at large eta increases.

#### PR validation:

When running extended on the prompt modules, you get back the same seeds saved and the same performance (efficiency and fake rate) as expected. Previously, the efficiency for extended on prompt modules was lower than for prompt tracking at high eta.
