### PR TITLE
Minor improvements

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
+++ b/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
@@ -7,6 +7,13 @@
 
 #include <vector>
 
+// Run algorithm to remove duplicate tracks.
+// Returns Track object that represent output at end of L1 track chain, 
+// (and are later converted to TTTrack). Duplicate Track objects are flagged,
+// but only deleted if using the Hybrid algo.
+// Also writes to memory the same tracks in more detailed Tracklet format,
+// where duplicates are all deleted.
+
 namespace trklet {
 
   class Settings;

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -298,6 +298,7 @@ namespace trklet {
     double phicritminmc() const { return phicritmin() - dphicritmc_; }
     double phicritmaxmc() const { return phicritmax() + dphicritmc_; }
 
+    // Stub digitization granularities
     double kphi() const { return dphisectorHG() / (1 << nphibitsstub(0)); }
     double kphi1() const { return dphisectorHG() / (1 << nphibitsstub(N_LAYER - 1)); }
     double kphi(unsigned int layerdisk) const { return dphisectorHG() / (1 << nphibitsstub(layerdisk)); }
@@ -383,6 +384,7 @@ namespace trklet {
     int chisqphifactbits() const { return chisqphifactbits_; }
     int chisqzfactbits() const { return chisqzfactbits_; }
 
+    // Helix param digisation granularities
     //0.02 here is the maximum range in rinv values that can be represented
     double krinvpars() const {
       int shift = ceil(-log2(0.02 * rmaxdisk_ / ((1 << nbitsrinv_) * dphisectorHG())));
@@ -775,6 +777,7 @@ namespace trklet {
                                                            {"PR", 108},
                                                            {"ME", 108},
                                                            {"MC", 105},
+                                                           {"TB", 108},
                                                            {"MP", 108},
                                                            {"TP", 108},
                                                            {"TRE", 108}};

--- a/L1Trigger/TrackFindingTracklet/interface/Track.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Track.h
@@ -17,8 +17,9 @@ namespace trklet {
 
   class Track {
   public:
-    Track(TrackPars<int> ipars,
-          int ichisqrphi,
+    // Create track from digitized helix params & stubs
+    Track(TrackPars<int> ipars, // digi helix
+          int ichisqrphi, // digi chi2
           int ichisqrz,
           double chisqrphi,
           double chisqrz,
@@ -54,6 +55,7 @@ namespace trklet {
       return (settings.c() * settings.bfield() * 0.01) / (ipars_.rinv() * settings.krinvpars());
     }
 
+    // Get floating point helix params by undigitized digi helix params
     double phi0(Settings const& settings) const;
 
     double eta(Settings const& settings) const { return asinh(ipars_.t() * settings.ktpars()); }

--- a/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
@@ -157,6 +157,7 @@ namespace trklet {
       return FPGAWord(ichisqrphifit_.value() + ichisqrzfit_.value(), ichisqrphifit_.nbits());
     }
 
+    // Note floating & digitized helix params after track fit.
     void setFitPars(double rinvfit,
                     double phi0fit,
                     double d0fit,
@@ -185,6 +186,7 @@ namespace trklet {
     const std::string diskstubstr(const unsigned disk) const;
     std::string trackfitstr() const;
 
+    // Create a Track object from stubs & digitized track helix params
     Track makeTrack(const std::vector<const L1TStub*>& l1stubs);
 
     Track* getTrack() {

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -324,22 +324,22 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
     // Make the final track objects, fit with KF, and send to output
     for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
       bool duplicateTrack = trackInfo[itrk].second;
-      if (not duplicateTrack) {
+      if (not duplicateTrack) { // Don't waste CPU by calling KF for duplicates
+
         Tracklet* tracklet = inputtracklets_[itrk];
         std::vector<const Stub*> trackstublist = inputstublists_[itrk];
 
+        // Run KF track fit 
         HybridFit hybridFitter(iSector, settings_, globals_);
         hybridFitter.Fit(tracklet, trackstublist);
 
         // If the track was accepted (and thus fit), add to output
         if (tracklet->fit()) {
-          // Add track to output if it wasn't merged into another
+          // Add fitted Track to output (later converted to TTTrack)
           Track* outtrack = tracklet->getTrack();
           outtrack->setSector(iSector);
-          if (trackInfo[itrk].second == true)
-            outtrack->setDuplicate(true);
-          else
-            outputtracklets_[trackInfo[itrk].first]->addTrack(tracklet);
+          // Also store fitted track as more detailed Tracklet object.
+          outputtracklets_[trackInfo[itrk].first]->addTrack(tracklet);
 
           // Add all tracks to standalone root file output
           outtrack->setStubIDpremerge(inputstubidslists_[itrk]);

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -323,26 +323,29 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
 
     // Make the final track objects, fit with KF, and send to output
     for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-      Tracklet* tracklet = inputtracklets_[itrk];
-      std::vector<const Stub*> trackstublist = inputstublists_[itrk];
+      bool duplicateTrack = trackInfo[itrk].second;
+      if (not duplicateTrack) {
+        Tracklet* tracklet = inputtracklets_[itrk];
+        std::vector<const Stub*> trackstublist = inputstublists_[itrk];
 
-      HybridFit hybridFitter(iSector, settings_, globals_);
-      hybridFitter.Fit(tracklet, trackstublist);
+        HybridFit hybridFitter(iSector, settings_, globals_);
+        hybridFitter.Fit(tracklet, trackstublist);
 
-      // If the track was accepted (and thus fit), add to output
-      if (tracklet->fit()) {
-        // Add track to output if it wasn't merged into another
-        Track* outtrack = tracklet->getTrack();
-        outtrack->setSector(iSector);
-        if (trackInfo[itrk].second == true)
-          outtrack->setDuplicate(true);
-        else
-          outputtracklets_[trackInfo[itrk].first]->addTrack(tracklet);
+        // If the track was accepted (and thus fit), add to output
+        if (tracklet->fit()) {
+          // Add track to output if it wasn't merged into another
+          Track* outtrack = tracklet->getTrack();
+          outtrack->setSector(iSector);
+          if (trackInfo[itrk].second == true)
+            outtrack->setDuplicate(true);
+          else
+            outputtracklets_[trackInfo[itrk].first]->addTrack(tracklet);
 
-        // Add all tracks to standalone root file output
-        outtrack->setStubIDpremerge(inputstubidslists_[itrk]);
-        outtrack->setStubIDprefit(mergedstubidslists_[itrk]);
-        outputtracks_.push_back(*outtrack);
+          // Add all tracks to standalone root file output
+          outtrack->setStubIDpremerge(inputstubidslists_[itrk]);
+          outtrack->setStubIDprefit(mergedstubidslists_[itrk]);
+          outputtracks_.push_back(*outtrack);
+        }
       }
     }
   }

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -410,12 +410,17 @@ void Sector::executeMP() {
   }
 }
 
+// Order here reflects Tracklet algo that calls FitTrack before PurgeDuplicates.
+// If using Hybrid, then PurgeDuplicates runs both duplicate removal & KF steps.
+// (unless duplicate removal disabled, in which case FitTrack runs KF).
+
 void Sector::executeFT() {
   for (auto& i : FT_) {
     i->execute(isector_);
   }
 }
 
+// Returns tracks reconstructed by L1 track chain.
 void Sector::executePD(std::vector<Track>& tracks) {
   for (auto& i : PD_) {
     i->execute(tracks, isector_);

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -735,9 +735,12 @@ std::string Tracklet::trackfitstr() const {
   return oss;
 }
 
+// Create a Track object from stubs & digitized track helix params
+
 Track Tracklet::makeTrack(const vector<const L1TStub*>& l1stubs) {
   assert(fit());
 
+  // Digitized track helix params
   TrackPars<int> ipars(fpgafitpars_.rinv().value(),
                        fpgafitpars_.phi0().value(),
                        fpgafitpars_.d0().value(),


### PR DESCRIPTION
#### PR description:

1) Added truncation of TrackBuilder output at 108 clock cycles.
2) Code no longer calls KF track fit for tracklets identified as duplicates by PurgeDuplicates. This saves CPU.
3) Cosmetic code change to TrackFit.cc to make it more obvious that it doesn't call HybridFit if the "merge" duplicate algo is enabled.
4) Added some comments to code.

Checked tracking performance and summer chain txt files unchanged.

