### PR TITLE
Summerchain new KF

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -241,6 +241,8 @@ namespace trklet {
     bool doMultipleMatches() const { return doMultipleMatches_; }
     bool fakefit() const { return fakefit_; }
     void setFakefit(bool fakefit) { fakefit_ = fakefit; }
+    void setRemovalType(std::string removalType) { removalType_ = removalType; }
+    void setDoMultipleMatches(bool doMultipleMatches) { doMultipleMatches_ = doMultipleMatches; }
 
     // configurable
     unsigned int nHelixPar() const { return nHelixPar_; }

--- a/L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannel.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannel.h
@@ -5,34 +5,53 @@
 #include "L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannelRcd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "L1Trigger/TrackTrigger/interface/Setup.h"
 
 #include <vector>
 
 namespace trackFindingTracklet {
 
   /*! \class  trackFindingTracklet::TrackBuilderChannel
-   *  \brief  Class to assign tracklet tracks to channel
-   *          based on ther Pt or seed type,
+   *  \brief  Class to assign tracklet tracks ans stubs to channel
+   *          based on their Pt or seed type
    *  \author Thomas Schuh
-   *  \date   2020, Nov
+   *  \date   2020, Nov; updated 2021 Oct
    */
   class TrackBuilderChannel {
   public:
     TrackBuilderChannel() {}
-    TrackBuilderChannel(const edm::ParameterSet& iConfig);
+    TrackBuilderChannel(const edm::ParameterSet& iConfig, const tt::Setup* setup);
     ~TrackBuilderChannel() {}
-    // sets channelId of given TTTrack, return false if track outside pt range
-    bool channelId(const TTTrack<Ref_Phase2TrackerDigi_>& ttTrack, int& channelId);
+    // sets channelId of given TTTrackRef, return false if track outside pt range
+    bool channelId(const TTTrackRef& ttTrackRef, int& channelId);
     // number of used channels
     int numChannels() const { return numChannels_; }
+    // sets layerId of given TTStubRef and TTTrackRef, returns false if seeed stub
+    bool layerId(const TTTrackRef& ttTrackRef, const TTStubRef& ttStubRef, int& layerId);
+    // max number layers a sedd type may project to
+    int maxNumProjectionLayers() const { return maxNumProjectionLayers_; }
 
   private:
+    // helper class to store configurations
+    const tt::Setup* setup_;
+    // reduce l1 tracking to summer chain configuration
+    bool summerChain_;
     // use tracklet seed type as channel id if False, binned track pt used if True
     bool useDuplicateRemoval_;
     // pt Boundaries in GeV, last boundary is infinity
     std::vector<double> boundaries_;
+    // seed type names
+    std::vector<std::string> seedTypeNames_;
+    // number of used seed types in tracklet algorithm
+    int numSeedTypes_;
     // number of used channels
     int numChannels_;
+    // max number layers a sedd type may project to
+    int maxNumProjectionLayers_;
+    // seeding layers of seed types using default layer id [barrel: 1-6, discs: 11-15]
+    std::vector<std::vector<int>> seedTypesSeedLayers_;
+    // layers a seed types can project to using default layer id [barrel: 1-6, discs: 11-15]
+    std::vector<std::vector<int>> seedTypesProjectionLayers_;
   };
 
 }  // namespace trackFindingTracklet

--- a/L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannelRcd.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannelRcd.h
@@ -1,5 +1,5 @@
-#ifndef L1Trigger_TrackFindingTracklet_LayerEncodingRcd_h
-#define L1Trigger_TrackFindingTracklet_LayerEncodingRcd_h
+#ifndef L1Trigger_TrackFindingTracklet_TrackBuilderChannelRcd_h
+#define L1Trigger_TrackFindingTracklet_TrackBuilderChannelRcd_h
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "FWCore/Utilities/interface/mplVector.h"

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -250,6 +250,8 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   settings.setWiresFile(wiresFile.fullPath());
 
   settings.setFakefit(iConfig.getParameter<bool>("Fakefit"));
+  settings.setRemovalType(iConfig.getParameter<string>("RemovalType"));
+  settings.setDoMultipleMatches(iConfig.getParameter<bool>("DoMultipleMatches"));
 
   if (extended_) {
     settings.setTableTEDFile(tableTEDFile.fullPath());

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFin.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFin.cc
@@ -134,23 +134,26 @@ namespace trackFindingTracklet {
     StreamsTrack streamLostTracks(numStreamsTracks);
     // read in hybrid track finding product and produce KFin product
     if (setup_->configurationSupported()) {
+      // create TTrackRefs
       Handle<TTTracks> handleTTTracks;
       iEvent.getByToken<TTTracks>(edGetTokenTTTracks_, handleTTTracks);
-      const TTTracks& ttTracks = *handleTTTracks;
+      vector<TTTrackRef> ttTrackRefs;
+      ttTrackRefs.reserve(handleTTTracks->size());
+      for (int i = 0; i < (int)handleTTTracks->size(); i++)
+        ttTrackRefs.emplace_back(TTTrackRef(handleTTTracks, i));
       // Assign input tracks to channels according to TrackBuilder step.
       vector<vector<TTTrackRef>> ttTrackRefsStreams(numStreamsTracks);
       vector<int> nTTTracksStreams(numStreamsTracks, 0);
       int channelId;
-      for (const TTTrack<Ref_Phase2TrackerDigi_>& ttTrack : ttTracks)
-        if (trackBuilderChannel_->channelId(ttTrack, channelId))
+      for (const TTTrackRef& ttTrackRef : ttTrackRefs)
+        if (trackBuilderChannel_->channelId(ttTrackRef, channelId))
           nTTTracksStreams[channelId]++;
       channelId = 0;
       for (int nTTTracksStream : nTTTracksStreams)
         ttTrackRefsStreams[channelId++].reserve(nTTTracksStream);
-      int i(0);
-      for (const TTTrack<Ref_Phase2TrackerDigi_>& ttTrack : ttTracks)
-        if (trackBuilderChannel_->channelId(ttTrack, channelId))
-          ttTrackRefsStreams[channelId].emplace_back(TTTrackRef(handleTTTracks, i++));
+      for (const TTTrackRef& ttTrackRef : ttTrackRefs)
+        if (trackBuilderChannel_->channelId(ttTrackRef, channelId))
+          ttTrackRefsStreams[channelId].push_back(ttTrackRef);
       for (channelId = 0; channelId < numStreamsTracks; channelId++) {
         // Create vector of stubs/tracks in KF format from TTTracks
         deque<FrameTrack> streamTracks;

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerTrackBuilderChannel.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerTrackBuilderChannel.cc
@@ -35,7 +35,8 @@ namespace trackFindingTracklet {
   }
 
   unique_ptr<TrackBuilderChannel> ProducerTrackBuilderChannel::produce(const TrackBuilderChannelRcd& rcd) {
-    return make_unique<TrackBuilderChannel>(*iConfig_);
+    const Setup* setup = &rcd.get(esGetToken_);
+    return make_unique<TrackBuilderChannel>(*iConfig_, setup);
   }
 
 }  // namespace trackFindingTracklet

--- a/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+def summerChainConfig(process):
+    process.TrackTriggerSetup.Firmware.FreqBE = 240
+    process.TrackTriggerSetup.KalmanFilter.NumWorker = 1
+    process.TrackBuilderChannel.SummerChain = True
+    process.TrackBuilderChannel.MaxNumProjectionLayers = 4
+    process.TrackFindingTrackletProducerIRin.SummerChain = True
+    process.TTTracksFromTrackletEmulation.Fakefit = True
+    process.TTTracksFromTrackletEmulation.RemovalType = ""
+    process.TTTracksFromTrackletEmulation.DoMultipleMatches = False
+    process.TTTracksFromTrackletEmulation.Reduced = True
+    process.TTTracksFromTrackletEmulation.memoryModulesFile = 'L1Trigger/TrackFindingTracklet/data/reduced_memorymodules.dat'
+    process.TTTracksFromTrackletEmulation.processingModulesFile = 'L1Trigger/TrackFindingTracklet/data/reduced_processingmodules.dat'
+    process.TTTracksFromTrackletEmulation.wiresFile = 'L1Trigger/TrackFindingTracklet/data/reduced_wires.dat'
+    return process
+
+def newKFConfig(process):
+    process.TTTracksFromTrackletEmulation.Fakefit = True

--- a/L1Trigger/TrackFindingTracklet/python/L1HybridEmulationTracks_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/L1HybridEmulationTracks_cff.py
@@ -9,7 +9,6 @@ from SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff import *
 # prompt hybrid emulation
 TTTrackAssociatorFromPixelDigis.TTTracks = cms.VInputTag(cms.InputTag("TTTracksFromTrackletEmulation", "Level1TTTracks") )
 
-L1TrackletTracks = cms.Sequence(offlineBeamSpot*TrackletTracksFromTrackletEmulation)
 L1HybridTracks = cms.Sequence(offlineBeamSpot*TTTracksFromTrackletEmulation)
 L1HybridTracksWithAssociators = cms.Sequence(offlineBeamSpot*TTTracksFromTrackletEmulation*TrackTriggerAssociatorTracks)
 

--- a/L1Trigger/TrackFindingTracklet/python/ProducerKF_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/ProducerKF_cff.py
@@ -8,6 +8,8 @@ from L1Trigger.TrackerTFP.KalmanFilterFormats_cff import TrackTriggerKalmanFilte
 from L1Trigger.TrackFindingTracklet.ProducerTrackBuilderChannel_cff import TrackBuilderChannel
 from L1Trigger.TrackFindingTracklet.ProducerKF_cfi import TrackFindingTrackletProducerKF_params
 
+TrackFindingTrackletProducerIRin = cms.EDProducer( 'trackFindingTracklet::ProducerIRin', TrackFindingTrackletProducerKF_params )
+TrackFindingTrackletProducerTBout = cms.EDProducer( 'trackFindingTracklet::ProducerTBout', TrackFindingTrackletProducerKF_params )
 TrackFindingTrackletProducerKFin = cms.EDProducer( 'trackFindingTracklet::ProducerKFin', TrackFindingTrackletProducerKF_params )
 TrackFindingTrackletProducerKF = cms.EDProducer( 'trackerTFP::ProducerKF', TrackFindingTrackletProducerKF_params )
 TrackFindingTrackletProducerTT = cms.EDProducer( 'trackFindingTracklet::ProducerTT', TrackFindingTrackletProducerKF_params )

--- a/L1Trigger/TrackFindingTracklet/python/ProducerKF_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/ProducerKF_cfi.py
@@ -2,17 +2,21 @@ import FWCore.ParameterSet.Config as cms
 
 TrackFindingTrackletProducerKF_params = cms.PSet (
 
-  InputTag             = cms.InputTag( "TrackletTracksFromTrackletEmulation", "Level1TTTracks"), #
-  LabelKFin            = cms.string  ( "TrackFindingTrackletProducerKFin"  ),                    #
-  LabelKF              = cms.string  ( "TrackFindingTrackletProducerKF"    ),                    #
-  LabelTT              = cms.string  ( "TrackFindingTrackletProducerTT"    ),                    #
-  LabelAS              = cms.string  ( "TrackFindingTrackletProducerAS"    ),                    #
-  LabelKFout           = cms.string  ( "TrackFindingTrackletProducerKFout" ),                    #
-  BranchAcceptedStubs  = cms.string  ( "StubAccepted"  ),                                        #
-  BranchAcceptedTracks = cms.string  ( "TrackAccepted" ),                                        #
-  BranchLostStubs      = cms.string  ( "StubLost"      ),                                        #
-  BranchLostTracks     = cms.string  ( "TrackLost"     ),                                        #
-  CheckHistory         = cms.bool    ( False ),                                                  # checks if input sample production is configured as current process
-  EnableTruncation     = cms.bool    ( True  )                                                   # enable emulation of truncation, lost stubs are filled in BranchLost
+  InputTag             = cms.InputTag( "TTTracksFromTrackletEmulation", "Level1TTTracks"), #
+  InputTagDTC          = cms.InputTag( "TrackerDTCProducer", "StubAccepted"),              #
+  LabelKFin            = cms.string  ( "TrackFindingTrackletProducerKFin"  ),              #
+  LabelKF              = cms.string  ( "TrackFindingTrackletProducerKF"    ),              #
+  LabelTT              = cms.string  ( "TrackFindingTrackletProducerTT"    ),              #
+  LabelAS              = cms.string  ( "TrackFindingTrackletProducerAS"    ),              #
+  LabelKFout           = cms.string  ( "TrackFindingTrackletProducerKFout" ),              #
+  BranchAcceptedStubs  = cms.string  ( "StubAccepted"  ),                                  #
+  BranchAcceptedTracks = cms.string  ( "TrackAccepted" ),                                  #
+  BranchLostStubs      = cms.string  ( "StubLost"      ),                                  #
+  BranchLostTracks     = cms.string  ( "TrackLost"     ),                                  #
+  CheckHistory         = cms.bool    ( False ),                                            # checks if input sample production is configured as current process
+  EnableTruncation     = cms.bool    ( True  ),                                            # enable emulation of truncation, lost stubs are filled in BranchLost
+
+  SummerChain         = cms.bool  ( False ),                                                    # reduce l1 tracking to summer chain configuration
+  SummerChainChannels = cms.vint32( 0, 1, 25, 2, 26, 4, 28, 5, 29, 6, 30, 7, 31, 8, 32, 9, 33 ) # map of used tfp channels in summer chain config
 
 )

--- a/L1Trigger/TrackFindingTracklet/python/ProducerTrackBuilderChannel_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/ProducerTrackBuilderChannel_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 from L1Trigger.TrackFindingTracklet.ProducerTrackBuilderChannel_cfi import TrackBuilderChannel_params
+from L1Trigger.TrackFindingTracklet.ProducerKF_cfi import TrackFindingTrackletProducerKF_params
 
-TrackBuilderChannel = cms.ESProducer("trackFindingTracklet::ProducerTrackBuilderChannel", TrackBuilderChannel_params)
+TrackBuilderChannel = cms.ESProducer("trackFindingTracklet::ProducerTrackBuilderChannel", TrackBuilderChannel_params, TrackFindingTrackletProducerKF_params)

--- a/L1Trigger/TrackFindingTracklet/python/ProducerTrackBuilderChannel_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/ProducerTrackBuilderChannel_cfi.py
@@ -2,9 +2,31 @@ import FWCore.ParameterSet.Config as cms
 
 TrackBuilderChannel_params = cms.PSet (
 
-    UseDuplicateRemoval = cms.bool   ( True ),                           # use tracklet seed type as channel id if False, binned track pt used if True
-    NumSeedTypes        = cms.int32  ( 8    ),                           # number of used seed types in tracklet algorithm
-    #PtBoundaries        = cms.vdouble( 1.8, 2.16, 2.7, 3.6, 5.4, 10.8 ), # pt Boundaries in GeV, last boundary is infinity
-    PtBoundaries        = cms.vdouble( 1.34 ), # pt Boundaries in GeV, last boundary is infinity
+    UseDuplicateRemoval = cms.bool   ( True ),                                                 # use tracklet seed type as channel id if False, binned track pt used if True
+    SeedTypes = cms.vstring( "L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L1D2" ), # seed types used in tracklet algorithm (position gives int value)
+    #PtBoundaries       = cms.vdouble( 1.8, 2.16, 2.7, 3.6, 5.4, 10.8 ),                       # pt Boundaries in GeV, last boundary is infinity
+    PtBoundaries        = cms.vdouble( 1.34 ),                                                 # pt Boundaries in GeV, last boundary is infinity
+
+    MaxNumProjectionLayers    = cms.int32( 8 ), # max number layers a sedd type may project to
+    SeedTypesSeedLayers       = cms.PSet (      # seeding layers of seed types using default layer id [barrel: 1-6, discs: 11-15]
+        L1L2 = cms.vint32(  1,  2 ),
+        L2L3 = cms.vint32(  2,  3 ),
+        L3L4 = cms.vint32(  3,  4 ),
+        L5L6 = cms.vint32(  5,  6 ),
+        D1D2 = cms.vint32( 11, 12 ),
+        D3D4 = cms.vint32( 13, 14 ),
+        L1D1 = cms.vint32(  1, 11 ),
+        L1D2 = cms.vint32(  1, 12 )
+    ),
+    SeedTypesProjectionLayers = cms.PSet (      # layers a seed types can project to using default layer id [barrel: 1-6, discs: 11-15]
+        L1L2 = cms.vint32(  3,  4,  5,  6, 11, 12, 13, 14 ),
+        L2L3 = cms.vint32(  1,  4,  5,  6, 11, 12, 13, 14 ),
+        L3L4 = cms.vint32(  1,  2,  5,  6, 11, 12 ),
+        L5L6 = cms.vint32(  1,  2,  3,  4 ),
+        D1D2 = cms.vint32(  1,  2, 13, 14, 15 ),
+        D3D4 = cms.vint32(  1, 11, 12, 15 ),
+        L1D1 = cms.vint32( 12, 13, 14, 15 ),
+        L1D2 = cms.vint32(  1, 12, 13, 14 )
+    )
 
 )

--- a/L1Trigger/TrackFindingTracklet/python/Tracklet_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/Tracklet_cfi.py
@@ -21,7 +21,9 @@ TTTracksFromTrackletEmulation = cms.EDProducer("L1FPGATrackProducer",
                                                # Quality Flag and Quality params
                                                TrackQuality = cms.bool(True),
                                                TrackQualityPSet = cms.PSet(TrackQualityParams),
-                                               Fakefit = cms.bool(False)
+                                               Fakefit = cms.bool(False),
+                                               RemovalType = cms.string("merge"),
+                                               DoMultipleMatches = cms.bool(True)
     )
 
 TTTracksFromExtendedTrackletEmulation = TTTracksFromTrackletEmulation.clone(
@@ -43,9 +45,4 @@ TTTracksFromReducedTrackletEmulation = TTTracksFromTrackletEmulation.clone(
                                                memoryModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/reduced_memorymodules.dat'),
                                                processingModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/reduced_processingmodules.dat'),
                                                wiresFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/reduced_wires.dat'),
-    )
-
-# this is to run Tracklet pattern reco with new KF
-TrackletTracksFromTrackletEmulation = TTTracksFromTrackletEmulation.clone(
-                                               Fakefit = cms.bool(True)
     )

--- a/L1Trigger/TrackFindingTracklet/src/TrackBuilderChannel.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackBuilderChannel.cc
@@ -4,19 +4,52 @@
 
 using namespace std;
 using namespace edm;
+using namespace tt;
 
 namespace trackFindingTracklet {
 
-  TrackBuilderChannel::TrackBuilderChannel(const edm::ParameterSet& iConfig)
-      : useDuplicateRemoval_(iConfig.getParameter<bool>("UseDuplicateRemoval")),
+  TrackBuilderChannel::TrackBuilderChannel(const edm::ParameterSet& iConfig, const Setup* setup)
+      : setup_(setup),
+        summerChain_(iConfig.getParameter<bool>("SummerChain")),
+        useDuplicateRemoval_(iConfig.getParameter<bool>("UseDuplicateRemoval")),
         boundaries_(iConfig.getParameter<vector<double>>("PtBoundaries")),
-        numChannels_(useDuplicateRemoval_ ? 2 * boundaries_.size() : iConfig.getParameter<int>("NumSeedTypes")) {}
+        seedTypeNames_(iConfig.getParameter<vector<string>>("SeedTypes")),
+        numSeedTypes_(seedTypeNames_.size()),
+        maxNumProjectionLayers_(iConfig.getParameter<int>("MaxNumProjectionLayers"))
+  {
+    if (summerChain_)
+      numChannels_ = 1;
+    else if (useDuplicateRemoval_)
+      numChannels_ = 2 * boundaries_.size();
+    else 
+      numChannels_ = numSeedTypes_;
+    const ParameterSet& pSetSeedTypesSeedLayers = iConfig.getParameter<ParameterSet>("SeedTypesSeedLayers");
+    const ParameterSet& pSetSeedTypesProjectionLayers = iConfig.getParameter<ParameterSet>("SeedTypesProjectionLayers");
+    seedTypesSeedLayers_.reserve(numSeedTypes_);
+    seedTypesProjectionLayers_.reserve(numSeedTypes_);
+    for (const string& s : seedTypeNames_) {
+      seedTypesSeedLayers_.emplace_back(pSetSeedTypesSeedLayers.getParameter<vector<int>>(s));
+      seedTypesProjectionLayers_.emplace_back(pSetSeedTypesProjectionLayers.getParameter<vector<int>>(s));
+    }
+  }
 
-  // sets channelId of given TTTrack, return false if track outside pt range
-  bool TrackBuilderChannel::channelId(const TTTrack<Ref_Phase2TrackerDigi_>& ttTrack, int& channelId) {
-    if (!useDuplicateRemoval_)
-      return ttTrack.trackSeedType();
-    const double pt = ttTrack.momentum().perp();
+  // sets channelId of given TTTrackRef, return false if track outside pt range
+  bool TrackBuilderChannel::channelId(const TTTrackRef& ttTrackRef, int& channelId) {
+    if (summerChain_) {
+      if (ttTrackRef->trackSeedType() != 0) {
+        cms::Exception exception("logic_error");
+        exception << "TTTracks form seed type L1L2 not supported in summer chain configuration.";
+        exception.addContext("trackFindingTracklet:TrackBuilderChannel:channelId");
+        throw exception;
+      }
+      channelId = ttTrackRef->phiSector();
+      return true;
+    }
+    if (!useDuplicateRemoval_) {
+      channelId = ttTrackRef->phiSector() * numSeedTypes_ + ttTrackRef->trackSeedType();
+      return true;
+    }
+    const double pt = ttTrackRef->momentum().perp();
     channelId = -1;
     for (double boundary : boundaries_) {
       if (pt < boundary)
@@ -26,9 +59,36 @@ namespace trackFindingTracklet {
     }
     if (channelId == -1)
       return false;
-    channelId = ttTrack.rInv() < 0. ? channelId : numChannels_ - channelId - 1;
-    channelId += ttTrack.phiSector() * numChannels_;
+    channelId = ttTrackRef->rInv() < 0. ? channelId : numChannels_ - channelId - 1;
+    channelId += ttTrackRef->phiSector() * numChannels_;
     return true;
   }
+
+  // sets layerId of given TTStubRef and TTTrackRef, returns false if seeed stub
+  bool TrackBuilderChannel::layerId(const TTTrackRef& ttTrackRef, const TTStubRef& ttStubRef, int& layerId) {
+    layerId = -1;
+    const int seedType = ttTrackRef->trackSeedType();
+    if (seedType < 0 || seedType >= numSeedTypes_) {
+      cms::Exception exception("logic_error");
+      exception.addContext("trackFindingTracklet::TrackBuilderChannel::layerId");
+      exception << "TTTracks with with seed type " << seedType << " not supported.";
+      throw exception;
+    }
+    const int layer = setup_->layerId(ttStubRef);
+    const vector<int>& seedingLayers = seedTypesSeedLayers_[seedType];
+    if (find(seedingLayers.begin(), seedingLayers.end(), layer) != seedingLayers.end())
+      return false;
+    const vector<int>& projectingLayers = seedTypesProjectionLayers_[seedType];
+    const auto pos = find(projectingLayers.begin(), projectingLayers.end(), layer);
+    if (pos == projectingLayers.end()) {
+      const string& name = seedTypeNames_[seedType];
+      cms::Exception exception("logic_error");
+      exception.addContext("trackFindingTracklet::TrackBuilderChannel::layerId");
+      exception << "TTStub from layer " << layer << " (barrel: 1-6; discs: 11-15) from seed type " << name << " not supported.";
+      throw exception;
+    }
+    layerId = distance(projectingLayers.begin(), pos);
+     return true;
+   }
 
 }  // namespace trackFindingTracklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackBuilderChannel.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackBuilderChannel.cc
@@ -15,13 +15,12 @@ namespace trackFindingTracklet {
         boundaries_(iConfig.getParameter<vector<double>>("PtBoundaries")),
         seedTypeNames_(iConfig.getParameter<vector<string>>("SeedTypes")),
         numSeedTypes_(seedTypeNames_.size()),
-        maxNumProjectionLayers_(iConfig.getParameter<int>("MaxNumProjectionLayers"))
-  {
+        maxNumProjectionLayers_(iConfig.getParameter<int>("MaxNumProjectionLayers")) {
     if (summerChain_)
       numChannels_ = 1;
     else if (useDuplicateRemoval_)
       numChannels_ = 2 * boundaries_.size();
-    else 
+    else
       numChannels_ = numSeedTypes_;
     const ParameterSet& pSetSeedTypesSeedLayers = iConfig.getParameter<ParameterSet>("SeedTypesSeedLayers");
     const ParameterSet& pSetSeedTypesProjectionLayers = iConfig.getParameter<ParameterSet>("SeedTypesProjectionLayers");
@@ -84,11 +83,12 @@ namespace trackFindingTracklet {
       const string& name = seedTypeNames_[seedType];
       cms::Exception exception("logic_error");
       exception.addContext("trackFindingTracklet::TrackBuilderChannel::layerId");
-      exception << "TTStub from layer " << layer << " (barrel: 1-6; discs: 11-15) from seed type " << name << " not supported.";
+      exception << "TTStub from layer " << layer << " (barrel: 1-6; discs: 11-15) from seed type " << name
+                << " not supported.";
       throw exception;
     }
     layerId = distance(projectingLayers.begin(), pos);
-     return true;
-   }
+    return true;
+  }
 
 }  // namespace trackFindingTracklet

--- a/L1Trigger/TrackFindingTracklet/test/HybridTracksNewKF_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/HybridTracksNewKF_cfg.py
@@ -26,6 +26,8 @@ process.load( 'L1Trigger.TrackerDTC.ProducerED_cff' )
 process.load( 'L1Trigger.TrackerDTC.Analyzer_cff' )
 # L1 tracking => hybrid emulation 
 process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
+from L1Trigger.TrackFindingTracklet.Customize_cff import *
+newKFConfig( process )
 #--- Load code that analyzes hybrid emulation 
 process.load( 'L1Trigger.TrackFindingTracklet.Analyzer_cff' )
 # load code that fits hybrid tracks
@@ -41,7 +43,7 @@ process.TTTrackAssociatorFromPixelDigis.TTTracks = cms.VInputTag( cms.InputTag(
 # build schedule
 process.mc = cms.Sequence( process.StubAssociator )
 process.dtc = cms.Sequence( process.TrackerDTCProducer + process.TrackerDTCAnalyzer )
-process.tracklet = cms.Sequence( process.L1TrackletTracks + process.TrackFindingTrackletAnalyzerTracklet )
+process.tracklet = cms.Sequence( process.L1HybridTracks + process.TrackFindingTrackletAnalyzerTracklet )
 process.interIn = cms.Sequence( process.TrackFindingTrackletProducerKFin + process.TrackFindingTrackletAnalyzerKFin )
 process.kf = cms.Sequence( process.TrackFindingTrackletProducerKF + process.TrackFindingTrackletAnalyzerKF )
 process.TTTracks = cms.Sequence( process.TrackFindingTrackletProducerTT + process.TrackFindingTrackletProducerAS + process.TrackTriggerAssociatorTracks )

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -150,13 +150,16 @@ elif (L1TRKALGO == 'HYBRID_DISPLACED'):
 
 # HYBRID_NEWKF: prompt tracking
 elif (L1TRKALGO == 'HYBRID_NEWKF'):
+    process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
+    from L1Trigger.TrackFindingTracklet.Customize_cff import *
+    newKFConfig( process )
     process.load( 'L1Trigger.TrackFindingTracklet.ProducerKF_cff' )
     NHELIXPAR = 4
     L1TRK_NAME  = process.TrackFindingTrackletProducerKF_params.LabelTT.value()
     L1TRK_LABEL = process.TrackFindingTrackletProducerKF_params.BranchAcceptedTracks.value()
     L1TRUTH_NAME = "TTTrackAssociatorFromPixelDigis"
     process.TTTrackAssociatorFromPixelDigis.TTTracks = cms.VInputTag( cms.InputTag(L1TRK_NAME, L1TRK_LABEL) )
-    process.HybridNewKF = cms.Sequence(process.L1TrackletTracks + process.TrackFindingTrackletProducerKFin + process.TrackFindingTrackletProducerKF + process.TrackFindingTrackletProducerTT + process.TrackFindingTrackletProducerAS + process.TrackFindingTrackletProducerKFout)
+    process.HybridNewKF = cms.Sequence(process.L1HybridTracks + process.TrackFindingTrackletProducerKFin + process.TrackFindingTrackletProducerKF + process.TrackFindingTrackletProducerTT + process.TrackFindingTrackletProducerAS + process.TrackFindingTrackletProducerKFout)
     process.TTTracksEmulation = cms.Path(process.HybridNewKF)
     #process.TTTracksEmulationWithTruth = cms.Path(process.HybridNewKF +  process.TrackTriggerAssociatorTracks)
     # Optionally include code producing performance plots & end-of-job summary.

--- a/L1Trigger/TrackFindingTracklet/test/ProducerIRin.cc
+++ b/L1Trigger/TrackFindingTracklet/test/ProducerIRin.cc
@@ -55,9 +55,7 @@ namespace trackFindingTracklet {
     vector<int> channelEncoding_;
   };
 
-  ProducerIRin::ProducerIRin(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerIRin::ProducerIRin(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const InputTag& inputTag = iConfig.getParameter<InputTag>("InputTagDTC");
     const string& branchStubs = iConfig.getParameter<string>("BranchAcceptedStubs");
     // book in- and output ED products
@@ -90,7 +88,8 @@ namespace trackFindingTracklet {
     if (setup_->configurationSupported()) {
       Handle<TTDTC> handleTTDTC;
       iEvent.getByToken<TTDTC>(edGetTokenTTDTC_, handleTTDTC);
-      const int numChannel = summerChain_ ? channelEncoding_.size() : handleTTDTC->tfpRegions().size() * handleTTDTC->tfpChannels().size();
+      const int numChannel =
+          summerChain_ ? channelEncoding_.size() : handleTTDTC->tfpRegions().size() * handleTTDTC->tfpChannels().size();
       streamStubs.reserve(numChannel);
       for (int tfpRegion : handleTTDTC->tfpRegions())
         for (int tfpChannel : summerChain_ ? channelEncoding_ : handleTTDTC->tfpChannels())
@@ -100,6 +99,6 @@ namespace trackFindingTracklet {
     iEvent.emplace(edPutTokenStubs_, move(streamStubs));
   }
 
-} // namespace trackFindingTracklet
+}  // namespace trackFindingTracklet
 
 DEFINE_FWK_MODULE(trackFindingTracklet::ProducerIRin);

--- a/L1Trigger/TrackFindingTracklet/test/ProducerIRin.cc
+++ b/L1Trigger/TrackFindingTracklet/test/ProducerIRin.cc
@@ -1,0 +1,105 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "L1Trigger/TrackTrigger/interface/Setup.h"
+
+#include <string>
+#include <vector>
+#include <deque>
+#include <iterator>
+#include <cmath>
+#include <numeric>
+
+using namespace std;
+using namespace edm;
+using namespace tt;
+
+namespace trackFindingTracklet {
+
+  /*! \class  trackFindingTracklet::ProducerIRin
+   *  \brief  Transforms TTTDCinto f/w comparable format for summer chain configuratiotn
+   *  \author Thomas Schuh
+   *  \date   2021, Oct
+   */
+  class ProducerIRin : public stream::EDProducer<> {
+  public:
+    explicit ProducerIRin(const ParameterSet&);
+    ~ProducerIRin() override {}
+
+  private:
+    virtual void beginRun(const Run&, const EventSetup&) override;
+    virtual void produce(Event&, const EventSetup&) override;
+    virtual void endJob() {}
+    // ED input token of DTC Stubs
+    EDGetTokenT<TTDTC> edGetTokenTTDTC_;
+    // ED output token for stubs
+    EDPutTokenT<StreamsStub> edPutTokenStubs_;
+    // Setup token
+    ESGetToken<Setup, SetupRcd> esGetTokenSetup_;
+    // configuration
+    ParameterSet iConfig_;
+    // helper class to store configurations
+    const Setup* setup_;
+    // reduce l1 tracking to summer chain configuration
+    bool summerChain_;
+    // map of used tfp channels in summer chain config
+    vector<int> channelEncoding_;
+  };
+
+  ProducerIRin::ProducerIRin(const ParameterSet& iConfig) :
+    iConfig_(iConfig)
+  {
+    const InputTag& inputTag = iConfig.getParameter<InputTag>("InputTagDTC");
+    const string& branchStubs = iConfig.getParameter<string>("BranchAcceptedStubs");
+    // book in- and output ED products
+    edGetTokenTTDTC_ = consumes<TTDTC>(inputTag);
+    edPutTokenStubs_ = produces<StreamsStub>(branchStubs);
+    // book ES products
+    esGetTokenSetup_ = esConsumes<Setup, SetupRcd, Transition::BeginRun>();
+    // initial ES products
+    setup_ = nullptr;
+  }
+
+  void ProducerIRin::beginRun(const Run& iRun, const EventSetup& iSetup) {
+    // helper class to store configurations
+    setup_ = &iSetup.getData(esGetTokenSetup_);
+    if (!setup_->configurationSupported())
+      return;
+    // check process history if desired
+    if (iConfig_.getParameter<bool>("CheckHistory"))
+      setup_->checkHistory(iRun.processHistory());
+    // reduce l1 tracking to summer chain configuration
+    summerChain_ = iConfig_.getParameter<bool>("SummerChain");
+    // map of used tfp channels in summer chain config
+    channelEncoding_ = iConfig_.getParameter<vector<int>>("SummerChainChannels");
+  }
+
+  void ProducerIRin::produce(Event& iEvent, const EventSetup& iSetup) {
+    // empty IRin product
+    StreamsStub streamStubs;
+    // read in hybrid track finding product and produce KFin product
+    if (setup_->configurationSupported()) {
+      Handle<TTDTC> handleTTDTC;
+      iEvent.getByToken<TTDTC>(edGetTokenTTDTC_, handleTTDTC);
+      const int numChannel = summerChain_ ? channelEncoding_.size() : handleTTDTC->tfpRegions().size() * handleTTDTC->tfpChannels().size();
+      streamStubs.reserve(numChannel);
+      for (int tfpRegion : handleTTDTC->tfpRegions())
+        for (int tfpChannel : summerChain_ ? channelEncoding_ : handleTTDTC->tfpChannels())
+          streamStubs.emplace_back(handleTTDTC->stream(tfpRegion, tfpChannel));
+    }
+    // store products
+    iEvent.emplace(edPutTokenStubs_, move(streamStubs));
+  }
+
+} // namespace trackFindingTracklet
+
+DEFINE_FWK_MODULE(trackFindingTracklet::ProducerIRin);

--- a/L1Trigger/TrackFindingTracklet/test/ProducerTBout.cc
+++ b/L1Trigger/TrackFindingTracklet/test/ProducerTBout.cc
@@ -1,0 +1,295 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Utilities/interface/EDPutToken.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "L1Trigger/TrackTrigger/interface/Setup.h"
+#include "L1Trigger/TrackerTFP/interface/DataFormats.h"
+#include "L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannel.h"
+#include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
+
+#include <string>
+#include <vector>
+#include <deque>
+#include <iterator>
+#include <cmath>
+#include <numeric>
+
+using namespace std;
+using namespace edm;
+using namespace trackerTFP;
+using namespace tt;
+
+namespace trackFindingTracklet {
+
+  /*! \class  trackFindingTracklet::ProducerTBout
+   *  \brief  Transforms TTTracks from Tracklet pattern reco. into f/w comparable format
+   *  \author Thomas Schuh
+   *  \date   2021, Oct
+   */
+  class ProducerTBout : public stream::EDProducer<> {
+  public:
+    explicit ProducerTBout(const ParameterSet&);
+    ~ProducerTBout() override {}
+
+  private:
+    virtual void beginRun(const Run&, const EventSetup&) override;
+    virtual void produce(Event&, const EventSetup&) override;
+    virtual void endJob() {}
+
+    // dtc stub
+    struct Stub {
+      Stub(const FrameStub& frame, int region, int channel, const Setup* setup) {
+        region_ = region;
+        ttStubRef_ = frame.first;
+        frame_ = frame.second;
+        gp_ = setup->stubPos(true, frame, region, channel);
+        barrel_ = setup->barrel(ttStubRef_);
+        const bool ps = setup->psModule(ttStubRef_);
+        const TTBV ttBV(frame.second);
+        r_ = TTBV(ttBV, 39, 39 - (barrel_ || ps ? 7 : 12), true);
+        if (!barrel_ && !ps)
+          r_.resize(12);
+      }
+      int region_;
+      TTStubRef ttStubRef_;
+      Frame frame_;
+      GlobalPoint gp_;
+      bool barrel_;
+      TTBV r_;
+    };
+    // return h/w bits for given ttTrackRef
+    Frame conv(const TTTrackRef& ttTrackRef) const;
+    // return h/w bits for given dtc stub and origin ttTrackRef
+    Frame conv(const TTTrackRef& ttTrackRef, const Stub& stub) const;
+
+    // ED input token of TTTracks
+    EDGetTokenT<TTTracks> edGetTokenTTTracks_;
+    // ED input token of DTC Stubs
+    EDGetTokenT<TTDTC> edGetTokenTTDTC_;
+    // ED output token for stubs
+    EDPutTokenT<StreamsStub> edPutTokenAcceptedStubs_;
+    EDPutTokenT<StreamsStub> edPutTokenLostStubs_;
+    // ED output token for tracks
+    EDPutTokenT<StreamsTrack> edPutTokenAcceptedTracks_;
+    EDPutTokenT<StreamsTrack> edPutTokenLostTracks_;
+    // Setup token
+    ESGetToken<Setup, SetupRcd> esGetTokenSetup_;
+    // DataFormats token
+    ESGetToken<DataFormats, DataFormatsRcd> esGetTokenDataFormats_;
+    // TrackBuilderChannel token
+    ESGetToken<TrackBuilderChannel, TrackBuilderChannelRcd> esGetTokenTrackBuilderChannel_;
+    // configuration
+    ParameterSet iConfig_;
+    // helper class to store configurations
+    const Setup* setup_;
+    // helper class to extract structured data from TTDTC::Frames
+    const DataFormats* dataFormats_;
+    // helper class to assign tracks to channel
+    TrackBuilderChannel* trackBuilderChannel_;
+    //
+    bool enableTruncation_;
+    //
+    trklet::Settings settings_;
+  };
+
+  ProducerTBout::ProducerTBout(const ParameterSet& iConfig) :
+    iConfig_(iConfig)
+  {
+    const InputTag& inputTag = iConfig.getParameter<InputTag>("InputTag");
+    const InputTag& inputTagDTC = iConfig.getParameter<InputTag>("InputTagDTC");
+    const string& branchAcceptedStubs = iConfig.getParameter<string>("BranchAcceptedStubs");
+    const string& branchAcceptedTracks = iConfig.getParameter<string>("BranchAcceptedTracks");
+    const string& branchLostStubs = iConfig.getParameter<string>("BranchLostStubs");
+    const string& branchLostTracks = iConfig.getParameter<string>("BranchLostTracks");
+    // book in- and output ED products
+    edGetTokenTTTracks_ = consumes<TTTracks>(inputTag);
+    edGetTokenTTDTC_ = consumes<TTDTC>(inputTagDTC);
+    edPutTokenAcceptedStubs_ = produces<StreamsStub>(branchAcceptedStubs);
+    edPutTokenAcceptedTracks_ = produces<StreamsTrack>(branchAcceptedTracks);
+    edPutTokenLostStubs_ = produces<StreamsStub>(branchLostStubs);
+    edPutTokenLostTracks_ = produces<StreamsTrack>(branchLostTracks);
+    // book ES products
+    esGetTokenSetup_ = esConsumes<Setup, SetupRcd, Transition::BeginRun>();
+    esGetTokenDataFormats_ = esConsumes<DataFormats, DataFormatsRcd, Transition::BeginRun>();
+    esGetTokenTrackBuilderChannel_ = esConsumes<TrackBuilderChannel, TrackBuilderChannelRcd, Transition::BeginRun>();
+    // initial ES products
+    setup_ = nullptr;
+    dataFormats_ = nullptr;
+    trackBuilderChannel_ = nullptr;
+    //
+    enableTruncation_ = iConfig.getParameter<bool>("EnableTruncation");
+  }
+
+  void ProducerTBout::beginRun(const Run& iRun, const EventSetup& iSetup) {
+    // helper class to store configurations
+    setup_ = &iSetup.getData(esGetTokenSetup_);
+    if (!setup_->configurationSupported())
+      return;
+    // check process history if desired
+    if (iConfig_.getParameter<bool>("CheckHistory"))
+      setup_->checkHistory(iRun.processHistory());
+    // helper class to extract structured data from TTDTC::Frames
+    dataFormats_ = &iSetup.getData(esGetTokenDataFormats_);
+    // helper class to assign tracks to channel
+    trackBuilderChannel_ = const_cast<TrackBuilderChannel*>(&iSetup.getData(esGetTokenTrackBuilderChannel_));
+  }
+
+  void ProducerTBout::produce(Event& iEvent, const EventSetup& iSetup) {
+    const int numStreamsTracks = setup_->numRegions() * trackBuilderChannel_->numChannels();
+    const int numStreamsStubs = numStreamsTracks * trackBuilderChannel_->maxNumProjectionLayers();
+    // empty KFin products
+    StreamsStub streamAcceptedStubs(numStreamsStubs);
+    StreamsTrack streamAcceptedTracks(numStreamsTracks);
+    StreamsStub streamLostStubs(numStreamsStubs);
+    StreamsTrack streamLostTracks(numStreamsTracks);
+    // read in hybrid track finding product and produce KFin product
+    if (setup_->configurationSupported()) {
+      // create DTC stub frames
+      Handle<TTDTC> handleTTDTC;
+      iEvent.getByToken<TTDTC>(edGetTokenTTDTC_, handleTTDTC);
+      const TTDTC& ttDTC = *handleTTDTC;
+      vector<Stub> stubsDTC;
+      stubsDTC.reserve(ttDTC.nStubs());
+      for (int region : ttDTC.tfpRegions())
+        for (int channel : ttDTC.tfpChannels())
+          for (const FrameStub& frame : ttDTC.stream(region, channel))
+            if (frame.first.isNonnull())
+              stubsDTC.emplace_back(frame, region, channel, setup_);
+      // create TTrackRefs
+      Handle<TTTracks> handleTTTracks;
+      iEvent.getByToken<TTTracks>(edGetTokenTTTracks_, handleTTTracks);
+      vector<TTTrackRef> ttTrackRefs;
+      ttTrackRefs.reserve(handleTTTracks->size());
+      for (int i = 0; i < (int)handleTTTracks->size(); i++)
+        ttTrackRefs.emplace_back(TTTrackRef(handleTTTracks, i));
+      // count tracks per channel and size output products
+      vector<int> nTTTracksStreams(numStreamsTracks, 0);
+      int channelId;
+      for (const TTTrackRef& ttTrackRef : ttTrackRefs)
+        if (trackBuilderChannel_->channelId(ttTrackRef, channelId))
+          nTTTracksStreams[channelId]++;
+      for (int channelTrack = 0; channelTrack < numStreamsTracks; channelTrack++) {
+        const int num = nTTTracksStreams[channelTrack];
+        const int lost = enableTruncation_ && num > setup_->numFrames() ? num - setup_->numFrames() : 0;
+        const int accepted = lost == 0 ? num : setup_->numFrames();
+        streamAcceptedTracks[channelTrack].reserve(accepted);
+        streamLostTracks[channelTrack].reserve(lost);
+        for (int projection = 0; projection < trackBuilderChannel_->maxNumProjectionLayers(); projection++) {
+          const int channelStub = channelTrack * trackBuilderChannel_->maxNumProjectionLayers() + projection;
+          streamAcceptedStubs[channelStub].reserve(accepted);
+          streamLostStubs[channelStub].reserve(lost);
+        }
+      }
+      // fill output products
+      for (const TTTrackRef& ttTrackRef : ttTrackRefs) {
+        const bool valid = trackBuilderChannel_->channelId(ttTrackRef, channelId);
+        const bool truncate = enableTruncation_ && (int)streamAcceptedTracks[channelId].size() > setup_->numFrames();
+        StreamTrack& tracks = truncate ? streamLostTracks[channelId] : streamAcceptedTracks[channelId];
+        if (!valid && !truncate) { // fill gap
+          tracks.emplace_back(FrameTrack());
+          for (int projection = 0; projection < trackBuilderChannel_->maxNumProjectionLayers(); projection++) {
+            const int channelStub = channelId * trackBuilderChannel_->maxNumProjectionLayers() + projection;
+            streamAcceptedStubs[channelStub].emplace_back(FrameStub());
+          }
+          continue;
+        }
+        // conv track word
+        tracks.emplace_back(ttTrackRef, conv(ttTrackRef));
+        // conv stub words
+        StreamsStub& streams = truncate ? streamLostStubs : streamAcceptedStubs;
+        TTBV pattern(0, trackBuilderChannel_->maxNumProjectionLayers());
+        int layerId;
+        for (const TTStubRef& ttStubRef : ttTrackRef->getStubRefs()) {
+          if (!trackBuilderChannel_->layerId(ttTrackRef, ttStubRef, layerId))
+            continue;
+          pattern.set(layerId);
+          StreamStub& stubs = streams[channelId * trackBuilderChannel_->maxNumProjectionLayers() + layerId];
+          // find dtc stub
+          auto found = [ttTrackRef, ttStubRef](const Stub& stub) {
+            return stub.ttStubRef_ == ttStubRef && stub.region_ == (int)ttTrackRef->phiSector();
+          };
+          const Stub& stub = *find_if(stubsDTC.begin(), stubsDTC.end(), found);
+          // conv stub word
+          stubs.emplace_back(ttStubRef, conv(ttTrackRef, stub));
+        }
+        // add gaps to layer w/o stub
+        for (int layerId : pattern.ids(false))
+          streams[channelId * trackBuilderChannel_->maxNumProjectionLayers() + layerId].emplace_back(FrameStub());
+      }
+    }
+    // store products
+    iEvent.emplace(edPutTokenAcceptedStubs_, move(streamAcceptedStubs));
+    iEvent.emplace(edPutTokenAcceptedTracks_, move(streamAcceptedTracks));
+    iEvent.emplace(edPutTokenLostStubs_, move(streamLostStubs));
+    iEvent.emplace(edPutTokenLostTracks_, move(streamLostTracks));
+  }
+
+  // return h/w bits for given ttTrackRef
+  Frame ProducerTBout::conv(const TTTrackRef& ttTrackRef) const {
+    static constexpr int widthSeedType = 3;
+    static constexpr int widthInvR = 14;
+    static constexpr int widthPhi0 = 18;
+    static constexpr int widthZ0 = 10;
+    static constexpr int widthTanL = 14;
+    static const double baseInvR = settings_.kphi1() / settings_.kr() * pow(2, settings_.rinv_shift());
+    static const double basePhi0 = settings_.kphi1() * pow(2, settings_.phi0_shift());
+    static const double baseZ0 = settings_.kz() * pow(2, settings_.z0_shift());
+    static const double baseTanL = settings_.kz() / settings_.kr() * pow(2, settings_.t_shift());
+    // sub words
+    // phi0 w.r.t. processing region border in rad
+    double phi0 = deltaPhi(ttTrackRef->phi() - ttTrackRef->phiSector() * setup_->baseRegion() + setup_->hybridRangePhi() / 2.);
+    if (phi0 < 0.)
+      phi0 += 2. * M_PI;
+    const TTBV hwValid(1, 1);
+    const TTBV hwSeedType((int)ttTrackRef->trackSeedType(), widthSeedType);
+    const TTBV hwInvR(ttTrackRef->rInv(), baseInvR, widthInvR, true);
+    const TTBV hwPhi0(phi0, basePhi0, widthPhi0, false);
+    const TTBV hwZ0(ttTrackRef->z0(), baseZ0, widthZ0, true);
+    const TTBV hwTanL(ttTrackRef->tanL(), baseTanL, widthTanL, true);
+    const TTBV hw(hwValid.str() + hwSeedType.str() + hwInvR.str() + hwZ0.str() + hwTanL.str());
+    return hw.bs();
+  }
+
+  // return h/w bits for given dtc stub and origin ttTrackRef
+  Frame ProducerTBout::conv(const TTTrackRef& ttTrackRef, const Stub& stub) const {
+    static constexpr int widthPhi = 12;
+    static constexpr int widthZ = 9;
+    static constexpr int widthR = 7;
+    static const double basePhi = settings_.kphi1();
+    static const double baseR = settings_.kr();
+    static const double baseZ = settings_.kz();
+    static const double baseInvR = settings_.kphi1() / settings_.kr() * pow(2, settings_.rinv_shift());
+    static const double basePhi0 = settings_.kphi1() * pow(2, settings_.phi0_shift());
+    static const double baseZ0 = settings_.kz() * pow(2, settings_.z0_shift());
+    static const double baseTanL = settings_.kz() / settings_.kr() * pow(2, settings_.t_shift());
+    const int widthRZ = stub.barrel_ ? widthZ : widthR;
+    const double baseRZ = stub.barrel_ ? baseZ : baseR;
+    // calc residuals
+    const double rInv = (ttTrackRef->rInv() / baseInvR + .5) * baseInvR;
+    const double phi0 = (ttTrackRef->phi() / basePhi0 + .5) * basePhi0;
+    const double z0 = (ttTrackRef->z0() / baseZ0 + .5) * baseZ0;
+    const double tanL = (ttTrackRef->tanL() / baseTanL + .5) * baseTanL;
+    const double phi = deltaPhi(phi0 - rInv * stub.gp_.perp() / 2. - stub.gp_.phi());
+    const double r = (stub.gp_.z() - z0) / tanL - stub.gp_.perp();
+    const double z = z0 + tanL * stub.gp_.perp() - stub.gp_.z();
+    const double rz = stub.barrel_ ? r : z;
+    // sub words
+    const TTBV hwValid(1, 1);
+    const TTBV hwR(stub.r_);
+    const TTBV hwPhi(phi, basePhi, widthPhi, true);
+    const TTBV hwRZ(rz, baseRZ, widthRZ, true);
+    const TTBV hw(hwValid.str() + hwR.str() + hwPhi.str() + hwRZ.str());
+    return hw.bs();
+  }
+
+} // namespace trackFindingTracklet
+
+DEFINE_FWK_MODULE(trackFindingTracklet::ProducerTBout);

--- a/L1Trigger/TrackFindingTracklet/test/ProducerTBout.cc
+++ b/L1Trigger/TrackFindingTracklet/test/ProducerTBout.cc
@@ -100,9 +100,7 @@ namespace trackFindingTracklet {
     trklet::Settings settings_;
   };
 
-  ProducerTBout::ProducerTBout(const ParameterSet& iConfig) :
-    iConfig_(iConfig)
-  {
+  ProducerTBout::ProducerTBout(const ParameterSet& iConfig) : iConfig_(iConfig) {
     const InputTag& inputTag = iConfig.getParameter<InputTag>("InputTag");
     const InputTag& inputTagDTC = iConfig.getParameter<InputTag>("InputTagDTC");
     const string& branchAcceptedStubs = iConfig.getParameter<string>("BranchAcceptedStubs");
@@ -193,7 +191,7 @@ namespace trackFindingTracklet {
         const bool valid = trackBuilderChannel_->channelId(ttTrackRef, channelId);
         const bool truncate = enableTruncation_ && (int)streamAcceptedTracks[channelId].size() > setup_->numFrames();
         StreamTrack& tracks = truncate ? streamLostTracks[channelId] : streamAcceptedTracks[channelId];
-        if (!valid && !truncate) { // fill gap
+        if (!valid && !truncate) {  // fill gap
           tracks.emplace_back(FrameTrack());
           for (int projection = 0; projection < trackBuilderChannel_->maxNumProjectionLayers(); projection++) {
             const int channelStub = channelId * trackBuilderChannel_->maxNumProjectionLayers() + projection;
@@ -245,7 +243,8 @@ namespace trackFindingTracklet {
     static const double baseTanL = settings_.kz() / settings_.kr() * pow(2, settings_.t_shift());
     // sub words
     // phi0 w.r.t. processing region border in rad
-    double phi0 = deltaPhi(ttTrackRef->phi() - ttTrackRef->phiSector() * setup_->baseRegion() + setup_->hybridRangePhi() / 2.);
+    double phi0 =
+        deltaPhi(ttTrackRef->phi() - ttTrackRef->phiSector() * setup_->baseRegion() + setup_->hybridRangePhi() / 2.);
     if (phi0 < 0.)
       phi0 += 2. * M_PI;
     const TTBV hwValid(1, 1);
@@ -290,6 +289,6 @@ namespace trackFindingTracklet {
     return hw.bs();
   }
 
-} // namespace trackFindingTracklet
+}  // namespace trackFindingTracklet
 
 DEFINE_FWK_MODULE(trackFindingTracklet::ProducerTBout);

--- a/L1Trigger/TrackFindingTracklet/test/SummerChain_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/SummerChain_cfg.py
@@ -1,0 +1,88 @@
+# this compares event by event the output of the C++ summer chain emulation with the ModelSim simulation
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process( "Demo" )
+process.load( 'FWCore.MessageService.MessageLogger_cfi' )
+process.load( 'Configuration.EventContent.EventContent_cff' )
+#process.load( 'Configuration.Geometry.GeometryExtended2026D76Reco_cff' ) 
+#process.load( 'Configuration.Geometry.GeometryExtended2026D76_cff' )
+process.load( 'Configuration.Geometry.GeometryExtended2026D49Reco_cff' ) 
+process.load( 'Configuration.Geometry.GeometryExtended2026D49_cff' )
+process.load( 'Configuration.StandardSequences.MagneticField_cff' )
+process.load( 'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff' )
+process.load( 'L1Trigger.TrackTrigger.TrackTrigger_cff' )
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+
+# load code that produces DTCStubs
+process.load( 'L1Trigger.TrackerDTC.ProducerED_cff' )
+# L1 tracking => hybrid emulation 
+process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
+# load code that fits hybrid tracks
+process.load( 'L1Trigger.TrackFindingTracklet.ProducerKF_cff' )
+from L1Trigger.TrackFindingTracklet.Customize_cff import *
+summerChainConfig( process )
+#--- Load code that compares s/w with f/w
+process.load( 'L1Trigger.TrackerTFP.Demonstrator_cff' )
+
+# build schedule
+process.tt = cms.Sequence (  process.TrackerDTCProducer
+                           + process.L1HybridTracks
+                           + process.TrackFindingTrackletProducerIRin
+                           + process.TrackFindingTrackletProducerTBout
+                          )
+process.demo = cms.Path( process.tt + process.TrackerTFPDemonstrator )
+process.schedule = cms.Schedule( process.demo )
+
+# create options
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing( 'analysis' )
+# specify input MC
+#from MCsamples.Scripts.getCMSdata_cfi import *
+#from MCsamples.Scripts.getCMSlocaldata_cfi import *
+#from MCsamples.RelVal_1130_D76.PU200_TTbar_14TeV_cfi import *
+#inputMC = getCMSdataFromCards()
+inputMC = [
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValSingleMuFlatPt2To100/GEN-SIM-DIGI-RAW/113X_mcRun4_realistic_v6_2026D76noPU-v1/10000/05f802b7-b0b3-4cca-8b70-754682c3bb4c.root'
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValDisplacedMuPt2To100Dxy100/GEN-SIM-DIGI-RAW/113X_mcRun4_realistic_v6_2026D76noPU-v1/00000/011da61a-9524-4a96-b91f-03e8690af3bd.root'
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/00026541-6200-4eed-b6f8-d3a1fd720e9c.root',
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/013d0125-8f6e-496b-8335-614398c9210d.root',
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/058bd134-86de-47e1-bcde-379ed9b79e1b.root',
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0915d66c-cbd4-4ef6-9971-7dd59e198b56.root',
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/09823c8d-e443-4066-8347-8c704929cb2b.root',
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0c39a1aa-93ee-41c1-8543-6d90c09114a7.root',
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0fcdcc53-fb9f-4f0b-8529-a4d60d914c14.root',
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/16760a5c-9cd2-41c3-82e5-399bb962d537.root',
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/1752640f-2001-4d14-9276-063ec07cea92.root',
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/180712c9-31a5-4f2a-bf92-a7fbee4dabad.root'
+  "/store/relval/CMSSW_11_3_0_pre3/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v3_2026D49PU200_rsb-v1/00000/00260a30-734a-4a3a-a4b0-f836ce5502c6.root"
+]
+options.register( 'inputMC', inputMC, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Files to be processed" )
+# specify number of events to process.
+options.register( 'Events',100,VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.int, "Number of Events to analyze" )
+options.parseArguments()
+
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(False) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(options.Events) )
+process.source = cms.Source(
+  "PoolSource",
+  fileNames = cms.untracked.vstring( options.inputMC ),
+  skipEvents = cms.untracked.uint32( 11 ),
+  secondaryFileNames = cms.untracked.vstring(),
+  duplicateCheckMode = cms.untracked.string( 'noDuplicateCheck' )
+)
+process.Timing = cms.Service( "Timing", summaryOnly = cms.untracked.bool( True ) )
+process.MessageLogger.cerr.enableStatistics = False
+process.TFileService = cms.Service( "TFileService", fileName = cms.string( "Hist.root" ) )
+
+if ( False ):
+  process.out = cms.OutputModule (
+    "PoolOutputModule",
+    fileName = cms.untracked.string("L1Tracks.root"),
+    fastCloning = cms.untracked.bool( False ),
+    outputCommands = cms.untracked.vstring('drop *', 'keep *_TTTrack*_*_*', 'keep *_TTStub*_*_*' ),
+
+  )
+  process.FEVToutput_step = cms.EndPath( process.out )
+  process.schedule.append( process.FEVToutput_step )

--- a/L1Trigger/TrackFindingTracklet/test/demonstrator_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/demonstrator_cfg.py
@@ -18,6 +18,8 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
 process.load( 'L1Trigger.TrackerDTC.ProducerED_cff' )
 # L1 tracking => hybrid emulation 
 process.load("L1Trigger.TrackFindingTracklet.L1HybridEmulationTracks_cff")
+from L1Trigger.TrackFindingTracklet.Customize_cff import *
+newKFConfig( process )
 # load code that fits hybrid tracks
 process.load( 'L1Trigger.TrackFindingTracklet.ProducerKF_cff' )
 #--- Load code that compares s/w with f/w
@@ -25,7 +27,7 @@ process.load( 'L1Trigger.TrackerTFP.Demonstrator_cff' )
 
 # build schedule
 process.tt = cms.Sequence (  process.TrackerDTCProducer
-                           + process.L1TrackletTracks
+                           + process.L1HybridTracks
                            + process.TrackFindingTrackletProducerKFin
                            + process.TrackFindingTrackletProducerKF
                            + process.TrackFindingTrackletProducerTT

--- a/L1Trigger/TrackTrigger/python/ProducerSetup_cfi.py
+++ b/L1Trigger/TrackTrigger/python/ProducerSetup_cfi.py
@@ -102,8 +102,8 @@ TrackTrigger_params = cms.PSet (
     TiltApproxIntercept = cms.double(   0.504            ), # 
     MindPhi             = cms.double(  0.0001            ), # minimum representable stub phi uncertainty
     MaxdPhi             = cms.double(  0.02              ), # maximum representable stub phi uncertainty
-    MindZ               = cms.double(  0.1               ), # minimum representable stub z uncertainty
-    MaxdZ               = cms.double( 30.                ), # maximum representable stub z uncertainty
+    MindZ               = cms.double(  0.01              ), # minimum representable stub z uncertainty
+    MaxdZ               = cms.double( 45.                ), # maximum representable stub z uncertainty
   ),
 
   # Parmeter specifying front-end

--- a/L1Trigger/TrackTrigger/src/Setup.cc
+++ b/L1Trigger/TrackTrigger/src/Setup.cc
@@ -564,7 +564,7 @@ namespace tt {
       exception.addContext("trackerDTC::Setup::dZ");
       exception << "Stub z uncertainty " << dZ << " "
                 << "is out of range " << mindZ_ << " to " << maxdZ_ << ".";
-      //throw exception;
+      throw exception;
     }
     return dZ;
   }
@@ -740,7 +740,8 @@ namespace tt {
       const double baseR = hybridBasesR_.at(type);
       // parse bit vector
       bv >>= 1 + hybridWidthLayerId_ + widthBend + widthAlpha;
-      double phi = (bv.val(widthPhi, 0, true) + .5) * basePhi;
+      double phi = (bv.val(widthPhi) + .5) * basePhi;
+      phi -= hybridRangePhi_ / 2.;
       bv >>= widthPhi;
       double z = (bv.val(widthZ, 0, true) + .5) * baseZ;
       bv >>= widthZ;

--- a/L1Trigger/TrackerDTC/python/Analyzer_cfi.py
+++ b/L1Trigger/TrackerDTC/python/Analyzer_cfi.py
@@ -2,10 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 TrackerDTCAnalyzer_params = cms.PSet (
 
-  InputTagAccepted        = cms.InputTag( "TrackerDTCProducer",                "StubAccepted"    ), # dtc passed stubs selection
-  InputTagLost            = cms.InputTag( "TrackerDTCProducer",                "StubLost"        ), # dtc lost stubs selection
-  InputTagTTStubDetSetVec = cms.InputTag( "TTStubsFromPhase2TrackerDigis",     "StubAccepted"    ), # original TTStub selection
-  InputTagTTClusterAssMap = cms.InputTag( "TTClusterAssociatorFromPixelDigis", "ClusterAccepted" ), # tag of AssociationMap between TTCluster and TrackingParticles
-  UseMCTruth              = cms.bool( True )                                                        # eneables analyze of TPs
+  InputTagAccepted           = cms.InputTag( "TrackerDTCProducer",                "StubAccepted"     ), # dtc passed stubs selection
+  InputTagLost               = cms.InputTag( "TrackerDTCProducer",                "StubLost"         ), # dtc lost stubs selection
+  InputTagTTStubDetSetVec    = cms.InputTag( "TTStubsFromPhase2TrackerDigis",     "StubAccepted"     ), # original TTStub selection
+  InputTagTTClusterDetSetVec = cms.InputTag( "TTClustersFromPhase2TrackerDigis",  "ClusterInclusive" ), # original TTCluster selection
+  InputTagTTClusterAssMap    = cms.InputTag( "TTClusterAssociatorFromPixelDigis", "ClusterAccepted"  ), # tag of AssociationMap between TTCluster and TrackingParticles
+  UseMCTruth                 = cms.bool( True )                                                         # eneables analyze of TPs
 
 )

--- a/L1Trigger/TrackerDTC/test/test_cfg.py
+++ b/L1Trigger/TrackerDTC/test/test_cfg.py
@@ -8,14 +8,15 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "Demo" )
-process.load( 'Configuration.Geometry.GeometryExtended2026D49Reco_cff' )
+process.load( 'FWCore.MessageService.MessageLogger_cfi' )
+process.load( 'Configuration.Geometry.GeometryExtended2026D76Reco_cff' ) 
+process.load( 'Configuration.Geometry.GeometryExtended2026D76_cff' )
 process.load( 'Configuration.StandardSequences.MagneticField_cff' )
 process.load( 'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff' )
-process.load( 'Configuration.StandardSequences.L1TrackTrigger_cff' )
-process.load( "FWCore.MessageLogger.MessageLogger_cfi" )
+process.load( 'L1Trigger.TrackTrigger.TrackTrigger_cff' )
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag( process.GlobalTag, 'auto:phase2_realistic', '' )
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
 
 # load code that produces DTCStubs
 process.load( 'L1Trigger.TrackerDTC.ProducerED_cff' )
@@ -35,21 +36,20 @@ process.schedule = cms.Schedule( process.produce, process.analyze )
 import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing( 'analysis' )
 # specify input MC
-Samples = {
-  #'/store/relval/CMSSW_11_2_0_pre6/RelValSingleMuFlatPt1p5To8/GEN-SIM-DIGI-RAW/112X_mcRun4_realistic_v2_2026D49noPU_L1T-v1/20000/4E15C795-152F-A040-8AF4-5AF5F97EB996.root'
-  #'/store/relval/CMSSW_11_2_0_pre6/RelValSingleMuFlatPt2To100/GEN-SIM-DIGI-RAW/112X_mcRun4_realistic_v2_2026D49noPU_L1T-v1/20000/05D370F9-B42A-9C40-A1D8-BDD261A43A0D.root'
-  '/store/relval/CMSSW_11_2_0_pre6/RelValDisplacedMuPt2To100/GEN-SIM-DIGI-RAW/112X_mcRun4_realistic_v2_2026D49noPU_L1T-v1/20000/13BB84A7-DFD5-4746-AE5C-F3E6C17A5AD1.root'
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/0074C44A-BBE2-6849-965D-CB73FE0C0E6C.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/00BE971B-A866-B34C-9EE3-48EF12C78C8D.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/011CEE57-5477-AE4D-A91F-4853259170CE.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/043F7E57-B485-7344-93A8-CE1C0BF92AF0.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/05C7E3C6-19A5-BB4C-84AF-A6F6D0DEFAE2.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/087810CE-EBBB-CF47-A9D7-23C96F1E77BE.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/13BBEBBC-BB36-8A46-8E7E-AB69FFB63CB5.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/15865F8B-C3F5-594E-8E21-F4A330A96FA9.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/187113F3-C0B0-514C-AFFD-28E7DCA3E524.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/1A0446C6-74F8-9749-BC4A-1D3A296CA4BA.root'
-}
+Samples = [
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValSingleMuFlatPt2To100/GEN-SIM-DIGI-RAW/113X_mcRun4_realistic_v6_2026D76noPU-v1/10000/05f802b7-b0b3-4cca-8b70-754682c3bb4c.root'
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValDisplacedMuPt2To100Dxy100/GEN-SIM-DIGI-RAW/113X_mcRun4_realistic_v6_2026D76noPU-v1/00000/011da61a-9524-4a96-b91f-03e8690af3bd.root'
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/00026541-6200-4eed-b6f8-d3a1fd720e9c.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/013d0125-8f6e-496b-8335-614398c9210d.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/058bd134-86de-47e1-bcde-379ed9b79e1b.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0915d66c-cbd4-4ef6-9971-7dd59e198b56.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/09823c8d-e443-4066-8347-8c704929cb2b.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0c39a1aa-93ee-41c1-8543-6d90c09114a7.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0fcdcc53-fb9f-4f0b-8529-a4d60d914c14.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/16760a5c-9cd2-41c3-82e5-399bb962d537.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/1752640f-2001-4d14-9276-063ec07cea92.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/180712c9-31a5-4f2a-bf92-a7fbee4dabad.root'
+]
 options.register( 'inputMC', Samples, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Files to be processed" )
 # specify number of events to process.
 options.register( 'Events',100,VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.int, "Number of Events to analyze" )

--- a/L1Trigger/TrackerTFP/python/Demonstrator_cfi.py
+++ b/L1Trigger/TrackerTFP/python/Demonstrator_cfi.py
@@ -10,9 +10,9 @@ TrackTriggerDemonstrator_params = cms.PSet (
   #RunTime  = cms.double( 6.0 )                                # runtime in us
 
   # hybrid
-  LabelIn  = cms.string( "TrackFindingTrackletProducerKF"    ), #
-  LabelOut = cms.string( "TrackFindingTrackletProducerKF"      ), #
-  DirIPBB  = cms.string( "/heplnw039/tschuh/work/proj/kfout/" ), # path to ipbb proj area
-  RunTime  = cms.double( 6.0 )                                    # runtime in us
+  LabelIn  = cms.string( "TrackFindingTrackletProducerIRin"  ), #
+  LabelOut = cms.string( "TrackFindingTrackletProducerTBout" ), #
+  DirIPBB  = cms.string( "/heplnw039/tschuh/work/proj/sim/"  ), # path to ipbb proj area
+  RunTime  = cms.double( 8.0 )                                  # runtime in us
 
 )

--- a/L1Trigger/TrackerTFP/src/Demonstrator.cc
+++ b/L1Trigger/TrackerTFP/src/Demonstrator.cc
@@ -40,15 +40,18 @@ namespace trackerTFP {
     // reset ss
     ss.str("");
     ss.clear();
+    // number of tranceiver in a quad
+    static constexpr int quad = 4;
     const int numChannel = bits.size() / numRegions_;
+    const int voidChannel = numChannel % quad == 0 ? 0 : quad - numChannel % quad;
     // start with header
-    ss << header(numChannel);
+    ss << header(numChannel + voidChannel);
     int nFrame(0);
     // create one packet per region
     for (int region = 0; region < numRegions_; region++) {
       const int offset = region * numChannel;
       // start with emp 6 frame gap
-      ss << infraGap(nFrame, numChannel);
+      ss << infraGap(nFrame, numChannel + voidChannel);
       for (int frame = 0; frame < numFrames_; frame++) {
         // write one frame for all channel
         ss << this->frame(nFrame);
@@ -56,6 +59,8 @@ namespace trackerTFP {
           const vector<Frame>& bvs = bits[offset + channel];
           ss << (frame < (int)bvs.size() ? hex(bvs[frame]) : hex(Frame()));
         }
+        for (int channel = 0; channel < voidChannel; channel++)
+          ss << " 0v" << string(TTBV::S_ / 4, '0' );
         ss << endl;
       }
     }
@@ -70,7 +75,7 @@ namespace trackerTFP {
     fs.close();
     // run modelsim
     stringstream cmd;
-    cmd << "cd " << dirIPBB_ << " && ./vsim -quiet -c work.top -do 'run " << runTime_ << "us' -do 'quit' &> /dev/null";
+    cmd << "cd " << dirIPBB_ << " && ./run_sim -quiet -c work.top -do 'run " << runTime_ << "us' -do 'quit' &> /dev/null";
     system(cmd.str().c_str());
   }
 

--- a/L1Trigger/TrackerTFP/src/Demonstrator.cc
+++ b/L1Trigger/TrackerTFP/src/Demonstrator.cc
@@ -60,7 +60,7 @@ namespace trackerTFP {
           ss << (frame < (int)bvs.size() ? hex(bvs[frame]) : hex(Frame()));
         }
         for (int channel = 0; channel < voidChannel; channel++)
-          ss << " 0v" << string(TTBV::S_ / 4, '0' );
+          ss << " 0v" << string(TTBV::S_ / 4, '0');
         ss << endl;
       }
     }
@@ -75,7 +75,8 @@ namespace trackerTFP {
     fs.close();
     // run modelsim
     stringstream cmd;
-    cmd << "cd " << dirIPBB_ << " && ./run_sim -quiet -c work.top -do 'run " << runTime_ << "us' -do 'quit' &> /dev/null";
+    cmd << "cd " << dirIPBB_ << " && ./run_sim -quiet -c work.top -do 'run " << runTime_
+        << "us' -do 'quit' &> /dev/null";
     system(cmd.str().c_str());
   }
 

--- a/L1Trigger/TrackerTFP/test/AnalyzerDemonstrator.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerDemonstrator.cc
@@ -72,7 +72,9 @@ namespace trackerTFP {
     if (labelIn == "TrackerTFPProducerKFin" || labelIn == "TrackerTFPProducerKF" ||
         labelIn == "TrackFindingTrackletProducerKFin" || labelIn == "TrackFindingTrackletProducerKF")
       edGetTokenTracksIn_ = consumes<StreamsTrack>(InputTag(labelIn, branchTracks));
-    if (labelOut == "TrackerTFPProducerKF" || labelOut == "TrackerTFPProducerDR" || labelOut == "TrackFindingTrackletProducerKF" || labelOut == "TrackFindingTrackletProducerKFout" || labelOut == "TrackFindingTrackletProducerTBout")
+    if (labelOut == "TrackerTFPProducerKF" || labelOut == "TrackerTFPProducerDR" ||
+        labelOut == "TrackFindingTrackletProducerKF" || labelOut == "TrackFindingTrackletProducerKFout" ||
+        labelOut == "TrackFindingTrackletProducerTBout")
       edGetTokenTracksOut_ = consumes<StreamsTrack>(InputTag(labelOut, branchTracks));
     // book ES products
     esGetTokenSetup_ = esConsumes<Setup, SetupRcd, Transition::BeginRun>();
@@ -94,7 +96,7 @@ namespace trackerTFP {
     vector<vector<Frame>> output;
     convert(iEvent, edGetTokenTracksIn_, edGetTokenStubsIn_, input);
     convert(iEvent, edGetTokenTracksOut_, edGetTokenStubsOut_, output);
-    if (!all_of(output.begin(), output.end(), [](const vector<Frame>& frames){ return frames.empty(); }))
+    if (!all_of(output.begin(), output.end(), [](const vector<Frame>& frames) { return frames.empty(); }))
       demonstrator_->analyze(input, output);
   }
 
@@ -127,7 +129,7 @@ namespace trackerTFP {
           const int offsetStubs = (region * numChannelTracks + channelTracks) * numChannelStubs;
           if (tracks)
             convert(handleTracks->at(offsetTracks + channelTracks), bits);
-          if (stubs){
+          if (stubs) {
             for (int channelStubs = 0; channelStubs < numChannelStubs; channelStubs++)
               convert(handleStubs->at(offsetStubs + channelStubs), bits);
           }


### PR DESCRIPTION
This PR does:
- adds set function in Settings for removalType_ and doMultipleMatches_
- updates TrackBuilderChannel::channelId using now TTTrackRef instead of TTTrack
- extends TrackBuilderChannel to assign TTStubs from found TTTracks to channel
- fixes wrong ifndef define in TrackBuilderChannelRcd
- extends L1FPGATrackProducer to manipulate Settings::removalType_ and Settings::doMultipleMatches_ via python config
- trackFindingTracklet::ProducerKFin uses now TTTrackRefs to get channelIds via TrackBuilderChannel
- ProducerTrackBuilderCannel construct TrackBuilderChannel with Setup which is needed to assign stubs to channel
- adds new File Customize_cff.py which allows no manipulate TrackletTracksFromTrackletEmulation to run configured as summerchain with new KF or full chain with new KF
- removes L1HybridsTracks anf TrackletTracksFromTrackletEmulation I had added in the past to configure full chain with new KF since I switched to the use of a customize function
- adds a map of which DTC links are used in summer chain configuration as python config
- adds seed type names, seeding layer Ids per seed type and projection layers per seed type as python config
- fixes firmware parameter in Setup and renables according sanity check related to stub z uncertainty
- fixes wrong stub phi position in function Setup::stubPos which is used to get bit accurate Stub positions after DTC
- add printout of number of TTCluster to DTC analzyer end job summary
- updates DTC test_cfg.py to new default geometry
- updates default Demonstrator_cfi.py parameter to run summer chain demonstration
- fixes Demonstrator to use new ipbb sim executable 'run_sim'
- fixes Demonstrator to add links to fill the quads with 0 data as ipbb sim and h/w test does
- adds new File ProducerIRin which transforms the TTDTC object in the same f/w near format as used in KF, KFin (output only atm), KFout which enables the use of Demonstrator to compare hybrid s/w with f/w
- add new File ProducerTBout which transforms found TTTracks in the same f/w near format as used in ProducerIRin which serves as input of KFin in future and enables the use of Demonstrator to compare tracklet pattern reco s/w with f/w
- add new File SummerChain_cfg.py which runs Demonstrator configured to summer chain IR to TB where the first event is the same event as used firmware-hls/reducedConfigPR mem prints