### PR TITLE
Update VMR maxstep

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -769,7 +769,7 @@ namespace trklet {
                                                                          //input links running at 25 Gbits/s
                                                                          //Set to 108 to match firmware project 240 MHz clock
 
-                                                           {"VMR", 108},
+                                                           {"VMR", 107},
                                                            {"TE", 107},
                                                            {"TC", 108},
                                                            {"PR", 108},


### PR DESCRIPTION
#### PR description:

In the firmware, we need to sacrifice the first loop iteration to clear write address counters to avoid issues when running the VMR with the VHDL top-level in Vivado.

Updated VMR maxstep to 107 (originally 108) to match firmware repo PR: https://github.com/cms-L1TK/firmware-hls/pull/219.
Reasons for decreasing the number of stubs the VMR can process are discussed here: https://github.com/cms-L1TK/firmware-hls/issues/188