### PR TITLE
Added git CI

### DIFF
--- a/.github/workflows/github_CI.yml
+++ b/.github/workflows/github_CI.yml
@@ -47,8 +47,8 @@ jobs:
         # Sets env. variable $current_branch
         echo "current_branch=$(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')" >> $GITHUB_ENV
 
-    - name: Mirror + trigger CI
-      # Communicate between gitlab & github.
+    - name: Trigger gitlab CI run
+      # Communicate between gitlab & github, and trigger gitlab CI run.
       # (Forked from https://github.com/SvanBoxel/gitlab-mirror-and-ci-action).
       uses: cms-L1TK/gitlab-mirror-and-ci-action@master
       env:

--- a/.github/workflows/github_CI.yml
+++ b/.github/workflows/github_CI.yml
@@ -1,12 +1,12 @@
 #####################################################################
-# This triggers git Continuous Integration tests when a PR is made  #
-# to the cms-L1TK default github branch or if code is committed to  #
-# any test branch specified below.                                  #
+# This triggers git Continuous Integration tests when a PR to       #
+# any branch is made. Or if a code-commit is made to any            #
+# test branch (temporarily) specified below.                        #
 #                                                                   #
 # The tests themselves are delegated to a gitlab CI runner          #
 # controlled by the .gitlab-ci.yml file at                          #
 # https://gitlab.cern.ch/cms-l1tk/cmssw_CI .                        #
-# (Both this file & that must be updated if CMSSW version changes). #
+# N.B. .gitlab-ci.yml must be update if the CMSSW version changes.  #
 #                                                                   # 
 # Communication between the github & gitlab CIs is done via scripts #
 # at https://github.com/cms-L1TK/gitlab-mirror-and-ci-action        #
@@ -18,8 +18,8 @@ on: # Controls when the action will run.
   workflow_dispatch:
   push: # Please specify your branch down here if you want CI to run for each push to it.
     branches: [myBranchUnderTest]
-  pull_request: # Run CI if someone makes a PR to default branch.
-    branches: [L1TK-dev-12_0_0_pre4]
+  pull_request: # Run CI if someone makes a PR to any branch
+    # branches: [L1TK-dev-12_0_0_pre4] # Optionally only run CI if PR is to this branch.
     
 env:
   mirror_repo: "https://gitlab.cern.ch/cms-l1tk/cmssw_CI" # gitlab mirror

--- a/.github/workflows/github_CI.yml
+++ b/.github/workflows/github_CI.yml
@@ -59,7 +59,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret
         MIRROR_REPO: ${{ env.mirror_repo }} # gitlab mirror.
         IS_CMSSW: "true" # Is repo CMSSW or something else (e.g. HLS)?
-        L1TRKALGO_CMSSW : "HYBRID" # If CMSSW, specify L1TRKALGO parameter in L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
         CHECKOUT_BRANCH: ${{ env.current_branch }} # Needed so push to gitlab can work
         REMOVE_BRANCH: "true" # Refreshes branch on mirror, which triggers CI run there.
         REBASE_MASTER: "false" # If true would rebase to "master", which isn't used in cms-L1TK.

--- a/.github/workflows/github_CI.yml
+++ b/.github/workflows/github_CI.yml
@@ -12,7 +12,7 @@
 # at https://github.com/cms-L1TK/gitlab-mirror-and-ci-action        #
 #####################################################################
 
-name: Mirror and run GitLab CI
+name: PR validation with GitLab CI
  
 on: # Controls when the action will run.
   workflow_dispatch:
@@ -26,8 +26,8 @@ env:
   current_branch: "unitialized"
 
 jobs:
-  mirror_trig: # https://github.com/marketplace/actions/mirror-to-gitlab-and-run-gitlab-ci
-    name: mirror_trig
+  trigger_gitlab_CI: # https://github.com/marketplace/actions/mirror-to-gitlab-and-run-gitlab-ci
+    name: trigger_gitlab_CI
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/github_CI.yml
+++ b/.github/workflows/github_CI.yml
@@ -59,6 +59,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret
         MIRROR_REPO: ${{ env.mirror_repo }} # gitlab mirror.
         IS_CMSSW: "true" # Is repo CMSSW or something else (e.g. HLS)?
+        L1TRKALGO_CMSSW : "HYBRID" # If CMSSW, specify L1TRKALGO parameter in L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
         CHECKOUT_BRANCH: ${{ env.current_branch }} # Needed so push to gitlab can work
         REMOVE_BRANCH: "true" # Refreshes branch on mirror, which triggers CI run there.
         REBASE_MASTER: "false" # If true would rebase to "master", which isn't used in cms-L1TK.

--- a/.github/workflows/github_CI.yml
+++ b/.github/workflows/github_CI.yml
@@ -1,0 +1,74 @@
+#####################################################################
+# This triggers git Continuous Integration tests when a PR is made  #
+# to the cms-L1TK default github branch or if code is committed to  #
+# any test branch specified below.                                  #
+#                                                                   #
+# The tests themselves are delegated to a gitlab CI runner          #
+# controlled by the .gitlab-ci.yml file at                          #
+# https://gitlab.cern.ch/cms-l1tk/cmssw_CI .                        #
+# (Both this file & that must be updated if CMSSW version changes). #
+#                                                                   # 
+# Communication between the github & gitlab CIs is done via scripts #
+# at https://github.com/cms-L1TK/gitlab-mirror-and-ci-action        #
+#####################################################################
+
+name: Mirror and run GitLab CI
+ 
+on: # Controls when the action will run.
+  workflow_dispatch:
+  push: # Please specify your branch down here if you want CI to run for each push to it.
+    branches: [myBranchUnderTest]
+  pull_request: # Run CI if someone makes a PR to default branch.
+    branches: [L1TK-dev-12_0_0_pre4]
+    
+env:
+  mirror_repo: "https://gitlab.cern.ch/cms-l1tk/cmssw_CI" # gitlab mirror
+  current_branch: "unitialized"
+
+jobs:
+  mirror_trig: # https://github.com/marketplace/actions/mirror-to-gitlab-and-run-gitlab-ci
+    name: mirror_trig
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: DebugPrint
+      run: |
+        echo "github.ref = ${{ github.ref }}"
+
+    - name: Redefine branch on pull_request
+      if: github.event_name == 'pull_request'
+      run: |
+        # Sets env. variable $current_branch
+        echo "current_branch=$(echo ${{ github.head_ref }})" >> $GITHUB_ENV
+
+    - name: Redefine branch on push
+      if: github.event_name == 'push'
+      run: |
+        # Sets env. variable $current_branch
+        echo "current_branch=$(echo ${{ github.ref }} | sed -E 's|refs/[a-zA-Z]+/||')" >> $GITHUB_ENV
+
+    - name: Mirror + trigger CI
+      # Communicate between gitlab & github.
+      # (Forked from https://github.com/SvanBoxel/gitlab-mirror-and-ci-action).
+      uses: cms-L1TK/gitlab-mirror-and-ci-action@master
+      env:
+        GITLAB_HOSTNAME: "gitlab.cern.ch"
+        GITLAB_USERNAME: "cms-l1tk"   
+        GITLAB_PASSWORD: ${{ secrets.GITLAB_L1TK_CMSSW_CI_TOKEN }} # Generate token here: https://gitlab.cern.ch/cms-l1tk/cmssw_CI/-/settings/access_tokens and add it to GitHub secrets https://github.com/cms-L1TK/cmssw/settings/secrets/actions   
+        GITLAB_PROJECT_ID: "124851" # ID visible at https://gitlab.cern.ch/cms-l1tk/cmssw 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret
+        MIRROR_REPO: ${{ env.mirror_repo }} # gitlab mirror.
+        IS_CMSSW: "true" # Is repo CMSSW or something else (e.g. HLS)?
+        CHECKOUT_BRANCH: ${{ env.current_branch }} # Needed so push to gitlab can work
+        REMOVE_BRANCH: "true" # Refreshes branch on mirror, which triggers CI run there.
+        REBASE_MASTER: "false" # If true would rebase to "master", which isn't used in cms-L1TK.
+        RETURN_FILE: "pipeline_url.txt" # Output file with gitlab pipeline url
+
+    - name: print summary
+      if: always()
+      run: |
+        echo ""
+        echo "==========================================================="
+        echo "DETAILED OUTPUT FROM CMSSW COMPILATION & RUN AVAILABLE "
+        echo "AT FOLLOWING GITLAB CI URL:"
+        cat pipeline_url.txt

--- a/L1Trigger/TrackFindingTracklet/test/makeHists.csh
+++ b/L1Trigger/TrackFindingTracklet/test/makeHists.csh
@@ -13,7 +13,7 @@
 ###########################################################################
 
 if ($#argv == 0) then
-  set inputFullFileName = "TTbar_PU200_D49.root"
+  set inputFullFileName = "TTbar_PU200_D76.root"
 else
   set inputFullFileName = $1
 endif

--- a/L1Trigger/TrackFindingTracklet/test/skimForCI_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/skimForCI_cfg.py
@@ -1,0 +1,73 @@
+#-----------------------------------------------------------
+# This job skims a MC dataset, selecting only products
+# that are needed to run the L1 tracking & measure its
+# performance. 
+#
+# It is typically used to create small datasets that
+# the git CI runs on to check new code.
+#
+# Whenever the L1 tracking group switches to a new default
+# MC dataset, this skim should be run on ttbar+0PU MC, 
+# and the skimmed dataset placed in
+# https://gitlab.cern.ch/cms-l1tk/cmssw_CI .
+#-----------------------------------------------------------
+
+############################################################
+# define basic process
+############################################################
+
+import FWCore.ParameterSet.Config as cms
+import FWCore.Utilities.FileUtils as FileUtils
+import os
+process = cms.Process("SKIM")
+
+ 
+############################################################
+# import standard configurations
+############################################################
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+
+# D49 geometry (T15 tracker)
+process.load('Configuration.Geometry.GeometryExtended2026D76Reco_cff')
+process.load('Configuration.Geometry.GeometryExtended2026D76_cff')
+
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))
+
+#--- To use MCsamples scripts, defining functions get*data*() for easy MC access,
+#--- follow instructions in https://github.com/cms-L1TK/MCsamples
+
+from MCsamples.Scripts.getCMSdata_cfi import *
+
+# Read data from card files (defines getCMSdataFromCards()):
+from MCsamples.RelVal_1130_D76.PU0_TTbar_14TeV_cfi import *
+inputMC = getCMSdataFromCards()
+
+process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(*inputMC))
+
+process.output = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = cms.untracked.vstring('drop *'),
+    fileName = cms.untracked.string('/tmp/skimmedForCI.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW')
+    )
+)
+
+process.output.outputCommands.append('keep  *_*_*Level1TTTracks*_*')
+process.output.outputCommands.append('keep  *_*_*StubAccepted*_*')
+process.output.outputCommands.append('keep  *_*_*ClusterAccepted*_*')
+process.output.outputCommands.append('keep  *_*_*MergedTrackTruth*_*')
+process.output.outputCommands.append('keep  *_genParticles_*_*')
+
+process.pd = cms.EndPath(process.output)
+
+process.schedule = cms.Schedule(process.pd)


### PR DESCRIPTION
This adds git Continuous Integration tests to cms-L1TK/cmssw.

The file .github/workflows/github_CI.yml launches CI on github whenever a PR is made to any branch (typically L1TK-dev-12_0_0_pre4). The CI can also be run for test purposes if a commit is made to any temporarily specified branch. The github CI then launches a gitlab CI run, controlled by https://gitlab.cern.ch/cms-l1tk/cmssw_CI/-/blob/masterCI/.gitlab-ci.yml , which checks out the branch under test from github, rebases it on top of the default branch, compiles it with CMSSW, performs standard code style checks on it, and runs L1TrackNtupleMaker_cfg.py for both HYBRID & HYBRID_NEWKF algos.

Both github_CI.yml & .gitlab-ci.yml will need editing (a few lines) if the CMSSW version changes. Since .github_CI.yml can't be added to the official release, it must be deleted from this repo whenever we make a PR to the official release, and readded when we branch off from it. (It could be backed up in https://gitlab.cern.ch/cms-l1tk/cmssw_CI . Not yet done).

Communication between gitlab & github CIs is done with https://github.com/cms-L1TK/gitlab-mirror-and-ci-action . This is based heavily on https://github.com/aperloff/gitlab-mirror-and-ci-action , which did this action already for the L1 track HLS repo. The new version should via option "IS_CMSSW" be able to work not only for CMSSW, but also for HLS (not yet checked), so if @aperloff agrees can replace the old one.