### PR TITLE
Fixed clang errors

### DIFF
--- a/DataFormats/L1TrackTrigger/src/TTDTC.cc
+++ b/DataFormats/L1TrackTrigger/src/TTDTC.cc
@@ -40,7 +40,7 @@ void TTDTC::setStream(int dtcRegion, int dtcBoard, int dtcChannel, const StreamS
                 << "(" << dtcChannel << ") is out of range 0 to " << numOverlappingRegions_ - 1 << ".";
     throw exception;
   }
-  streams_[index(dtcRegion, dtcBoard, dtcChannel)] = move(stream);
+  streams_[index(dtcRegion, dtcBoard, dtcChannel)] = stream;
 }
 
 // read one specific stream of TTStubRefs using TFP identifier (region[0-8], channel[0-47])

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFin.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFin.cc
@@ -40,8 +40,8 @@ namespace trackFindingTracklet {
     ~ProducerKFin() override {}
 
   private:
-    virtual void beginRun(const Run&, const EventSetup&) override;
-    virtual void produce(Event&, const EventSetup&) override;
+    void beginRun(const Run&, const EventSetup&) override;
+    void produce(Event&, const EventSetup&) override;
     virtual void endJob() {}
 
     // ED input token of TTTracks

--- a/L1Trigger/TrackerTFP/interface/KalmanFilterFormats.h
+++ b/L1Trigger/TrackerTFP/interface/KalmanFilterFormats.h
@@ -94,7 +94,7 @@ namespace trackerTFP {
   class FormatKF : public DataFormatKF {
   public:
     FormatKF(const DataFormats* dataFormats, const edm::ParameterSet& iConfig);
-    ~FormatKF() {}
+    ~FormatKF() override {}
 
   private:
     void calcRange() { range_ = base_ * pow(2, width_); }

--- a/L1Trigger/TrackerTFP/src/DataFormats.cc
+++ b/L1Trigger/TrackerTFP/src/DataFormats.cc
@@ -32,7 +32,7 @@ namespace trackerTFP {
   }
 
   // method to count number of unique data formats
-  template <Variable v = Variable::begin, Process p = Process::begin>
+  template <Variable v, Process p>
   void DataFormats::countFormats() {
     if constexpr (config_[+v][+p] == p)
       numDataFormats_++;
@@ -72,7 +72,7 @@ namespace trackerTFP {
   }
 
   // constructs data formats of all unique used variables and flavours
-  template <Variable v = Variable::begin, Process p = Process::begin>
+  template <Variable v, Process p>
   void DataFormats::fillDataFormats() {
     if constexpr (config_[+v][+p] == p) {
       dataFormats_.emplace_back(Format<v, p>(iConfig_, setup_));
@@ -85,7 +85,7 @@ namespace trackerTFP {
   }
 
   // helper (loop) data formats of all unique used variables and flavours
-  template <Variable v, Process p, Process it = Process::begin>
+  template <Variable v, Process p, Process it>
   void DataFormats::fillFormats() {
     if (config_[+v][+it] == p) {
       formats_[+v][+it] = &dataFormats_.back();
@@ -102,7 +102,7 @@ namespace trackerTFP {
   }
 
   // helper (loop) to convert bits to ntuple of variables
-  template <int it = 0, typename... Ts>
+  template <int it, typename... Ts>
   void DataFormats::extractStub(Process p, TTBV& ttBV, std::tuple<Ts...>& data) const {
     Variable v = *next(stubs_[+p].begin(), sizeof...(Ts) - 1 - it);
     formats_[+v][+p]->extract(ttBV, get<sizeof...(Ts) - 1 - it>(data));
@@ -119,7 +119,7 @@ namespace trackerTFP {
   }
 
   // helper (loop) to convert ntuple of variables to bits
-  template <int it = 0, typename... Ts>
+  template <int it, typename... Ts>
   void DataFormats::attachStub(Process p, const tuple<Ts...>& data, TTBV& ttBV) const {
     Variable v = *next(stubs_[+p].begin(), it);
     formats_[+v][+p]->attach(get<it>(data), ttBV);
@@ -135,7 +135,7 @@ namespace trackerTFP {
   }
 
   // helper (loop) to convert bits to ntuple of variables
-  template <int it = 0, typename... Ts>
+  template <int it, typename... Ts>
   void DataFormats::extractTrack(Process p, TTBV& ttBV, std::tuple<Ts...>& data) const {
     Variable v = *next(tracks_[+p].begin(), sizeof...(Ts) - 1 - it);
     formats_[+v][+p]->extract(ttBV, get<sizeof...(Ts) - 1 - it>(data));
@@ -152,7 +152,7 @@ namespace trackerTFP {
   }
 
   // helper (loop) to convert ntuple of variables to bits
-  template <int it = 0, typename... Ts>
+  template <int it, typename... Ts>
   void DataFormats::attachTrack(Process p, const tuple<Ts...>& data, TTBV& ttBV) const {
     Variable v = *next(tracks_[+p].begin(), it);
     formats_[+v][+p]->attach(get<it>(data), ttBV);

--- a/L1Trigger/TrackerTFP/src/KalmanFilterFormats.cc
+++ b/L1Trigger/TrackerTFP/src/KalmanFilterFormats.cc
@@ -50,7 +50,7 @@ namespace trackerTFP {
     fillFormats();
   }
 
-  template <VariableKF it = VariableKF::begin>
+  template <VariableKF it>
   void KalmanFilterFormats::fillFormats() {
     formats_.emplace_back(FormatKF<it>(dataFormats_, iConfig_));
     if constexpr (++it != VariableKF::end)


### PR DESCRIPTION
New KF code is causing L1 tracking code to fail CI tests. Specifically:

scram b code-checks-run

See https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/3422/1/1.html .

This PR fixes this. Have checked that tracking performance doesn't change.