### PR TITLE
Correction so that D! stubs are processed in the correct order

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -707,7 +707,7 @@ namespace trklet {
          {{3.6, 3.8, 0.0, 0.0, 3.6, 0.0, 3.5, 3.8, 0.0, 0.0, 3.0, 3.0}},    //disk 4
          {{0.0, 0.0, 0.0, 0.0, 3.6, 3.4, 3.7, 0.0, 0.0, 0.0, 0.0, 3.0}}}};  //disk 5
 
-    //returns the mean bend (in strips at a 1.8cm separation) for bendcode
+    //returns the mean bend (in strips at a 1.8 mm separation) for bendcode
     std::array<std::array<double, 16>, 16> benddecode_{
         {{{0.0, 0.5, 0.7, 0.8, 89.9, -1.0, -0.9, -0.8, 99.9, 99.9, 99.9, 99.9, 99.9, 99.9, 99.9, 99.9}},  //L1 PS
          {{0.0, 0.7, 1.0, 1.5, 89.9, -1.5, -1.0, -0.7, 99.9, 99.9, 99.9, 99.9, 99.9, 99.9, 99.9, 99.9}},  //L2 PS
@@ -726,7 +726,7 @@ namespace trklet {
          {{0.0, 2.0, 2.6, 3.2, 3.8, 4.0, 4.4, 4.4, 89.9, -4.4, -4.4, -4.0, -3.8, -3.2, -2.6, -2.0}},      //D4 2S
          {{0.0, 2.0, 3.2, 3.4, 3.9, 3.9, 4.4, 4.4, 89.9, -4.4, -4.4, -3.9, -3.9, -3.4, -3.2, -2.0}}}};    //D5 2S
 
-    //returns the bend 'cut' (in strips at a 1.8cm separation) for bendcode
+    //returns the bend 'cut' (in strips at a 1.8 mm separation) for bendcode
     std::array<std::array<double, 16>, 16> bendcut_{
         {{{1.5, 1.2, 0.8, 0.8, 99.9, 0.8, 0.8, 1.2, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0}},  //L1 PS
          {{1.5, 1.3, 1.0, 1.0, 99.9, 1.0, 1.0, 1.3, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0}},  //L2 PS

--- a/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
@@ -166,7 +166,7 @@ void VMRouter::addInput(MemoryBase* memory, string input) {
     InputLinkMemory* tmp1 = dynamic_cast<InputLinkMemory*>(memory);
     assert(tmp1 != nullptr);
     if (tmp1 != nullptr) {
-      if (layerdisk_ > N_LAYER && tmp1->getName().find("2S_") != string::npos) {
+      if (layerdisk_ >= N_LAYER && tmp1->getName().find("2S_") != string::npos) {
         stubinputdisk2stmp_.push_back(tmp1);
       } else {
         stubinputtmp_.push_back(tmp1);


### PR DESCRIPTION
#### PR description:

Corrects a typo such that stubs in D1 are processed in the correct order.

#### PR validation:

Check that the tracking results are still OK with this change. (Almost no changes expected and none seen, but order important for agreement with the HLS code.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:


Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
