### PR TITLE
Fix d0 bias

### DIFF
--- a/L1Trigger/TrackFindingTMTT/interface/KFParamsComb.h
+++ b/L1Trigger/TrackFindingTMTT/interface/KFParamsComb.h
@@ -5,8 +5,30 @@
 #include "L1Trigger/TrackFindingTMTT/interface/L1track3D.h"
 
 ///=== This is the Kalman Combinatorial Filter for 4 & 5 helix parameters track fit algorithm.
+///===
 ///=== All variable names & equations come from Fruhwirth KF paper
 ///=== http://dx.doi.org/10.1016/0168-9002%2887%2990887-4
+///===   
+///=== Summary of variables:
+///=== m = hit position (phi,z)
+///=== V = hit position 2x2 covariance matrix in (phi,z).
+///=== x = helix params
+///=== C = helix params 4x4 covariance matrix
+///=== r = residuals
+///=== H = 2x4 derivative matrix (expected stub position w.r.t. helix params)
+///=== K = KF gain 2x2 matrix
+///=== x' & C': Updated values of x & C after KF iteration
+///=== Boring: F = unit matrix; pxcov = C
+///===
+///=== Summary of equations:
+///=== S = H*C (2x4 matrix); St = Transpose S
+///=== R = V + H*C*Ht (KF paper) = V + H*St (used here at simpler): 2x2 matrix
+///=== Rinv = Inverse R
+///=== K = St * Rinv : 2x2 Kalman gain matrix * det(R) 
+///=== r = m - H*x 
+///=== x' = x + K*r
+///=== C' = C - K*H*C (KF paper) = C - K*S (used here as simpler)
+///=== delta(chi2) = r(transpose) * Rinv * r : Increase in chi2 from new stub added during iteration.
 
 namespace tmtt {
 

--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -600,6 +600,8 @@ namespace tmtt {
     TVectorD delta = vd - hx;
 
     // Calculate higher order corrections to residuals.
+    // TO DO: Check if these could be determined using Tracklet/HT input track helix params,
+    //        so only need applying at input to KF, instead of very iteration?
 
     if (not settings_->kalmanHOfw()) {
       TVectorD correction(2);
@@ -618,6 +620,11 @@ namespace tmtt {
 
         deltaS = (1. / 6.) * (stub->r()) * pow(corr, 2);
         correction[1] -= deltaS * tanL;
+
+        if (nHelixPar_ == 5) {
+          float d0 = vecX[D0];
+          correction[0] += (1. / 6.) * pow(d0/stub->r(), 3); // Division by r hard in FPGA? 
+        }
       }
 
       if ((not stub->barrel()) && not(stub->psModule())) {


### PR DESCRIPTION
Fix d0 bias in displaced KF track fit, reported by Olivia Courtney at https://indico.cern.ch/event/1117241/ , by applying higher order correction shift to stub phi coordinate.

Also documented KF variables & maths equations in comments at top of KFParamsComb.h