### PR TITLE
code-format, llvm-ccdb and clang-tidy

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTBV.h
+++ b/DataFormats/L1TrackTrigger/interface/TTBV.h
@@ -268,7 +268,9 @@ public:
   double val(double base) const { return (this->val() + .5) * base; }
 
   // conversion: range based to double for given precision assuming biased (floor) representation, reinterpret sign
-  double val(double base, int start, int end = 0, bool twos = false) const { return (this->val(start, end, twos) + .5) * base; }
+  double val(double base, int start, int end = 0, bool twos = false) const {
+    return (this->val(start, end, twos) + .5) * base;
+  }
 
   // maniplulation and conversion: extracts range based to double reinterpret sign and removes these bits
   double extract(double base, int size, bool twos = false) {
@@ -332,7 +334,7 @@ public:
   std::vector<int> ids(bool b = true, bool singed = false) const {
     std::vector<int> v;
     v.reserve(bs_.count());
-    for(int i = 0; i < size_; i++)
+    for (int i = 0; i < size_; i++)
       if (bs_[i] == b)
         v.push_back(singed ? i + size_ / 2 : i);
     return v;
@@ -355,7 +357,5 @@ private:
     return lut[size_];
   }
 };
-
-
 
 #endif

--- a/DataFormats/L1TrackTrigger/interface/TTTypes.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTypes.h
@@ -24,17 +24,17 @@
 
 /// Templated aliases
 template <typename T>
-using TTClusterDetSetVecT = edmNew::DetSetVector<TTCluster<T> >;
+using TTClusterDetSetVecT = edmNew::DetSetVector<TTCluster<T>>;
 template <typename T>
-using TTStubDetSetVecT = edmNew::DetSetVector<TTStub<T> >;
+using TTStubDetSetVecT = edmNew::DetSetVector<TTStub<T>>;
 
 template <typename T>
-using TTClusterRefT = edm::Ref<TTClusterDetSetVecT<T>, TTCluster<T> >;
+using TTClusterRefT = edm::Ref<TTClusterDetSetVecT<T>, TTCluster<T>>;
 template <typename T>
-using TTStubRefT = edm::Ref<TTStubDetSetVecT<T>, TTStub<T> >;
+using TTStubRefT = edm::Ref<TTStubDetSetVecT<T>, TTStub<T>>;
 
 template <typename T>
-using TTTrackPtrT = edm::Ptr<TTTrack<T> >;
+using TTTrackPtrT = edm::Ptr<TTTrack<T>>;
 
 /// Specialized aliases
 typedef edm::Ref<edm::DetSetVector<Phase2TrackerDigi>, Phase2TrackerDigi> Ref_Phase2TrackerDigi_;
@@ -45,8 +45,8 @@ typedef TTStubDetSetVecT<Ref_Phase2TrackerDigi_> TTStubDetSetVec;
 typedef TTClusterRefT<Ref_Phase2TrackerDigi_> TTClusterRef;
 typedef TTStubRefT<Ref_Phase2TrackerDigi_> TTStubRef;
 
-typedef edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_> > TTStubDetSet;
-typedef edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_> > TTClusterDetSet;
+typedef edmNew::DetSet<TTStub<Ref_Phase2TrackerDigi_>> TTStubDetSet;
+typedef edmNew::DetSet<TTCluster<Ref_Phase2TrackerDigi_>> TTClusterDetSet;
 
 typedef edm::Ref<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>, TTTrack<Ref_Phase2TrackerDigi_>> TTTrackRef;
 typedef TTTrackPtrT<Ref_Phase2TrackerDigi_> TTTrackPtr;
@@ -66,6 +66,6 @@ namespace tt {
   typedef std::vector<StreamTrack> StreamsTrack;
   typedef std::map<TTTrackRef, TTTrackRef> TTTrackRefMap;
   typedef std::vector<TTTrack<Ref_Phase2TrackerDigi_>> TTTracks;
-} // namespace tt
+}  // namespace tt
 
 #endif

--- a/L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannel.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannel.h
@@ -20,11 +20,12 @@ namespace trackFindingTracklet {
   public:
     TrackBuilderChannel() {}
     TrackBuilderChannel(const edm::ParameterSet& iConfig);
-    ~TrackBuilderChannel(){}
+    ~TrackBuilderChannel() {}
     // sets channelId of given TTTrack, return false if track outside pt range
     bool channelId(const TTTrack<Ref_Phase2TrackerDigi_>& ttTrack, int& channelId);
     // number of used channels
     int numChannels() const { return numChannels_; }
+
   private:
     // use tracklet seed type as channel id if False, binned track pt used if True
     bool useDuplicateRemoval_;
@@ -34,7 +35,7 @@ namespace trackFindingTracklet {
     int numChannels_;
   };
 
-} // namespace trackFindingTracklet
+}  // namespace trackFindingTracklet
 
 EVENTSETUP_DATA_DEFAULT_RECORD(trackFindingTracklet::TrackBuilderChannel, trackFindingTracklet::TrackBuilderChannelRcd);
 

--- a/L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannelRcd.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannelRcd.h
@@ -9,7 +9,8 @@ namespace trackFindingTracklet {
 
   typedef edm::mpl::Vector<tt::SetupRcd> RcdsTrackBuilderChannel;
 
-  class TrackBuilderChannelRcd : public edm::eventsetup::DependentRecordImplementation<TrackBuilderChannelRcd, RcdsTrackBuilderChannel> {};
+  class TrackBuilderChannelRcd
+      : public edm::eventsetup::DependentRecordImplementation<TrackBuilderChannelRcd, RcdsTrackBuilderChannel> {};
 
 }  // namespace trackFindingTracklet
 

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerAS.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerAS.cc
@@ -50,9 +50,7 @@ namespace trackFindingTracklet {
     const Setup* setup_;
   };
 
-  ProducerAS::ProducerAS(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerAS::ProducerAS(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& labelKF = iConfig.getParameter<string>("LabelKF");
     const string& labelTT = iConfig.getParameter<string>("LabelTT");
     const string& branch = iConfig.getParameter<string>("BranchAcceptedTracks");
@@ -96,6 +94,6 @@ namespace trackFindingTracklet {
     iEvent.emplace(edPutToken_, move(ttTrackMap));
   }
 
-} // namespace trackFindingTracklet
+}  // namespace trackFindingTracklet
 
 DEFINE_FWK_MODULE(trackFindingTracklet::ProducerAS);

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFin.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFin.cc
@@ -74,9 +74,7 @@ namespace trackFindingTracklet {
     bool enableTruncation_;
   };
 
-  ProducerKFin::ProducerKFin(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerKFin::ProducerKFin(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const InputTag& inputTag = iConfig.getParameter<InputTag>("InputTag");
     const string& branchAcceptedStubs = iConfig.getParameter<string>("BranchAcceptedStubs");
     const string& branchAcceptedTracks = iConfig.getParameter<string>("BranchAcceptedTracks");
@@ -180,13 +178,15 @@ namespace trackFindingTracklet {
           // get rphi parameter
           double inv2R = dfinv2R.digi(-ttTrackRef->rInv() / 2.);
           // calculcate track phi at radius hybridChosenRofPhi with respect to phi sector centre
-          double phiT = dfphiT.digi(deltaPhi(ttTrackRef->phi() + dataFormats_->chosenRofPhi() * inv2R - ttTrackRef->phiSector() * setup_->baseRegion()));
-          const int sectorPhi = phiT < 0. ? 0 : 1; // dirty hack
+          double phiT = dfphiT.digi(deltaPhi(ttTrackRef->phi() + dataFormats_->chosenRofPhi() * inv2R -
+                                             ttTrackRef->phiSector() * setup_->baseRegion()));
+          const int sectorPhi = phiT < 0. ? 0 : 1;  // dirty hack
           phiT -= (sectorPhi - .5) * setup_->baseSector();
           // cut on nonant size and pt
           if (!dfphiT.inRange(phiT) || !dfinv2R.inRange(inv2R))
             continue;
-          const double offsetPhi = (ttTrackRef->phiSector() * setup_->numSectorsPhi() + sectorPhi - .5) * setup_->baseSector();
+          const double offsetPhi =
+              (ttTrackRef->phiSector() * setup_->numSectorsPhi() + sectorPhi - .5) * setup_->baseSector();
           // check hitPattern
           TTBV hitPattern(0, setup_->numLayers());
           static constexpr double scalePhi = 4.0;
@@ -279,6 +279,6 @@ namespace trackFindingTracklet {
     iEvent.emplace(edPutTokenLostTracks_, move(streamLostTracks));
   }
 
-} // namespace trackFindingTracklet
+}  // namespace trackFindingTracklet
 
 DEFINE_FWK_MODULE(trackFindingTracklet::ProducerKFin);

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerTT.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerTT.cc
@@ -56,9 +56,7 @@ namespace trackFindingTracklet {
     const DataFormats* dataFormats_;
   };
 
-  ProducerTT::ProducerTT(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerTT::ProducerTT(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& label = iConfig.getParameter<string>("LabelKF");
     const string& branchStubs = iConfig.getParameter<string>("BranchAcceptedStubs");
     const string& branchTracks = iConfig.getParameter<string>("BranchAcceptedTracks");
@@ -100,7 +98,9 @@ namespace trackFindingTracklet {
       // count number of kf tracks
       int nTracks(0);
       for (const StreamTrack& stream : streamsTracks)
-        nTracks += accumulate(stream.begin(), stream.end(), 0, [](int& sum, const FrameTrack& frame){ return sum += frame.first.isNonnull() ? 1 : 0; });
+        nTracks += accumulate(stream.begin(), stream.end(), 0, [](int& sum, const FrameTrack& frame) {
+          return sum += frame.first.isNonnull() ? 1 : 0;
+        });
       ttTracks.reserve(nTracks);
       // convert kf track frames per channel and stub frames per channel and layer to TTTracks
       for (int channel = 0; channel < (int)streamsTracks.size(); channel++) {
@@ -129,6 +129,6 @@ namespace trackFindingTracklet {
     iEvent.emplace(edPutToken_, move(ttTracks));
   }
 
-} // namespace trackFindingTracklet
+}  // namespace trackFindingTracklet
 
 DEFINE_FWK_MODULE(trackFindingTracklet::ProducerTT);

--- a/L1Trigger/TrackFindingTracklet/src/TrackBuilderChannel.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackBuilderChannel.cc
@@ -7,11 +7,10 @@ using namespace edm;
 
 namespace trackFindingTracklet {
 
-  TrackBuilderChannel::TrackBuilderChannel(const edm::ParameterSet& iConfig) :
-    useDuplicateRemoval_(iConfig.getParameter<bool>("UseDuplicateRemoval")),
-    boundaries_(iConfig.getParameter<vector<double>>("PtBoundaries")),
-    numChannels_(useDuplicateRemoval_ ? 2 * boundaries_.size() : iConfig.getParameter<int>("NumSeedTypes"))
-  {}
+  TrackBuilderChannel::TrackBuilderChannel(const edm::ParameterSet& iConfig)
+      : useDuplicateRemoval_(iConfig.getParameter<bool>("UseDuplicateRemoval")),
+        boundaries_(iConfig.getParameter<vector<double>>("PtBoundaries")),
+        numChannels_(useDuplicateRemoval_ ? 2 * boundaries_.size() : iConfig.getParameter<int>("NumSeedTypes")) {}
 
   // sets channelId of given TTTrack, return false if track outside pt range
   bool TrackBuilderChannel::channelId(const TTTrack<Ref_Phase2TrackerDigi_>& ttTrack, int& channelId) {
@@ -32,4 +31,4 @@ namespace trackFindingTracklet {
     return true;
   }
 
-} // namespace trackFindingTracklet
+}  // namespace trackFindingTracklet

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerKFin.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerKFin.cc
@@ -50,7 +50,10 @@ namespace trackFindingTracklet {
 
   private:
     //
-    void formTracks(const StreamsTrack& streamsTrack, const StreamsStub& streamsStubs, vector<vector<TTStubRef>>& tracks, int channel) const;
+    void formTracks(const StreamsTrack& streamsTrack,
+                    const StreamsStub& streamsStubs,
+                    vector<vector<TTStubRef>>& tracks,
+                    int channel) const;
     //
     void associate(const vector<vector<TTStubRef>>& tracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum) const;
 
@@ -93,7 +96,8 @@ namespace trackFindingTracklet {
     stringstream log_;
   };
 
-  AnalyzerKFin::AnalyzerKFin(const ParameterSet& iConfig) : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
+  AnalyzerKFin::AnalyzerKFin(const ParameterSet& iConfig)
+      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
     usesResource("TFileService");
     // book in- and output ED products
     const string& label = iConfig.getParameter<string>("LabelKFin");
@@ -195,7 +199,9 @@ namespace trackFindingTracklet {
         vector<vector<TTStubRef>> lost;
         formTracks(lostTracks, lostStubs, lost, offset + channel);
         nTracks += tracks.size();
-        nStubs += accumulate(tracks.begin(), tracks.end(), 0, [](int& sum, const vector<TTStubRef>& track){ return sum += (int)track.size(); });
+        nStubs += accumulate(tracks.begin(), tracks.end(), 0, [](int& sum, const vector<TTStubRef>& track) {
+          return sum += (int)track.size();
+        });
         nLost += lost.size();
         allTracks += tracks.size();
         if (!useMCTruth_)
@@ -212,7 +218,7 @@ namespace trackFindingTracklet {
     vector<TPPtr> recovered;
     recovered.reserve(tpPtrsLost.size());
     set_intersection(tpPtrsLost.begin(), tpPtrsLost.end(), tpPtrs.begin(), tpPtrs.end(), back_inserter(recovered));
-    for(const TPPtr& tpPtr : recovered)
+    for (const TPPtr& tpPtr : recovered)
       tpPtrsLost.erase(tpPtr);
     prof_->Fill(4, allMatched);
     prof_->Fill(5, allTracks);
@@ -250,8 +256,10 @@ namespace trackFindingTracklet {
     const int wErrs = ceil(log10(*max_element(errs.begin(), errs.end()))) + 5;
     log_ << "                        KFin  SUMMARY                        " << endl;
     log_ << "number of stubs       per TFP = " << setw(wNums) << numStubs << " +- " << setw(wErrs) << errStubs << endl;
-    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks << endl;
-    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost << endl;
+    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks
+         << endl;
+    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost
+         << endl;
     log_ << "     max  tracking efficiency = " << setw(wNums) << eff << " +- " << setw(wErrs) << errEff << endl;
     log_ << "     lost tracking efficiency = " << setw(wNums) << effLoss << " +- " << setw(wErrs) << errEffLoss << endl;
     log_ << "                    fake rate = " << setw(wNums) << fracFake << endl;
@@ -261,21 +269,31 @@ namespace trackFindingTracklet {
   }
 
   //
-  void AnalyzerKFin::formTracks(const StreamsTrack& streamsTrack, const StreamsStub& streamsStubs, vector<vector<TTStubRef>>& tracks, int channel) const {
+  void AnalyzerKFin::formTracks(const StreamsTrack& streamsTrack,
+                                const StreamsStub& streamsStubs,
+                                vector<vector<TTStubRef>>& tracks,
+                                int channel) const {
     const int offset = channel * setup_->numLayers();
     const StreamTrack& streamTrack = streamsTrack[channel];
-    const int numTracks = accumulate(streamTrack.begin(), streamTrack.end(), 0, [](int& sum, const FrameTrack& frame){ return sum += (frame.first.isNonnull() ? 1 : 0); });
+    const int numTracks = accumulate(streamTrack.begin(), streamTrack.end(), 0, [](int& sum, const FrameTrack& frame) {
+      return sum += (frame.first.isNonnull() ? 1 : 0);
+    });
     tracks.reserve(numTracks);
     for (int frame = 0; frame < (int)streamTrack.size(); frame++) {
       const FrameTrack& frameTrack = streamTrack[frame];
       if (frameTrack.first.isNull())
         continue;
-      const auto end = find_if(next(streamTrack.begin(), frame + 1), streamTrack.end(), [](const FrameTrack& frame){ return frame.first.isNonnull(); });
+      const auto end = find_if(next(streamTrack.begin(), frame + 1), streamTrack.end(), [](const FrameTrack& frame) {
+        return frame.first.isNonnull();
+      });
       const int size = distance(next(streamTrack.begin(), frame), end);
       int numStubs(0);
       for (int layer = 0; layer < setup_->numLayers(); layer++) {
         const StreamStub& stream = streamsStubs[offset + layer];
-        numStubs += accumulate(stream.begin() + frame, stream.begin() + frame + size, 0, [](int& sum, const FrameStub& frame){ return sum += (frame.first.isNonnull() ? 1 : 0); });
+        numStubs +=
+            accumulate(stream.begin() + frame, stream.begin() + frame + size, 0, [](int& sum, const FrameStub& frame) {
+              return sum += (frame.first.isNonnull() ? 1 : 0);
+            });
       }
       vector<TTStubRef> stubs;
       stubs.reserve(numStubs);
@@ -291,7 +309,10 @@ namespace trackFindingTracklet {
   }
 
   //
-  void AnalyzerKFin::associate(const vector<vector<TTStubRef>>& tracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum) const {
+  void AnalyzerKFin::associate(const vector<vector<TTStubRef>>& tracks,
+                               const StubAssociation* ass,
+                               set<TPPtr>& tps,
+                               int& sum) const {
     for (const vector<TTStubRef>& ttStubRefs : tracks) {
       const vector<TPPtr>& tpPtrs = ass->associate(ttStubRefs);
       if (tpPtrs.empty())

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerKFout.cc
@@ -82,10 +82,8 @@ namespace trackFindingTracklet {
     stringstream log_;
   };
 
-  AnalyzerKFout::AnalyzerKFout(const ParameterSet& iConfig) :
-    useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")),
-    nEvents_(0)
-  {
+  AnalyzerKFout::AnalyzerKFout(const ParameterSet& iConfig)
+      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
     usesResource("TFileService");
     // book in- and output ED products
     const string& label = iConfig.getParameter<string>("LabelKFout");
@@ -171,7 +169,9 @@ namespace trackFindingTracklet {
           if (frame.first.isNonnull())
             tracks.insert(frame.first);
         nTracksRegion += tracks.size();
-        nStubsRegion += accumulate(tracks.begin(), tracks.end(), 0, [](int& sum, const TTTrackRef& ttTrackRef){ return sum += (int)ttTrackRef->getStubRefs().size(); });
+        nStubsRegion += accumulate(tracks.begin(), tracks.end(), 0, [](int& sum, const TTTrackRef& ttTrackRef) {
+          return sum += (int)ttTrackRef->getStubRefs().size();
+        });
         set<TTTrackRef> tracksLost;
         for (const FrameTrack& frame : lost)
           if (frame.first.isNonnull())
@@ -225,8 +225,10 @@ namespace trackFindingTracklet {
     const int wErrs = ceil(log10(*max_element(errs.begin(), errs.end()))) + 5;
     log_ << "                        KFout SUMMARY                        " << endl;
     //log_ << "number of stubs       per TFP = " << setw(wNums) << numStubs << " +- " << setw(wErrs) << errStubs << endl;
-    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks << endl;
-    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost << endl;
+    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks
+         << endl;
+    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost
+         << endl;
     log_ << "          tracking efficiency = " << setw(wNums) << eff << " +- " << setw(wErrs) << errEff << endl;
     log_ << "     lost tracking efficiency = " << setw(wNums) << effLoss << " +- " << setw(wErrs) << errEffLoss << endl;
     log_ << "                    fake rate = " << setw(wNums) << fracFake << endl;
@@ -236,7 +238,10 @@ namespace trackFindingTracklet {
   }
 
   //
-  void AnalyzerKFout::associate(const set<TTTrackRef>& ttTracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum) const {
+  void AnalyzerKFout::associate(const set<TTTrackRef>& ttTracks,
+                                const StubAssociation* ass,
+                                set<TPPtr>& tps,
+                                int& sum) const {
     for (const TTTrackRef& ttTrack : ttTracks) {
       const vector<TTStubRef>& ttStubRefs = ttTrack->getStubRefs();
       const vector<TPPtr>& tpPtrs = ass->associate(ttStubRefs);

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerTT.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerTT.cc
@@ -38,7 +38,6 @@ namespace trackFindingTracklet {
     void endJob() override {}
 
   private:
-
     // ED input token of TTTrackRefMap
     EDGetTokenT<TTTrackRefMap> edGetTokenTTTrackMap_;
     // ED input token of TTStubRef to TPPtr association for tracking efficiency
@@ -47,9 +46,9 @@ namespace trackFindingTracklet {
     ESGetToken<Setup, SetupRcd> esGetTokenSetup_;
     // stores, calculates and provides run-time constants
     const Setup* setup_;
-  
+
     // histos
-    
+
     TH1F* hisQoverPt_;
     TH1F* hisPhi0_;
     TH1F* hisEta_;
@@ -58,7 +57,6 @@ namespace trackFindingTracklet {
     TProfile* profResPhi0OverEta_;
     TProfile* profResEtaOverEta_;
     TProfile* profResZ0OverEta_;
-  
   };
 
   AnalyzerTT::AnalyzerTT(const ParameterSet& iConfig) {
@@ -106,7 +104,7 @@ namespace trackFindingTracklet {
         continue;
       const TPPtr& tpPtr = tpPtrs.front();
       const math::XYZPointD& v = tpPtr->vertex();
-      const double qOverPtTT = ttTrackRef->rInv() /  setup_->invPtToDphi() / 2.0;
+      const double qOverPtTT = ttTrackRef->rInv() / setup_->invPtToDphi() / 2.0;
       const double qOverPtTP = tpPtr->charge() / tpPtr->pt();
       const double qOverPtDiff = qOverPtTP - qOverPtTT;
       const double phi0TT = deltaPhi(ttTrackRef->phi() + ttTrackRef->phiSector() * setup_->baseRegion());

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerTracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerTracklet.cc
@@ -50,7 +50,11 @@ namespace trackFindingTracklet {
 
   private:
     // gets all TPs associated too any of the tracks & number of tracks matching at least one TP
-    void associate(const vector<vector<TTStubRef>>& tracks, const StubAssociation* ass, set<TPPtr>& tps, int& nMatchTrk, bool perfect = false) const;
+    void associate(const vector<vector<TTStubRef>>& tracks,
+                   const StubAssociation* ass,
+                   set<TPPtr>& tps,
+                   int& nMatchTrk,
+                   bool perfect = false) const;
 
     // ED input token of tracks
     EDGetTokenT<TTTracks> edGetToken_;
@@ -86,7 +90,8 @@ namespace trackFindingTracklet {
     stringstream log_;
   };
 
-  AnalyzerTracklet::AnalyzerTracklet(const ParameterSet& iConfig) : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
+  AnalyzerTracklet::AnalyzerTracklet(const ParameterSet& iConfig)
+      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
     usesResource("TFileService");
     // book in- and output ED products
     const InputTag& inputTag = iConfig.getParameter<InputTag>("InputTag");
@@ -171,7 +176,10 @@ namespace trackFindingTracklet {
       ttTrackRefsRegions[ttTrack.phiSector()].emplace_back(TTTrackRef(handle, i++));
     for (int region = 0; region < setup_->numRegions(); region++) {
       const vector<TTTrackRef>& ttTrackRefs = ttTrackRefsRegions[region];
-      const int nStubs = accumulate(ttTrackRefs.begin(), ttTrackRefs.end(), 0, [](int& sum, const TTTrackRef& ttTrackRef){ return sum += ttTrackRef->getStubRefs().size(); });
+      const int nStubs =
+          accumulate(ttTrackRefs.begin(), ttTrackRefs.end(), 0, [](int& sum, const TTTrackRef& ttTrackRef) {
+            return sum += ttTrackRef->getStubRefs().size();
+          });
       const int nTracks = ttTrackRefs.size();
       hisChannel_->Fill(nTracks);
       profChannel_->Fill(region, nTracks);
@@ -188,7 +196,10 @@ namespace trackFindingTracklet {
     // convert vector of tracks to vector of vector of associated stubs
     vector<vector<TTStubRef>> tracks;
     tracks.reserve(ttTracks.size());
-    transform(ttTracks.begin(), ttTracks.end(), back_inserter(tracks), [](const TTTrack<Ref_Phase2TrackerDigi_>& ttTrack){ return ttTrack.getStubRefs(); });
+    transform(
+        ttTracks.begin(), ttTracks.end(), back_inserter(tracks), [](const TTTrack<Ref_Phase2TrackerDigi_>& ttTrack) {
+          return ttTrack.getStubRefs();
+        });
     if (useMCTruth_) {
       int tmp(0);
       associate(tracks, selection, tpPtrsSelection, tmp);
@@ -212,7 +223,7 @@ namespace trackFindingTracklet {
       return;
     // effi
     eff_->SetPassedHistogram(*hisEff_, "f");
-    eff_->SetTotalHistogram (*hisEffTotal_, "f");
+    eff_->SetTotalHistogram(*hisEffTotal_, "f");
     // printout SF summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
@@ -237,7 +248,8 @@ namespace trackFindingTracklet {
     log_ << "                      Tracklet  SUMMARY                      " << endl;
     log_ << "number of stubs     per TFP = " << setw(wNums) << numStubs << " +- " << setw(wErrs) << errStubs << endl;
     log_ << "number of tracks    per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks << endl;
-    log_ << "current tracking efficiency = " << setw(wNums) << effPerfect << " +- " << setw(wErrs) << errEffPerfect << endl;
+    log_ << "current tracking efficiency = " << setw(wNums) << effPerfect << " +- " << setw(wErrs) << errEffPerfect
+         << endl;
     log_ << "max     tracking efficiency = " << setw(wNums) << eff << " +- " << setw(wErrs) << errEff << endl;
     log_ << "                  fake rate = " << setw(wNums) << fracFake << endl;
     log_ << "             duplicate rate = " << setw(wNums) << fracDup << endl;
@@ -246,7 +258,11 @@ namespace trackFindingTracklet {
   }
 
   // gets all TPs associated too any of the tracks & number of tracks matching at least one TP
-  void AnalyzerTracklet::associate(const vector<vector<TTStubRef>>& tracks, const StubAssociation* ass, set<TPPtr>& tps, int& nMatchTrk, bool perfect) const {
+  void AnalyzerTracklet::associate(const vector<vector<TTStubRef>>& tracks,
+                                   const StubAssociation* ass,
+                                   set<TPPtr>& tps,
+                                   int& nMatchTrk,
+                                   bool perfect) const {
     for (const vector<TTStubRef>& ttStubRefs : tracks) {
       const vector<TPPtr>& tpPtrs = perfect ? ass->associateFinal(ttStubRefs) : ass->associate(ttStubRefs);
       if (tpPtrs.empty())

--- a/L1Trigger/TrackTrigger/interface/Setup.h
+++ b/L1Trigger/TrackTrigger/interface/Setup.h
@@ -85,7 +85,7 @@ namespace tt {
     GlobalPoint stubPos(const TTStubRef& ttStubRef) const;
     // empty trackerDTC EDProduct
     TTDTC ttDTC() const { return TTDTC(numRegions_, numOverlappingRegions_, numDTCsPerRegion_); }
-    // checks if stub collection is considered forming a reconstructable track 
+    // checks if stub collection is considered forming a reconstructable track
     bool reconstructable(const std::vector<TTStubRef>& ttStubRefs) const;
     // checks if tracking particle is selected for efficiency measurements
     bool useForAlgEff(const TrackingParticle& tp) const;
@@ -452,12 +452,12 @@ namespace tt {
     double kfRangeFactor() const { return kfRangeFactor_; }
 
     // Parameter specifying KalmanFilter Output Formatter
-    
-    // Final Chi2rphi digitization TODO extract from TTTrack Word 
+
+    // Final Chi2rphi digitization TODO extract from TTTrack Word
     std::vector<double> kfoutchi2rphiBins() const { return kfoutchi2rphiBins_; }
-    // Final Chi2rz digitization TODO extract from TTTrack Word 
+    // Final Chi2rz digitization TODO extract from TTTrack Word
     std::vector<double> kfoutchi2rzBins() const { return kfoutchi2rzBins_; }
-    // Conversion factor between dphi^2/weight and chi2rphi 
+    // Conversion factor between dphi^2/weight and chi2rphi
     int kfoutchi2rphiConv() const { return kfoutchi2rphiConv_; }
     // Conversion factor between dz^2/weight and chi2rz
     int kfoutchi2rzConv() const { return kfoutchi2rzConv_; }
@@ -829,18 +829,18 @@ namespace tt {
     // Parameter specifying KalmanFilter Output Formatter
     edm::ParameterSet pSetKFOut_;
     // Bins used to digitize dPhi for chi2 calculation
-    std::vector<int> kfoutdPhiBins_; 
+    std::vector<int> kfoutdPhiBins_;
     // Bins used to digitize dZ for chi2 calculation
     std::vector<int> kfoutdZBins_;
     // v0 weight Bins corresponding to dPhi Bins for chi2 calculation
     std::vector<int> kfoutv0Bins_;
     // v1 weight Bins corresponding to dZ Bins for chi2 calculation
     std::vector<int> kfoutv1Bins_;
-    // Final Chi2rphi digitization TODO extract from TTTrack Word 
+    // Final Chi2rphi digitization TODO extract from TTTrack Word
     std::vector<double> kfoutchi2rphiBins_;
-    // Final Chi2rz digitization TODO extract from TTTrack Word 
+    // Final Chi2rz digitization TODO extract from TTTrack Word
     std::vector<double> kfoutchi2rzBins_;
-    // Conversion factor between dphi^2/weight and chi2rphi 
+    // Conversion factor between dphi^2/weight and chi2rphi
     int kfoutchi2rphiConv_;
     // Conversion factor between dz^2/weight and chi2rz
     int kfoutchi2rzConv_;
@@ -998,7 +998,6 @@ namespace tt {
     // KF
 
     int kfWidthLayerCount_;
-
   };
 
 }  // namespace tt

--- a/L1Trigger/TrackTrigger/interface/SetupRcd.h
+++ b/L1Trigger/TrackTrigger/interface/SetupRcd.h
@@ -15,11 +15,11 @@
 namespace tt {
 
   typedef edm::mpl::Vector<TrackerDigiGeometryRecord,
-                             TrackerTopologyRcd,
-                             IdealMagneticFieldRecord,
-                             IdealGeometryRecord,
-                             TrackerDetToDTCELinkCablingMapRcd,
-                             TTStubAlgorithmRecord>
+                           TrackerTopologyRcd,
+                           IdealMagneticFieldRecord,
+                           IdealGeometryRecord,
+                           TrackerDetToDTCELinkCablingMapRcd,
+                           TTStubAlgorithmRecord>
       Rcds;
 
   // record of tt::Setup

--- a/L1Trigger/TrackTrigger/src/Setup.cc
+++ b/L1Trigger/TrackTrigger/src/Setup.cc
@@ -469,7 +469,8 @@ namespace tt {
     constexpr bool stableOnly = false;
     tpSelector_ = TrackingParticleSelector(
         ptMin, ptMax, -etaMax, etaMax, tip, lip, minHit, signalOnly, intimeOnly, chargedOnly, stableOnly);
-    tpSelectorLoose_ = TrackingParticleSelector(ptMin, ptMax, -etaMax, etaMax, tip, lip, minHit, false, false, false, stableOnly);
+    tpSelectorLoose_ =
+        TrackingParticleSelector(ptMin, ptMax, -etaMax, etaMax, tip, lip, minHit, false, false, false, stableOnly);
   }
 
   // stub layer id (barrel: 1 - 6, endcap: 11 - 15)
@@ -578,7 +579,6 @@ namespace tt {
     const double extra = sm->barrel() ? 0. : pow(sm->pitchCol() * inv2R, 2);
     const double digi = pow(tmttBasePhi_ / 12., 2);
     return sigma + scat + extra + digi;
-
   }
 
   // stub projected chi2z wheight
@@ -590,7 +590,7 @@ namespace tt {
     return sigma + digi;
   }
 
-  // checks if stub collection is considered forming a reconstructable track 
+  // checks if stub collection is considered forming a reconstructable track
   bool Setup::reconstructable(const vector<TTStubRef>& ttStubRefs) const {
     set<int> hitPattern;
     for (const TTStubRef& ttStubRef : ttStubRefs)
@@ -653,7 +653,8 @@ namespace tt {
     tmttWidthLayer_ = ceil(log2(numLayers_));
     tmttWidthSectorEta_ = ceil(log2(numSectorsEta_));
     tmttWidthInv2R_ = ceil(log2(htNumBinsInv2R_));
-    tmttNumUnusedBits_ = TTBV::S_ - tmttWidthLayer_ - 2 * tmttWidthSectorEta_ - tmttWidthR_ - tmttWidthPhi_ - tmttWidthZ_ - 2 *tmttWidthInv2R_ - numSectorsPhi_ - 1;
+    tmttNumUnusedBits_ = TTBV::S_ - tmttWidthLayer_ - 2 * tmttWidthSectorEta_ - tmttWidthR_ - tmttWidthPhi_ -
+                         tmttWidthZ_ - 2 * tmttWidthInv2R_ - numSectorsPhi_ - 1;
     // hybrid
     const double hybridRangeInv2R = 2. * invPtToDphi_ / hybridMinPtStub_;
     const double hybridRangeR =

--- a/L1Trigger/TrackerDTC/interface/LayerEncoding.h
+++ b/L1Trigger/TrackerDTC/interface/LayerEncoding.h
@@ -20,9 +20,10 @@ namespace trackerDTC {
   public:
     LayerEncoding() {}
     LayerEncoding(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-    ~LayerEncoding(){}
+    ~LayerEncoding() {}
     // decode layer id for given sensor module
     int decode(tt::SensorModule* sm) const;
+
   private:
     // helper class to store configurations
     const tt::Setup* setup_;
@@ -30,7 +31,7 @@ namespace trackerDTC {
     std::vector<std::vector<int>> encodingsLayerId_;
   };
 
-} // namespace trackerDTC
+}  // namespace trackerDTC
 
 EVENTSETUP_DATA_DEFAULT_RECORD(trackerDTC::LayerEncoding, trackerDTC::LayerEncodingRcd);
 

--- a/L1Trigger/TrackerDTC/interface/LayerEncodingRcd.h
+++ b/L1Trigger/TrackerDTC/interface/LayerEncodingRcd.h
@@ -10,7 +10,8 @@ namespace trackerDTC {
   typedef edm::mpl::Vector<tt::SetupRcd> RcdsLayerEncoding;
 
   // record of trackerDTC::LayerEncoding
-  class LayerEncodingRcd : public edm::eventsetup::DependentRecordImplementation<LayerEncodingRcd, RcdsLayerEncoding> {};
+  class LayerEncodingRcd : public edm::eventsetup::DependentRecordImplementation<LayerEncodingRcd, RcdsLayerEncoding> {
+  };
 
 }  // namespace trackerDTC
 

--- a/L1Trigger/TrackerDTC/plugins/ProducerED.cc
+++ b/L1Trigger/TrackerDTC/plugins/ProducerED.cc
@@ -61,8 +61,7 @@ namespace trackerDTC {
     ParameterSet iConfig_;
   };
 
-  ProducerED::ProducerED(const ParameterSet& iConfig)
-      : iConfig_(iConfig) {
+  ProducerED::ProducerED(const ParameterSet& iConfig) : iConfig_(iConfig) {
     // book in- and output ED products
     const auto& inputTag = iConfig.getParameter<InputTag>("InputTag");
     const auto& branchAccepted = iConfig.getParameter<string>("BranchAccepted");

--- a/L1Trigger/TrackerDTC/src/LayerEncoding.cc
+++ b/L1Trigger/TrackerDTC/src/LayerEncoding.cc
@@ -41,4 +41,4 @@ namespace trackerDTC {
     return distance(encoding.begin(), pos);
   }
 
-} // namespace trackerDTC
+}  // namespace trackerDTC

--- a/L1Trigger/TrackerDTC/src/Stub.cc
+++ b/L1Trigger/TrackerDTC/src/Stub.cc
@@ -11,8 +11,17 @@ using namespace tt;
 
 namespace trackerDTC {
 
-  Stub::Stub(const ParameterSet& iConfig, const Setup* setup, const LayerEncoding* layerEncoding, SensorModule* sm, const TTStubRef& ttStubRef)
-      : setup_(setup), layerEncoding_(layerEncoding), sm_(sm), ttStubRef_(ttStubRef), hybrid_(iConfig.getParameter<bool>("UseHybrid")), valid_(true) {
+  Stub::Stub(const ParameterSet& iConfig,
+             const Setup* setup,
+             const LayerEncoding* layerEncoding,
+             SensorModule* sm,
+             const TTStubRef& ttStubRef)
+      : setup_(setup),
+        layerEncoding_(layerEncoding),
+        sm_(sm),
+        ttStubRef_(ttStubRef),
+        hybrid_(iConfig.getParameter<bool>("UseHybrid")),
+        valid_(true) {
     regions_.reserve(setup->numOverlappingRegions());
     // get stub local coordinates
     const MeasurementPoint& mp = ttStubRef->clusterRef(0)->findAverageLocalCoordinatesCentered();
@@ -166,7 +175,7 @@ namespace trackerDTC {
     const TTBV hwValid(1, 1);
     // assemble final bitset
     return Frame(hwGap.str() + hwR.str() + hwZ.str() + hwPhi.str() + hwAlpha.str() + hwBend.str() + hwLayer.str() +
-                     hwValid.str());
+                 hwValid.str());
   }
 
   Frame Stub::formatTMTT(int region) const {
@@ -235,7 +244,9 @@ namespace trackerDTC {
     for (int sectorPhi = 0; sectorPhi < setup_->numSectorsPhi(); sectorPhi++)
       hwSectorPhis[sectorPhi] = sectorsPhi[region * setup_->numSectorsPhi() + sectorPhi];
     // assemble final bitset
-    return Frame(hwGap.str() + hwValid.str() + hwR.str() + hwPhi.str() + hwZ.str() + hwLayer.str() + hwSectorPhis.str() + hwSectorEtaMin.str() + hwSectorEtaMax.str() + hwInv2RMin.str() + hwInv2RMax.str());
+    return Frame(hwGap.str() + hwValid.str() + hwR.str() + hwPhi.str() + hwZ.str() + hwLayer.str() +
+                 hwSectorPhis.str() + hwSectorEtaMin.str() + hwSectorEtaMax.str() + hwInv2RMin.str() +
+                 hwInv2RMax.str());
   }
 
 }  // namespace trackerDTC

--- a/L1Trigger/TrackerDTC/test/Analyzer.cc
+++ b/L1Trigger/TrackerDTC/test/Analyzer.cc
@@ -147,7 +147,9 @@ namespace trackerDTC {
   };
 
   Analyzer::Analyzer(const ParameterSet& iConfig)
-      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), hybrid_(iConfig.getParameter<bool>("UseHybrid")), nEvents_(0) {
+      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")),
+        hybrid_(iConfig.getParameter<bool>("UseHybrid")),
+        nEvents_(0) {
     usesResource("TFileService");
     // book in- and output ED products
     const auto& inputTagAccepted = iConfig.getParameter<InputTag>("InputTagAccepted");
@@ -453,7 +455,8 @@ namespace trackerDTC {
     constexpr bool stableOnly = false;
     tpSelector_ = TrackingParticleSelector(
         ptMin, ptMax, -etaMax, etaMax, tip, lip, minHit, signalOnly, intimeOnly, chargedOnly, stableOnly);
-    tpSelectorLoose_ = TrackingParticleSelector(ptMin, ptMax, -etaMax, etaMax, tip, lip, minHit, false, false, false, stableOnly);
+    tpSelectorLoose_ =
+        TrackingParticleSelector(ptMin, ptMax, -etaMax, etaMax, tip, lip, minHit, false, false, false, stableOnly);
   }
 
   // book histograms

--- a/L1Trigger/TrackerDTC/test/AnalyzerDAQ.cc
+++ b/L1Trigger/TrackerDTC/test/AnalyzerDAQ.cc
@@ -41,7 +41,6 @@ namespace trackerDTC {
     void endJob() override {}
 
   private:
-
     // ED input token of accepted TTClusters
     EDGetTokenT<TTClusterDetSetVec> edGetToken_;
     // Setup token
@@ -96,7 +95,7 @@ namespace trackerDTC {
     iEvent.getByToken<TTClusterDetSetVec>(edGetToken_, handle);
     // apply cabling map, reorganise cluster collections
     vector<vector<deque<TTClusterRef>>> dtcs(setup_->numDTCs(),
-                                              vector<deque<TTClusterRef>>(setup_->numModulesPerDTC()));
+                                             vector<deque<TTClusterRef>>(setup_->numModulesPerDTC()));
     for (auto itModule = handle->begin(); itModule != handle->end(); itModule++) {
       // DetSetVec->detId - 1 or + 0 = tk layout det id depending from which of both sensor planes the cluster has been constructed
       const DetId& detIdModule = itModule->detId();

--- a/L1Trigger/TrackerTFP/interface/DataFormats.h
+++ b/L1Trigger/TrackerTFP/interface/DataFormats.h
@@ -27,9 +27,39 @@ namespace trackerTFP {
   // track trigger processes
   enum class Process { begin, fe = begin, dtc, pp, gp, ht, mht, zht, kfin, kf, dr, end, x };
   // track trigger variables
-  enum class Variable { begin, r = begin, phi, z, layer, sectorsPhi, sectorEta, sectorPhi, phiT, inv2R, zT, cot, dPhi, dZ, match, hitPattern, phi0, z0, end, x };
+  enum class Variable {
+    begin,
+    r = begin,
+    phi,
+    z,
+    layer,
+    sectorsPhi,
+    sectorEta,
+    sectorPhi,
+    phiT,
+    inv2R,
+    zT,
+    cot,
+    dPhi,
+    dZ,
+    match,
+    hitPattern,
+    phi0,
+    z0,
+    end,
+    x
+  };
   // track trigger process order
-  constexpr std::initializer_list<Process> Processes = {Process::fe, Process::dtc, Process::pp, Process::gp, Process::ht, Process::mht, Process::zht, Process::kfin, Process::kf, Process::dr};
+  constexpr std::initializer_list<Process> Processes = {Process::fe,
+                                                        Process::dtc,
+                                                        Process::pp,
+                                                        Process::gp,
+                                                        Process::ht,
+                                                        Process::mht,
+                                                        Process::zht,
+                                                        Process::kfin,
+                                                        Process::kf,
+                                                        Process::dr};
   // conversion: Process to int
   inline constexpr int operator+(Process p) { return static_cast<int>(p); }
   // conversion: Variable to int
@@ -82,6 +112,7 @@ namespace trackerTFP {
     double base() const { return base_; }
     // covered range
     double range() const { return range_; }
+
   protected:
     // true if twos'complement or false if binary representation is chosen
     bool twos_;
@@ -94,46 +125,79 @@ namespace trackerTFP {
   };
 
   // class representing format of a specific variable
-  template<Variable v, Process p>
+  template <Variable v, Process p>
   class Format : public DataFormat {
   public:
     Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
     ~Format() {}
   };
 
-  template<> Format<Variable::phiT, Process::ht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::phiT, Process::mht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::inv2R, Process::ht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::inv2R, Process::mht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::r, Process::ht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::phi, Process::ht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::phi, Process::mht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::phi, Process::zht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::phi, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::phi, Process::gp>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::phi, Process::dtc>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::z, Process::dtc>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::z, Process::gp>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::z, Process::zht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::z, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::zT, Process::zht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::cot, Process::zht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::layer, Process::ht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::sectorEta, Process::gp>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::sectorPhi, Process::gp>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::sectorsPhi, Process::gp>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::match, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::hitPattern, Process::kfin>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::phi0, Process::dr>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::inv2R, Process::dr>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::z0, Process::dr>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::cot, Process::dr>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::phiT, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::inv2R, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::zT, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::cot, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::dPhi, Process::kfin>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-  template<> Format<Variable::dZ, Process::kfin>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::phiT, Process::ht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::phiT, Process::mht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::inv2R, Process::ht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::inv2R, Process::mht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::r, Process::ht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::phi, Process::ht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::phi, Process::mht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::phi, Process::zht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::phi, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::phi, Process::gp>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::phi, Process::dtc>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::z, Process::dtc>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::z, Process::gp>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::z, Process::zht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::z, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::zT, Process::zht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::cot, Process::zht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::layer, Process::ht>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::sectorEta, Process::gp>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::sectorPhi, Process::gp>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::sectorsPhi, Process::gp>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::match, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::hitPattern, Process::kfin>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::phi0, Process::dr>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::inv2R, Process::dr>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::z0, Process::dr>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::cot, Process::dr>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::phiT, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::inv2R, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::zT, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::cot, Process::kf>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::dPhi, Process::kfin>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
+  template <>
+  Format<Variable::dZ, Process::kfin>::Format(const edm::ParameterSet& iConfig, const tt::Setup* setup);
 
   /*! \class  trackerTFP::DataFormats
    *  \brief  Class to calculate and provide dataformats used by Track Trigger emulator
@@ -144,68 +208,272 @@ namespace trackerTFP {
   private:
     // variable flavour mapping, Each row below declares which processing steps use the variable named in the comment at the end of the row
     static constexpr std::array<std::array<Process, +Process::end>, +Variable::end> config_ = {{
-    //  Process::fe  Process::dtc  Process::pp   Process::gp  Process::ht  Process::mht  Process::zht  Process::kfin  Process::kf    Process::dr
-      {{Process::x,  Process::ht,  Process::ht,  Process::ht, Process::ht, Process::ht,  Process::ht,  Process::ht,   Process::ht,   Process::x }}, // Variable::r
-      {{Process::x,  Process::dtc, Process::dtc, Process::gp, Process::ht, Process::mht, Process::zht, Process::zht,  Process::kf,   Process::x }}, // Variable::phi
-      {{Process::x,  Process::dtc, Process::dtc, Process::gp, Process::gp, Process::gp,  Process::zht, Process::zht,  Process::kf,   Process::x }}, // Variable::z
-      {{Process::x,  Process::ht,  Process::ht,  Process::ht, Process::ht, Process::ht,  Process::ht,  Process::x,    Process::x,    Process::x }}, // Variable::layer
-      {{Process::x,  Process::dtc, Process::dtc, Process::x,  Process::x,  Process::x,   Process::x,   Process::x,    Process::x,    Process::x }}, // Variable::sectorsPhi
-      {{Process::x,  Process::gp,  Process::gp,  Process::gp, Process::gp, Process::gp,  Process::gp,  Process::gp,   Process::gp,   Process::x }}, // Variable::sectorEta
-      {{Process::x,  Process::x,   Process::x,   Process::gp, Process::gp, Process::gp,  Process::gp,  Process::gp,   Process::gp,   Process::x }}, // Variable::sectorPhi
-      {{Process::x,  Process::ht,  Process::ht,  Process::ht, Process::ht, Process::mht, Process::mht, Process::mht,  Process::kf,   Process::x }}, // Variable::phiT
-      {{Process::x,  Process::ht,  Process::ht,  Process::ht, Process::ht, Process::mht, Process::mht, Process::mht,  Process::kf,   Process::dr}}, // Variable::inv2R
-      {{Process::x,  Process::x,   Process::x,   Process::x,  Process::x,  Process::x,   Process::zht, Process::zht,  Process::kf,   Process::x }}, // Variable::zT
-      {{Process::x,  Process::x,   Process::x,   Process::x,  Process::x,  Process::x,   Process::zht, Process::zht,  Process::kf,   Process::dr}}, // Variable::cot
-      {{Process::x,  Process::x,   Process::x,   Process::x,  Process::x,  Process::x,   Process::x,   Process::kfin, Process::kfin, Process::x }}, // Variable::dPhi
-      {{Process::x,  Process::x,   Process::x,   Process::x,  Process::x,  Process::x,   Process::x,   Process::kfin, Process::kfin, Process::x }}, // Variable::dZ
-      {{Process::x,  Process::x,   Process::x,   Process::x,  Process::x,  Process::x,   Process::x,   Process::x,    Process::kf,   Process::x }}, // Variable::match
-      {{Process::x,  Process::x,   Process::x,   Process::x,  Process::x,  Process::x,   Process::x,   Process::kfin, Process::x,    Process::x }}, // Variable::hitPattern
-      {{Process::x,  Process::x,   Process::x,   Process::x,  Process::x,  Process::x,   Process::x,   Process::x,    Process::x,    Process::dr}}, // Variable::phi0
-      {{Process::x,  Process::x,   Process::x,   Process::x,  Process::x,  Process::x,   Process::x,   Process::x,    Process::x,    Process::dr}}  // Variable::z0
+        //  Process::fe  Process::dtc  Process::pp   Process::gp  Process::ht  Process::mht  Process::zht  Process::kfin  Process::kf    Process::dr
+        {{Process::x,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::x}},  // Variable::r
+        {{Process::x,
+          Process::dtc,
+          Process::dtc,
+          Process::gp,
+          Process::ht,
+          Process::mht,
+          Process::zht,
+          Process::zht,
+          Process::kf,
+          Process::x}},  // Variable::phi
+        {{Process::x,
+          Process::dtc,
+          Process::dtc,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::zht,
+          Process::zht,
+          Process::kf,
+          Process::x}},  // Variable::z
+        {{Process::x,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::x,
+          Process::x,
+          Process::x}},  // Variable::layer
+        {{Process::x,
+          Process::dtc,
+          Process::dtc,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x}},  // Variable::sectorsPhi
+        {{Process::x,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::x}},  // Variable::sectorEta
+        {{Process::x,
+          Process::x,
+          Process::x,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::gp,
+          Process::x}},  // Variable::sectorPhi
+        {{Process::x,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::mht,
+          Process::mht,
+          Process::mht,
+          Process::kf,
+          Process::x}},  // Variable::phiT
+        {{Process::x,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::ht,
+          Process::mht,
+          Process::mht,
+          Process::mht,
+          Process::kf,
+          Process::dr}},  // Variable::inv2R
+        {{Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::zht,
+          Process::zht,
+          Process::kf,
+          Process::x}},  // Variable::zT
+        {{Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::zht,
+          Process::zht,
+          Process::kf,
+          Process::dr}},  // Variable::cot
+        {{Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::kfin,
+          Process::kfin,
+          Process::x}},  // Variable::dPhi
+        {{Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::kfin,
+          Process::kfin,
+          Process::x}},  // Variable::dZ
+        {{Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::kf,
+          Process::x}},  // Variable::match
+        {{Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::kfin,
+          Process::x,
+          Process::x}},  // Variable::hitPattern
+        {{Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::dr}},  // Variable::phi0
+        {{Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::x,
+          Process::dr}}  // Variable::z0
     }};
     // stub word assembly, shows which stub variables are used by each process
     static constexpr std::array<std::initializer_list<Variable>, +Process::end> stubs_ = {{
-      {},                                                                                                                                                                 // Process::fe
-      {Variable::r, Variable::phi, Variable::z, Variable::layer, Variable::sectorsPhi, Variable::sectorEta, Variable::sectorEta, Variable::inv2R, Variable::inv2R},       // Process::dtc
-      {Variable::r, Variable::phi, Variable::z, Variable::layer, Variable::sectorsPhi, Variable::sectorEta, Variable::sectorEta, Variable::inv2R, Variable::inv2R},       // Process::pp
-      {Variable::r, Variable::phi, Variable::z, Variable::layer, Variable::inv2R, Variable::inv2R},                                                                       // Process::gp
-      {Variable::r, Variable::phi, Variable::z, Variable::layer, Variable::sectorPhi, Variable::sectorEta, Variable::phiT},                                               // Process::ht
-      {Variable::r, Variable::phi, Variable::z, Variable::layer, Variable::sectorPhi, Variable::sectorEta, Variable::phiT, Variable::inv2R},                              // Process::mht
-      {Variable::r, Variable::phi, Variable::z, Variable::layer, Variable::sectorPhi, Variable::sectorEta, Variable::phiT, Variable::inv2R, Variable::zT, Variable::cot}, // Process::zht
-      {Variable::r, Variable::phi, Variable::z, Variable::dPhi, Variable::dZ},                                                                                            // Process::kfin
-      {Variable::r, Variable::phi, Variable::z, Variable::dPhi, Variable::dZ},                                                                                            // Process::kf
-      {}                                                                                                                                                                  // Process::dr
+        {},  // Process::fe
+        {Variable::r,
+         Variable::phi,
+         Variable::z,
+         Variable::layer,
+         Variable::sectorsPhi,
+         Variable::sectorEta,
+         Variable::sectorEta,
+         Variable::inv2R,
+         Variable::inv2R},  // Process::dtc
+        {Variable::r,
+         Variable::phi,
+         Variable::z,
+         Variable::layer,
+         Variable::sectorsPhi,
+         Variable::sectorEta,
+         Variable::sectorEta,
+         Variable::inv2R,
+         Variable::inv2R},                                                                             // Process::pp
+        {Variable::r, Variable::phi, Variable::z, Variable::layer, Variable::inv2R, Variable::inv2R},  // Process::gp
+        {Variable::r,
+         Variable::phi,
+         Variable::z,
+         Variable::layer,
+         Variable::sectorPhi,
+         Variable::sectorEta,
+         Variable::phiT},  // Process::ht
+        {Variable::r,
+         Variable::phi,
+         Variable::z,
+         Variable::layer,
+         Variable::sectorPhi,
+         Variable::sectorEta,
+         Variable::phiT,
+         Variable::inv2R},  // Process::mht
+        {Variable::r,
+         Variable::phi,
+         Variable::z,
+         Variable::layer,
+         Variable::sectorPhi,
+         Variable::sectorEta,
+         Variable::phiT,
+         Variable::inv2R,
+         Variable::zT,
+         Variable::cot},                                                          // Process::zht
+        {Variable::r, Variable::phi, Variable::z, Variable::dPhi, Variable::dZ},  // Process::kfin
+        {Variable::r, Variable::phi, Variable::z, Variable::dPhi, Variable::dZ},  // Process::kf
+        {}                                                                        // Process::dr
     }};
     // track word assembly, shows which track variables are used by each process
     static constexpr std::array<std::initializer_list<Variable>, +Process::end> tracks_ = {{
-      {},                                                                                                                             // Process::fe
-      {},                                                                                                                             // Process::dtc
-      {},                                                                                                                             // Process::pp
-      {},                                                                                                                             // Process::gp
-      {},                                                                                                                             // Process::ht
-      {},                                                                                                                             // Process::mht
-      {},                                                                                                                             // Process::zht
-      {Variable::hitPattern, Variable::sectorPhi, Variable::sectorEta, Variable::phiT, Variable::inv2R, Variable::zT, Variable::cot}, // Process::kfin
-      {Variable::match, Variable::sectorPhi, Variable::sectorEta, Variable::phiT, Variable::inv2R, Variable::cot, Variable::zT},      // Process::kf
-      {Variable::phi0, Variable::inv2R, Variable::z0, Variable::cot}                                                                  // Process::dr
+        {},  // Process::fe
+        {},  // Process::dtc
+        {},  // Process::pp
+        {},  // Process::gp
+        {},  // Process::ht
+        {},  // Process::mht
+        {},  // Process::zht
+        {Variable::hitPattern,
+         Variable::sectorPhi,
+         Variable::sectorEta,
+         Variable::phiT,
+         Variable::inv2R,
+         Variable::zT,
+         Variable::cot},  // Process::kfin
+        {Variable::match,
+         Variable::sectorPhi,
+         Variable::sectorEta,
+         Variable::phiT,
+         Variable::inv2R,
+         Variable::cot,
+         Variable::zT},                                                 // Process::kf
+        {Variable::phi0, Variable::inv2R, Variable::z0, Variable::cot}  // Process::dr
     }};
+
   public:
     DataFormats();
     DataFormats(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-    ~DataFormats(){}
+    ~DataFormats() {}
     // bool indicating if hybrid or tmtt being used
     bool hybrid() const { return iConfig_.getParameter<bool>("UseHybrid"); }
     // converts bits to ntuple of variables
-    template<typename ...Ts>
+    template <typename... Ts>
     void convertStub(Process p, const tt::Frame& bv, std::tuple<Ts...>& data) const;
     // converts ntuple of variables to bits
-    template<typename... Ts>
+    template <typename... Ts>
     void convertStub(Process p, const std::tuple<Ts...>& data, tt::Frame& bv) const;
     // converts bits to ntuple of variables
-    template<typename ...Ts>
+    template <typename... Ts>
     void convertTrack(Process p, const tt::Frame& bv, std::tuple<Ts...>& data) const;
     // converts ntuple of variables to bits
-    template<typename... Ts>
+    template <typename... Ts>
     void convertTrack(Process p, const std::tuple<Ts...>& data, tt::Frame& bv) const;
     // access to run-time constants
     const tt::Setup* setup() const { return setup_; }
@@ -221,37 +489,38 @@ namespace trackerTFP {
     int numChannel(Process p) const { return numChannel_[+p]; }
     // number of channels of a given process for whole system
     int numStreams(Process p) const { return numStreams_[+p]; }
-    // 
+    //
     int numStreamsStubs(Process p) const { return numStreamsStubs_[+p]; }
-    // 
+    //
     int numStreamsTracks(Process p) const { return numStreamsTracks_[+p]; }
     // access to spedific format
     const DataFormat& format(Variable v, Process p) const { return *formats_[+v][+p]; }
     // critical radius defining region overlap shape in cm
     double chosenRofPhi() const { return hybrid() ? setup_->hybridChosenRofPhi() : setup_->chosenRofPhi(); }
+
   private:
     // number of unique data formats
     int numDataFormats_;
     // method to count number of unique data formats
-    template<Variable v = Variable::begin, Process p = Process::begin>
+    template <Variable v = Variable::begin, Process p = Process::begin>
     void countFormats();
     // constructs data formats of all unique used variables and flavours
-    template<Variable v = Variable::begin, Process p = Process::begin>
+    template <Variable v = Variable::begin, Process p = Process::begin>
     void fillDataFormats();
     // helper (loop) data formats of all unique used variables and flavours
-    template<Variable v, Process p, Process it = Process::begin>
+    template <Variable v, Process p, Process it = Process::begin>
     void fillFormats();
     // helper (loop) to convert bits to ntuple of variables
-    template<int it = 0, typename ...Ts>
+    template <int it = 0, typename... Ts>
     void extractStub(Process p, TTBV& ttBV, std::tuple<Ts...>& data) const;
     // helper (loop) to convert bits to ntuple of variables
-    template<int it = 0, typename ...Ts>
+    template <int it = 0, typename... Ts>
     void extractTrack(Process p, TTBV& ttBV, std::tuple<Ts...>& data) const;
     // helper (loop) to convert ntuple of variables to bits
-    template<int it = 0, typename... Ts>
+    template <int it = 0, typename... Ts>
     void attachStub(Process p, const std::tuple<Ts...>& data, TTBV& ttBV) const;
     // helper (loop) to convert ntuple of variables to bits
-    template<int it = 0, typename... Ts>
+    template <int it = 0, typename... Ts>
     void attachTrack(Process p, const std::tuple<Ts...>& data, TTBV& ttBV) const;
     // configuration during construction
     edm::ParameterSet iConfig_;
@@ -276,12 +545,12 @@ namespace trackerTFP {
   };
 
   // base class to represent stubs
-  template<typename ...Ts>
+  template <typename... Ts>
   class Stub {
   public:
     // construct Stub from Frame
     Stub(const tt::FrameStub& frame, const DataFormats* dataFormats, Process p);
-    template<typename ...Others>
+    template <typename... Others>
     // construct Stub from other Stub
     Stub(const Stub<Others...>& stub, Ts... data);
     // construct Stub from TTStubRef
@@ -302,6 +571,7 @@ namespace trackerTFP {
     const tt::Frame& bv() const { return frame_.second; }
     // id of collection this stub belongs to
     int trackId() const { return trackId_; }
+
   protected:
     // number of used bits for given variable
     int width(Variable v) const { return dataFormats_->width(v, p_); }
@@ -326,7 +596,7 @@ namespace trackerTFP {
   public:
     // construct StubPP from Frame
     StubPP(const tt::FrameStub& frame, const DataFormats* dataFormats);
-    ~StubPP(){}
+    ~StubPP() {}
     // true if stub belongs to given sector
     bool inSector(int sector) const { return sectors_[sector]; }
     // sectors this stub belongs to
@@ -349,6 +619,7 @@ namespace trackerTFP {
     int inv2RMin() const { return std::get<7>(data_); }
     // last inv2R bin this stub belongs to
     int inv2RMax() const { return std::get<8>(data_); }
+
   private:
     // sectors this stub belongs to
     TTBV sectors_;
@@ -361,7 +632,7 @@ namespace trackerTFP {
     StubGP(const tt::FrameStub& frame, const DataFormats* dataFormats, int sectorPhi, int sectorEta);
     // construct StubGO from StubPP
     StubGP(const StubPP& stub, int sectorPhi, int sectorEta);
-    ~StubGP(){}
+    ~StubGP() {}
     // true if stub belongs to given inv2R bin
     bool inInv2RBin(int inv2RBin) const { return inv2RBins_[inv2RBin]; }
     // inv2R bins  this stub belongs to
@@ -382,6 +653,7 @@ namespace trackerTFP {
     int inv2RMin() const { return std::get<4>(data_); }
     // last inv2R bin this stub belongs to
     int inv2RMax() const { return std::get<5>(data_); }
+
   private:
     // inv2R bins this stub belongs to
     TTBV inv2RBins_;
@@ -398,7 +670,7 @@ namespace trackerTFP {
     StubHT(const tt::FrameStub& frame, const DataFormats* dataFormats, int inv2R);
     // construct StubHT from StubGP and HT cell assignment
     StubHT(const StubGP& stub, int phiT, int inv2R);
-    ~StubHT(){}
+    ~StubHT() {}
     // stub qOver pt
     int inv2R() const { return inv2R_; }
     // stub radius wrt chosenRofPhi
@@ -415,6 +687,7 @@ namespace trackerTFP {
     int sectorEta() const { return std::get<5>(data_); };
     // stub phi at radius chosenRofPhi wrt phi sector centre
     int phiT() const { return std::get<6>(data_); };
+
   private:
     // fills track id
     void fillTrackId();
@@ -429,7 +702,7 @@ namespace trackerTFP {
     StubMHT(const tt::FrameStub& frame, const DataFormats* dataFormats);
     // construct StubMHT from StubHT and MHT cell assignment
     StubMHT(const StubHT& stub, int phiT, int inv2R);
-    ~StubMHT(){}
+    ~StubMHT() {}
     // stub radius wrt choenRofPhi
     double r() const { return std::get<0>(data_); }
     // stub phi residual wrt finer track parameter
@@ -446,6 +719,7 @@ namespace trackerTFP {
     int phiT() const { return std::get<6>(data_); }
     // stub inv2R
     int inv2R() const { return std::get<7>(data_); }
+
   private:
     // fills track id
     void fillTrackId();
@@ -462,7 +736,7 @@ namespace trackerTFP {
     StubZHT(const StubZHT& stub, double zT, double cot, int id);
     //
     StubZHT(const StubZHT& stub, int cot, int zT);
-    ~StubZHT(){}
+    ~StubZHT() {}
     // stub radius wrt chonseRofPhi
     double r() const { return std::get<0>(data_); }
     // stub phiresiudal wrt finer track parameter
@@ -486,6 +760,7 @@ namespace trackerTFP {
     double cotf() const { return cot_; }
     double ztf() const { return zT_; }
     double chi() const { return chi_; }
+
   private:
     // fills track id
     void fillTrackId();
@@ -503,8 +778,15 @@ namespace trackerTFP {
     // construct StubKFin from StubZHT
     StubKFin(const StubZHT& stub, double dPhi, double dZ, int layer);
     // construct StubKFin from TTStubRef
-    StubKFin(const TTStubRef& ttStubRef, const DataFormats* dataFormats, double r, double phi, double z, double dPhi, double dZ, int layer);
-    ~StubKFin(){}
+    StubKFin(const TTStubRef& ttStubRef,
+             const DataFormats* dataFormats,
+             double r,
+             double phi,
+             double z,
+             double dPhi,
+             double dZ,
+             int layer);
+    ~StubKFin() {}
     // kf layer id
     int layer() const { return layer_; }
     // stub radius wrt chosenRofPhi
@@ -517,6 +799,7 @@ namespace trackerTFP {
     double dPhi() const { return std::get<3>(data_); }
     // stub z uncertainty
     double dZ() const { return std::get<4>(data_); }
+
   private:
     // kf layer id
     int layer_;
@@ -529,7 +812,7 @@ namespace trackerTFP {
     StubKF(const tt::FrameStub& frame, const DataFormats* dataFormats, int layer);
     // construct StubKF from StubKFin
     StubKF(const StubKFin& stub, double inv2R, double phiT, double cot, double zT);
-    ~StubKF(){}
+    ~StubKF() {}
     // kf layer id
     int layer() const { return layer_; }
     // stub radius wrt choenRofPhi
@@ -542,22 +825,23 @@ namespace trackerTFP {
     double dPhi() const { return std::get<3>(data_); }
     // stub z uncertainty
     double dZ() const { return std::get<4>(data_); }
+
   private:
     // kf layer id
     int layer_;
   };
 
   // base class to represent tracks
-  template<typename ...Ts>
+  template <typename... Ts>
   class Track {
   public:
     // construct Track from Frame
     Track(const tt::FrameTrack& frame, const DataFormats* dataFormats, Process p);
     // construct Track from other Track
-    template<typename ...Others>
+    template <typename... Others>
     Track(const Track<Others...>& track, Ts... data);
     // construct Track from Stub
-    template<typename ...Others>
+    template <typename... Others>
     Track(const Stub<Others...>& stub, const TTTrackRef& ttTrackRef, Ts... data);
     // construct Track from TTTrackRef
     Track(const TTTrackRef& ttTrackRef, const DataFormats* dataFormats, Process p, Ts... data);
@@ -576,6 +860,7 @@ namespace trackerTFP {
     const tt::Frame& bv() const { return frame_.second; }
     // access to ntuple of variables this track is assemled of
     const std::tuple<Ts...>& data() const { return data_; }
+
   protected:
     //number of bits uesd of given variable
     int width(Variable v) const { return dataFormats_->width(v, p_); }
@@ -604,8 +889,16 @@ namespace trackerTFP {
     // construct TrackKFin from StubKFin
     TrackKFin(const StubZHT& stub, const TTTrackRef& ttTrackRef, const TTBV& maybePattern);
     // construct TrackKFin from TTTrackRef
-    TrackKFin(const TTTrackRef& ttTrackRef, const DataFormats* dataFormats, const TTBV& maybePattern, double phiT, double qOverPt, double zT, double cot, int sectorPhi, int sectorEta);
-    ~TrackKFin(){}
+    TrackKFin(const TTTrackRef& ttTrackRef,
+              const DataFormats* dataFormats,
+              const TTBV& maybePattern,
+              double phiT,
+              double qOverPt,
+              double zT,
+              double cot,
+              int sectorPhi,
+              int sectorEta);
+    ~TrackKFin() {}
     // pattern of layers which are only maybe crossed by found candidate
     const TTBV& maybePattern() const { return std::get<0>(data_); }
     // phi sector
@@ -636,6 +929,7 @@ namespace trackerTFP {
     const std::vector<std::vector<StubKFin*>>& stubs() const { return stubs_; }
     // global cotTheta
     double cotGlobal() const { return cot() + setup()->sectorCot(sectorEta()); }
+
   private:
     // stubs organized in layer
     std::vector<std::vector<StubKFin*>> stubs_;
@@ -650,7 +944,7 @@ namespace trackerTFP {
     TrackKF(const tt::FrameTrack& frame, const DataFormats* dataFormats);
     // construct TrackKF from TrackKFKFin
     TrackKF(const TrackKFin& track, double phiT, double inv2R, double zT, double cot);
-    ~TrackKF(){}
+    ~TrackKF() {}
     // true if kf prameter consistent with mht parameter
     bool match() const { return std::get<0>(data_); }
     // phi sector
@@ -669,56 +963,63 @@ namespace trackerTFP {
     double cotGlobal() const { return cot() + setup()->sectorCot(sectorEta()); }
     // conversion to TTTrack with given stubs
     TTTrack<Ref_Phase2TrackerDigi_> ttTrack(const std::vector<StubKF>& stubs) const;
+
   private:
   };
 
   //Class to represent KFout 96-bit track for use in distribution server
   class TrackKFOut {
-    public:
-      TrackKFOut() : TrackKFOut(0,0,0,0,tt::FrameTrack(), 0, 0, false) {}
-      // construct TrackKF from Partial Tracks
-      TrackKFOut(TTBV PartialTrack1, TTBV PartialTrack2, TTBV PartialTrack3, int sortKey,const tt::FrameTrack& track,int trackID, int linkID, bool valid)
-      : PartialTrack1_(PartialTrack1),
-        PartialTrack2_(PartialTrack2),
-        PartialTrack3_(PartialTrack3),
-        sortKey_(sortKey),
-        track_(track),
-        trackID_(trackID),
-        linkID_(linkID),
-        valid_(valid)  {
-      };
-      
-      ~TrackKFOut(){}
+  public:
+    TrackKFOut() : TrackKFOut(0, 0, 0, 0, tt::FrameTrack(), 0, 0, false) {}
+    // construct TrackKF from Partial Tracks
+    TrackKFOut(TTBV PartialTrack1,
+               TTBV PartialTrack2,
+               TTBV PartialTrack3,
+               int sortKey,
+               const tt::FrameTrack& track,
+               int trackID,
+               int linkID,
+               bool valid)
+        : PartialTrack1_(PartialTrack1),
+          PartialTrack2_(PartialTrack2),
+          PartialTrack3_(PartialTrack3),
+          sortKey_(sortKey),
+          track_(track),
+          trackID_(trackID),
+          linkID_(linkID),
+          valid_(valid){};
 
-      int sortKey() const { return sortKey_; }
+    ~TrackKFOut() {}
 
-      bool dataValid() const { return valid_; }
+    int sortKey() const { return sortKey_; }
 
-      int trackID() const { return trackID_; }
-      int linkID() const { return linkID_; }
+    bool dataValid() const { return valid_; }
 
-      TTBV PartialTrack1() const { return PartialTrack1_; }
-      TTBV PartialTrack2() const { return PartialTrack2_; }
-      TTBV PartialTrack3() const { return PartialTrack3_; }
+    int trackID() const { return trackID_; }
+    int linkID() const { return linkID_; }
 
-      tt::FrameTrack track() const { return track_; }
-      
-    private:
-      TTBV PartialTrack1_ ;
-      TTBV PartialTrack2_;
-      TTBV PartialTrack3_;
-      int sortKey_;
-      tt::FrameTrack track_;
-      int trackID_;
-      int linkID_;
-      bool valid_;
+    TTBV PartialTrack1() const { return PartialTrack1_; }
+    TTBV PartialTrack2() const { return PartialTrack2_; }
+    TTBV PartialTrack3() const { return PartialTrack3_; }
+
+    tt::FrameTrack track() const { return track_; }
+
+  private:
+    TTBV PartialTrack1_;
+    TTBV PartialTrack2_;
+    TTBV PartialTrack3_;
+    int sortKey_;
+    tt::FrameTrack track_;
+    int trackID_;
+    int linkID_;
+    bool valid_;
   };
 
   typedef std::vector<TrackKFOut> TrackKFOutSACollection;
   typedef std::shared_ptr<TrackKFOut> TrackKFOutSAPtr;
   typedef std::vector<TrackKFOutSAPtr> TrackKFOutSAPtrCollection;
-  typedef std::vector< std::vector<std::shared_ptr<TrackKFOut> > > TrackKFOutSAPtrCollections;
-  typedef std::vector< std::vector< std::vector<std::shared_ptr<TrackKFOut> > > > TrackKFOutSAPtrCollectionss;
+  typedef std::vector<std::vector<std::shared_ptr<TrackKFOut>>> TrackKFOutSAPtrCollections;
+  typedef std::vector<std::vector<std::vector<std::shared_ptr<TrackKFOut>>>> TrackKFOutSAPtrCollectionss;
   // class to represent tracks generated by process duplicate removal
   class TrackDR : public Track<double, double, double, double> {
   public:
@@ -726,7 +1027,7 @@ namespace trackerTFP {
     TrackDR(const tt::FrameTrack& frame, const DataFormats* dataFormats);
     // construct TrackDR from TrackKF
     TrackDR(const TrackKF& track);
-    ~TrackDR(){}
+    ~TrackDR() {}
     // track phi at radius 0 wrt processing nonant centre
     double phi0() const { return std::get<0>(data_); }
     // track inv2R
@@ -737,10 +1038,11 @@ namespace trackerTFP {
     double cot() const { return std::get<3>(data_); }
     // conversion to TTTrack
     TTTrack<Ref_Phase2TrackerDigi_> ttTrack() const;
+
   private:
   };
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 EVENTSETUP_DATA_DEFAULT_RECORD(trackerTFP::DataFormats, trackerTFP::DataFormatsRcd);
 

--- a/L1Trigger/TrackerTFP/interface/Demonstrator.h
+++ b/L1Trigger/TrackerTFP/interface/Demonstrator.h
@@ -18,11 +18,13 @@ namespace trackerTFP {
    */
   class Demonstrator {
   public:
-    Demonstrator(){}
+    Demonstrator() {}
     Demonstrator(const edm::ParameterSet& iConfig, const tt::Setup* setup);
-    ~Demonstrator(){}
+    ~Demonstrator() {}
     // plays input through modelsim and compares result with output
-    void analyze(const std::vector<std::vector<tt::Frame>>& input, const std::vector<std::vector<tt::Frame>>& output) const;
+    void analyze(const std::vector<std::vector<tt::Frame>>& input,
+                 const std::vector<std::vector<tt::Frame>>& output) const;
+
   private:
     // converts streams of bv into stringstream
     void convert(const std::vector<std::vector<tt::Frame>>& bits, std::stringstream& ss) const;
@@ -59,7 +61,7 @@ namespace trackerTFP {
     int numRegions_;
   };
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 EVENTSETUP_DATA_DEFAULT_RECORD(trackerTFP::Demonstrator, trackerTFP::DemonstratorRcd);
 

--- a/L1Trigger/TrackerTFP/interface/DistServer.h
+++ b/L1Trigger/TrackerTFP/interface/DistServer.h
@@ -7,27 +7,27 @@
 
 namespace trackerTFP {
 
-    class DistServer {
-    public:
-        DistServer( unsigned int nInputs, unsigned int nOutputs, unsigned int nInterleaving );
-        ~DistServer() {}
+  class DistServer {
+  public:
+    DistServer(unsigned int nInputs, unsigned int nOutputs, unsigned int nInterleaving);
+    ~DistServer() {}
 
-        TrackKFOutSAPtrCollection clock(TrackKFOutSAPtrCollection& inputs);
+    TrackKFOutSAPtrCollection clock(TrackKFOutSAPtrCollection& inputs);
 
-        unsigned int nInputs() const { return nInputs_; }
-        unsigned int nOutputs() const { return nOutputs_; }
-        unsigned int nInterleaving() const { return nInterleaving_; }
-        std::vector< std::vector< unsigned int> >& addr() { return addr_; }
-        TrackKFOutSAPtrCollections& inputs() { return inputs_; }
+    unsigned int nInputs() const { return nInputs_; }
+    unsigned int nOutputs() const { return nOutputs_; }
+    unsigned int nInterleaving() const { return nInterleaving_; }
+    std::vector<std::vector<unsigned int> >& addr() { return addr_; }
+    TrackKFOutSAPtrCollections& inputs() { return inputs_; }
 
-    private:
-        unsigned int nInputs_;
-        unsigned int nOutputs_;
-        unsigned int nInterleaving_;
+  private:
+    unsigned int nInputs_;
+    unsigned int nOutputs_;
+    unsigned int nInterleaving_;
 
-        TrackKFOutSAPtrCollections inputs_;
-        std::vector< std::vector< unsigned int> > addr_;        
-    };
-}
+    TrackKFOutSAPtrCollections inputs_;
+    std::vector<std::vector<unsigned int> > addr_;
+  };
+}  // namespace trackerTFP
 
 #endif

--- a/L1Trigger/TrackerTFP/interface/GeometricProcessor.h
+++ b/L1Trigger/TrackerTFP/interface/GeometricProcessor.h
@@ -13,8 +13,11 @@ namespace trackerTFP {
   // Class to route Stubs of one region to one stream per sector
   class GeometricProcessor {
   public:
-    GeometricProcessor(const edm::ParameterSet& iConfig, const tt::Setup* setup_, const DataFormats* dataFormats, int region);
-    ~GeometricProcessor(){}
+    GeometricProcessor(const edm::ParameterSet& iConfig,
+                       const tt::Setup* setup_,
+                       const DataFormats* dataFormats,
+                       int region);
+    ~GeometricProcessor() {}
 
     // read in and organize input product (fill vector input_)
     void consume(const TTDTC& ttDTC);
@@ -23,7 +26,7 @@ namespace trackerTFP {
 
   private:
     // remove and return first element of deque, returns nullptr if empty
-    template<class T>
+    template <class T>
     T* pop_front(std::deque<T*>& ts) const;
 
     // true if truncation is enbaled
@@ -42,6 +45,6 @@ namespace trackerTFP {
     std::vector<std::vector<std::deque<StubPP*>>> input_;
   };
 
-}
+}  // namespace trackerTFP
 
 #endif

--- a/L1Trigger/TrackerTFP/interface/HoughTransform.h
+++ b/L1Trigger/TrackerTFP/interface/HoughTransform.h
@@ -15,7 +15,7 @@ namespace trackerTFP {
   class HoughTransform {
   public:
     HoughTransform(const edm::ParameterSet& iConfig, const tt::Setup* setup, const DataFormats* dataFormats, int region);
-    ~HoughTransform(){}
+    ~HoughTransform() {}
 
     // read in and organize input product
     void consume(const tt::StreamsStub& streams);
@@ -24,12 +24,18 @@ namespace trackerTFP {
 
   private:
     // remove and return first element of deque, returns nullptr if empty
-    template<class T>
+    template <class T>
     T* pop_front(std::deque<T*>& ts) const;
     // associate stubs with phiT bins in this inv2R column
-    void fillIn(int inv2R, std::deque<StubGP*>& inputSector, std::vector<StubHT*>& acceptedSector, std::vector<StubHT*>& lostSector);
+    void fillIn(int inv2R,
+                std::deque<StubGP*>& inputSector,
+                std::vector<StubHT*>& acceptedSector,
+                std::vector<StubHT*>& lostSector);
     // identify tracks
-    void readOut(const std::vector<StubHT*>& acceptedSector, const std::vector<StubHT*>& lostSector, std::deque<StubHT*>& acceptedAll, std::deque<StubHT*>& lostAll) const;
+    void readOut(const std::vector<StubHT*>& acceptedSector,
+                 const std::vector<StubHT*>& lostSector,
+                 std::deque<StubHT*>& acceptedAll,
+                 std::deque<StubHT*>& lostAll) const;
     // identify lost tracks
     void analyze();
     // store tracks
@@ -55,6 +61,6 @@ namespace trackerTFP {
     std::vector<std::vector<std::deque<StubGP*>>> input_;
   };
 
-}
+}  // namespace trackerTFP
 
 #endif

--- a/L1Trigger/TrackerTFP/interface/KalmanFilter.h
+++ b/L1Trigger/TrackerTFP/interface/KalmanFilter.h
@@ -14,20 +14,29 @@ namespace trackerTFP {
   // Class to do helix fit to all tracks in a region.
   class KalmanFilter {
   public:
-    KalmanFilter(const edm::ParameterSet& iConfig, const tt::Setup* setup, const DataFormats* dataFormats, KalmanFilterFormats* kalmanFilterFormats, int region);
-    ~KalmanFilter(){}
+    KalmanFilter(const edm::ParameterSet& iConfig,
+                 const tt::Setup* setup,
+                 const DataFormats* dataFormats,
+                 KalmanFilterFormats* kalmanFilterFormats,
+                 int region);
+    ~KalmanFilter() {}
 
     // read in and organize input tracks and stubs
     void consume(const tt::StreamsTrack& streamsTrack, const tt::StreamsStub& streamsStub);
     // fill output products
-    void produce(tt::StreamsStub& accpetedStubs, tt::StreamsTrack& acceptedTracks, tt::StreamsStub& lostStubs, tt::StreamsTrack& lostTracks, int& numAcceptedStates, int& numLostStates);
+    void produce(tt::StreamsStub& accpetedStubs,
+                 tt::StreamsTrack& acceptedTracks,
+                 tt::StreamsStub& lostStubs,
+                 tt::StreamsTrack& lostTracks,
+                 int& numAcceptedStates,
+                 int& numLostStates);
 
   private:
     // remove and return first element of deque, returns nullptr if empty
-    template<class T>
+    template <class T>
     T* pop_front(std::deque<T*>& ts) const;
     // remove and return first element of vector, returns nullptr if empty
-    template<class T>
+    template <class T>
     T* pop_front(std::vector<T*>& ts) const;
 
     // adds a layer to states
@@ -98,9 +107,8 @@ namespace trackerTFP {
     DataFormatKF* C22_;
     DataFormatKF* C23_;
     DataFormatKF* C33_;
- 
   };
 
-}
+}  // namespace trackerTFP
 
 #endif

--- a/L1Trigger/TrackerTFP/interface/KalmanFilterFormats.h
+++ b/L1Trigger/TrackerTFP/interface/KalmanFilterFormats.h
@@ -21,7 +21,47 @@ enabling tuning of bit widths
 
 namespace trackerTFP {
 
-  enum class VariableKF { begin, x0 = begin, x1, x2, x3, H00, H12, m0, m1, v0, v1, r0, r1, S00, S01, S12, S13, K00, K10, K21, K31, R00, R11, R00Rough, R11Rough, invR00Approx, invR11Approx, invR00Cor, invR11Cor, invR00, invR11, C00, C01, C11, C22, C23, C33, end, x };
+  enum class VariableKF {
+    begin,
+    x0 = begin,
+    x1,
+    x2,
+    x3,
+    H00,
+    H12,
+    m0,
+    m1,
+    v0,
+    v1,
+    r0,
+    r1,
+    S00,
+    S01,
+    S12,
+    S13,
+    K00,
+    K10,
+    K21,
+    K31,
+    R00,
+    R11,
+    R00Rough,
+    R11Rough,
+    invR00Approx,
+    invR11Approx,
+    invR00Cor,
+    invR11Cor,
+    invR00,
+    invR11,
+    C00,
+    C01,
+    C11,
+    C22,
+    C23,
+    C33,
+    end,
+    x
+  };
   inline constexpr int operator+(VariableKF v) { return static_cast<int>(v); }
   inline constexpr VariableKF operator++(VariableKF v) { return VariableKF(+v + 1); }
 
@@ -40,6 +80,7 @@ namespace trackerTFP {
     bool inRange(double d) const;
     void updateRangeActual(double d);
     int integer(double d) const { return floor(d / base_); }
+
   protected:
     VariableKF v_;
     bool twos_;
@@ -49,65 +90,103 @@ namespace trackerTFP {
     std::pair<double, double> rangeActual_;
   };
 
-  template<VariableKF v>
+  template <VariableKF v>
   class FormatKF : public DataFormatKF {
   public:
     FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
     ~FormatKF() {}
+
   private:
-    void calcRange() { range_ = base_ * pow( 2, width_ ); }
+    void calcRange() { range_ = base_ * pow(2, width_); }
   };
 
-  template<> FormatKF<VariableKF::x0>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::x1>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::x2>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::x3>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::H00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::H12>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::m0>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::m1>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::v0>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::v1>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::r0>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::r1>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::S00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::S01>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::S12>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::S13>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::K00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::K10>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::K21>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::K31>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::R00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::R11>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::R00Rough>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::R11Rough>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::invR00Approx>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::invR11Approx>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::invR00Cor>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::invR11Cor>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::invR00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::invR11>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::C00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::C01>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::C11>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::C22>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::C23>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-  template<> FormatKF<VariableKF::C33>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::x0>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::x1>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::x2>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::x3>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::H00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::H12>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::m0>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::m1>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::v0>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::v1>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::r0>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::r1>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::S00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::S01>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::S12>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::S13>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::K00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::K10>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::K21>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::K31>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::R00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::R11>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::R00Rough>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::R11Rough>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::invR00Approx>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::invR11Approx>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::invR00Cor>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::invR11Cor>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::invR00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::invR11>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::C00>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::C01>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::C11>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::C22>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::C23>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
+  template <>
+  FormatKF<VariableKF::C33>::FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
 
   class KalmanFilterFormats {
   public:
     KalmanFilterFormats();
     KalmanFilterFormats(const edm::ParameterSet& iConfig, const DataFormats* dataFormats);
-    ~KalmanFilterFormats(){}
+    ~KalmanFilterFormats() {}
     const tt::Setup* setup() const { return setup_; }
     const DataFormats* dataFormats() const { return dataFormats_; }
     int width(VariableKF v) const { return formats_[+v].width(); }
     double base(VariableKF v) const { return formats_[+v].base(); }
     DataFormatKF& format(VariableKF v) { return formats_[+v]; }
     void endJob();
+
   private:
-    template<VariableKF it = VariableKF::begin>
+    template <VariableKF it = VariableKF::begin>
     void fillFormats();
     const edm::ParameterSet iConfig_;
     const DataFormats* dataFormats_;
@@ -115,7 +194,7 @@ namespace trackerTFP {
     std::vector<DataFormatKF> formats_;
   };
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 EVENTSETUP_DATA_DEFAULT_RECORD(trackerTFP::KalmanFilterFormats, trackerTFP::KalmanFilterFormatsRcd);
 

--- a/L1Trigger/TrackerTFP/interface/KalmanFilterFormatsRcd.h
+++ b/L1Trigger/TrackerTFP/interface/KalmanFilterFormatsRcd.h
@@ -9,7 +9,8 @@ namespace trackerTFP {
 
   typedef edm::mpl::Vector<DataFormatsRcd> RcdsKalmanFilterFormats;
 
-  class KalmanFilterFormatsRcd : public edm::eventsetup::DependentRecordImplementation<KalmanFilterFormatsRcd, RcdsKalmanFilterFormats> {};
+  class KalmanFilterFormatsRcd
+      : public edm::eventsetup::DependentRecordImplementation<KalmanFilterFormatsRcd, RcdsKalmanFilterFormats> {};
 
 }  // namespace trackerTFP
 

--- a/L1Trigger/TrackerTFP/interface/LayerEncoding.h
+++ b/L1Trigger/TrackerTFP/interface/LayerEncoding.h
@@ -19,15 +19,20 @@ namespace trackerTFP {
   public:
     LayerEncoding() {}
     LayerEncoding(const DataFormats* dataFormats);
-    ~LayerEncoding(){}
+    ~LayerEncoding() {}
     // Set of layers in each (zT,tanL) digi Bin of each eta sector numbered 0->N
-    const std::vector<int>& layerEncoding(int binEta, int binZT, int binCot) const { return layerEncoding_.at(binEta).at(binZT).at(binCot); }
+    const std::vector<int>& layerEncoding(int binEta, int binZT, int binCot) const {
+      return layerEncoding_.at(binEta).at(binZT).at(binCot);
+    }
     // maybe layers for given ets sector, bin in zT and bin in cotThea
-    const std::vector<int>& maybeLayer(int binEta, int binZT, int binCot) const { return maybeLayer_.at(binEta).at(binZT).at(binCot); }
+    const std::vector<int>& maybeLayer(int binEta, int binZT, int binCot) const {
+      return maybeLayer_.at(binEta).at(binZT).at(binCot);
+    }
     // encoded layer id for given eta sector, bin in zT, bin in cotThea and decoed layer id
     const int layerIdKF(int binEta, int binZT, int binCot, int layerId) const;
     // pattern of maybe layers for given eta sector, bin in zT and bin in cotThea
     TTBV maybePattern(int binEta, int binZT, int binCot) const;
+
   private:
     // helper class providing run-time constants
     const tt::Setup* setup_;
@@ -43,7 +48,7 @@ namespace trackerTFP {
     std::vector<std::vector<std::vector<std::vector<int>>>> maybeLayer_;
   };
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 EVENTSETUP_DATA_DEFAULT_RECORD(trackerTFP::LayerEncoding, trackerTFP::LayerEncodingRcd);
 

--- a/L1Trigger/TrackerTFP/interface/LayerEncodingRcd.h
+++ b/L1Trigger/TrackerTFP/interface/LayerEncodingRcd.h
@@ -10,7 +10,8 @@ namespace trackerTFP {
   typedef edm::mpl::Vector<DataFormatsRcd> RcdsLayerEncoding;
 
   // record of trackerTFP::LayerEncoding
-  class LayerEncodingRcd : public edm::eventsetup::DependentRecordImplementation<LayerEncodingRcd, RcdsLayerEncoding> {};
+  class LayerEncodingRcd : public edm::eventsetup::DependentRecordImplementation<LayerEncodingRcd, RcdsLayerEncoding> {
+  };
 
 }  // namespace trackerTFP
 

--- a/L1Trigger/TrackerTFP/interface/MiniHoughTransform.h
+++ b/L1Trigger/TrackerTFP/interface/MiniHoughTransform.h
@@ -14,8 +14,11 @@ namespace trackerTFP {
   // Class to refine HT track candidates in r-phi, by subdividing each HT cell into a finer granularity array
   class MiniHoughTransform {
   public:
-    MiniHoughTransform(const edm::ParameterSet& iConfig, const tt::Setup* setup, const DataFormats* dataFormats, int region);
-    ~MiniHoughTransform(){}
+    MiniHoughTransform(const edm::ParameterSet& iConfig,
+                       const tt::Setup* setup,
+                       const DataFormats* dataFormats,
+                       int region);
+    ~MiniHoughTransform() {}
 
     // read in and organize input product (fill vector input_)
     void consume(const tt::StreamsStub& streams);
@@ -24,7 +27,7 @@ namespace trackerTFP {
 
   private:
     // remove and return first element of deque, returns nullptr if empty
-    template<class T>
+    template <class T>
     T* pop_front(std::deque<T*>& ts) const;
     // perform finer pattern recognition per track
     void fill(int channel, const std::vector<StubHT*>& input, std::vector<std::deque<StubMHT*>>& output);
@@ -61,6 +64,6 @@ namespace trackerTFP {
     std::vector<std::vector<StubHT*>> input_;
   };
 
-}
+}  // namespace trackerTFP
 
 #endif

--- a/L1Trigger/TrackerTFP/interface/State.h
+++ b/L1Trigger/TrackerTFP/interface/State.h
@@ -7,7 +7,6 @@
 #include <vector>
 #include <numeric>
 
-
 namespace trackerTFP {
 
   // Class to represent a Kalman Filter State
@@ -21,7 +20,7 @@ namespace trackerTFP {
     State(State* state, StubKFin* stub);
     // updated state constructor
     State(State* state, const std::vector<double>& doubles);
-    ~State(){}
+    ~State() {}
 
     // Determine quality of completed state
     void finish();
@@ -127,6 +126,6 @@ namespace trackerTFP {
     int numConsistentLayers_;
   };
 
-}
+}  // namespace trackerTFP
 
 #endif

--- a/L1Trigger/TrackerTFP/interface/ZHoughTransform.h
+++ b/L1Trigger/TrackerTFP/interface/ZHoughTransform.h
@@ -13,8 +13,11 @@ namespace trackerTFP {
   // Class to refine MHT track candidates in r-z
   class ZHoughTransform {
   public:
-    ZHoughTransform(const edm::ParameterSet& iConfig, const tt::Setup* setup, const DataFormats* dataFormats, int region);
-    ~ZHoughTransform(){}
+    ZHoughTransform(const edm::ParameterSet& iConfig,
+                    const tt::Setup* setup,
+                    const DataFormats* dataFormats,
+                    int region);
+    ~ZHoughTransform() {}
 
     // read in and organize input product (fill vector input_)
     void consume(const tt::StreamsStub& streams);
@@ -23,7 +26,7 @@ namespace trackerTFP {
 
   private:
     // remove and return first element of deque, returns nullptr if empty
-    template<class T>
+    template <class T>
     T* pop_front(std::deque<T*>& ts) const;
     // perform finer pattern recognition per track
     void fill(int channel, const std::deque<StubZHT*>& input, std::vector<std::deque<StubZHT*>>& output);
@@ -48,6 +51,6 @@ namespace trackerTFP {
     int stage_;
   };
 
-}
+}  // namespace trackerTFP
 
 #endif

--- a/L1Trigger/TrackerTFP/plugins/ProducerGP.cc
+++ b/L1Trigger/TrackerTFP/plugins/ProducerGP.cc
@@ -36,8 +36,8 @@ namespace trackerTFP {
     ~ProducerGP() override {}
 
   private:
-    virtual void beginRun(const Run&, const EventSetup&) override;
-    virtual void produce(Event&, const EventSetup&) override;
+    void beginRun(const Run&, const EventSetup&) override;
+    void produce(Event&, const EventSetup&) override;
     virtual void endJob() {}
 
     // ED input token of DTC stubs
@@ -58,9 +58,7 @@ namespace trackerTFP {
     const DataFormats* dataFormats_;
   };
 
-  ProducerGP::ProducerGP(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerGP::ProducerGP(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& label = iConfig.getParameter<string>("LabelDTC");
     const string& branchAccepted = iConfig.getParameter<string>("BranchAcceptedStubs");
     const string& branchLost = iConfig.getParameter<string>("BranchLostStubs");
@@ -109,6 +107,6 @@ namespace trackerTFP {
     iEvent.emplace(edPutTokenLost_, move(lost));
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 DEFINE_FWK_MODULE(trackerTFP::ProducerGP);

--- a/L1Trigger/TrackerTFP/plugins/ProducerHT.cc
+++ b/L1Trigger/TrackerTFP/plugins/ProducerHT.cc
@@ -35,8 +35,8 @@ namespace trackerTFP {
     ~ProducerHT() override {}
 
   private:
-    virtual void beginRun(const Run&, const EventSetup&) override;
-    virtual void produce(Event&, const EventSetup&) override;
+    void beginRun(const Run&, const EventSetup&) override;
+    void produce(Event&, const EventSetup&) override;
     virtual void endJob() {}
 
     // ED input token of gp stubs
@@ -57,9 +57,7 @@ namespace trackerTFP {
     const DataFormats* dataFormats_;
   };
 
-  ProducerHT::ProducerHT(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerHT::ProducerHT(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& label = iConfig.getParameter<string>("LabelGP");
     const string& branchAccepted = iConfig.getParameter<string>("BranchAcceptedStubs");
     const string& branchLost = iConfig.getParameter<string>("BranchLostStubs");
@@ -110,6 +108,6 @@ namespace trackerTFP {
     iEvent.emplace(edPutTokenLost_, move(lost));
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 DEFINE_FWK_MODULE(trackerTFP::ProducerHT);

--- a/L1Trigger/TrackerTFP/plugins/ProducerKF.cc
+++ b/L1Trigger/TrackerTFP/plugins/ProducerKF.cc
@@ -39,7 +39,7 @@ namespace trackerTFP {
     void beginRun(const Run&, const EventSetup&) override;
     void produce(Event&, const EventSetup&) override;
     //void endStream() { kalmanFilterFormats_->endJob(); }
-    void endStream() {}
+    void endStream() override {}
 
     // ED input token of sf stubs and tracks
     EDGetTokenT<StreamsStub> edGetTokenStubs_;
@@ -69,8 +69,7 @@ namespace trackerTFP {
     KalmanFilterFormats* kalmanFilterFormats_;
   };
 
-  ProducerKF::ProducerKF(const ParameterSet& iConfig) : iConfig_(iConfig)
-  {
+  ProducerKF::ProducerKF(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& label = iConfig.getParameter<string>("LabelKFin");
     const string& branchAcceptedStubs = iConfig.getParameter<string>("BranchAcceptedStubs");
     const string& branchAcceptedTracks = iConfig.getParameter<string>("BranchAcceptedTracks");
@@ -139,10 +138,10 @@ namespace trackerTFP {
     iEvent.emplace(edPutTokenAcceptedTracks_, move(acceptedTracks));
     iEvent.emplace(edPutTokenLostStubs_, move(lostStubs));
     iEvent.emplace(edPutTokenLostTracks_, move(lostTracks));
-    iEvent.emplace(edPutTokenNumAcceptedStates_, move(numAcceptedStates));
-    iEvent.emplace(edPutTokenNumLostStates_, move(numLostStates));
+    iEvent.emplace(edPutTokenNumAcceptedStates_, numAcceptedStates);
+    iEvent.emplace(edPutTokenNumLostStates_, numLostStates);
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 DEFINE_FWK_MODULE(trackerTFP::ProducerKF);

--- a/L1Trigger/TrackerTFP/plugins/ProducerKFin.cc
+++ b/L1Trigger/TrackerTFP/plugins/ProducerKFin.cc
@@ -40,8 +40,8 @@ namespace trackerTFP {
     ~ProducerKFin() override {}
 
   private:
-    virtual void beginRun(const Run&, const EventSetup&) override;
-    virtual void produce(Event&, const EventSetup&) override;
+    void beginRun(const Run&, const EventSetup&) override;
+    void produce(Event&, const EventSetup&) override;
     virtual void endJob() {}
 
     // ED input token of TTTracks
@@ -72,9 +72,7 @@ namespace trackerTFP {
     bool enableTruncation_;
   };
 
-  ProducerKFin::ProducerKFin(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerKFin::ProducerKFin(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& labelTTTracks = iConfig.getParameter<string>("LabelZHTout");
     const string& labelStubs = iConfig.getParameter<string>("LabelZHT");
     const string& branchAcceptedStubs = iConfig.getParameter<string>("BranchAcceptedStubs");
@@ -82,7 +80,8 @@ namespace trackerTFP {
     const string& branchLostStubs = iConfig.getParameter<string>("BranchLostStubs");
     const string& branchLostTracks = iConfig.getParameter<string>("BranchLostTracks");
     // book in- and output ED products
-    edGetTokenTTTracks_ = consumes<vector<TTTrack<Ref_Phase2TrackerDigi_>>>(InputTag(labelTTTracks, branchAcceptedTracks));
+    edGetTokenTTTracks_ =
+        consumes<vector<TTTrack<Ref_Phase2TrackerDigi_>>>(InputTag(labelTTTracks, branchAcceptedTracks));
     edGetTokenStubs_ = consumes<StreamsStub>(InputTag(labelStubs, branchAcceptedStubs));
     edPutTokenAcceptedStubs_ = produces<StreamsStub>(branchAcceptedStubs);
     edPutTokenAcceptedTracks_ = produces<StreamsTrack>(branchAcceptedTracks);
@@ -139,7 +138,9 @@ namespace trackerTFP {
         for (int channel = 0; channel < dataFormats_->numChannel(Process::zht); channel++) {
           const int index = region * dataFormats_->numChannel(Process::zht) + channel;
           const StreamStub& stream = streams[index];
-          nStubsZHR += accumulate(stream.begin(), stream.end(), 0, [](int& sum, const FrameStub& frame){ return sum += frame.first.isNonnull() ? 1 : 0; });
+          nStubsZHR += accumulate(stream.begin(), stream.end(), 0, [](int& sum, const FrameStub& frame) {
+            return sum += frame.first.isNonnull() ? 1 : 0;
+          });
         }
         vector<StubZHT> stubsZHT;
         stubsZHT.reserve(nStubsZHR);
@@ -171,7 +172,7 @@ namespace trackerTFP {
               continue;
             layerCounts[layerIdKF]++;
             deque<FrameStub>& stubs = dequesStubs[sectorPhi * setup_->numLayers() + layerIdKF];
-            auto identical = [ttStubRef, ttTrack](const StubZHT& stub){
+            auto identical = [ttStubRef, ttTrack](const StubZHT& stub) {
               return (int)ttTrack.trackSeedType() == stub.trackId() && ttStubRef == stub.ttStubRef();
             };
             stubZHT = &*find_if(stubsZHT.begin(), stubsZHT.end(), identical);
@@ -222,6 +223,6 @@ namespace trackerTFP {
     iEvent.emplace(edPutTokenLostTracks_, move(streamLostTracks));
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 DEFINE_FWK_MODULE(trackerTFP::ProducerKFin);

--- a/L1Trigger/TrackerTFP/plugins/ProducerMHT.cc
+++ b/L1Trigger/TrackerTFP/plugins/ProducerMHT.cc
@@ -35,8 +35,8 @@ namespace trackerTFP {
     ~ProducerMHT() override {}
 
   private:
-    virtual void beginRun(const Run&, const EventSetup&) override;
-    virtual void produce(Event&, const EventSetup&) override;
+    void beginRun(const Run&, const EventSetup&) override;
+    void produce(Event&, const EventSetup&) override;
     virtual void endJob() {}
 
     // ED input token of gp stubs
@@ -57,9 +57,7 @@ namespace trackerTFP {
     const DataFormats* dataFormats_;
   };
 
-  ProducerMHT::ProducerMHT(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerMHT::ProducerMHT(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& label = iConfig.getParameter<string>("LabelHT");
     const string& branchAccepted = iConfig.getParameter<string>("BranchAcceptedStubs");
     const string& branchLost = iConfig.getParameter<string>("BranchLostStubs");
@@ -110,6 +108,6 @@ namespace trackerTFP {
     iEvent.emplace(edPutTokenLost_, move(lost));
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 DEFINE_FWK_MODULE(trackerTFP::ProducerMHT);

--- a/L1Trigger/TrackerTFP/plugins/ProducerTT.cc
+++ b/L1Trigger/TrackerTFP/plugins/ProducerTT.cc
@@ -56,9 +56,7 @@ namespace trackerTFP {
     const DataFormats* dataFormats_;
   };
 
-  ProducerTT::ProducerTT(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerTT::ProducerTT(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& label = iConfig.getParameter<string>("LabelKF");
     const string& branchStubs = iConfig.getParameter<string>("BranchAcceptedStubs");
     const string& branchTracks = iConfig.getParameter<string>("BranchAcceptedTracks");
@@ -99,7 +97,9 @@ namespace trackerTFP {
       const StreamsStub& streamsStubs = *handleStubs.product();
       int nTracks(0);
       for (const StreamTrack& stream : streamsTracks)
-        nTracks += accumulate(stream.begin(), stream.end(), 0, [](int& sum, const FrameTrack& frame){ return sum += frame.first.isNonnull() ? 1 : 0; });
+        nTracks += accumulate(stream.begin(), stream.end(), 0, [](int& sum, const FrameTrack& frame) {
+          return sum += frame.first.isNonnull() ? 1 : 0;
+        });
       ttTracks.reserve(nTracks);
       for (int channel = 0; channel < dataFormats_->numStreamsTracks(Process::kf); channel++) {
         int iTrk(0);
@@ -122,6 +122,6 @@ namespace trackerTFP {
     iEvent.emplace(edPutToken_, move(ttTracks));
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 DEFINE_FWK_MODULE(trackerTFP::ProducerTT);

--- a/L1Trigger/TrackerTFP/plugins/ProducerZHT.cc
+++ b/L1Trigger/TrackerTFP/plugins/ProducerZHT.cc
@@ -35,8 +35,8 @@ namespace trackerTFP {
     ~ProducerZHT() override {}
 
   private:
-    virtual void beginRun(const Run&, const EventSetup&) override;
-    virtual void produce(Event&, const EventSetup&) override;
+    void beginRun(const Run&, const EventSetup&) override;
+    void produce(Event&, const EventSetup&) override;
     virtual void endJob() {}
 
     // ED input token of gp stubs
@@ -57,9 +57,7 @@ namespace trackerTFP {
     const DataFormats* dataFormats_;
   };
 
-  ProducerZHT::ProducerZHT(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerZHT::ProducerZHT(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& label = iConfig.getParameter<string>("LabelMHT");
     const string& branchAccepted = iConfig.getParameter<string>("BranchAcceptedStubs");
     const string& branchLost = iConfig.getParameter<string>("BranchLostStubs");
@@ -110,6 +108,6 @@ namespace trackerTFP {
     iEvent.emplace(edPutTokenLost_, move(lost));
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 DEFINE_FWK_MODULE(trackerTFP::ProducerZHT);

--- a/L1Trigger/TrackerTFP/plugins/ProducerZHTout.cc
+++ b/L1Trigger/TrackerTFP/plugins/ProducerZHTout.cc
@@ -35,8 +35,8 @@ namespace trackerTFP {
     ~ProducerZHTout() override {}
 
   private:
-    virtual void beginRun(const Run&, const EventSetup&) override;
-    virtual void produce(Event&, const EventSetup&) override;
+    void beginRun(const Run&, const EventSetup&) override;
+    void produce(Event&, const EventSetup&) override;
     virtual void endJob() {}
 
     // ED input token of sf stubs
@@ -55,9 +55,7 @@ namespace trackerTFP {
     const DataFormats* dataFormats_;
   };
 
-  ProducerZHTout::ProducerZHTout(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerZHTout::ProducerZHTout(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& label = iConfig.getParameter<string>("LabelZHT");
     const string& branchAcceptedStubs = iConfig.getParameter<string>("BranchAcceptedStubs");
     const string& branchAcceptedTracks = iConfig.getParameter<string>("BranchAcceptedTracks");
@@ -96,7 +94,7 @@ namespace trackerTFP {
       Handle<StreamsStub> handle;
       iEvent.getByToken<StreamsStub>(edGetToken_, handle);
       const StreamsStub& streams = *handle.product();
-      for (int region = 0; region < setup_->numRegions(); region++ ) {
+      for (int region = 0; region < setup_->numRegions(); region++) {
         for (int channel = 0; channel < dataFormats_->numChannel(Process::zht); channel++) {
           const int index = region * dataFormats_->numChannel(Process::zht) + channel;
           // convert stream to stubs
@@ -104,18 +102,18 @@ namespace trackerTFP {
           vector<StubZHT> stubs;
           stubs.reserve(stream.size());
           for (const FrameStub& frame : stream)
-            if(frame.first.isNonnull())
+            if (frame.first.isNonnull())
               stubs.emplace_back(frame, dataFormats_);
           // form tracks
           int i(0);
           for (auto it = stubs.begin(); it != stubs.end();) {
             const auto start = it;
             const int id = it->trackId();
-            auto different = [id](const StubZHT& stub){ return id != stub.trackId(); };
+            auto different = [id](const StubZHT& stub) { return id != stub.trackId(); };
             it = find_if(it, stubs.end(), different);
             vector<TTStubRef> ttStubRefs;
             ttStubRefs.reserve(distance(start, it));
-            transform(start, it, back_inserter(ttStubRefs), [](const StubZHT& stub){ return stub.ttStubRef(); });
+            transform(start, it, back_inserter(ttStubRefs), [](const StubZHT& stub) { return stub.ttStubRef(); });
             const double zT = dfZT.floating(start->zT());
             const double cot = dfCot.floating(start->cot());
             const double phiT = dfPhiT.floating(start->phiT());
@@ -135,6 +133,6 @@ namespace trackerTFP {
     iEvent.emplace(edPutToken_, ttTracks.begin(), ttTracks.end());
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 DEFINE_FWK_MODULE(trackerTFP::ProducerZHTout);

--- a/L1Trigger/TrackerTFP/src/DataFormats.cc
+++ b/L1Trigger/TrackerTFP/src/DataFormats.cc
@@ -17,13 +17,12 @@ using namespace tt;
 namespace trackerTFP {
 
   // default constructor, trying to needs space as proper constructed object
-  DataFormats::DataFormats() :
-    numDataFormats_(0),
-    formats_(+Variable::end, std::vector<DataFormat*>(+Process::end, nullptr)),
-    numUnusedBitsStubs_(+Process::end, TTBV::S_),
-    numUnusedBitsTracks_(+Process::end, TTBV::S_),
-    numChannel_(+Process::end, 0)
-  {
+  DataFormats::DataFormats()
+      : numDataFormats_(0),
+        formats_(+Variable::end, std::vector<DataFormat*>(+Process::end, nullptr)),
+        numUnusedBitsStubs_(+Process::end, TTBV::S_),
+        numUnusedBitsTracks_(+Process::end, TTBV::S_),
+        numChannel_(+Process::end, 0) {
     setup_ = nullptr;
     countFormats();
     dataFormats_.reserve(numDataFormats_);
@@ -33,13 +32,13 @@ namespace trackerTFP {
   }
 
   // method to count number of unique data formats
-  template<Variable v = Variable::begin, Process p = Process::begin>
+  template <Variable v = Variable::begin, Process p = Process::begin>
   void DataFormats::countFormats() {
-    if constexpr(config_[+v][+p] == p)
+    if constexpr (config_[+v][+p] == p)
       numDataFormats_++;
-    if constexpr(++p != Process::end)
+    if constexpr (++p != Process::end)
       countFormats<v, ++p>();
-    else if constexpr(++v != Variable::end)
+    else if constexpr (++v != Variable::end)
       countFormats<++v>();
   }
 
@@ -62,7 +61,9 @@ namespace trackerTFP {
     numChannel_[+Process::zht] = setup_->htNumBinsInv2R();
     numChannel_[+Process::kfin] = setup_->kfNumWorker() * setup_->numLayers();
     numChannel_[+Process::kf] = setup_->kfNumWorker();
-    transform(numChannel_.begin(), numChannel_.end(), back_inserter(numStreams_), [this](int channel){ return channel * setup_->numRegions(); });
+    transform(numChannel_.begin(), numChannel_.end(), back_inserter(numStreams_), [this](int channel) {
+      return channel * setup_->numRegions();
+    });
     numStreamsStubs_ = numStreams_;
     numStreamsStubs_[+Process::kf] = numStreams_[+Process::kfin];
     numStreamsTracks_ = vector<int>(+Process::end, 0);
@@ -71,46 +72,46 @@ namespace trackerTFP {
   }
 
   // constructs data formats of all unique used variables and flavours
-  template<Variable v = Variable::begin, Process p = Process::begin>
+  template <Variable v = Variable::begin, Process p = Process::begin>
   void DataFormats::fillDataFormats() {
-    if constexpr(config_[+v][+p] == p) {
+    if constexpr (config_[+v][+p] == p) {
       dataFormats_.emplace_back(Format<v, p>(iConfig_, setup_));
       fillFormats<v, p>();
     }
-    if constexpr(++p != Process::end)
+    if constexpr (++p != Process::end)
       fillDataFormats<v, ++p>();
-    else if constexpr(++v != Variable::end)
+    else if constexpr (++v != Variable::end)
       fillDataFormats<++v>();
   }
 
   // helper (loop) data formats of all unique used variables and flavours
-  template<Variable v, Process p, Process it = Process::begin>
+  template <Variable v, Process p, Process it = Process::begin>
   void DataFormats::fillFormats() {
     if (config_[+v][+it] == p) {
       formats_[+v][+it] = &dataFormats_.back();
     }
-    if constexpr(++it != Process::end)
+    if constexpr (++it != Process::end)
       fillFormats<v, p, ++it>();
   }
 
   // converts bits to ntuple of variables
-  template<typename ...Ts>
+  template <typename... Ts>
   void DataFormats::convertStub(Process p, const Frame& bv, tuple<Ts...>& data) const {
     TTBV ttBV(bv);
     extractStub(p, ttBV, data);
   }
 
   // helper (loop) to convert bits to ntuple of variables
-  template<int it = 0, typename ...Ts>
+  template <int it = 0, typename... Ts>
   void DataFormats::extractStub(Process p, TTBV& ttBV, std::tuple<Ts...>& data) const {
     Variable v = *next(stubs_[+p].begin(), sizeof...(Ts) - 1 - it);
     formats_[+v][+p]->extract(ttBV, get<sizeof...(Ts) - 1 - it>(data));
-    if constexpr(it + 1 != sizeof...(Ts))
+    if constexpr (it + 1 != sizeof...(Ts))
       extractStub<it + 1>(p, ttBV, data);
   }
 
   // converts ntuple of variables to bits
-  template<typename... Ts>
+  template <typename... Ts>
   void DataFormats::convertStub(Process p, const std::tuple<Ts...>& data, Frame& bv) const {
     TTBV ttBV(1, numUnusedBitsStubs_[+p]);
     attachStub(p, data, ttBV);
@@ -118,32 +119,32 @@ namespace trackerTFP {
   }
 
   // helper (loop) to convert ntuple of variables to bits
-  template<int it = 0, typename... Ts>
+  template <int it = 0, typename... Ts>
   void DataFormats::attachStub(Process p, const tuple<Ts...>& data, TTBV& ttBV) const {
     Variable v = *next(stubs_[+p].begin(), it);
     formats_[+v][+p]->attach(get<it>(data), ttBV);
-    if constexpr(it + 1 != sizeof...(Ts))
+    if constexpr (it + 1 != sizeof...(Ts))
       attachStub<it + 1>(p, data, ttBV);
   }
 
   // converts bits to ntuple of variables
-  template<typename ...Ts>
+  template <typename... Ts>
   void DataFormats::convertTrack(Process p, const Frame& bv, tuple<Ts...>& data) const {
     TTBV ttBV(bv);
     extractTrack(p, ttBV, data);
   }
 
   // helper (loop) to convert bits to ntuple of variables
-  template<int it = 0, typename ...Ts>
+  template <int it = 0, typename... Ts>
   void DataFormats::extractTrack(Process p, TTBV& ttBV, std::tuple<Ts...>& data) const {
     Variable v = *next(tracks_[+p].begin(), sizeof...(Ts) - 1 - it);
     formats_[+v][+p]->extract(ttBV, get<sizeof...(Ts) - 1 - it>(data));
-    if constexpr(it + 1 != sizeof...(Ts))
+    if constexpr (it + 1 != sizeof...(Ts))
       extractTrack<it + 1>(p, ttBV, data);
   }
 
   // converts ntuple of variables to bits
-  template<typename... Ts>
+  template <typename... Ts>
   void DataFormats::convertTrack(Process p, const std::tuple<Ts...>& data, Frame& bv) const {
     TTBV ttBV(1, numUnusedBitsTracks_[+p]);
     attachTrack(p, data, ttBV);
@@ -151,61 +152,46 @@ namespace trackerTFP {
   }
 
   // helper (loop) to convert ntuple of variables to bits
-  template<int it = 0, typename... Ts>
+  template <int it = 0, typename... Ts>
   void DataFormats::attachTrack(Process p, const tuple<Ts...>& data, TTBV& ttBV) const {
     Variable v = *next(tracks_[+p].begin(), it);
     formats_[+v][+p]->attach(get<it>(data), ttBV);
-    if constexpr(it + 1 != sizeof...(Ts))
+    if constexpr (it + 1 != sizeof...(Ts))
       attachTrack<it + 1>(p, data, ttBV);
   }
 
   // construct Stub from Frame
-  template<typename ...Ts>
-  Stub<Ts...>::Stub(const FrameStub& frame, const DataFormats* dataFormats, Process p) :
-    dataFormats_(dataFormats),
-    p_(p),
-    frame_(frame),
-    trackId_(0)
-  {
+  template <typename... Ts>
+  Stub<Ts...>::Stub(const FrameStub& frame, const DataFormats* dataFormats, Process p)
+      : dataFormats_(dataFormats), p_(p), frame_(frame), trackId_(0) {
     dataFormats_->convertStub(p, frame.second, data_);
   }
 
   // construct Stub from other Stub
-  template<typename ...Ts>
-  template<typename ...Others>
-  Stub<Ts...>::Stub(const Stub<Others...>& stub, Ts... data) :
-    dataFormats_(stub.dataFormats()),
-    p_(++stub.p()),
-    frame_(stub.frame().first, Frame()),
-    data_(data...),
-    trackId_(0)
-  {
-  }
+  template <typename... Ts>
+  template <typename... Others>
+  Stub<Ts...>::Stub(const Stub<Others...>& stub, Ts... data)
+      : dataFormats_(stub.dataFormats()),
+        p_(++stub.p()),
+        frame_(stub.frame().first, Frame()),
+        data_(data...),
+        trackId_(0) {}
 
   // construct Stub from TTStubRef
-  template<typename ...Ts>
-  Stub<Ts...>::Stub(const TTStubRef& ttStubRef, const DataFormats* dataFormats, Process p, Ts... data) :
-    dataFormats_(dataFormats),
-    p_(p),
-    frame_(ttStubRef, Frame()),
-    data_(data...),
-    trackId_(0)
-  {
-  }
+  template <typename... Ts>
+  Stub<Ts...>::Stub(const TTStubRef& ttStubRef, const DataFormats* dataFormats, Process p, Ts... data)
+      : dataFormats_(dataFormats), p_(p), frame_(ttStubRef, Frame()), data_(data...), trackId_(0) {}
 
   // construct StubPP from Frame
-  StubPP::StubPP(const FrameStub& frame, const DataFormats* formats) :
-    Stub(frame, formats, Process::pp)
-  {
-    for(int sectorEta = sectorEtaMin(); sectorEta <= sectorEtaMax(); sectorEta++)
-      for(int sectorPhi = 0; sectorPhi < width(Variable::sectorsPhi); sectorPhi++)
+  StubPP::StubPP(const FrameStub& frame, const DataFormats* formats) : Stub(frame, formats, Process::pp) {
+    for (int sectorEta = sectorEtaMin(); sectorEta <= sectorEtaMax(); sectorEta++)
+      for (int sectorPhi = 0; sectorPhi < width(Variable::sectorsPhi); sectorPhi++)
         sectors_[sectorEta * width(Variable::sectorsPhi) + sectorPhi] = sectorsPhi()[sectorPhi];
   }
 
   // construct StubGP from Frame
-  StubGP::StubGP(const FrameStub& frame, const DataFormats* formats, int sectorPhi, int sectorEta) :
-    Stub(frame, formats, Process::gp), sectorPhi_(sectorPhi), sectorEta_(sectorEta)
-  {
+  StubGP::StubGP(const FrameStub& frame, const DataFormats* formats, int sectorPhi, int sectorEta)
+      : Stub(frame, formats, Process::gp), sectorPhi_(sectorPhi), sectorEta_(sectorEta) {
     const Setup* setup = dataFormats_->setup();
     inv2RBins_ = TTBV(0, setup->htNumBinsInv2R());
     for (int inv2R = inv2RMin(); inv2R <= inv2RMax(); inv2R++)
@@ -213,11 +199,10 @@ namespace trackerTFP {
   }
 
   // construct StubGP from StubPP
-  StubGP::StubGP(const StubPP& stub, int sectorPhi, int sectorEta) :
-    Stub(stub, stub.r(), stub.phi(), stub.z(), stub.layer(), stub.inv2RMin(), stub.inv2RMax()),
-    sectorPhi_(sectorPhi),
-    sectorEta_(sectorEta)
-  {
+  StubGP::StubGP(const StubPP& stub, int sectorPhi, int sectorEta)
+      : Stub(stub, stub.r(), stub.phi(), stub.z(), stub.layer(), stub.inv2RMin(), stub.inv2RMax()),
+        sectorPhi_(sectorPhi),
+        sectorEta_(sectorEta) {
     const Setup* setup = dataFormats_->setup();
     get<1>(data_) -= (sectorPhi_ - .5) * setup->baseSector();
     get<2>(data_) -= (r() + dataFormats_->chosenRofPhi()) * setup->sectorCot(sectorEta_);
@@ -225,18 +210,17 @@ namespace trackerTFP {
   }
 
   // construct StubHT from Frame
-  StubHT::StubHT(const FrameStub& frame, const DataFormats* formats, int inv2R) :
-    Stub(frame, formats, Process::ht), inv2R_(inv2R)
-  {
+  StubHT::StubHT(const FrameStub& frame, const DataFormats* formats, int inv2R)
+      : Stub(frame, formats, Process::ht), inv2R_(inv2R) {
     fillTrackId();
   }
 
   // construct StubHT from StubGP and HT cell assignment
-  StubHT::StubHT(const StubGP& stub, int phiT, int inv2R) :
-    Stub(stub, stub.r(), stub.phi(), stub.z(), stub.layer(), stub.sectorPhi(), stub.sectorEta(), phiT),
-    inv2R_(inv2R)
-  {
-    get<1>(data_) -= format(Variable::inv2R).floating(this->inv2R()) * r() + format(Variable::phiT).floating(this->phiT());
+  StubHT::StubHT(const StubGP& stub, int phiT, int inv2R)
+      : Stub(stub, stub.r(), stub.phi(), stub.z(), stub.layer(), stub.sectorPhi(), stub.sectorEta(), phiT),
+        inv2R_(inv2R) {
+    get<1>(data_) -=
+        format(Variable::inv2R).floating(this->inv2R()) * r() + format(Variable::phiT).floating(this->phiT());
     fillTrackId();
     dataFormats_->convertStub(p_, data_, frame_.second);
   }
@@ -247,16 +231,21 @@ namespace trackerTFP {
   }
 
   // construct StubMHT from Frame
-  StubMHT::StubMHT(const FrameStub& frame, const DataFormats* formats) :
-    Stub(frame, formats, Process::mht)
-  {
+  StubMHT::StubMHT(const FrameStub& frame, const DataFormats* formats) : Stub(frame, formats, Process::mht) {
     fillTrackId();
   }
 
   // construct StubMHT from StubHT and MHT cell assignment
-  StubMHT::StubMHT(const StubHT& stub, int phiT, int inv2R) :
-    Stub(stub, stub.r(), stub.phi(), stub.z(), stub.layer(), stub.sectorPhi(), stub.sectorEta(), stub.phiT(), stub.inv2R())
-  {
+  StubMHT::StubMHT(const StubHT& stub, int phiT, int inv2R)
+      : Stub(stub,
+             stub.r(),
+             stub.phi(),
+             stub.z(),
+             stub.layer(),
+             stub.sectorPhi(),
+             stub.sectorEta(),
+             stub.phiT(),
+             stub.inv2R()) {
     const Setup* setup = dataFormats_->setup();
     // update track (phIT, inv2R), and phi residuals w.r.t. track, to reflect MHT cell assignment.
     get<6>(data_) = this->phiT() * setup->mhtNumBinsPhiT() + phiT;
@@ -269,22 +258,30 @@ namespace trackerTFP {
   // fills track id
   void StubMHT::fillTrackId() {
     TTBV ttBV(bv());
-    trackId_ = ttBV.extract(width(Variable::sectorPhi) + width(Variable::sectorEta) + width(Variable::phiT) + width(Variable::inv2R));
+    trackId_ = ttBV.extract(width(Variable::sectorPhi) + width(Variable::sectorEta) + width(Variable::phiT) +
+                            width(Variable::inv2R));
   }
 
   // construct StubZHT from Frame
-  StubZHT::StubZHT(const FrameStub& frame, const DataFormats* formats) :
-    Stub(frame, formats, Process::zht)
-  {
+  StubZHT::StubZHT(const FrameStub& frame, const DataFormats* formats) : Stub(frame, formats, Process::zht) {
     cot_ = 0.;
     zT_ = 0.;
     fillTrackId();
   }
 
   // construct StubZHT from StubMHT
-  StubZHT::StubZHT(const StubMHT& stub) :
-    Stub(stub, stub.r(), stub.phi(), stub.z(), stub.layer(), stub.sectorPhi(), stub.sectorEta(), stub.phiT(), stub.inv2R(), 0, 0)
-  {
+  StubZHT::StubZHT(const StubMHT& stub)
+      : Stub(stub,
+             stub.r(),
+             stub.phi(),
+             stub.z(),
+             stub.layer(),
+             stub.sectorPhi(),
+             stub.sectorEta(),
+             stub.phiT(),
+             stub.inv2R(),
+             0,
+             0) {
     cot_ = 0.;
     zT_ = 0.;
     r_ = format(Variable::r).digi(this->r() + dataFormats_->chosenRofPhi() - dataFormats_->setup()->chosenRofZ());
@@ -292,10 +289,21 @@ namespace trackerTFP {
     trackId_ = stub.trackId();
   }
 
-  // 
-  StubZHT::StubZHT(const StubZHT& stub, double zT, double cot, int id) :
-    Stub(stub.frame().first, stub.dataFormats(), Process::zht, stub.r(), stub.phi(), stub.z(), stub.layer(), stub.sectorPhi(), stub.sectorEta(), stub.phiT(), stub.inv2R(), stub.zT(), stub.cot())
-  {
+  //
+  StubZHT::StubZHT(const StubZHT& stub, double zT, double cot, int id)
+      : Stub(stub.frame().first,
+             stub.dataFormats(),
+             Process::zht,
+             stub.r(),
+             stub.phi(),
+             stub.z(),
+             stub.layer(),
+             stub.sectorPhi(),
+             stub.sectorEta(),
+             stub.phiT(),
+             stub.inv2R(),
+             stub.zT(),
+             stub.cot()) {
     // update track (zT, cot), and phi residuals w.r.t. track, to reflect ZHT cell assignment.
     r_ = stub.r_;
     cot_ = stub.cotf() + cot;
@@ -308,10 +316,23 @@ namespace trackerTFP {
   }
 
   //
-  StubZHT::StubZHT(const StubZHT& stub, int cot, int zT) :
-    Stub(stub.frame().first, stub.dataFormats(), Process::zht, stub.r(), stub.phi(), 0., stub.layer(), stub.sectorPhi(), stub.sectorEta(), stub.phiT(), stub.inv2R(), zT, cot)
-  {
-    get<2>(data_) = format(Variable::z).digi(stub.z() - (format(Variable::zT).floating(zT) - stub.r_ * format(Variable::cot).floating(cot)));
+  StubZHT::StubZHT(const StubZHT& stub, int cot, int zT)
+      : Stub(stub.frame().first,
+             stub.dataFormats(),
+             Process::zht,
+             stub.r(),
+             stub.phi(),
+             0.,
+             stub.layer(),
+             stub.sectorPhi(),
+             stub.sectorEta(),
+             stub.phiT(),
+             stub.inv2R(),
+             zT,
+             cot) {
+    get<2>(data_) =
+        format(Variable::z)
+            .digi(stub.z() - (format(Variable::zT).floating(zT) - stub.r_ * format(Variable::cot).floating(cot)));
     dataFormats_->convertStub(p_, data_, frame_.second);
     fillTrackId();
   }
@@ -319,89 +340,76 @@ namespace trackerTFP {
   // fills track id
   void StubZHT::fillTrackId() {
     TTBV ttBV(bv());
-    trackId_ = ttBV.extract(width(Variable::sectorPhi) + width(Variable::sectorEta) + width(Variable::phiT) + width(Variable::inv2R) + width(Variable::zT) + width(Variable::cot));
+    trackId_ = ttBV.extract(width(Variable::sectorPhi) + width(Variable::sectorEta) + width(Variable::phiT) +
+                            width(Variable::inv2R) + width(Variable::zT) + width(Variable::cot));
   }
 
   // construct StubKFin from Frame
-  StubKFin::StubKFin(const FrameStub& frame, const DataFormats* formats, int layer) :
-    Stub(frame, formats, Process::kfin),
-    layer_(layer) {}
+  StubKFin::StubKFin(const FrameStub& frame, const DataFormats* formats, int layer)
+      : Stub(frame, formats, Process::kfin), layer_(layer) {}
 
   // construct StubKFin from StubZHT
-  StubKFin::StubKFin(const StubZHT& stub, double dPhi, double dZ, int layer) :
-    Stub(stub, stub.r(), stub.phi(), stub.z(), dPhi, dZ),
-    layer_(layer)
-  {
+  StubKFin::StubKFin(const StubZHT& stub, double dPhi, double dZ, int layer)
+      : Stub(stub, stub.r(), stub.phi(), stub.z(), dPhi, dZ), layer_(layer) {
     dataFormats_->convertStub(p_, data_, frame_.second);
   }
 
   // construct StubKFin from TTStubRef
-  StubKFin::StubKFin(const TTStubRef& ttStubRef, const DataFormats* dataFormats, double r, double phi, double z, double dPhi, double dZ, int layer) :
-    Stub(ttStubRef, dataFormats, Process::kfin, r, phi, z, dPhi, dZ),
-    layer_(layer)
-  {
+  StubKFin::StubKFin(const TTStubRef& ttStubRef,
+                     const DataFormats* dataFormats,
+                     double r,
+                     double phi,
+                     double z,
+                     double dPhi,
+                     double dZ,
+                     int layer)
+      : Stub(ttStubRef, dataFormats, Process::kfin, r, phi, z, dPhi, dZ), layer_(layer) {
     dataFormats_->convertStub(p_, data_, frame_.second);
   }
 
   // construct StubKF from Frame
-  StubKF::StubKF(const FrameStub& frame, const DataFormats* formats, int layer) :
-    Stub(frame, formats, Process::kf), layer_(layer) {}
+  StubKF::StubKF(const FrameStub& frame, const DataFormats* formats, int layer)
+      : Stub(frame, formats, Process::kf), layer_(layer) {}
 
   // construct StubKF from StubKFin
-  StubKF::StubKF(const StubKFin& stub, double inv2R, double phiT, double cot, double zT) :
-    Stub(stub, stub.r(), 0., 0., stub.dPhi(), stub.dZ()),
-    layer_(stub.layer())
-  {
+  StubKF::StubKF(const StubKFin& stub, double inv2R, double phiT, double cot, double zT)
+      : Stub(stub, stub.r(), 0., 0., stub.dPhi(), stub.dZ()), layer_(stub.layer()) {
     const Setup* setup = dataFormats_->setup();
     get<1>(data_) = format(Variable::phi).digi(stub.phi() - (phiT + this->r() * inv2R));
-    const double d = (dataFormats_->hybrid() ? setup->hybridChosenRofPhi() : setup->chosenRofPhi()) - setup->chosenRofZ();
+    const double d =
+        (dataFormats_->hybrid() ? setup->hybridChosenRofPhi() : setup->chosenRofPhi()) - setup->chosenRofZ();
     const double rz = format(Variable::r).digi(this->r() + d);
     get<2>(data_) = format(Variable::z).digi(stub.z() - (zT + rz * cot));
     dataFormats_->convertStub(p_, data_, frame_.second);
   }
 
   // construct Track from Frame
-  template<typename ...Ts>
-  Track<Ts...>::Track(const FrameTrack& frame, const DataFormats* dataFormats, Process p) :
-    dataFormats_(dataFormats),
-    p_(p),
-    frame_(frame)
-  {
+  template <typename... Ts>
+  Track<Ts...>::Track(const FrameTrack& frame, const DataFormats* dataFormats, Process p)
+      : dataFormats_(dataFormats), p_(p), frame_(frame) {
     dataFormats_->convertTrack(p_, frame.second, data_);
   }
 
   // construct Track from other Track
-  template<typename ...Ts>
-  template<typename ...Others>
-  Track<Ts...>::Track(const Track<Others...>& track, Ts... data) :
-    dataFormats_(track.dataFormats()),
-    p_(++track.p()),
-    frame_(track.frame().first, Frame()),
-    data_(data...) {}
+  template <typename... Ts>
+  template <typename... Others>
+  Track<Ts...>::Track(const Track<Others...>& track, Ts... data)
+      : dataFormats_(track.dataFormats()), p_(++track.p()), frame_(track.frame().first, Frame()), data_(data...) {}
 
   // construct Track from Stub
-  template<typename ...Ts>
-  template<typename ...Others>
-  Track<Ts...>::Track(const Stub<Others...>& stub, const TTTrackRef& ttTrackRef, Ts... data) :
-    dataFormats_(stub.dataFormats()),
-    p_(++stub.p()),
-    frame_(ttTrackRef, Frame()),
-    data_(data...) {}
+  template <typename... Ts>
+  template <typename... Others>
+  Track<Ts...>::Track(const Stub<Others...>& stub, const TTTrackRef& ttTrackRef, Ts... data)
+      : dataFormats_(stub.dataFormats()), p_(++stub.p()), frame_(ttTrackRef, Frame()), data_(data...) {}
 
   // construct Track from TTTrackRef
-  template<typename ...Ts>
-  Track<Ts...>::Track(const TTTrackRef& ttTrackRef, const DataFormats* dataFormats, Process p, Ts... data) :
-    dataFormats_(dataFormats),
-    p_(p),
-    frame_(ttTrackRef, Frame()),
-    data_(data...) {}
+  template <typename... Ts>
+  Track<Ts...>::Track(const TTTrackRef& ttTrackRef, const DataFormats* dataFormats, Process p, Ts... data)
+      : dataFormats_(dataFormats), p_(p), frame_(ttTrackRef, Frame()), data_(data...) {}
 
   // construct TrackKFin from Frame
-  TrackKFin::TrackKFin(const FrameTrack& frame, const DataFormats* dataFormats, const vector<StubKFin*>& stubs) :
-    Track(frame, dataFormats, Process::kfin),
-    stubs_(setup()->numLayers()),
-    hitPattern_(0, setup()->numLayers())
-  {
+  TrackKFin::TrackKFin(const FrameTrack& frame, const DataFormats* dataFormats, const vector<StubKFin*>& stubs)
+      : Track(frame, dataFormats, Process::kfin), stubs_(setup()->numLayers()), hitPattern_(0, setup()->numLayers()) {
     vector<int> nStubs(stubs_.size(), 0);
     for (StubKFin* stub : stubs)
       nStubs[stub->layer()]++;
@@ -415,11 +423,10 @@ namespace trackerTFP {
   }
 
   // construct TrackKFin from StubZHT
-  TrackKFin::TrackKFin(const StubZHT& stub, const TTTrackRef& ttTrackRef, const TTBV& maybePattern) :
-    Track(stub, ttTrackRef, maybePattern, stub.sectorPhi(), stub.sectorEta(), 0., 0., 0., 0.),
-    stubs_(setup()->numLayers()),
-    hitPattern_(0, setup()->numLayers())
-  {
+  TrackKFin::TrackKFin(const StubZHT& stub, const TTTrackRef& ttTrackRef, const TTBV& maybePattern)
+      : Track(stub, ttTrackRef, maybePattern, stub.sectorPhi(), stub.sectorEta(), 0., 0., 0., 0.),
+        stubs_(setup()->numLayers()),
+        hitPattern_(0, setup()->numLayers()) {
     get<3>(data_) = format(Variable::phiT, Process::mht).floating(stub.phiT());
     get<4>(data_) = format(Variable::inv2R, Process::mht).floating(stub.inv2R());
     get<5>(data_) = format(Variable::zT, Process::zht).floating(stub.zT());
@@ -428,11 +435,18 @@ namespace trackerTFP {
   }
 
   // construct TrackKFin from TTTrackRef
-  TrackKFin::TrackKFin(const TTTrackRef& ttTrackRef, const DataFormats* dataFormats, const TTBV& maybePattern, double phiT, double inv2R, double zT, double cot, int sectorPhi, int sectorEta) :
-    Track(ttTrackRef, dataFormats, Process::kfin, maybePattern, sectorPhi, sectorEta, phiT, inv2R, zT, cot),
-    stubs_(setup()->numLayers()),
-    hitPattern_(0, setup()->numLayers())
-  {
+  TrackKFin::TrackKFin(const TTTrackRef& ttTrackRef,
+                       const DataFormats* dataFormats,
+                       const TTBV& maybePattern,
+                       double phiT,
+                       double inv2R,
+                       double zT,
+                       double cot,
+                       int sectorPhi,
+                       int sectorEta)
+      : Track(ttTrackRef, dataFormats, Process::kfin, maybePattern, sectorPhi, sectorEta, phiT, inv2R, zT, cot),
+        stubs_(setup()->numLayers()),
+        hitPattern_(0, setup()->numLayers()) {
     dataFormats_->convertTrack(p_, data_, frame_.second);
   }
 
@@ -446,14 +460,14 @@ namespace trackerTFP {
   }
 
   // construct TrackKF from Frame
-  TrackKF::TrackKF(const FrameTrack& frame, const DataFormats* dataFormats) :
-    Track(frame, dataFormats, Process::kf) {}
+  TrackKF::TrackKF(const FrameTrack& frame, const DataFormats* dataFormats) : Track(frame, dataFormats, Process::kf) {}
 
   // construct TrackKF from TrackKfin
-  TrackKF::TrackKF(const TrackKFin& track, double phiT, double inv2R, double zT, double cot) :
-    Track(track, false, track.sectorPhi(), track.sectorEta(), track.phiT(), track.inv2R(), track.cot(), track.zT())
-  {
-    get<0>(data_) = abs(inv2R) < dataFormats_->format(Variable::inv2R, Process::zht).base() / 2. && abs(phiT) < dataFormats_->format(Variable::phiT, Process::zht).base() / 2.;
+  TrackKF::TrackKF(const TrackKFin& track, double phiT, double inv2R, double zT, double cot)
+      : Track(
+            track, false, track.sectorPhi(), track.sectorEta(), track.phiT(), track.inv2R(), track.cot(), track.zT()) {
+    get<0>(data_) = abs(inv2R) < dataFormats_->format(Variable::inv2R, Process::zht).base() / 2. &&
+                    abs(phiT) < dataFormats_->format(Variable::phiT, Process::zht).base() / 2.;
     get<3>(data_) += phiT;
     get<4>(data_) += inv2R;
     get<5>(data_) += cot;
@@ -464,7 +478,9 @@ namespace trackerTFP {
   // conversion to TTTrack with given stubs
   TTTrack<Ref_Phase2TrackerDigi_> TrackKF::ttTrack(const vector<StubKF>& stubs) const {
     const double invR = -this->inv2R() * 2.;
-    const double phi0 = deltaPhi(this->phiT() - this->inv2R() * dataFormats_->chosenRofPhi() + setup()->baseSector() * (this->sectorPhi() - .5) + setup()->baseRegion() * frame_.first->phiSector());
+    const double phi0 =
+        deltaPhi(this->phiT() - this->inv2R() * dataFormats_->chosenRofPhi() +
+                 setup()->baseSector() * (this->sectorPhi() - .5) + setup()->baseRegion() * frame_.first->phiSector());
     const double cot = this->cot() + setup()->sectorCot(this->sectorEta());
     const double z0 = this->zT() - this->cot() * setup()->chosenRofZ();
     TTBV hitVector(0, setup()->numLayers());
@@ -487,25 +503,24 @@ namespace trackerTFP {
     static constexpr double trkMVA3 = 0.;
     const int hitPattern = hitVector.val();
     const double bField = setup()->bField();
-    TTTrack<Ref_Phase2TrackerDigi_> ttTrack(invR, phi0, cot, z0, d0, chi2phi, chi2z, trkMVA1, trkMVA2, trkMVA3, hitPattern, nPar, bField);
+    TTTrack<Ref_Phase2TrackerDigi_> ttTrack(
+        invR, phi0, cot, z0, d0, chi2phi, chi2z, trkMVA1, trkMVA2, trkMVA3, hitPattern, nPar, bField);
     ttTrack.setStubRefs(ttStubRefs);
     ttTrack.setPhiSector(frame_.first->phiSector());
     ttTrack.setEtaSector(this->sectorEta());
     ttTrack.setTrackSeedType(frame_.first->trackSeedType());
-    ttTrack.setStubPtConsistency(
-        StubPtConsistency::getConsistency(ttTrack, setup()->trackerGeometry(), setup()->trackerTopology(), bField, nPar));
+    ttTrack.setStubPtConsistency(StubPtConsistency::getConsistency(
+        ttTrack, setup()->trackerGeometry(), setup()->trackerTopology(), bField, nPar));
     return ttTrack;
   }
 
   // construct TrackDR from Frame
-  TrackDR::TrackDR(const FrameTrack& frame, const DataFormats* dataFormats) :
-    Track(frame, dataFormats, Process::dr) {}
+  TrackDR::TrackDR(const FrameTrack& frame, const DataFormats* dataFormats) : Track(frame, dataFormats, Process::dr) {}
 
   // construct TrackDR from TrackKF
-  TrackDR::TrackDR(const TrackKF& track) :
-    Track(track, 0., 0., 0., 0.)
-  {
-    get<0>(data_) = track.phiT() + track.inv2R() * dataFormats_->chosenRofPhi() + dataFormats_->format(Variable::phi, Process::gp).range() * (track.sectorPhi() - .5);
+  TrackDR::TrackDR(const TrackKF& track) : Track(track, 0., 0., 0., 0.) {
+    get<0>(data_) = track.phiT() + track.inv2R() * dataFormats_->chosenRofPhi() +
+                    dataFormats_->format(Variable::phi, Process::gp).range() * (track.sectorPhi() - .5);
     get<1>(data_) = track.inv2R();
     get<2>(data_) = track.zT() - track.cot() * setup()->chosenRofZ();
     get<3>(data_) = track.cot() + setup()->sectorCot(track.sectorEta());
@@ -529,20 +544,21 @@ namespace trackerTFP {
     static constexpr double bField = 0.;
     const int sectorPhi = frame_.first->phiSector();
     const int sectorEta = frame_.first->etaSector();
-    TTTrack<Ref_Phase2TrackerDigi_> ttTrack(inv2R, phi0, cot, z0, d0, chi2phi, chi2z, trkMVA1, trkMVA2, trkMVA3, hitPattern, nPar, bField);
+    TTTrack<Ref_Phase2TrackerDigi_> ttTrack(
+        inv2R, phi0, cot, z0, d0, chi2phi, chi2z, trkMVA1, trkMVA2, trkMVA3, hitPattern, nPar, bField);
     ttTrack.setPhiSector(sectorPhi);
     ttTrack.setEtaSector(sectorEta);
     return ttTrack;
   }
 
-  template<>
+  template <>
   Format<Variable::phiT, Process::ht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     range_ = 2. * M_PI / (double)(setup->numRegions() * setup->numSectorsPhi());
     base_ = range_ / (double)setup->htNumBinsPhiT();
     width_ = ceil(log2(setup->htNumBinsPhiT()));
   }
 
-  template<>
+  template <>
   Format<Variable::phiT, Process::mht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::phiT, Process::ht> ht(iConfig, setup);
     range_ = ht.range();
@@ -550,7 +566,7 @@ namespace trackerTFP {
     width_ = ceil(log2(setup->htNumBinsPhiT() * setup->mhtNumBinsPhiT()));
   }
 
-  template<>
+  template <>
   Format<Variable::inv2R, Process::ht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const double mintPt = iConfig.getParameter<bool>("UseHybrid") ? setup->hybridMinPtCand() : setup->minPt();
     range_ = 2. * setup->invPtToDphi() / mintPt;
@@ -558,7 +574,7 @@ namespace trackerTFP {
     width_ = ceil(log2(setup->htNumBinsInv2R()));
   }
 
-  template<>
+  template <>
   Format<Variable::inv2R, Process::mht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::inv2R, Process::ht> ht(iConfig, setup);
     range_ = ht.range();
@@ -566,9 +582,10 @@ namespace trackerTFP {
     width_ = ceil(log2(setup->htNumBinsInv2R() * setup->mhtNumBinsInv2R()));
   }
 
-  template<>
+  template <>
   Format<Variable::r, Process::ht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
-    const double chosenRofPhi = iConfig.getParameter<bool>("UseHybrid") ? setup->hybridChosenRofPhi() : setup->chosenRofPhi();
+    const double chosenRofPhi =
+        iConfig.getParameter<bool>("UseHybrid") ? setup->hybridChosenRofPhi() : setup->chosenRofPhi();
     width_ = setup->tmttWidthR();
     range_ = 2. * max(abs(setup->outerRadius() - chosenRofPhi), abs(setup->innerRadius() - chosenRofPhi));
     const Format<Variable::phiT, Process::ht> phiT(iConfig, setup);
@@ -578,7 +595,7 @@ namespace trackerTFP {
     base_ *= pow(2., shift);
   }
 
-  template<>
+  template <>
   Format<Variable::phi, Process::gp>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::phiT, Process::ht> phiT(iConfig, setup);
     const Format<Variable::inv2R, Process::ht> inv2R(iConfig, setup);
@@ -589,7 +606,7 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
+  template <>
   Format<Variable::phi, Process::dtc>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     width_ = setup->tmttWidthPhi();
     const Format<Variable::phiT, Process::ht> phiT(iConfig, setup);
@@ -600,7 +617,7 @@ namespace trackerTFP {
     base_ = phiT.base() * pow(2., shift);
   }
 
-  template<>
+  template <>
   Format<Variable::phi, Process::ht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::phiT, Process::ht> phiT(iConfig, setup);
     range_ = 2. * phiT.base();
@@ -609,7 +626,7 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
+  template <>
   Format<Variable::phi, Process::mht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::phiT, Process::mht> phiT(iConfig, setup);
     range_ = 2. * phiT.base();
@@ -618,7 +635,7 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
+  template <>
   Format<Variable::phi, Process::kf>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::phi, Process::zht> phi(iConfig, setup);
     const double rangeFactor = iConfig.getParameter<ParameterSet>("KalmanFilter").getParameter<double>("RangeFactor");
@@ -627,7 +644,7 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
+  template <>
   Format<Variable::z, Process::dtc>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     width_ = setup->tmttWidthZ();
     range_ = 2. * setup->halfLength();
@@ -636,7 +653,7 @@ namespace trackerTFP {
     base_ = r.base() * pow(2., shift);
   }
 
-  template<>
+  template <>
   Format<Variable::z, Process::gp>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     range_ = setup->neededRangeChiZ();
     const Format<Variable::z, Process::dtc> dtc(iConfig, setup);
@@ -644,7 +661,7 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
+  template <>
   Format<Variable::zT, Process::zht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const int numBinsZT = iConfig.getParameter<ParameterSet>("ZHoughTransform").getParameter<int>("NumBinsZT");
     const int numStages = iConfig.getParameter<ParameterSet>("ZHoughTransform").getParameter<int>("NumStages");
@@ -658,7 +675,7 @@ namespace trackerTFP {
     base_ = z.base() * pow(2., shift);
   }
 
-  template<>
+  template <>
   Format<Variable::cot, Process::zht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const int numBinsCot = iConfig.getParameter<ParameterSet>("ZHoughTransform").getParameter<int>("NumBinsCot");
     const int numStages = iConfig.getParameter<ParameterSet>("ZHoughTransform").getParameter<int>("NumStages");
@@ -669,7 +686,7 @@ namespace trackerTFP {
     base_ = pow(2., shift);
   }
 
-  template<>
+  template <>
   Format<Variable::z, Process::zht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     /*const Format<Variable::zT, Process::zht> zT(iConfig, setup);
     const Format<Variable::cot, Process::zht> cot(iConfig, setup);
@@ -686,11 +703,12 @@ namespace trackerTFP {
     base_ = z.base();
   }
 
-  template<>
+  template <>
   Format<Variable::phi, Process::zht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::phiT, Process::mht> phiT(iConfig, setup);
     const Format<Variable::inv2R, Process::mht> inv2R(iConfig, setup);
-    const double chosenRofPhi = iConfig.getParameter<bool>("UseHybrid") ? setup->hybridChosenRofPhi() : setup->chosenRofPhi();
+    const double chosenRofPhi =
+        iConfig.getParameter<bool>("UseHybrid") ? setup->hybridChosenRofPhi() : setup->chosenRofPhi();
     const double rangeR = 2. * max(abs(setup->outerRadius() - chosenRofPhi), abs(setup->innerRadius() - chosenRofPhi));
     range_ = phiT.base() + inv2R.base() * rangeR + setup->maxdPhi();
     const Format<Variable::phi, Process::dtc> dtc(iConfig, setup);
@@ -698,7 +716,7 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
+  template <>
   Format<Variable::z, Process::kf>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     /*const Format<Variable::z, Process::zht> z(iConfig, setup);
     const double rangeFactor = iConfig.getParameter<ParameterSet>("KalmanFilter").getParameter<double>("RangeFactor");
@@ -707,7 +725,8 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));*/
     const Format<Variable::zT, Process::zht> zT(iConfig, setup);
     const Format<Variable::cot, Process::zht> cot(iConfig, setup);
-    const double rangeR = 2. * max(abs(setup->outerRadius() - setup->chosenRofZ()), abs(setup->innerRadius() - setup->chosenRofZ()));
+    const double rangeR =
+        2. * max(abs(setup->outerRadius() - setup->chosenRofZ()), abs(setup->innerRadius() - setup->chosenRofZ()));
     range_ = zT.base() + cot.base() * rangeR + setup->maxdZ();
     const Format<Variable::z, Process::dtc> dtc(iConfig, setup);
     base_ = dtc.base();
@@ -716,46 +735,52 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
+  template <>
   Format<Variable::layer, Process::ht>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(false) {
     range_ = setup->numLayers();
     width_ = ceil(log2(range_));
   }
 
-  template<>
-  Format<Variable::sectorEta, Process::gp>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(false) {
+  template <>
+  Format<Variable::sectorEta, Process::gp>::Format(const ParameterSet& iConfig, const Setup* setup)
+      : DataFormat(false) {
     range_ = setup->numSectorsEta();
     width_ = ceil(log2(range_));
   }
 
-  template<>
-  Format<Variable::sectorPhi, Process::gp>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(false) {
+  template <>
+  Format<Variable::sectorPhi, Process::gp>::Format(const ParameterSet& iConfig, const Setup* setup)
+      : DataFormat(false) {
     range_ = setup->numSectorsPhi();
     width_ = ceil(log2(range_));
   }
 
-  template<>
-  Format<Variable::sectorsPhi, Process::dtc>::Format(const ParameterSet& iConfig, const Setup* setup) : DataFormat(false) {
+  template <>
+  Format<Variable::sectorsPhi, Process::dtc>::Format(const ParameterSet& iConfig, const Setup* setup)
+      : DataFormat(false) {
     range_ = setup->numSectorsPhi();
     width_ = setup->numSectorsPhi();
   }
 
-  template<>
-  Format<Variable::match, Process::kf>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(false) {
+  template <>
+  Format<Variable::match, Process::kf>::Format(const edm::ParameterSet& iConfig, const Setup* setup)
+      : DataFormat(false) {
     width_ = 1;
     range_ = 1.;
   }
 
-  template<>
-  Format<Variable::hitPattern, Process::kfin>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(false) {
+  template <>
+  Format<Variable::hitPattern, Process::kfin>::Format(const edm::ParameterSet& iConfig, const Setup* setup)
+      : DataFormat(false) {
     width_ = setup->numLayers();
   }
 
-  template<>
+  template <>
   Format<Variable::phi0, Process::dr>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::inv2R, Process::ht> inv2R(iConfig, setup);
     const Format<Variable::phiT, Process::ht> phiT(iConfig, setup);
-    const double chosenRofPhi = iConfig.getParameter<bool>("UseHybrid") ? setup->hybridChosenRofPhi() : setup->chosenRofPhi();
+    const double chosenRofPhi =
+        iConfig.getParameter<bool>("UseHybrid") ? setup->hybridChosenRofPhi() : setup->chosenRofPhi();
     width_ = setup->tfpWidthPhi0();
     range_ = 2. * M_PI / (double)setup->numRegions() + inv2R.range() * chosenRofPhi;
     base_ = phiT.base();
@@ -763,8 +788,9 @@ namespace trackerTFP {
     base_ *= pow(2., shift);
   }
 
-  template<>
-  Format<Variable::inv2R, Process::dr>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
+  template <>
+  Format<Variable::inv2R, Process::dr>::Format(const edm::ParameterSet& iConfig, const Setup* setup)
+      : DataFormat(true) {
     const Format<Variable::inv2R, Process::ht> inv2R(iConfig, setup);
     width_ = setup->tfpWidthInv2R();
     range_ = inv2R.range();
@@ -773,7 +799,7 @@ namespace trackerTFP {
     base_ *= pow(2., shift);
   }
 
-  template<>
+  template <>
   Format<Variable::z0, Process::dr>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::zT, Process::zht> zT(iConfig, setup);
     width_ = setup->tfpWidthZ0();
@@ -783,7 +809,7 @@ namespace trackerTFP {
     base_ *= pow(2., shift);
   }
 
-  template<>
+  template <>
   Format<Variable::cot, Process::dr>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::cot, Process::zht> cot(iConfig, setup);
     width_ = setup->tfpWidthCot();
@@ -793,7 +819,7 @@ namespace trackerTFP {
     base_ *= pow(2., shift);
   }
 
-  template<>
+  template <>
   Format<Variable::phiT, Process::kf>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::phi0, Process::dr> phi0(iConfig, setup);
     const Format<Variable::phiT, Process::ht> phiT(iConfig, setup);
@@ -803,8 +829,9 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
-  Format<Variable::inv2R, Process::kf>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
+  template <>
+  Format<Variable::inv2R, Process::kf>::Format(const edm::ParameterSet& iConfig, const Setup* setup)
+      : DataFormat(true) {
     const Format<Variable::inv2R, Process::dr> dr(iConfig, setup);
     const Format<Variable::inv2R, Process::mht> mht(iConfig, setup);
     const double rangeFactor = iConfig.getParameter<ParameterSet>("KalmanFilter").getParameter<double>("RangeFactor");
@@ -813,7 +840,7 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
+  template <>
   Format<Variable::zT, Process::kf>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::z0, Process::dr> z0(iConfig, setup);
     const Format<Variable::zT, Process::zht> zT(iConfig, setup);
@@ -823,7 +850,7 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
+  template <>
   Format<Variable::cot, Process::kf>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(true) {
     const Format<Variable::cot, Process::dr> dr(iConfig, setup);
     const Format<Variable::cot, Process::zht> zht(iConfig, setup);
@@ -833,20 +860,22 @@ namespace trackerTFP {
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
-  Format<Variable::dPhi, Process::kfin>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(false) {
+  template <>
+  Format<Variable::dPhi, Process::kfin>::Format(const edm::ParameterSet& iConfig, const Setup* setup)
+      : DataFormat(false) {
     const Format<Variable::phi, Process::mht> phi(iConfig, setup);
     range_ = setup->maxdPhi();
     base_ = phi.base();
     width_ = ceil(log2(range_ / base_));
   }
 
-  template<>
-  Format<Variable::dZ, Process::kfin>::Format(const edm::ParameterSet& iConfig, const Setup* setup) : DataFormat(false) {
+  template <>
+  Format<Variable::dZ, Process::kfin>::Format(const edm::ParameterSet& iConfig, const Setup* setup)
+      : DataFormat(false) {
     const Format<Variable::z, Process::zht> z(iConfig, setup);
     range_ = setup->maxdZ();
     base_ = z.base();
     width_ = ceil(log2(range_ / base_));
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP

--- a/L1Trigger/TrackerTFP/src/Demonstrator.cc
+++ b/L1Trigger/TrackerTFP/src/Demonstrator.cc
@@ -11,16 +11,16 @@ using namespace tt;
 
 namespace trackerTFP {
 
-  Demonstrator::Demonstrator(const ParameterSet& iConfig, const Setup* setup) :
-    dirIPBB_(iConfig.getParameter<string>("DirIPBB")),
-    runTime_(iConfig.getParameter<double>("RunTime")),
-    dirIn_(dirIPBB_ + "in.txt"),
-    dirOut_(dirIPBB_ + "out.txt"),
-    dirPre_(dirIPBB_ + "pre.txt"),
-    dirDiff_(dirIPBB_ + "diff.txt"),
-    numFrames_(setup->numFramesIO()),
-    numFramesInfra_(setup->numFramesInfra()),
-    numRegions_(setup->numRegions()) {}
+  Demonstrator::Demonstrator(const ParameterSet& iConfig, const Setup* setup)
+      : dirIPBB_(iConfig.getParameter<string>("DirIPBB")),
+        runTime_(iConfig.getParameter<double>("RunTime")),
+        dirIn_(dirIPBB_ + "in.txt"),
+        dirOut_(dirIPBB_ + "out.txt"),
+        dirPre_(dirIPBB_ + "pre.txt"),
+        dirDiff_(dirIPBB_ + "diff.txt"),
+        numFrames_(setup->numFramesIO()),
+        numFramesInfra_(setup->numFramesInfra()),
+        numRegions_(setup->numRegions()) {}
 
   // plays input through modelsim and compares result with output
   void Demonstrator::analyze(const vector<vector<Frame>>& input, const vector<vector<Frame>>& output) const {
@@ -101,7 +101,6 @@ namespace trackerTFP {
       exception << "Bit error detected.";
       throw exception;
     }
-
   }
 
   // creates emp file header
@@ -127,7 +126,7 @@ namespace trackerTFP {
     for (int gap = 0; gap < numFramesInfra_; gap++) {
       ss << frame(nFrame);
       for (int link = 0; link < numLinks; link++)
-        ss << " 0v" << string(TTBV::S_ / 4, '0' );
+        ss << " 0v" << string(TTBV::S_ / 4, '0');
       ss << endl;
     }
     return ss.str();
@@ -147,4 +146,4 @@ namespace trackerTFP {
     return ss.str();
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP

--- a/L1Trigger/TrackerTFP/src/DistServer.cc
+++ b/L1Trigger/TrackerTFP/src/DistServer.cc
@@ -1,66 +1,61 @@
 #include "L1Trigger/TrackerTFP/interface/DistServer.h"
 #include "L1Trigger/TrackerTFP/interface/DataFormats.h"
 
-
 #include <algorithm>
-#include<iostream>
+#include <iostream>
 
 using namespace std;
 using namespace trackerTFP;
 
-DistServer::DistServer( unsigned int nInputs, unsigned int nOutputs, unsigned int nInterleaving ) : 
-    nInputs_(nInputs),
-    nOutputs_(nOutputs),
-    nInterleaving_(nInterleaving),
-    inputs_(nInputs_) {
-        for ( unsigned int iInput=0; iInput<this->nInputs(); ++iInput ) {
-            addr_.emplace_back(this->nInterleaving(),0);
-            for ( unsigned int iInterleave=0; iInterleave<this->nInterleaving(); ++iInterleave ) {
-                addr_[iInput][iInterleave] = iInterleave;
-            }
-        }
+DistServer::DistServer(unsigned int nInputs, unsigned int nOutputs, unsigned int nInterleaving)
+    : nInputs_(nInputs), nOutputs_(nOutputs), nInterleaving_(nInterleaving), inputs_(nInputs_) {
+  for (unsigned int iInput = 0; iInput < this->nInputs(); ++iInput) {
+    addr_.emplace_back(this->nInterleaving(), 0);
+    for (unsigned int iInterleave = 0; iInterleave < this->nInterleaving(); ++iInterleave) {
+      addr_[iInput][iInterleave] = iInterleave;
     }
+  }
+}
 
 TrackKFOutSAPtrCollection DistServer::clock(TrackKFOutSAPtrCollection& data) {
-    for ( unsigned int iInput=0; iInput<nInputs(); ++iInput ) {
-        if ( data[iInput]->dataValid() ) {
-            inputs()[iInput].push_back( data[iInput] );
-        }
+  for (unsigned int iInput = 0; iInput < nInputs(); ++iInput) {
+    if (data[iInput]->dataValid()) {
+      inputs()[iInput].push_back(data[iInput]);
     }
-    
-    vector< vector< bool > > lMap(nInputs(), vector<bool>(nOutputs()) );
+  }
 
-    TrackKFOutSAPtrCollection lInputs(nInputs(),std::make_shared<TrackKFOut>());
+  vector<vector<bool> > lMap(nInputs(), vector<bool>(nOutputs()));
 
-    std::vector< std::vector< unsigned int> >& addr = this->addr();
+  TrackKFOutSAPtrCollection lInputs(nInputs(), std::make_shared<TrackKFOut>());
 
-    for ( unsigned int iInput = 0; iInput<nInputs(); ++iInput ) {
-        unsigned int lAddr = addr[iInput][0];
-        if ( lAddr < inputs()[iInput].size() ) {
-            lInputs[iInput] = inputs()[iInput][lAddr];
-            lMap[iInput][ lInputs[iInput]->sortKey() ] = true;
-        }
+  std::vector<std::vector<unsigned int> >& addr = this->addr();
+
+  for (unsigned int iInput = 0; iInput < nInputs(); ++iInput) {
+    unsigned int lAddr = addr[iInput][0];
+    if (lAddr < inputs()[iInput].size()) {
+      lInputs[iInput] = inputs()[iInput][lAddr];
+      lMap[iInput][lInputs[iInput]->sortKey()] = true;
     }
-    
-    for ( unsigned int iInput = 0; iInput<nInputs(); ++iInput ) {
-        vector< unsigned int>& toRotate = addr[iInput];
-        rotate(toRotate.begin(),  toRotate.begin()+1, toRotate.end() );
+  }
+
+  for (unsigned int iInput = 0; iInput < nInputs(); ++iInput) {
+    vector<unsigned int>& toRotate = addr[iInput];
+    rotate(toRotate.begin(), toRotate.begin() + 1, toRotate.end());
+  }
+
+  TrackKFOutSAPtrCollection lOutputs(nOutputs(), std::make_shared<TrackKFOut>());
+
+  unsigned int nOutputs = 0;
+  for (unsigned int iOutput = 0; iOutput < lOutputs.size(); ++iOutput) {
+    for (unsigned int iInput = 0; iInput < nInputs(); ++iInput) {
+      if (lMap[iInput][iOutput]) {
+        lOutputs[iOutput] = lInputs[iInput];
+        addr[iInput].back() += this->nInterleaving();
+        nOutputs++;
+        break;
+      }
     }
+  }
 
-    TrackKFOutSAPtrCollection lOutputs(nOutputs(),std::make_shared<TrackKFOut>());
-
-    unsigned int nOutputs = 0;
-    for ( unsigned int iOutput = 0; iOutput<lOutputs.size(); ++iOutput ) {
-        for ( unsigned int iInput = 0; iInput<nInputs(); ++iInput ) {
-            if ( lMap[iInput][iOutput] ) {
-                lOutputs[iOutput] = lInputs[iInput];
-                addr[iInput].back() += this->nInterleaving();
-                nOutputs++;
-                break;
-            }
-        }
-    }
-
-
-    return lOutputs; 
+  return lOutputs;
 }

--- a/L1Trigger/TrackerTFP/src/GeometricProcessor.cc
+++ b/L1Trigger/TrackerTFP/src/GeometricProcessor.cc
@@ -12,16 +12,19 @@ using namespace tt;
 
 namespace trackerTFP {
 
-  GeometricProcessor::GeometricProcessor(const ParameterSet& iConfig, const Setup* setup, const DataFormats* dataFormats, int region) :
-    enableTruncation_(iConfig.getParameter<bool>("EnableTruncation")),
-    setup_(setup),
-    dataFormats_(dataFormats),
-    region_(region),
-    input_(dataFormats_->numChannel(Process::gp), vector<deque<StubPP*>>(dataFormats_->numChannel(Process::pp))) {}
+  GeometricProcessor::GeometricProcessor(const ParameterSet& iConfig,
+                                         const Setup* setup,
+                                         const DataFormats* dataFormats,
+                                         int region)
+      : enableTruncation_(iConfig.getParameter<bool>("EnableTruncation")),
+        setup_(setup),
+        dataFormats_(dataFormats),
+        region_(region),
+        input_(dataFormats_->numChannel(Process::gp), vector<deque<StubPP*>>(dataFormats_->numChannel(Process::pp))) {}
 
   // read in and organize input product (fill vector input_)
   void GeometricProcessor::consume(const TTDTC& ttDTC) {
-    auto validFrame = [](int& sum, const FrameStub& frame){ return sum += frame.first.isNonnull() ? 1 : 0; };
+    auto validFrame = [](int& sum, const FrameStub& frame) { return sum += frame.first.isNonnull() ? 1 : 0; };
     int nStubsPP(0);
     for (int channel = 0; channel < dataFormats_->numChannel(Process::pp); channel++) {
       const StreamStub& stream = ttDTC.stream(region_, channel);
@@ -41,11 +44,11 @@ namespace trackerTFP {
       }
     }
     // remove all gaps between end and last stub
-    for(vector<deque<StubPP*>>& input : input_)
-      for(deque<StubPP*>& stubs : input)
-        for(auto it = stubs.end(); it != stubs.begin();)
+    for (vector<deque<StubPP*>>& input : input_)
+      for (deque<StubPP*>& stubs : input)
+        for (auto it = stubs.end(); it != stubs.begin();)
           it = (*--it) ? stubs.begin() : stubs.erase(it);
-    auto validStub = [](int& sum, StubPP* stub){ return sum += stub ? 1 : 0; };
+    auto validStub = [](int& sum, StubPP* stub) { return sum += stub ? 1 : 0; };
     int nStubsGP(0);
     for (const vector<deque<StubPP*>>& sector : input_)
       for (const deque<StubPP*>& channel : sector)
@@ -60,15 +63,15 @@ namespace trackerTFP {
       vector<deque<StubGP*>> stacks(dataFormats_->numChannel(Process::pp));
       const int sectorPhi = sector % setup_->numSectorsPhi();
       const int sectorEta = sector / setup_->numSectorsPhi();
-      auto size =  [](int& sum, const deque<StubPP*>& stubs){ return sum += stubs.size(); };
+      auto size = [](int& sum, const deque<StubPP*>& stubs) { return sum += stubs.size(); };
       const int nStubs = accumulate(inputs.begin(), inputs.end(), 0, size);
       vector<StubGP*> acceptedSector;
       vector<StubGP*> lostSector;
       acceptedSector.reserve(nStubs);
       lostSector.reserve(nStubs);
       // clock accurate firmware emulation, each while trip describes one clock tick, one stub in and one stub out per tick
-      while(!all_of(inputs.begin(), inputs.end(), [](const deque<StubPP*>& stubs){ return stubs.empty(); }) or
-            !all_of(stacks.begin(), stacks.end(), [](const deque<StubGP*>& stubs){ return stubs.empty(); })) {
+      while (!all_of(inputs.begin(), inputs.end(), [](const deque<StubPP*>& stubs) { return stubs.empty(); }) or
+             !all_of(stacks.begin(), stacks.end(), [](const deque<StubGP*>& stubs) { return stubs.empty(); })) {
         // fill input fifos
         for (int channel = 0; channel < dataFormats_->numChannel(Process::pp); channel++) {
           deque<StubGP*>& stack = stacks[channel];
@@ -96,15 +99,15 @@ namespace trackerTFP {
       // truncate if desired
       if (enableTruncation_ && (int)acceptedSector.size() > setup_->numFrames()) {
         const auto limit = next(acceptedSector.begin(), setup_->numFrames());
-        copy_if(limit, acceptedSector.end(), back_inserter(lostSector), [](const StubGP* stub){ return stub; });
+        copy_if(limit, acceptedSector.end(), back_inserter(lostSector), [](const StubGP* stub) { return stub; });
         acceptedSector.erase(limit, acceptedSector.end());
       }
       // remove all gaps between end and last stub
-      for(auto it = acceptedSector.end(); it != acceptedSector.begin();)
+      for (auto it = acceptedSector.end(); it != acceptedSector.begin();)
         it = (*--it) ? acceptedSector.begin() : acceptedSector.erase(it);
       // fill products
       auto put = [](const vector<StubGP*>& stubs, StreamStub& stream) {
-        auto toFrame = [](StubGP* stub){ return stub ? stub->frame() : FrameStub(); };
+        auto toFrame = [](StubGP* stub) { return stub ? stub->frame() : FrameStub(); };
         stream.reserve(stubs.size());
         transform(stubs.begin(), stubs.end(), back_inserter(stream), toFrame);
       };
@@ -115,7 +118,7 @@ namespace trackerTFP {
   }
 
   // remove and return first element of deque, returns nullptr if empty
-  template<class T>
+  template <class T>
   T* GeometricProcessor::pop_front(deque<T*>& ts) const {
     T* t = nullptr;
     if (!ts.empty()) {
@@ -125,4 +128,4 @@ namespace trackerTFP {
     return t;
   }
 
-}
+}  // namespace trackerTFP

--- a/L1Trigger/TrackerTFP/src/KalmanFilter.cc
+++ b/L1Trigger/TrackerTFP/src/KalmanFilter.cc
@@ -15,55 +15,59 @@ using namespace tt;
 
 namespace trackerTFP {
 
-  KalmanFilter::KalmanFilter(const ParameterSet& iConfig, const Setup* setup, const DataFormats* dataFormats, KalmanFilterFormats* kalmanFilterFormats, int region) :
-    enableTruncation_(iConfig.getParameter<bool>("EnableTruncation")),
-    setup_(setup),
-    dataFormats_(dataFormats),
-    kalmanFilterFormats_(kalmanFilterFormats),
-    region_(region),
-    input_(dataFormats_->numChannel(Process::kf)),
-    layer_(0),
-    x0_(&kalmanFilterFormats_->format(VariableKF::x0)),
-    x1_(&kalmanFilterFormats_->format(VariableKF::x1)),
-    x2_(&kalmanFilterFormats_->format(VariableKF::x2)),
-    x3_(&kalmanFilterFormats_->format(VariableKF::x3)),
-    H00_(&kalmanFilterFormats_->format(VariableKF::H00)),
-    H12_(&kalmanFilterFormats_->format(VariableKF::H12)),
-    m0_(&kalmanFilterFormats_->format(VariableKF::m0)),
-    m1_(&kalmanFilterFormats_->format(VariableKF::m1)),
-    v0_(&kalmanFilterFormats_->format(VariableKF::v0)),
-    v1_(&kalmanFilterFormats_->format(VariableKF::v1)),
-    r0_(&kalmanFilterFormats_->format(VariableKF::r0)),
-    r1_(&kalmanFilterFormats_->format(VariableKF::r1)),
-    S00_(&kalmanFilterFormats_->format(VariableKF::S00)),
-    S01_(&kalmanFilterFormats_->format(VariableKF::S01)),
-    S12_(&kalmanFilterFormats_->format(VariableKF::S12)),
-    S13_(&kalmanFilterFormats_->format(VariableKF::S13)),
-    K00_(&kalmanFilterFormats_->format(VariableKF::K00)),
-    K10_(&kalmanFilterFormats_->format(VariableKF::K10)),
-    K21_(&kalmanFilterFormats_->format(VariableKF::K21)),
-    K31_(&kalmanFilterFormats_->format(VariableKF::K31)),
-    R00_(&kalmanFilterFormats_->format(VariableKF::R00)),
-    R11_(&kalmanFilterFormats_->format(VariableKF::R11)),
-    R00Rough_(&kalmanFilterFormats_->format(VariableKF::R00Rough)),
-    R11Rough_(&kalmanFilterFormats_->format(VariableKF::R11Rough)),
-    invR00Approx_(&kalmanFilterFormats_->format(VariableKF::invR00Approx)),
-    invR11Approx_(&kalmanFilterFormats_->format(VariableKF::invR11Approx)),
-    invR00Cor_(&kalmanFilterFormats_->format(VariableKF::invR00Cor)),
-    invR11Cor_(&kalmanFilterFormats_->format(VariableKF::invR11Cor)),
-    invR00_(&kalmanFilterFormats_->format(VariableKF::invR00)),
-    invR11_(&kalmanFilterFormats_->format(VariableKF::invR11)),
-    C00_(&kalmanFilterFormats_->format(VariableKF::C00)),
-    C01_(&kalmanFilterFormats_->format(VariableKF::C01)),
-    C11_(&kalmanFilterFormats_->format(VariableKF::C11)),
-    C22_(&kalmanFilterFormats_->format(VariableKF::C22)),
-    C23_(&kalmanFilterFormats_->format(VariableKF::C23)),
-    C33_(&kalmanFilterFormats_->format(VariableKF::C33)) {}
+  KalmanFilter::KalmanFilter(const ParameterSet& iConfig,
+                             const Setup* setup,
+                             const DataFormats* dataFormats,
+                             KalmanFilterFormats* kalmanFilterFormats,
+                             int region)
+      : enableTruncation_(iConfig.getParameter<bool>("EnableTruncation")),
+        setup_(setup),
+        dataFormats_(dataFormats),
+        kalmanFilterFormats_(kalmanFilterFormats),
+        region_(region),
+        input_(dataFormats_->numChannel(Process::kf)),
+        layer_(0),
+        x0_(&kalmanFilterFormats_->format(VariableKF::x0)),
+        x1_(&kalmanFilterFormats_->format(VariableKF::x1)),
+        x2_(&kalmanFilterFormats_->format(VariableKF::x2)),
+        x3_(&kalmanFilterFormats_->format(VariableKF::x3)),
+        H00_(&kalmanFilterFormats_->format(VariableKF::H00)),
+        H12_(&kalmanFilterFormats_->format(VariableKF::H12)),
+        m0_(&kalmanFilterFormats_->format(VariableKF::m0)),
+        m1_(&kalmanFilterFormats_->format(VariableKF::m1)),
+        v0_(&kalmanFilterFormats_->format(VariableKF::v0)),
+        v1_(&kalmanFilterFormats_->format(VariableKF::v1)),
+        r0_(&kalmanFilterFormats_->format(VariableKF::r0)),
+        r1_(&kalmanFilterFormats_->format(VariableKF::r1)),
+        S00_(&kalmanFilterFormats_->format(VariableKF::S00)),
+        S01_(&kalmanFilterFormats_->format(VariableKF::S01)),
+        S12_(&kalmanFilterFormats_->format(VariableKF::S12)),
+        S13_(&kalmanFilterFormats_->format(VariableKF::S13)),
+        K00_(&kalmanFilterFormats_->format(VariableKF::K00)),
+        K10_(&kalmanFilterFormats_->format(VariableKF::K10)),
+        K21_(&kalmanFilterFormats_->format(VariableKF::K21)),
+        K31_(&kalmanFilterFormats_->format(VariableKF::K31)),
+        R00_(&kalmanFilterFormats_->format(VariableKF::R00)),
+        R11_(&kalmanFilterFormats_->format(VariableKF::R11)),
+        R00Rough_(&kalmanFilterFormats_->format(VariableKF::R00Rough)),
+        R11Rough_(&kalmanFilterFormats_->format(VariableKF::R11Rough)),
+        invR00Approx_(&kalmanFilterFormats_->format(VariableKF::invR00Approx)),
+        invR11Approx_(&kalmanFilterFormats_->format(VariableKF::invR11Approx)),
+        invR00Cor_(&kalmanFilterFormats_->format(VariableKF::invR00Cor)),
+        invR11Cor_(&kalmanFilterFormats_->format(VariableKF::invR11Cor)),
+        invR00_(&kalmanFilterFormats_->format(VariableKF::invR00)),
+        invR11_(&kalmanFilterFormats_->format(VariableKF::invR11)),
+        C00_(&kalmanFilterFormats_->format(VariableKF::C00)),
+        C01_(&kalmanFilterFormats_->format(VariableKF::C01)),
+        C11_(&kalmanFilterFormats_->format(VariableKF::C11)),
+        C22_(&kalmanFilterFormats_->format(VariableKF::C22)),
+        C23_(&kalmanFilterFormats_->format(VariableKF::C23)),
+        C33_(&kalmanFilterFormats_->format(VariableKF::C33)) {}
 
   // read in and organize input product (fill vector input_)
   void KalmanFilter::consume(const StreamsTrack& streamsTrack, const StreamsStub& streamsStub) {
-    auto valid = [](const auto& frame){ return frame.first.isNonnull(); };
-    auto acc = [](int& sum, const auto& frame){ return sum += (frame.first.isNonnull() ? 1 : 0); };
+    auto valid = [](const auto& frame) { return frame.first.isNonnull(); };
+    auto acc = [](int& sum, const auto& frame) { return sum += (frame.first.isNonnull() ? 1 : 0); };
     int nTracks(0);
     int nStubs(0);
     const int offset = region_ * dataFormats_->numChannel(Process::kf);
@@ -116,8 +120,14 @@ namespace trackerTFP {
   }
 
   // fill output products
-  void KalmanFilter::produce(StreamsStub& acceptedStubs, StreamsTrack& acceptedTracks, StreamsStub& lostStubs, StreamsTrack& lostTracks, int& numAcceptedStates, int& numLostStates) {
-    auto put = [this](const deque<State*>& states, StreamsStub& streamsStubs, StreamsTrack& streamsTracks, int channel) {
+  void KalmanFilter::produce(StreamsStub& acceptedStubs,
+                             StreamsTrack& acceptedTracks,
+                             StreamsStub& lostStubs,
+                             StreamsTrack& lostTracks,
+                             int& numAcceptedStates,
+                             int& numLostStates) {
+    auto put = [this](
+                   const deque<State*>& states, StreamsStub& streamsStubs, StreamsTrack& streamsTracks, int channel) {
       const int streamId = region_ * dataFormats_->numChannel(Process::kf) + channel;
       const int offset = streamId * setup_->numLayers();
       StreamTrack& tracks = streamsTracks[streamId];
@@ -169,7 +179,11 @@ namespace trackerTFP {
       // storing of best states missed due to truncation
       sort(untruncatedStream.begin(), untruncatedStream.end());
       sort(truncatedStream.begin(), truncatedStream.end());
-      set_difference(untruncatedStream.begin(), untruncatedStream.end(), truncatedStream.begin(), truncatedStream.end(), back_inserter(lost));
+      set_difference(untruncatedStream.begin(),
+                     untruncatedStream.end(),
+                     truncatedStream.begin(),
+                     truncatedStream.end(),
+                     back_inserter(lost));
       // store found tracks
       put(stream, acceptedStubs, acceptedTracks, channel);
       // store lost tracks
@@ -193,7 +207,8 @@ namespace trackerTFP {
     vector<State*> delay(latency, nullptr);
     // each trip corresponds to a f/w clock tick
     // done if no states to process left, taking as much time as needed
-    while (!stream.empty() || !stack.empty() || !all_of(delay.begin(), delay.end(), [](const State* state){ return state == nullptr; })) {
+    while (!stream.empty() || !stack.empty() ||
+           !all_of(delay.begin(), delay.end(), [](const State* state) { return state == nullptr; })) {
       State* state = pop_front(stream);
       // Process a combinatoric state if no (non-combinatoric?) state available
       if (!state)
@@ -201,7 +216,7 @@ namespace trackerTFP {
       streamOutput.push_back(state);
       // The remainder of the code in this loop deals with combinatoric states.
       //if (!state || !state->stub() || state->layer() != layer_)
-        //state = nullptr;
+      //state = nullptr;
       if (state != nullptr)
         // Assign next combinatoric stub to state
         comb(state);
@@ -212,7 +227,7 @@ namespace trackerTFP {
     }
     stream = streamOutput;
     for (State*& state : stream) {
-      if (!state || !state->stub() || state->layer() != layer_ )
+      if (!state || !state->stub() || state->layer() != layer_)
         continue;
       // Update state with next stub using KF maths
       update(state);
@@ -242,7 +257,8 @@ namespace trackerTFP {
         if (hitPattern.count() == setup_->kfMaxLayers())
           valid = false;
         // Impossible for this state to ever get enough layers to form valid track
-        if (hitPattern.count() + track->hitPattern().count(stub->layer() + 1, setup_->numLayers()) < setup_->kfMinLayers())
+        if (hitPattern.count() + track->hitPattern().count(stub->layer() + 1, setup_->numLayers()) <
+            setup_->kfMinLayers())
           valid = false;
         if (layer_ == setup_->numLayers() - 1)
           valid = false;
@@ -269,7 +285,11 @@ namespace trackerTFP {
   void KalmanFilter::accumulator(deque<State*>& stream) {
     // accumulator delivers contigious stream of best state per track
     // remove gaps and not final states
-    stream.erase(remove_if(stream.begin(), stream.end(), [this](State* state){ return !state || state->hitPattern().count() < setup_->kfMinLayers(); }), stream.end());
+    stream.erase(
+        remove_if(stream.begin(),
+                  stream.end(),
+                  [this](State* state) { return !state || state->hitPattern().count() < setup_->kfMinLayers(); }),
+        stream.end());
     // Determine quality of completed state
     for (State* state : stream)
       state->finish();
@@ -277,12 +297,16 @@ namespace trackerTFP {
     auto lessSkippedLayers = [](State* lhs, State* rhs) { return lhs->numSkippedLayers() < rhs->numSkippedLayers(); };
     stable_sort(stream.begin(), stream.end(), lessSkippedLayers);
     // sort in number of consistent stubs
-    auto moreConsistentLayers = [](State* lhs, State* rhs) { return lhs->numConsistentLayers() > rhs->numConsistentLayers(); };
+    auto moreConsistentLayers = [](State* lhs, State* rhs) {
+      return lhs->numConsistentLayers() > rhs->numConsistentLayers();
+    };
     stable_sort(stream.begin(), stream.end(), moreConsistentLayers);
     // sort in track id
-    stable_sort(stream.begin(), stream.end(), [](State* lhs, State* rhs){ return lhs->trackId() < rhs->trackId(); });
+    stable_sort(stream.begin(), stream.end(), [](State* lhs, State* rhs) { return lhs->trackId() < rhs->trackId(); });
     // keep first state (best due to previous sorts) per track id
-    stream.erase(unique(stream.begin(), stream.end(), [](State* lhs, State* rhs){ return lhs->track() == rhs->track(); }), stream.end());
+    stream.erase(
+        unique(stream.begin(), stream.end(), [](State* lhs, State* rhs) { return lhs->track() == rhs->track(); }),
+        stream.end());
   }
 
   // updates state
@@ -319,11 +343,11 @@ namespace trackerTFP {
     const double r0C = x1_->digi(m0 - x1);
     const double r0 = r0_->digi(r0C - x0 * H00);
     // stub z residual wrt current state
-    const double r1C = x3_->digi(m1  - x3);
+    const double r1C = x3_->digi(m1 - x3);
     const double r1 = r1_->digi(r1C - x2 * H12);
     // matrix S = H*C
-    const double S00 = S00_->digi(C01  + H00 * C00);
-    const double S01 = S01_->digi(C11  + H00 * C01);
+    const double S00 = S00_->digi(C01 + H00 * C00);
+    const double S01 = S01_->digi(C11 + H00 * C01);
     const double S12 = S12_->digi(C23 + H12 * C22);
     const double S13 = S13_->digi(C33 + H12 * C23);
     // Cov. matrix of predicted residuals R = V+HCHt = C+H*St
@@ -401,7 +425,7 @@ namespace trackerTFP {
   }
 
   // remove and return first element of deque, returns nullptr if empty
-  template<class T>
+  template <class T>
   T* KalmanFilter::pop_front(deque<T*>& ts) const {
     T* t = nullptr;
     if (!ts.empty()) {
@@ -412,7 +436,7 @@ namespace trackerTFP {
   }
 
   // remove and return first element of vector, returns nullptr if empty
-  template<class T>
+  template <class T>
   T* KalmanFilter::pop_front(vector<T*>& ts) const {
     T* t = nullptr;
     if (!ts.empty()) {
@@ -422,4 +446,4 @@ namespace trackerTFP {
     return t;
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP

--- a/L1Trigger/TrackerTFP/src/State.cc
+++ b/L1Trigger/TrackerTFP/src/State.cc
@@ -6,68 +6,64 @@ using namespace tt;
 namespace trackerTFP {
 
   // default constructor
-  State::State(State* state) :
-    dataFormats_(state->dataFormats_),
-    setup_(state->setup_),
-    track_(state->track_),
-    trackId_(state->trackId_),
-    parent_(state->parent_),
-    stub_(state->stub_),
-    layerMap_(state->layerMap_),
-    hitPattern_(state->hitPattern_),
-    x0_(state->x0_),
-    x1_(state->x1_),
-    x2_(state->x2_),
-    x3_(state->x3_),
-    C00_(state->C00_),
-    C01_(state->C01_),
-    C11_(state->C11_),
-    C22_(state->C22_),
-    C23_(state->C23_),
-    C33_(state->C33_),
-    numSkippedLayers_(state->numSkippedLayers_),
-    numConsistentLayers_(state->numConsistentLayers_)
-  {}
+  State::State(State* state)
+      : dataFormats_(state->dataFormats_),
+        setup_(state->setup_),
+        track_(state->track_),
+        trackId_(state->trackId_),
+        parent_(state->parent_),
+        stub_(state->stub_),
+        layerMap_(state->layerMap_),
+        hitPattern_(state->hitPattern_),
+        x0_(state->x0_),
+        x1_(state->x1_),
+        x2_(state->x2_),
+        x3_(state->x3_),
+        C00_(state->C00_),
+        C01_(state->C01_),
+        C11_(state->C11_),
+        C22_(state->C22_),
+        C23_(state->C23_),
+        C33_(state->C33_),
+        numSkippedLayers_(state->numSkippedLayers_),
+        numConsistentLayers_(state->numConsistentLayers_) {}
 
   // proto state constructor
-  State::State(const DataFormats* dataFormats, TrackKFin* track, int trackId) :
-    dataFormats_(dataFormats),
-    setup_(dataFormats->setup()),
-    track_(track),
-    trackId_(trackId),
-    parent_(nullptr),
-    stub_(nullptr),
-    layerMap_(setup_->numLayers()),
-    hitPattern_(0, setup_->numLayers()),
-    numSkippedLayers_(0),
-    numConsistentLayers_(0)
-  {
+  State::State(const DataFormats* dataFormats, TrackKFin* track, int trackId)
+      : dataFormats_(dataFormats),
+        setup_(dataFormats->setup()),
+        track_(track),
+        trackId_(trackId),
+        parent_(nullptr),
+        stub_(nullptr),
+        layerMap_(setup_->numLayers()),
+        hitPattern_(0, setup_->numLayers()),
+        numSkippedLayers_(0),
+        numConsistentLayers_(0) {
     // initial track parameter residuals w.r.t. found track
     x0_ = 0.;
     x1_ = 0.;
     x2_ = 0.;
     x3_ = 0.;
     // initial uncertainties
-    C00_  = pow(dataFormats_->base(Variable::inv2R, Process::zht), 2);
-    C11_  = pow(dataFormats_->base(Variable::phiT, Process::zht), 2);
-    C22_  = pow(dataFormats_->base(Variable::cot, Process::zht), 2);
-    C33_  = pow(dataFormats_->base(Variable::zT, Process::zht), 2);
-    C01_  = 0.;
-    C23_  = 0.;
+    C00_ = pow(dataFormats_->base(Variable::inv2R, Process::zht), 2);
+    C11_ = pow(dataFormats_->base(Variable::phiT, Process::zht), 2);
+    C22_ = pow(dataFormats_->base(Variable::cot, Process::zht), 2);
+    C33_ = pow(dataFormats_->base(Variable::zT, Process::zht), 2);
+    C01_ = 0.;
+    C23_ = 0.;
     // first stub from first layer on input track with stubs
     stub_ = track->layerStub(track->hitPattern().plEncode());
   }
 
   // combinatoric state constructor
-  State::State(State* state, StubKFin* stub) : State(state)
-  {
+  State::State(State* state, StubKFin* stub) : State(state) {
     parent_ = state->parent();
     stub_ = stub;
   }
 
   // updated state constructor
-  State::State(State* state, const std::vector<double>& doubles) : State(state)
-  {
+  State::State(State* state, const std::vector<double>& doubles) : State(state) {
     parent_ = state;
     // updated track parameter and uncertainties
     x0_ = doubles[0];
@@ -113,10 +109,12 @@ namespace trackerTFP {
   void State::finish() {
     const vector<StubKF> stubs = this->stubs();
     auto consistent = [this](int& sum, const StubKF& stub) {
-      auto inConsistentRange = [](float v, float r, float d){ return abs(v) <= (r + d) / 2.; };
+      auto inConsistentRange = [](float v, float r, float d) { return abs(v) <= (r + d) / 2.; };
       // Check stub consistent with helix, allowing for stub & digi uncertainty
-      const bool inRange0 = inConsistentRange(stub.phi(), stub.dPhi(), dataFormats_->format(Variable::dPhi, Process::kf).base());
-      const bool inRange1 = inConsistentRange(stub.z(), stub.dZ(), dataFormats_->format(Variable::dZ, Process::kf).base());
+      const bool inRange0 =
+          inConsistentRange(stub.phi(), stub.dPhi(), dataFormats_->format(Variable::dPhi, Process::kf).base());
+      const bool inRange1 =
+          inConsistentRange(stub.z(), stub.dZ(), dataFormats_->format(Variable::dZ, Process::kf).base());
       return sum += (inRange0 && inRange1 ? 1 : 0);
     };
     numConsistentLayers_ = accumulate(stubs.begin(), stubs.end(), 0, consistent);
@@ -126,4 +124,4 @@ namespace trackerTFP {
     numSkippedLayers_ = pattern.count(0, hitPattern_.pmEncode(), false);
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP

--- a/L1Trigger/TrackerTFP/test/AnalyzerDemonstrator.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerDemonstrator.cc
@@ -36,9 +36,12 @@ namespace trackerTFP {
 
   private:
     //
-    void convert(const Event& iEvent, const EDGetTokenT<StreamsTrack>& tokenTracks, const EDGetTokenT<StreamsStub>& tokenStubs, vector<vector<Frame>>& bits) const;
+    void convert(const Event& iEvent,
+                 const EDGetTokenT<StreamsTrack>& tokenTracks,
+                 const EDGetTokenT<StreamsStub>& tokenStubs,
+                 vector<vector<Frame>>& bits) const;
     //
-    template<typename T>
+    template <typename T>
     void convert(const T& collection, vector<vector<Frame>>& bits) const;
     // ED input token of Tracks
     EDGetTokenT<StreamsStub> edGetTokenStubsIn_;
@@ -66,9 +69,11 @@ namespace trackerTFP {
     edGetTokenStubsIn_ = consumes<StreamsStub>(InputTag(labelIn, branchStubs));
     if (labelOut != "TrackFindingTrackletProducerKFout")
       edGetTokenStubsOut_ = consumes<StreamsStub>(InputTag(labelOut, branchStubs));
-    if (labelIn == "TrackerTFPProducerKFin" || labelIn == "TrackerTFPProducerKF" || labelIn == "TrackFindingTrackletProducerKFin" || labelIn == "TrackFindingTrackletProducerKF")
+    if (labelIn == "TrackerTFPProducerKFin" || labelIn == "TrackerTFPProducerKF" ||
+        labelIn == "TrackFindingTrackletProducerKFin" || labelIn == "TrackFindingTrackletProducerKF")
       edGetTokenTracksIn_ = consumes<StreamsTrack>(InputTag(labelIn, branchTracks));
-    if (labelOut == "TrackerTFPProducerKF" || labelOut == "TrackerTFPProducerDR" || labelOut == "TrackFindingTrackletProducerKF" || labelOut == "TrackFindingTrackletProducerKFout")
+    if (labelOut == "TrackerTFPProducerKF" || labelOut == "TrackerTFPProducerDR" ||
+        labelOut == "TrackFindingTrackletProducerKF" || labelOut == "TrackFindingTrackletProducerKFout")
       edGetTokenTracksOut_ = consumes<StreamsTrack>(InputTag(labelOut, branchTracks));
     // book ES products
     esGetTokenSetup_ = esConsumes<Setup, SetupRcd, Transition::BeginRun>();
@@ -94,13 +99,16 @@ namespace trackerTFP {
   }
 
   //
-  void AnalyzerDemonstrator::convert(const Event& iEvent, const EDGetTokenT<StreamsTrack>& tokenTracks, const EDGetTokenT<StreamsStub>& tokenStubs, vector<vector<Frame>>& bits) const {
+  void AnalyzerDemonstrator::convert(const Event& iEvent,
+                                     const EDGetTokenT<StreamsTrack>& tokenTracks,
+                                     const EDGetTokenT<StreamsStub>& tokenStubs,
+                                     vector<vector<Frame>>& bits) const {
     const bool tracks = !tokenTracks.isUninitialized();
     const bool stubs = !tokenStubs.isUninitialized();
     Handle<StreamsStub> handleStubs;
     Handle<StreamsTrack> handleTracks;
     int numChannelStubs(0);
-    if (stubs){
+    if (stubs) {
       iEvent.getByToken<StreamsStub>(tokenStubs, handleStubs);
       numChannelStubs = handleStubs->size();
     }
@@ -118,7 +126,7 @@ namespace trackerTFP {
         const int offsetStubs = (region * numChannelTracks + channelTracks) * numChannelStubs;
         if (tracks)
           convert(handleTracks->at(offsetTracks + channelTracks), bits);
-        if (stubs){
+        if (stubs) {
           for (int channelStubs = 0; channelStubs < numChannelStubs; channelStubs++)
             convert(handleStubs->at(offsetStubs + channelStubs), bits);
         }
@@ -126,14 +134,13 @@ namespace trackerTFP {
     }
   }
 
-
   //
-  template<typename T>
+  template <typename T>
   void AnalyzerDemonstrator::convert(const T& collection, vector<vector<Frame>>& bits) const {
     bits.emplace_back();
     vector<Frame>& bvs = bits.back();
     bvs.reserve(collection.size());
-    transform(collection.begin(), collection.end(), back_inserter(bvs), [](const auto& frame){ return frame.second; });
+    transform(collection.begin(), collection.end(), back_inserter(bvs), [](const auto& frame) { return frame.second; });
   }
 
 }  // namespace trackerTFP

--- a/L1Trigger/TrackerTFP/test/AnalyzerGP.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerGP.cc
@@ -69,7 +69,8 @@ namespace trackerTFP {
     stringstream log_;
   };
 
-  AnalyzerGP::AnalyzerGP(const ParameterSet& iConfig) : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
+  AnalyzerGP::AnalyzerGP(const ParameterSet& iConfig)
+      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
     usesResource("TFileService");
     // book in- and output ED products
     const string& label = iConfig.getParameter<string>("LabelGP");
@@ -179,7 +180,8 @@ namespace trackerTFP {
     const int wErrs = ceil(log10(*max_element(errs.begin(), errs.end()))) + 5;
     log_ << "                         GP  SUMMARY                         " << endl;
     log_ << "number of stubs      per TFP = " << setw(wNums) << numStubs << " +- " << setw(wErrs) << errStubs << endl;
-    log_ << "number of lost stubs per TFP = " << setw(wNums) << numStubsLost << " +- " << setw(wErrs) << errStubsLost << endl;
+    log_ << "number of lost stubs per TFP = " << setw(wNums) << numStubsLost << " +- " << setw(wErrs) << errStubsLost
+         << endl;
     log_ << "     max tracking efficiency = " << setw(wNums) << eff << " +- " << setw(wErrs) << errEff << endl;
     log_ << "=============================================================";
     LogPrint("L1Trigger/TrackerTFP") << log_.str();

--- a/L1Trigger/TrackerTFP/test/AnalyzerHT.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerHT.cc
@@ -83,7 +83,8 @@ namespace trackerTFP {
     stringstream log_;
   };
 
-  AnalyzerHT::AnalyzerHT(const ParameterSet& iConfig) : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
+  AnalyzerHT::AnalyzerHT(const ParameterSet& iConfig)
+      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
     usesResource("TFileService");
     // book in- and output ED products
     const string& label = iConfig.getParameter<string>("LabelHT");
@@ -190,7 +191,7 @@ namespace trackerTFP {
     vector<TPPtr> recovered;
     recovered.reserve(tpPtrsLost.size());
     set_intersection(tpPtrsLost.begin(), tpPtrsLost.end(), tpPtrs.begin(), tpPtrs.end(), back_inserter(recovered));
-    for(const TPPtr& tpPtr : recovered)
+    for (const TPPtr& tpPtr : recovered)
       tpPtrsLost.erase(tpPtr);
     prof_->Fill(4, allMatched);
     prof_->Fill(5, allTracks);
@@ -228,8 +229,10 @@ namespace trackerTFP {
     const int wErrs = ceil(log10(*max_element(errs.begin(), errs.end()))) + 5;
     log_ << "                         HT  SUMMARY                         " << endl;
     log_ << "number of stubs       per TFP = " << setw(wNums) << numStubs << " +- " << setw(wErrs) << errStubs << endl;
-    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks << endl;
-    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost << endl;
+    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks
+         << endl;
+    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost
+         << endl;
     log_ << "     max  tracking efficiency = " << setw(wNums) << eff << " +- " << setw(wErrs) << errEff << endl;
     log_ << "     lost tracking efficiency = " << setw(wNums) << effLoss << " +- " << setw(wErrs) << errEffLoss << endl;
     log_ << "                    fake rate = " << setw(wNums) << fracFake << endl;
@@ -247,17 +250,20 @@ namespace trackerTFP {
     for (auto it = stubs.begin(); it != stubs.end();) {
       const auto start = it;
       const int id = it->trackId();
-      auto different = [id](const StubHT& stub){ return id != stub.trackId(); };
+      auto different = [id](const StubHT& stub) { return id != stub.trackId(); };
       it = find_if(it, stubs.end(), different);
       vector<TTStubRef> ttStubRefs;
       ttStubRefs.reserve(distance(start, it));
-      transform(start, it, back_inserter(ttStubRefs), [](const StubHT& stub){ return stub.ttStubRef(); });
+      transform(start, it, back_inserter(ttStubRefs), [](const StubHT& stub) { return stub.ttStubRef(); });
       tracks.push_back(ttStubRefs);
     }
   }
 
   //
-  void AnalyzerHT::associate(const vector<vector<TTStubRef>>& tracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum) const {
+  void AnalyzerHT::associate(const vector<vector<TTStubRef>>& tracks,
+                             const StubAssociation* ass,
+                             set<TPPtr>& tps,
+                             int& sum) const {
     for (const vector<TTStubRef>& ttStubRefs : tracks) {
       const vector<TPPtr>& tpPtrs = ass->associate(ttStubRefs);
       if (tpPtrs.empty())

--- a/L1Trigger/TrackerTFP/test/AnalyzerKF.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerKF.cc
@@ -51,7 +51,12 @@ namespace trackerTFP {
 
   private:
     //
-    void associate(const TTTracks& ttTracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum, const vector<TH1F*>& his, TProfile* prof) const;
+    void associate(const TTTracks& ttTracks,
+                   const StubAssociation* ass,
+                   set<TPPtr>& tps,
+                   int& sum,
+                   const vector<TH1F*>& his,
+                   TProfile* prof) const;
 
     // ED input token of accepted Tracks
     EDGetTokenT<StreamsStub> edGetTokenAcceptedStubs_;
@@ -106,11 +111,8 @@ namespace trackerTFP {
     stringstream log_;
   };
 
-  AnalyzerKF::AnalyzerKF(const ParameterSet& iConfig) :
-    useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")),
-    nEvents_(0),
-    hisRes_(4)
-  {
+  AnalyzerKF::AnalyzerKF(const ParameterSet& iConfig)
+      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0), hisRes_(4) {
     usesResource("TFileService");
     // book in- and output ED products
     const string& label = iConfig.getParameter<string>("LabelKF");
@@ -122,8 +124,10 @@ namespace trackerTFP {
     edGetTokenAcceptedTracks_ = consumes<StreamsTrack>(InputTag(label, branchAcceptedTracks));
     edGetTokenLostStubs_ = consumes<StreamsStub>(InputTag(label, branchLostStubs));
     edGetTokenLostTracks_ = consumes<StreamsTrack>(InputTag(label, branchLostTracks));
-    edGetTokenNumAcceptedStates_ = consumes<int>(InputTag(label, branchAcceptedTracks));;
-    edGetTokenNumLostStates_ = consumes<int>(InputTag(label, branchLostTracks));;
+    edGetTokenNumAcceptedStates_ = consumes<int>(InputTag(label, branchAcceptedTracks));
+    ;
+    edGetTokenNumLostStates_ = consumes<int>(InputTag(label, branchLostTracks));
+    ;
     if (useMCTruth_) {
       const auto& inputTagSelecttion = iConfig.getParameter<InputTag>("InputTagSelection");
       const auto& inputTagReconstructable = iConfig.getParameter<InputTag>("InputTagReconstructable");
@@ -258,15 +262,21 @@ namespace trackerTFP {
         hisChannel_->Fill(accepted.size());
         profChannel_->Fill(channel, accepted.size());
         TTTracks tracks;
-        const int nTracks = accumulate(accepted.begin(), accepted.end(), 0, [](int& sum, const FrameTrack& frame){ return sum += frame.first.isNonnull() ? 1 : 0; });
+        const int nTracks = accumulate(accepted.begin(), accepted.end(), 0, [](int& sum, const FrameTrack& frame) {
+          return sum += frame.first.isNonnull() ? 1 : 0;
+        });
         nTracksRegion += nTracks;
         tracks.reserve(nTracks);
         consume(accepted, acceptedStubs, index, tracks);
         for (const TTTrack<Ref_Phase2TrackerDigi_>& ttTrack : tracks)
           hisPhi_->Fill(ttTrack.momentum().phi());
-        nStubsRegion += accumulate(tracks.begin(), tracks.end(), 0, [](int& sum, const auto& ttTrack){ return sum += (int)ttTrack.getStubRefs().size(); });
+        nStubsRegion += accumulate(tracks.begin(), tracks.end(), 0, [](int& sum, const auto& ttTrack) {
+          return sum += (int)ttTrack.getStubRefs().size();
+        });
         TTTracks tracksLost;
-        const int nLost = accumulate(lost.begin(), lost.end(), 0, [](int& sum, const FrameTrack& frame){ return sum += frame.first.isNonnull() ? 1 : 0; });
+        const int nLost = accumulate(lost.begin(), lost.end(), 0, [](int& sum, const FrameTrack& frame) {
+          return sum += frame.first.isNonnull() ? 1 : 0;
+        });
         nLostRegion += nLost;
         tracksLost.reserve(nLost);
         consume(lost, lostStubs, index, tracksLost);
@@ -301,9 +311,9 @@ namespace trackerTFP {
       return;
     // effi
     effEta_->SetPassedHistogram(*hisEffEta_, "f");
-    effEta_->SetTotalHistogram (*hisEffEtaTotal_, "f");
+    effEta_->SetTotalHistogram(*hisEffEtaTotal_, "f");
     effInv2R_->SetPassedHistogram(*hisEffInv2R_, "f");
-    effInv2R_->SetTotalHistogram (*hisEffInv2RTotal_, "f");
+    effInv2R_->SetTotalHistogram(*hisEffInv2RTotal_, "f");
     // printout SF summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
@@ -332,8 +342,10 @@ namespace trackerTFP {
     const int wErrs = ceil(log10(*max_element(errs.begin(), errs.end()))) + 5;
     log_ << "                         KF  SUMMARY                         " << endl;
     log_ << "number of stubs       per TFP = " << setw(wNums) << numStubs << " +- " << setw(wErrs) << errStubs << endl;
-    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks << endl;
-    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost << endl;
+    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks
+         << endl;
+    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost
+         << endl;
     log_ << "          tracking efficiency = " << setw(wNums) << eff << " +- " << setw(wErrs) << errEff << endl;
     log_ << "     lost tracking efficiency = " << setw(wNums) << effLoss << " +- " << setw(wErrs) << errEffLoss << endl;
     log_ << "                    fake rate = " << setw(wNums) << fracFake << endl;
@@ -344,7 +356,12 @@ namespace trackerTFP {
   }
 
   //
-  void AnalyzerKF::associate(const TTTracks& ttTracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum, const vector<TH1F*>& his, TProfile* prof) const {
+  void AnalyzerKF::associate(const TTTracks& ttTracks,
+                             const StubAssociation* ass,
+                             set<TPPtr>& tps,
+                             int& sum,
+                             const vector<TH1F*>& his,
+                             TProfile* prof) const {
     for (const TTTrack<Ref_Phase2TrackerDigi_>& ttTrack : ttTracks) {
       const vector<TTStubRef>& ttStubRefs = ttTrack.getStubRefs();
       const vector<TPPtr>& tpPtrs = ass->associateFinal(ttStubRefs);

--- a/L1Trigger/TrackerTFP/test/AnalyzerKFin.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerKFin.cc
@@ -49,7 +49,10 @@ namespace trackerTFP {
 
   private:
     //
-    void formTracks(const StreamsTrack& streamsTrack, const StreamsStub& streamsStubs, vector<vector<TTStubRef>>& tracks, int channel) const;
+    void formTracks(const StreamsTrack& streamsTrack,
+                    const StreamsStub& streamsStubs,
+                    vector<vector<TTStubRef>>& tracks,
+                    int channel) const;
     //
     void associate(const vector<vector<TTStubRef>>& tracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum) const;
 
@@ -88,7 +91,8 @@ namespace trackerTFP {
     stringstream log_;
   };
 
-  AnalyzerKFin::AnalyzerKFin(const ParameterSet& iConfig) : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
+  AnalyzerKFin::AnalyzerKFin(const ParameterSet& iConfig)
+      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
     usesResource("TFileService");
     // book in- and output ED products
     const string& label = iConfig.getParameter<string>("LabelKFin");
@@ -186,7 +190,9 @@ namespace trackerTFP {
         vector<vector<TTStubRef>> lost;
         formTracks(lostTracks, lostStubs, lost, offset + channel);
         nTracks += tracks.size();
-        nStubs += accumulate(tracks.begin(), tracks.end(), 0, [](int& sum, const vector<TTStubRef>& track){ return sum += (int)track.size(); });
+        nStubs += accumulate(tracks.begin(), tracks.end(), 0, [](int& sum, const vector<TTStubRef>& track) {
+          return sum += (int)track.size();
+        });
         nLost += lost.size();
         allTracks += tracks.size();
         if (!useMCTruth_)
@@ -203,7 +209,7 @@ namespace trackerTFP {
     vector<TPPtr> recovered;
     recovered.reserve(tpPtrsLost.size());
     set_intersection(tpPtrsLost.begin(), tpPtrsLost.end(), tpPtrs.begin(), tpPtrs.end(), back_inserter(recovered));
-    for(const TPPtr& tpPtr : recovered)
+    for (const TPPtr& tpPtr : recovered)
       tpPtrsLost.erase(tpPtr);
     prof_->Fill(4, allMatched);
     prof_->Fill(5, allTracks);
@@ -241,8 +247,10 @@ namespace trackerTFP {
     const int wErrs = ceil(log10(*max_element(errs.begin(), errs.end()))) + 5;
     log_ << "                        KFin  SUMMARY                        " << endl;
     log_ << "number of stubs       per TFP = " << setw(wNums) << numStubs << " +- " << setw(wErrs) << errStubs << endl;
-    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks << endl;
-    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost << endl;
+    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks
+         << endl;
+    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost
+         << endl;
     log_ << "     max  tracking efficiency = " << setw(wNums) << eff << " +- " << setw(wErrs) << errEff << endl;
     log_ << "     lost tracking efficiency = " << setw(wNums) << effLoss << " +- " << setw(wErrs) << errEffLoss << endl;
     log_ << "                    fake rate = " << setw(wNums) << fracFake << endl;
@@ -252,21 +260,31 @@ namespace trackerTFP {
   }
 
   //
-  void AnalyzerKFin::formTracks(const StreamsTrack& streamsTrack, const StreamsStub& streamsStubs, vector<vector<TTStubRef>>& tracks, int channel) const {
+  void AnalyzerKFin::formTracks(const StreamsTrack& streamsTrack,
+                                const StreamsStub& streamsStubs,
+                                vector<vector<TTStubRef>>& tracks,
+                                int channel) const {
     const int offset = channel * setup_->numLayers();
     const StreamTrack& streamTrack = streamsTrack[channel];
-    const int numTracks = accumulate(streamTrack.begin(), streamTrack.end(), 0, [](int& sum, const FrameTrack& frame){ return sum += (frame.first.isNonnull() ? 1 : 0); });
+    const int numTracks = accumulate(streamTrack.begin(), streamTrack.end(), 0, [](int& sum, const FrameTrack& frame) {
+      return sum += (frame.first.isNonnull() ? 1 : 0);
+    });
     tracks.reserve(numTracks);
     for (int frame = 0; frame < (int)streamTrack.size(); frame++) {
       const FrameTrack& frameTrack = streamTrack[frame];
       if (frameTrack.first.isNull())
         continue;
-      const auto end = find_if(next(streamTrack.begin(), frame + 1), streamTrack.end(), [](const FrameTrack& frame){ return frame.first.isNonnull(); });
+      const auto end = find_if(next(streamTrack.begin(), frame + 1), streamTrack.end(), [](const FrameTrack& frame) {
+        return frame.first.isNonnull();
+      });
       const int size = distance(next(streamTrack.begin(), frame), end);
       int numStubs(0);
       for (int layer = 0; layer < setup_->numLayers(); layer++) {
         const StreamStub& stream = streamsStubs[offset + layer];
-        numStubs += accumulate(stream.begin() + frame, stream.begin() + frame + size, 0, [](int& sum, const FrameStub& frame){ return sum += (frame.first.isNonnull() ? 1 : 0); });
+        numStubs +=
+            accumulate(stream.begin() + frame, stream.begin() + frame + size, 0, [](int& sum, const FrameStub& frame) {
+              return sum += (frame.first.isNonnull() ? 1 : 0);
+            });
       }
       vector<TTStubRef> stubs;
       stubs.reserve(numStubs);
@@ -282,7 +300,10 @@ namespace trackerTFP {
   }
 
   //
-  void AnalyzerKFin::associate(const vector<vector<TTStubRef>>& tracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum) const {
+  void AnalyzerKFin::associate(const vector<vector<TTStubRef>>& tracks,
+                               const StubAssociation* ass,
+                               set<TPPtr>& tps,
+                               int& sum) const {
     for (const vector<TTStubRef>& ttStubRefs : tracks) {
       const vector<TPPtr>& tpPtrs = ass->associate(ttStubRefs);
       if (tpPtrs.empty())

--- a/L1Trigger/TrackerTFP/test/AnalyzerMHT.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerMHT.cc
@@ -53,7 +53,6 @@ namespace trackerTFP {
     //
     void associate(const vector<vector<TTStubRef>>& tracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum) const;
 
-
     // ED input token of stubs
     EDGetTokenT<StreamsStub> edGetTokenAccepted_;
     // ED input token of lost stubs
@@ -88,7 +87,8 @@ namespace trackerTFP {
     stringstream log_;
   };
 
-  AnalyzerMHT::AnalyzerMHT(const ParameterSet& iConfig) : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
+  AnalyzerMHT::AnalyzerMHT(const ParameterSet& iConfig)
+      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
     usesResource("TFileService");
     // book in- and output ED products
     const string& label = iConfig.getParameter<string>("LabelMHT");
@@ -179,7 +179,9 @@ namespace trackerTFP {
         const StreamStub& accepted = handleAccepted->at(index);
         hisChannel_->Fill(accepted.size());
         profChannel_->Fill(channel, accepted.size());
-        nStubs += accumulate(accepted.begin(), accepted.end(), 0, [](int& sum, const FrameStub& frame){ return sum += frame.first.isNonnull() ? 1 : 0; });
+        nStubs += accumulate(accepted.begin(), accepted.end(), 0, [](int& sum, const FrameStub& frame) {
+          return sum += frame.first.isNonnull() ? 1 : 0;
+        });
         vector<vector<TTStubRef>> tracks;
         vector<vector<TTStubRef>> lost;
         formTracks(accepted, tracks);
@@ -203,7 +205,7 @@ namespace trackerTFP {
     vector<TPPtr> recovered;
     recovered.reserve(tpPtrsLost.size());
     set_intersection(tpPtrsLost.begin(), tpPtrsLost.end(), tpPtrs.begin(), tpPtrs.end(), back_inserter(recovered));
-    for(const TPPtr& tpPtr : recovered)
+    for (const TPPtr& tpPtr : recovered)
       tpPtrsLost.erase(tpPtr);
     prof_->Fill(4, allMatched);
     prof_->Fill(5, allTracks);
@@ -218,7 +220,7 @@ namespace trackerTFP {
       return;
     // effi
     eff_->SetPassedHistogram(*hisEff_, "f");
-    eff_->SetTotalHistogram (*hisEffTotal_, "f");
+    eff_->SetTotalHistogram(*hisEffTotal_, "f");
     // printout MHT summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
@@ -244,8 +246,10 @@ namespace trackerTFP {
     const int wErrs = ceil(log10(*max_element(errs.begin(), errs.end()))) + 5;
     log_ << "                         MHT SUMMARY                         " << endl;
     log_ << "number of stubs       per TFP = " << setw(wNums) << numStubs << " +- " << setw(wErrs) << errStubs << endl;
-    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks << endl;
-    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost << endl;
+    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks
+         << endl;
+    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost
+         << endl;
     log_ << "     max  tracking efficiency = " << setw(wNums) << eff << " +- " << setw(wErrs) << errEff << endl;
     log_ << "     lost tracking efficiency = " << setw(wNums) << effLoss << " +- " << setw(wErrs) << errEffLoss << endl;
     log_ << "                    fake rate = " << setw(wNums) << fracFake << endl;
@@ -259,22 +263,25 @@ namespace trackerTFP {
     vector<StubMHT> stubs;
     stubs.reserve(stream.size());
     for (const FrameStub& frame : stream)
-      if(frame.first.isNonnull())
+      if (frame.first.isNonnull())
         stubs.emplace_back(frame, dataFormats_);
     for (auto it = stubs.begin(); it != stubs.end();) {
       const auto start = it;
       const int id = it->trackId();
-      auto different = [id](const StubMHT& stub){ return id != stub.trackId(); };
+      auto different = [id](const StubMHT& stub) { return id != stub.trackId(); };
       it = find_if(it, stubs.end(), different);
       vector<TTStubRef> ttStubRefs;
       ttStubRefs.reserve(distance(start, it));
-      transform(start, it, back_inserter(ttStubRefs), [](const StubMHT& stub){ return stub.ttStubRef(); });
+      transform(start, it, back_inserter(ttStubRefs), [](const StubMHT& stub) { return stub.ttStubRef(); });
       tracks.push_back(ttStubRefs);
     }
   }
 
   //
-  void AnalyzerMHT::associate(const vector<vector<TTStubRef>>& tracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum) const {
+  void AnalyzerMHT::associate(const vector<vector<TTStubRef>>& tracks,
+                              const StubAssociation* ass,
+                              set<TPPtr>& tps,
+                              int& sum) const {
     for (const vector<TTStubRef>& ttStubRefs : tracks) {
       const vector<TPPtr>& tpPtrs = ass->associate(ttStubRefs);
       if (tpPtrs.empty())

--- a/L1Trigger/TrackerTFP/test/AnalyzerTT.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerTT.cc
@@ -33,7 +33,6 @@ namespace trackerTFP {
     void endJob() override {}
 
   private:
-
     // ED input token of tt::TTTrackRefMap
     EDGetTokenT<tt::TTTrackRefMap> edGetTokenTTTrackMap_;
     // ED input token of TTStubRef to TPPtr association for tracking efficiency
@@ -100,19 +99,31 @@ namespace trackerTFP {
         cout << gp.perp() << " " << gp.phi() << " " << gp.z() << " " << setup_->layerId(ttStubRef) << endl;
       }
       cout << found->hitPattern() << " " << found->trackSeedType() << endl;
-      cout << "m0SF = " << " " << -found->rInv() << endl;
-      cout << "c0SF = " << " " << deltaPhi(found->phi() + found->rInv() * setup_->chosenRofPhi() + off) << endl;
-      cout << "m1SF = " << " " << found->tanL() + setup_->sectorCot(found->etaSector()) << endl;
-      cout << "c1SF = " << " " << found->z0() - found->tanL() * setup_->chosenRofZ() << endl;
-      cout << "m0KF = " << " " << -fitted->rInv() * setup_->invPtToDphi() << endl;
-      cout << "c0KF = " << " " << fitted->phi() << endl;
-      cout << "m1KF = " << " " << fitted->tanL() << endl;
-      cout << "c1KF = " << " " << fitted->z0() << endl;
-      cout << "m0TP = " << " " << -tpPtr->charge() / tpPtr->pt() * setup_->invPtToDphi() << endl;
-      cout << "c0TP = " << " " << tpPtr->phi() << endl;
-      cout << "m1TP = " << " " << sinh(tpPtr->eta()) << endl;
+      cout << "m0SF = "
+           << " " << -found->rInv() << endl;
+      cout << "c0SF = "
+           << " " << deltaPhi(found->phi() + found->rInv() * setup_->chosenRofPhi() + off) << endl;
+      cout << "m1SF = "
+           << " " << found->tanL() + setup_->sectorCot(found->etaSector()) << endl;
+      cout << "c1SF = "
+           << " " << found->z0() - found->tanL() * setup_->chosenRofZ() << endl;
+      cout << "m0KF = "
+           << " " << -fitted->rInv() * setup_->invPtToDphi() << endl;
+      cout << "c0KF = "
+           << " " << fitted->phi() << endl;
+      cout << "m1KF = "
+           << " " << fitted->tanL() << endl;
+      cout << "c1KF = "
+           << " " << fitted->z0() << endl;
+      cout << "m0TP = "
+           << " " << -tpPtr->charge() / tpPtr->pt() * setup_->invPtToDphi() << endl;
+      cout << "c0TP = "
+           << " " << tpPtr->phi() << endl;
+      cout << "m1TP = "
+           << " " << sinh(tpPtr->eta()) << endl;
       const math::XYZPointD& v = tpPtr->vertex();
-      cout << "c1TP = " << " " << v.z() - sinh(tpPtr->eta()) * (v.x() * cos(tpPtr->phi()) + v.y() * sin(tpPtr->phi())) << endl;
+      cout << "c1TP = "
+           << " " << v.z() - sinh(tpPtr->eta()) * (v.x() * cos(tpPtr->phi()) + v.y() * sin(tpPtr->phi())) << endl;
       throw cms::Exception("...");
     }
   }

--- a/L1Trigger/TrackerTFP/test/AnalyzerZHT.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerZHT.cc
@@ -87,7 +87,8 @@ namespace trackerTFP {
     stringstream log_;
   };
 
-  AnalyzerZHT::AnalyzerZHT(const ParameterSet& iConfig) : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
+  AnalyzerZHT::AnalyzerZHT(const ParameterSet& iConfig)
+      : useMCTruth_(iConfig.getParameter<bool>("UseMCTruth")), nEvents_(0) {
     usesResource("TFileService");
     // book in- and output ED products
     const string& label = iConfig.getParameter<string>("LabelZHT");
@@ -178,7 +179,9 @@ namespace trackerTFP {
         const StreamStub& accepted = handleAccepted->at(index);
         hisChannel_->Fill(accepted.size());
         profChannel_->Fill(channel, accepted.size());
-        nStubs += accumulate(accepted.begin(), accepted.end(), 0, [](int& sum, const FrameStub& frame){ return sum += frame.first.isNonnull() ? 1 : 0; });
+        nStubs += accumulate(accepted.begin(), accepted.end(), 0, [](int& sum, const FrameStub& frame) {
+          return sum += frame.first.isNonnull() ? 1 : 0;
+        });
         vector<vector<TTStubRef>> tracks;
         vector<vector<TTStubRef>> lost;
         formTracks(accepted, tracks);
@@ -202,7 +205,7 @@ namespace trackerTFP {
     vector<TPPtr> recovered;
     recovered.reserve(tpPtrsLost.size());
     set_intersection(tpPtrsLost.begin(), tpPtrsLost.end(), tpPtrs.begin(), tpPtrs.end(), back_inserter(recovered));
-    for(const TPPtr& tpPtr : recovered)
+    for (const TPPtr& tpPtr : recovered)
       tpPtrsLost.erase(tpPtr);
     prof_->Fill(4, allMatched);
     prof_->Fill(5, allTracks);
@@ -211,7 +214,7 @@ namespace trackerTFP {
     prof_->Fill(8, tpPtrsLost.size());
     nEvents_++;
     //if ((int)tpPtrsSelection.size() != selection->numTPs())
-      //throw cms::Exception("...");
+    //throw cms::Exception("...");
   }
 
   void AnalyzerZHT::endJob() {
@@ -219,7 +222,7 @@ namespace trackerTFP {
       return;
     // effi
     eff_->SetPassedHistogram(*hisEff_, "f");
-    eff_->SetTotalHistogram (*hisEffTotal_, "f");
+    eff_->SetTotalHistogram(*hisEffTotal_, "f");
     // printout SF summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
@@ -245,8 +248,10 @@ namespace trackerTFP {
     const int wErrs = ceil(log10(*max_element(errs.begin(), errs.end()))) + 5;
     log_ << "                         ZHT SUMMARY                         " << endl;
     log_ << "number of stubs       per TFP = " << setw(wNums) << numStubs << " +- " << setw(wErrs) << errStubs << endl;
-    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks << endl;
-    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost << endl;
+    log_ << "number of tracks      per TFP = " << setw(wNums) << numTracks << " +- " << setw(wErrs) << errTracks
+         << endl;
+    log_ << "number of lost tracks per TFP = " << setw(wNums) << numTracksLost << " +- " << setw(wErrs) << errTracksLost
+         << endl;
     log_ << "     max  tracking efficiency = " << setw(wNums) << eff << " +- " << setw(wErrs) << errEff << endl;
     log_ << "     lost tracking efficiency = " << setw(wNums) << effLoss << " +- " << setw(wErrs) << errEffLoss << endl;
     log_ << "                    fake rate = " << setw(wNums) << fracFake << endl;
@@ -260,22 +265,25 @@ namespace trackerTFP {
     vector<StubZHT> stubs;
     stubs.reserve(stream.size());
     for (const FrameStub& frame : stream)
-      if(frame.first.isNonnull())
+      if (frame.first.isNonnull())
         stubs.emplace_back(frame, dataFormats_);
     for (auto it = stubs.begin(); it != stubs.end();) {
       const auto start = it;
       const int id = it->trackId();
-      auto different = [id](const StubZHT& stub){ return id != stub.trackId(); };
+      auto different = [id](const StubZHT& stub) { return id != stub.trackId(); };
       it = find_if(it, stubs.end(), different);
       vector<TTStubRef> ttStubRefs;
       ttStubRefs.reserve(distance(start, it));
-      transform(start, it, back_inserter(ttStubRefs), [](const StubZHT& stub){ return stub.ttStubRef(); });
+      transform(start, it, back_inserter(ttStubRefs), [](const StubZHT& stub) { return stub.ttStubRef(); });
       tracks.push_back(ttStubRefs);
     }
   }
 
   //
-  void AnalyzerZHT::associate(const vector<vector<TTStubRef>>& tracks, const StubAssociation* ass, set<TPPtr>& tps, int& sum) const {
+  void AnalyzerZHT::associate(const vector<vector<TTStubRef>>& tracks,
+                              const StubAssociation* ass,
+                              set<TPPtr>& tps,
+                              int& sum) const {
     for (const vector<TTStubRef>& ttStubRefs : tracks) {
       const vector<TPPtr>& tpPtrs = ass->associate(ttStubRefs);
       if (tpPtrs.empty())

--- a/L1Trigger/TrackerTFP/test/ProducerAS.cc
+++ b/L1Trigger/TrackerTFP/test/ProducerAS.cc
@@ -50,9 +50,7 @@ namespace trackerTFP {
     const Setup* setup_;
   };
 
-  ProducerAS::ProducerAS(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerAS::ProducerAS(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const string& labelKF = iConfig.getParameter<string>("LabelKF");
     const string& labelTT = iConfig.getParameter<string>("LabelTT");
     const string& branch = iConfig.getParameter<string>("BranchAcceptedTracks");
@@ -96,6 +94,6 @@ namespace trackerTFP {
     iEvent.emplace(edPutToken_, move(ttTrackMap));
   }
 
-} // namespace trackerTFP
+}  // namespace trackerTFP
 
 DEFINE_FWK_MODULE(trackerTFP::ProducerAS);

--- a/SimTracker/TrackTriggerAssociation/interface/StubAssociation.h
+++ b/SimTracker/TrackTriggerAssociation/interface/StubAssociation.h
@@ -25,9 +25,13 @@ namespace tt {
     // insert a TPPtr and its associated collection of TTstubRefs into the underlayering maps
     void insert(const TPPtr& tpPtr, const std::vector<TTStubRef>& ttSTubRefs);
     // returns map containing TTStubRef and their associated collection of TPPtrs
-    const std::map<TTStubRef, std::vector<TPPtr>>& getTTStubToTrackingParticlesMap() const { return mapTTStubRefsTPPtrs_; }
+    const std::map<TTStubRef, std::vector<TPPtr>>& getTTStubToTrackingParticlesMap() const {
+      return mapTTStubRefsTPPtrs_;
+    }
     // returns map containing TPPtr and their associated collection of TTStubRefs
-    const std::map<TPPtr, std::vector<TTStubRef>>& getTrackingParticleToTTStubsMap() const { return mapTPPtrsTTStubRefs_; }
+    const std::map<TPPtr, std::vector<TTStubRef>>& getTrackingParticleToTTStubsMap() const {
+      return mapTPPtrsTTStubRefs_;
+    }
     // returns collection of TPPtrs associated to given TTstubRef
     const std::vector<TPPtr>& findTrackingParticlePtrs(const TTStubRef& ttStubRef) const;
     // returns collection of TTStubRefs associated to given TPPtr
@@ -54,6 +58,6 @@ namespace tt {
     const std::vector<TTStubRef> emptyTTStubRefs_;
   };
 
-} // namespace tt
+}  // namespace tt
 
 #endif

--- a/SimTracker/TrackTriggerAssociation/plugins/StubAssociator.cc
+++ b/SimTracker/TrackTriggerAssociation/plugins/StubAssociator.cc
@@ -59,8 +59,7 @@ namespace tt {
     ESGetToken<Setup, SetupRcd> esGetTokenSetup_;
   };
 
-  StubAssociator::StubAssociator(const ParameterSet& iConfig)
-  {
+  StubAssociator::StubAssociator(const ParameterSet& iConfig) {
     // book in- and output ed products
     getTokenTTStubDetSetVec_ = consumes<TTStubDetSetVec>(iConfig.getParameter<InputTag>("InputTagTTStubDetSetVec"));
     getTokenTTClusterAssMap_ = consumes<TTClusterAssMap>(iConfig.getParameter<InputTag>("InputTagTTClusterAssMap"));
@@ -82,15 +81,16 @@ namespace tt {
     Handle<TTStubAssMap> handleTTStubAssMap;
     iEvent.getByToken<TTClusterAssMap>(getTokenTTClusterAssMap_, handleTTClusterAssMap);
     map<TPPtr, vector<TTStubRef>> mapTPPtrsTTStubRefs;
-    auto isNonnull = [](const TPPtr& tpPtr){ return tpPtr.isNonnull(); };
+    auto isNonnull = [](const TPPtr& tpPtr) { return tpPtr.isNonnull(); };
     for (TTStubDetSetVec::const_iterator ttModule = handleTTStubDetSetVec->begin();
-        ttModule != handleTTStubDetSetVec->end();
-        ttModule++) {
+         ttModule != handleTTStubDetSetVec->end();
+         ttModule++) {
       for (TTStubDetSet::const_iterator ttStub = ttModule->begin(); ttStub != ttModule->end(); ttStub++) {
         const TTStubRef ttStubRef = makeRefTo(handleTTStubDetSetVec, ttStub);
         set<TPPtr> tpPtrs;
         for (unsigned int iClus = 0; iClus < 2; iClus++) {
-          const vector<TPPtr>& assocPtrs = handleTTClusterAssMap->findTrackingParticlePtrs(ttStubRef->clusterRef(iClus));
+          const vector<TPPtr>& assocPtrs =
+              handleTTClusterAssMap->findTrackingParticlePtrs(ttStubRef->clusterRef(iClus));
           copy_if(assocPtrs.begin(), assocPtrs.end(), inserter(tpPtrs, tpPtrs.begin()), isNonnull);
         }
         for (const TPPtr& tpPtr : tpPtrs)
@@ -111,6 +111,6 @@ namespace tt {
     iEvent.emplace(putTokenSelection_, move(selection));
   }
 
-} // namespace tt
+}  // namespace tt
 
 DEFINE_FWK_MODULE(tt::StubAssociator);

--- a/SimTracker/TrackTriggerAssociation/src/StubAssociation.cc
+++ b/SimTracker/TrackTriggerAssociation/src/StubAssociation.cc
@@ -76,4 +76,4 @@ namespace tt {
     return tpPtrs;
   }
 
-} // namespace tt
+}  // namespace tt


### PR DESCRIPTION
@tomalin requested the execution of

- scram b code-format 
- scram b llvm-ccdb
- clang-tidy --fix-errors --header-filter="$CMSSW_BASE/src/L1Trigger/TrackFindingTracklet/.*" --checks=-clang-diagnostic-unused-command-line-argument `find L1Trigger/TrackerTFP/ -type f -name '*.cc'`
- Ditto for new code in a few other packages too.

This PR contains the changes produced by these. I don't know what "Ditto for new code in a few other packages too." meant, therefore I ignored that for the moment. Could you please list all command you want to have executed Ian?