### PR TITLE
several bug fixes.

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannelRcd.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackBuilderChannelRcd.h
@@ -1,5 +1,5 @@
-#ifndef L1Trigger_TrackFindingTracklet_LayerEncodingRcd_h
-#define L1Trigger_TrackFindingTracklet_LayerEncodingRcd_h
+#ifndef L1Trigger_TrackFindingTracklet_TrackBuilderChannelRcd_h
+#define L1Trigger_TrackFindingTracklet_TrackBuilderChannelRcd_h
 
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "FWCore/Utilities/interface/mplVector.h"

--- a/L1Trigger/TrackFindingTracklet/test/HybridTracksNewKF_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/HybridTracksNewKF_cfg.py
@@ -16,7 +16,7 @@ process.load( 'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff'
 process.load( 'L1Trigger.TrackTrigger.TrackTrigger_cff' )
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 # load code that associates stubs with mctruth
 process.load( 'SimTracker.TrackTriggerAssociation.StubAssociator_cff' )

--- a/L1Trigger/TrackFindingTracklet/test/demonstrator_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/demonstrator_cfg.py
@@ -10,7 +10,7 @@ process.load( 'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff'
 process.load( 'L1Trigger.TrackTrigger.TrackTrigger_cff' )
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 
 

--- a/L1Trigger/TrackTrigger/src/Setup.cc
+++ b/L1Trigger/TrackTrigger/src/Setup.cc
@@ -564,7 +564,7 @@ namespace tt {
       exception.addContext("trackerDTC::Setup::dZ");
       exception << "Stub z uncertainty " << dZ << " "
                 << "is out of range " << mindZ_ << " to " << maxdZ_ << ".";
-      //throw exception;
+      throw exception;
     }
     return dZ;
   }
@@ -740,7 +740,7 @@ namespace tt {
       const double baseR = hybridBasesR_.at(type);
       // parse bit vector
       bv >>= 1 + hybridWidthLayerId_ + widthBend + widthAlpha;
-      double phi = (bv.val(widthPhi, 0, true) + .5) * basePhi;
+      double phi = (bv.val(widthPhi) + .5) * basePhi - hybridRangePhi_ / 2.;
       bv >>= widthPhi;
       double z = (bv.val(widthZ, 0, true) + .5) * baseZ;
       bv >>= widthZ;

--- a/L1Trigger/TrackerDTC/test/testDAQ_cfg.py
+++ b/L1Trigger/TrackerDTC/test/testDAQ_cfg.py
@@ -8,14 +8,15 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "Demo" )
-process.load( 'Configuration.Geometry.GeometryExtended2026D49Reco_cff' )
+process.load( 'FWCore.MessageService.MessageLogger_cfi' )
+process.load( 'Configuration.Geometry.GeometryExtended2026D76Reco_cff' ) 
+process.load( 'Configuration.Geometry.GeometryExtended2026D76_cff' )
 process.load( 'Configuration.StandardSequences.MagneticField_cff' )
 process.load( 'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff' )
-process.load( 'Configuration.StandardSequences.L1TrackTrigger_cff' )
-process.load( "FWCore.MessageLogger.MessageLogger_cfi" )
+process.load( 'L1Trigger.TrackTrigger.TrackTrigger_cff' )
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag( process.GlobalTag, 'auto:phase2_realistic', '' )
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 # load code that analyzes TTCluster
 process.load( 'L1Trigger.TrackerDTC.AnalyzerDAQ_cff' )
@@ -28,28 +29,20 @@ process.schedule = cms.Schedule( process.path )
 import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing( 'analysis' )
 # specify input MC
-Samples = {
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/0330453B-9B8E-CA41-88B0-A047B68D1AF9.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/02180D14-024D-ED46-9899-B275EADB82CE.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/0207F436-9BAC-904D-B86A-C2CE18CC2A46.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/01323A12-1A0B-AE43-B7AB-BAAE294E4EFA.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/D87319E3-F541-5840-AA58-10F84ACE1523.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/D7384F02-54C2-AB49-AEF3-E4E7303541CA.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/D3629C85-EA34-C147-AC4D-939C41DEC68A.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/D253E174-69A1-A544-9719-0D9BFDAD5320.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/D0D41CBC-08BA-E14E-8FE9-BD982CC6CA95.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/CD22CEB0-26EE-3147-8076-82926A26FAD4.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/CB67FBC0-0BF9-BE4E-A6D6-1388B2B2D2BF.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/CB36BB1A-67D7-C04D-ADB9-50DEB9B49E73.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/C9DEB7AA-E520-8C4C-AE74-A482BF59B048.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/C8ABAD54-6291-FA44-92E1-5BEECB1D6793.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/C74CD357-330E-E442-8F9F-C060CA44964A.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/C6BD36D2-79B9-2142-9A17-1CCC4FA2DDF1.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/C5DE1FC8-F963-7641-8020-451DB641C609.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/C57720E8-F837-0448-8483-D06474BB316B.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/C41FF339-435A-EC4A-A830-3D9DB7630B0A.root',
-  '/store/relval/CMSSW_11_1_0_pre1/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v2_2026D49PU200_ext1-v1/20000/C38AE82D-587E-C34B-89DC-FBAE92696270.root'
-}
+Samples = [
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValSingleMuFlatPt2To100/GEN-SIM-DIGI-RAW/113X_mcRun4_realistic_v6_2026D76noPU-v1/10000/05f802b7-b0b3-4cca-8b70-754682c3bb4c.root'
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValDisplacedMuPt2To100Dxy100/GEN-SIM-DIGI-RAW/113X_mcRun4_realistic_v6_2026D76noPU-v1/00000/011da61a-9524-4a96-b91f-03e8690af3bd.root'
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/00026541-6200-4eed-b6f8-d3a1fd720e9c.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/013d0125-8f6e-496b-8335-614398c9210d.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/058bd134-86de-47e1-bcde-379ed9b79e1b.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0915d66c-cbd4-4ef6-9971-7dd59e198b56.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/09823c8d-e443-4066-8347-8c704929cb2b.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0c39a1aa-93ee-41c1-8543-6d90c09114a7.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0fcdcc53-fb9f-4f0b-8529-a4d60d914c14.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/16760a5c-9cd2-41c3-82e5-399bb962d537.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/1752640f-2001-4d14-9276-063ec07cea92.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/180712c9-31a5-4f2a-bf92-a7fbee4dabad.root'
+]
 options.register( 'inputMC', Samples, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Files to be processed" )
 # specify number of events to process.
 options.register( 'Events',100,VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.int, "Number of Events to analyze" )

--- a/L1Trigger/TrackerDTC/test/test_cfg.py
+++ b/L1Trigger/TrackerDTC/test/test_cfg.py
@@ -16,7 +16,7 @@ process.load( 'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff'
 process.load( 'L1Trigger.TrackTrigger.TrackTrigger_cff' )
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 # load code that produces DTCStubs
 process.load( 'L1Trigger.TrackerDTC.ProducerED_cff' )

--- a/L1Trigger/TrackerDTC/test/test_cfg.py
+++ b/L1Trigger/TrackerDTC/test/test_cfg.py
@@ -8,14 +8,15 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "Demo" )
-process.load( 'Configuration.Geometry.GeometryExtended2026D49Reco_cff' )
+process.load( 'FWCore.MessageService.MessageLogger_cfi' )
+process.load( 'Configuration.Geometry.GeometryExtended2026D76Reco_cff' ) 
+process.load( 'Configuration.Geometry.GeometryExtended2026D76_cff' )
 process.load( 'Configuration.StandardSequences.MagneticField_cff' )
 process.load( 'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff' )
-process.load( 'Configuration.StandardSequences.L1TrackTrigger_cff' )
-process.load( "FWCore.MessageLogger.MessageLogger_cfi" )
+process.load( 'L1Trigger.TrackTrigger.TrackTrigger_cff' )
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag( process.GlobalTag, 'auto:phase2_realistic', '' )
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
 
 # load code that produces DTCStubs
 process.load( 'L1Trigger.TrackerDTC.ProducerED_cff' )
@@ -35,21 +36,20 @@ process.schedule = cms.Schedule( process.produce, process.analyze )
 import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing( 'analysis' )
 # specify input MC
-Samples = {
-  #'/store/relval/CMSSW_11_2_0_pre6/RelValSingleMuFlatPt1p5To8/GEN-SIM-DIGI-RAW/112X_mcRun4_realistic_v2_2026D49noPU_L1T-v1/20000/4E15C795-152F-A040-8AF4-5AF5F97EB996.root'
-  #'/store/relval/CMSSW_11_2_0_pre6/RelValSingleMuFlatPt2To100/GEN-SIM-DIGI-RAW/112X_mcRun4_realistic_v2_2026D49noPU_L1T-v1/20000/05D370F9-B42A-9C40-A1D8-BDD261A43A0D.root'
-  '/store/relval/CMSSW_11_2_0_pre6/RelValDisplacedMuPt2To100/GEN-SIM-DIGI-RAW/112X_mcRun4_realistic_v2_2026D49noPU_L1T-v1/20000/13BB84A7-DFD5-4746-AE5C-F3E6C17A5AD1.root'
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/0074C44A-BBE2-6849-965D-CB73FE0C0E6C.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/00BE971B-A866-B34C-9EE3-48EF12C78C8D.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/011CEE57-5477-AE4D-A91F-4853259170CE.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/043F7E57-B485-7344-93A8-CE1C0BF92AF0.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/05C7E3C6-19A5-BB4C-84AF-A6F6D0DEFAE2.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/087810CE-EBBB-CF47-A9D7-23C96F1E77BE.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/13BBEBBC-BB36-8A46-8E7E-AB69FFB63CB5.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/15865F8B-C3F5-594E-8E21-F4A330A96FA9.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/187113F3-C0B0-514C-AFFD-28E7DCA3E524.root',
-  #'/store/relval/CMSSW_11_2_0_pre5/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU25ns_110X_mcRun4_realistic_v3_2026D49PU200-v1/20000/1A0446C6-74F8-9749-BC4A-1D3A296CA4BA.root'
-}
+Samples = [
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValSingleMuFlatPt2To100/GEN-SIM-DIGI-RAW/113X_mcRun4_realistic_v6_2026D76noPU-v1/10000/05f802b7-b0b3-4cca-8b70-754682c3bb4c.root'
+  #'/store/relval/CMSSW_11_3_0_pre6/RelValDisplacedMuPt2To100Dxy100/GEN-SIM-DIGI-RAW/113X_mcRun4_realistic_v6_2026D76noPU-v1/00000/011da61a-9524-4a96-b91f-03e8690af3bd.root'
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/00026541-6200-4eed-b6f8-d3a1fd720e9c.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/013d0125-8f6e-496b-8335-614398c9210d.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/058bd134-86de-47e1-bcde-379ed9b79e1b.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0915d66c-cbd4-4ef6-9971-7dd59e198b56.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/09823c8d-e443-4066-8347-8c704929cb2b.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0c39a1aa-93ee-41c1-8543-6d90c09114a7.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/0fcdcc53-fb9f-4f0b-8529-a4d60d914c14.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/16760a5c-9cd2-41c3-82e5-399bb962d537.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/1752640f-2001-4d14-9276-063ec07cea92.root',
+  '/store/relval/CMSSW_11_3_0_pre6/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_113X_mcRun4_realistic_v6_2026D76PU200-v1/00000/180712c9-31a5-4f2a-bf92-a7fbee4dabad.root'
+]
 options.register( 'inputMC', Samples, VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.string, "Files to be processed" )
 # specify number of events to process.
 options.register( 'Events',100,VarParsing.VarParsing.multiplicity.singleton, VarParsing.VarParsing.varType.int, "Number of Events to analyze" )

--- a/L1Trigger/TrackerTFP/src/Demonstrator.cc
+++ b/L1Trigger/TrackerTFP/src/Demonstrator.cc
@@ -40,15 +40,18 @@ namespace trackerTFP {
     // reset ss
     ss.str("");
     ss.clear();
+    // number of tranceiver in a quad
+    static constexpr int quad = 4;
     const int numChannel = bits.size() / numRegions_;
+    const int voidChannel = numChannel % quad == 0 ? 0 : quad - numChannel % quad;
     // start with header
-    ss << header(numChannel);
+    ss << header(numChannel + voidChannel);
     int nFrame(0);
     // create one packet per region
     for (int region = 0; region < numRegions_; region++) {
       const int offset = region * numChannel;
       // start with emp 6 frame gap
-      ss << infraGap(nFrame, numChannel);
+      ss << infraGap(nFrame, numChannel + voidChannel);
       for (int frame = 0; frame < numFrames_; frame++) {
         // write one frame for all channel
         ss << this->frame(nFrame);
@@ -56,6 +59,8 @@ namespace trackerTFP {
           const vector<Frame>& bvs = bits[offset + channel];
           ss << (frame < (int)bvs.size() ? hex(bvs[frame]) : hex(Frame()));
         }
+        for (int channel = 0; channel < voidChannel; channel++)
+          ss << " 0v" << string(TTBV::S_ / 4, '0' );
         ss << endl;
       }
     }
@@ -70,7 +75,7 @@ namespace trackerTFP {
     fs.close();
     // run modelsim
     stringstream cmd;
-    cmd << "cd " << dirIPBB_ << " && ./vsim -quiet -c work.top -do 'run " << runTime_ << "us' -do 'quit' &> /dev/null";
+    cmd << "cd " << dirIPBB_ << " && ./run_sim -quiet -c work.top -do 'run " << runTime_ << "us' -do 'quit' &> /dev/null";
     system(cmd.str().c_str());
   }
 

--- a/L1Trigger/TrackerTFP/src/Demonstrator.cc
+++ b/L1Trigger/TrackerTFP/src/Demonstrator.cc
@@ -60,7 +60,7 @@ namespace trackerTFP {
           ss << (frame < (int)bvs.size() ? hex(bvs[frame]) : hex(Frame()));
         }
         for (int channel = 0; channel < voidChannel; channel++)
-          ss << " 0v" << string(TTBV::S_ / 4, '0' );
+          ss << " 0v" << string(TTBV::S_ / 4, '0');
         ss << endl;
       }
     }
@@ -75,7 +75,8 @@ namespace trackerTFP {
     fs.close();
     // run modelsim
     stringstream cmd;
-    cmd << "cd " << dirIPBB_ << " && ./run_sim -quiet -c work.top -do 'run " << runTime_ << "us' -do 'quit' &> /dev/null";
+    cmd << "cd " << dirIPBB_ << " && ./run_sim -quiet -c work.top -do 'run " << runTime_
+        << "us' -do 'quit' &> /dev/null";
     system(cmd.str().c_str());
   }
 

--- a/L1Trigger/TrackerTFP/test/AnalyzerDemonstrator.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerDemonstrator.cc
@@ -121,15 +121,21 @@ namespace trackerTFP {
     numChannelStubs /= (setup_->numRegions() * (tracks ? numChannelTracks : 1));
     bits.reserve(numChannelTracks + numChannelStubs);
     for (int region = 0; region < setup_->numRegions(); region++) {
-      const int offsetTracks = region * numChannelTracks;
-      for (int channelTracks = 0; channelTracks < numChannelTracks; channelTracks++) {
-        const int offsetStubs = (region * numChannelTracks + channelTracks) * numChannelStubs;
-        if (tracks)
-          convert(handleTracks->at(offsetTracks + channelTracks), bits);
-        if (stubs) {
-          for (int channelStubs = 0; channelStubs < numChannelStubs; channelStubs++)
-            convert(handleStubs->at(offsetStubs + channelStubs), bits);
+      if (tracks) {
+        const int offsetTracks = region * numChannelTracks;
+        for (int channelTracks = 0; channelTracks < numChannelTracks; channelTracks++) {
+          const int offsetStubs = (region * numChannelTracks + channelTracks) * numChannelStubs;
+          if (tracks)
+            convert(handleTracks->at(offsetTracks + channelTracks), bits);
+          if (stubs){
+            for (int channelStubs = 0; channelStubs < numChannelStubs; channelStubs++)
+              convert(handleStubs->at(offsetStubs + channelStubs), bits);
+          }
         }
+      } else {
+        const int offsetStubs = region * numChannelStubs;
+        for (int channelStubs = 0; channelStubs < numChannelStubs; channelStubs++)
+          convert(handleStubs->at(offsetStubs + channelStubs), bits);
       }
     }
   }

--- a/L1Trigger/TrackerTFP/test/demonstrator_cfg.py
+++ b/L1Trigger/TrackerTFP/test/demonstrator_cfg.py
@@ -10,7 +10,7 @@ process.load( 'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff'
 process.load( 'L1Trigger.TrackTrigger.TrackTrigger_cff' )
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 # load code that produces DTCStubs
 process.load( 'L1Trigger.TrackerDTC.ProducerED_cff' )

--- a/L1Trigger/TrackerTFP/test/test_cfg.py
+++ b/L1Trigger/TrackerTFP/test/test_cfg.py
@@ -17,7 +17,7 @@ process.load( 'Configuration.StandardSequences.FrontierConditions_GlobalTag_cff'
 process.load( 'L1Trigger.TrackTrigger.TrackTrigger_cff' )
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 # load code that associates stubs with mctruth
 process.load( 'SimTracker.TrackTriggerAssociation.StubAssociator_cff' )


### PR DESCRIPTION
This PR does:
- fixes firmware parameter in Setup and renables according sanity check related to stub z uncertainty
- fixes wrong stub phi position in function Setup::stubPos which is used to get bit accurate Stub positions after DTC
- updates DTC test_cfg.py to new default geometry
- fixes Demonstrator to use new ipbb sim executable 'run_sim'
- fixes Demonstrator to add links to fill the quads with 0 data as ipbb sim and h/w test does