### PR TITLE
Test vector fixes

### DIFF
--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -165,6 +165,9 @@ private:
   // settings containing various constants for the tracklet processing
   trklet::Settings settings;
 
+  // event processor for the tracklet track finding
+  trklet::TrackletEventProcessor eventProcessor;
+
   unsigned int nHelixPar_;
   bool extended_;
   bool reduced_;
@@ -338,15 +341,13 @@ void L1FPGATrackProducer::beginRun(const edm::Run& run, const edm::EventSetup& i
 
   setup_ = iSetup.getData(esGetToken_);
   channelAssignment_ = &iSetup.getData(esGetTokenChannelAssignment_);
+  // initialize the tracklet event processing (this sets all the processing & memory modules, wiring, etc)
+  eventProcessor.init(settings, channelAssignment_);
 }
 
 //////////
 // PRODUCE
 void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  // event processor for the tracklet track finding
-  trklet::TrackletEventProcessor eventProcessor;
-  // initialize the tracklet event processing (this sets all the processing & memory modules, wiring, etc)
-  eventProcessor.init(settings, channelAssignment_);
   typedef std::map<trklet::L1TStub,
                    edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>,
                    L1TStubCompare>

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculator.cc
@@ -42,8 +42,11 @@ TrackletCalculator::TrackletCalculator(string name, Settings const& settings, Gl
           << "TrackletCalculator::TrackletCalculator phicrit approximation may be invalid! Please check.";
   }
 
+  // reduced config has only one TC, so this must be the first
+  const bool isFirstTC = (iTC_ == 0 || settings_.reduced());
+
   // write the drinv and invt inverse tables
-  if ((settings_.writeInvTable() || settings_.writeHLSInvTable() || settings_.writeTable()) && iTC_ == 0) {
+  if ((settings_.writeInvTable() || settings_.writeHLSInvTable() || settings_.writeTable()) && isFirstTC) {
     void (*writeLUT)(const VarInv&, const string&) = nullptr;
     if (settings.writeInvTable()) {  // Verilog version
       writeLUT = [](const VarInv& x, const string& basename) -> void {
@@ -61,7 +64,7 @@ TrackletCalculator::TrackletCalculator(string name, Settings const& settings, Gl
 
   // write the firmware design for the calculation of the tracklet parameters
   // and projections
-  if ((settings_.writeVerilog() || settings_.writeHLS()) && iTC_ == 0) {
+  if ((settings_.writeVerilog() || settings_.writeHLS()) && isFirstTC) {
     void (*writeDesign)(const vector<VarBase*>&, const string&) = nullptr;
     if (settings.writeVerilog()) {  // Verilog version
       writeDesign = [](const vector<VarBase*>& v, const string& basename) -> void {


### PR DESCRIPTION
#### PR description:

Test vector generation is currently broken. This is because the TrackletEventProcessor object is local to `L1FPGATrackProducer::produce`, so it is re-constructed on every event. This means the Sector objects that belong to the TrackletEventProcessor, as well as the various memory objects that belong to the Sector objects, are re-constructed on every event. In particular, this causes `MemoryBase::event_` to be reset, so the test vectors are never opened for appending, they are just overwritten on every event.

To fix this, I made `eventProcessor` a member of L1FPGATrackProducer, so that it persists between events. I also fixed a minor bug where the TC lookup tables were not generated in the reduced config.

#### PR validation:

Test vectors are once again successfully generated for multiple events, and the TC lookup tables are successfully generated in the reduced config.