### PR TITLE
Ian tidy up

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -546,6 +546,7 @@ namespace trklet {
 
     double ptcutte_{1.8};  //Minimum pt in TE
 
+    // VALUE AUTOMATICALLY INCREASED FOR EXTENDED TRACKING BY PYTHON CFG
     unsigned int nbitstrackletindex_{7};  //Bits used to store the tracklet index
 
     unsigned int nbitsitc_{4};           //Bits used to store the iTC, a unique
@@ -898,35 +899,38 @@ namespace trklet {
     unsigned int minIndStubs_{3};  // not used with merge removal
 
 #ifdef USEHYBRID
+    // Duplicate track removal algo. VALUE HERE OVERRIDDEN BY PYTHON CFG
     std::string removalType_{"merge"};
     // "CompareBest" (recommended) Compares only the best stub in each track for each region (best = smallest phi residual)
     // and will merge the two tracks if stubs are shared in three or more regions
     // "CompareAll" Compares all stubs in a region, looking for matches, and will merge the two tracks if stubs are shared in three or more regions
     std::string mergeComparison_{"CompareBest"};
     bool doKF_{true};
-#endif
-
-#ifndef USEHYBRID
-    bool doKF_{false};
+#else
     std::string removalType_{"ichi"};
     std::string mergeComparison_{""};
+    bool doKF_{false};
 #endif
 
+    // VALUE OVERRIDDEN BY PYTHON CFG
     // When false, match calculator does not save multiple matches, even when doKF=true.
     // This is a temporary fix for compatibilty with HLS. We will need to implement multiple match
     // printing in emulator eventually, possibly after CMSSW-integration inspired rewrites
     // Use false when generating HLS files, use true when doing full hybrid tracking
     bool doMultipleMatches_{true};
 
+    // NEXT 2 VALUES OVERRIDDEN BY PYTHON CFG
     // if true, run a dummy fit, producing TTracks directly from output of tracklet pattern reco stage
     bool fakefit_{false};
-    // if true EDProducer fills additionaly bit and clock accurate TrackBuilder EDProduct
+    // if true, EDProducer fills additional bit & clock accurate TrackBuilder EDProduct
     bool storeTrackBuilderOutput_{false};
 
+    // NEXT 3 VALUES OVERRIDDEN BY PYTHON CFG
     unsigned int nHelixPar_{4};  // 4 or 5 param helix fit
     bool extended_{false};       // turn on displaced tracking
-    bool combined_{false};       // use combined TP (TE+TC) and MP (PR+ME+MC) configuration
     bool reduced_{false};        // use reduced (Summer Chain) config
+
+    bool combined_{false};       // use combined TP (TE+TC) and MP (PR+ME+MC) configuration
 
     std::string skimfile_{""};  //if not empty events will be written out in ascii format to this file
 

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -428,6 +428,10 @@ namespace trklet {
       return bendcut;
     }
 
+    // DTC in given ATCA crate slot.
+    std::string slotToDTCname(unsigned int slot) const {return slotToDTCname_.at(slot);}
+
+    // Tracker layers read by given DTC.
     const std::vector<int>& dtcLayers(const std::string& dtcName) const {
       auto iter = dtclayers_.find(dtcName);
       assert(iter != dtclayers_.end());
@@ -496,6 +500,8 @@ namespace trklet {
         {{{2, 2, 2, 2, 2, 2, 1, 1, 2, 2, 3, 2}},  // (3 = #stubs/triplet, only row 1+2 used for tracklet)
          {{3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2}},
          {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1}}}};
+
+    std::vector<std::string> slotToDTCname_{"PS10G_1","PS10G_2","PS10G_3","PS10G_4","PS_1","PS_2","2S_1","2S_2","2S_3","2S_4","2S_5","2S_6"};
 
     std::map<std::string, std::vector<int> > dtclayers_{{"PS10G_1", {0, 6, 8, 10}},
                                                         {"PS10G_2", {0, 7, 9}},

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
@@ -180,9 +180,6 @@ namespace trklet {
     //FitTrack module name
     std::string FTName(unsigned int l1, unsigned int l2, unsigned int l3) const;
 
-    //TrackletCalculator name
-    std::string TCNAme(unsigned int iseed, unsigned int iTC) const;
-
     //
     // This group of methods are used to print out the configuration as a file
     //

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
@@ -31,28 +31,28 @@ namespace trklet {
     //
 
     //Seed string, eg. L1L2
-    std::string iSeedStr(unsigned int iSeed);
+    std::string iSeedStr(unsigned int iSeed) const;
 
     //Return unsigned as string
     static std::string numStr(unsigned int i);
 
-    //Retunr iTC as string - ie A, B, C, etc
-    std::string iTCStr(unsigned int iTC);
+    //Return iTC as string - ie A, B, C, etc
+    std::string iTCStr(unsigned int iTC) const;
 
     //The region string A, B, C etc for layers and disks; X, Y, Z etc for overlap
-    std::string iRegStr(unsigned int iReg, unsigned int iSeed);
+    std::string iRegStr(unsigned int iReg, unsigned int iSeed) const;
 
     //TC Name
-    std::string TCName(unsigned int iSeed, unsigned int iTC);
+    std::string TCName(unsigned int iSeed, unsigned int iTC) const;
 
     //Name of layer or disk, e.g. L1 or D1
     static std::string LayerName(unsigned int ilayer);
 
     //Tracklet projection name
-    std::string TPROJName(unsigned int iSeed, unsigned int iTC, unsigned int ilayer, unsigned int ireg);
+    std::string TPROJName(unsigned int iSeed, unsigned int iTC, unsigned int ilayer, unsigned int ireg) const;
 
     //Projection router name
-    std::string PRName(unsigned int ilayer, unsigned int ireg);
+    std::string PRName(unsigned int ilayer, unsigned int ireg) const;
 
   private:
     //
@@ -113,7 +113,7 @@ namespace trklet {
                        unsigned int l2,
                        unsigned int ireg2,
                        unsigned int ivm2,
-                       unsigned int iseed);
+                       unsigned int iseed) const;
 
     //StubPaur displaced name
     std::string SPDName(unsigned int l1,
@@ -125,7 +125,7 @@ namespace trklet {
                         unsigned int l3,
                         unsigned int ireg3,
                         unsigned int ivm3,
-                        unsigned int iseed);
+                        unsigned int iseed) const;
 
     //Stub Triplet name
     std::string STName(unsigned int l1,
@@ -135,7 +135,7 @@ namespace trklet {
                        unsigned int l3,
                        unsigned int ireg3,
                        unsigned int iseed,
-                       unsigned int count);
+                       unsigned int count) const;
 
     //TrackletEngine name
     std::string TEName(unsigned int l1,
@@ -144,7 +144,7 @@ namespace trklet {
                        unsigned int l2,
                        unsigned int ireg2,
                        unsigned int ivm2,
-                       unsigned int iseed);
+                       unsigned int iseed) const;
 
     //Triplet engine name
     std::string TREName(unsigned int l1,
@@ -152,7 +152,7 @@ namespace trklet {
                         unsigned int l2,
                         unsigned int ireg2,
                         unsigned int iseed,
-                        unsigned int count);
+                        unsigned int count) const;
 
     //TrackletEngine displaced name
     std::string TEDName(unsigned int l1,
@@ -161,13 +161,13 @@ namespace trklet {
                         unsigned int l2,
                         unsigned int ireg2,
                         unsigned int ivm2,
-                        unsigned int iseed);
+                        unsigned int iseed) const;
 
     //Tracklet parameter memory name
-    std::string TParName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc);
+    std::string TParName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc) const;
 
     //TrackletCalculator displaced name
-    std::string TCDName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc);
+    std::string TCDName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc) const;
 
     //TrackletProjection name
     std::string TPROJName(unsigned int l1,
@@ -175,13 +175,13 @@ namespace trklet {
                           unsigned int l3,
                           unsigned int itc,
                           unsigned int projlay,
-                          unsigned int projreg);
+                          unsigned int projreg) const;
 
     //FitTrack module name
-    std::string FTName(unsigned int l1, unsigned int l2, unsigned int l3);
+    std::string FTName(unsigned int l1, unsigned int l2, unsigned int l3) const;
 
     //TrackletCalculator name
-    std::string TCNAme(unsigned int iseed, unsigned int iTC);
+    std::string TCNAme(unsigned int iseed, unsigned int iTC) const;
 
     //
     // This group of methods are used to print out the configuration as a file
@@ -213,8 +213,9 @@ namespace trklet {
     void writeILMemories(std::ostream& os, std::ostream& memories, std::ostream& modules);
 
     //
-    // Store constants extracted from Settings
+    //--- Store constants extracted from Settings
     //
+
     unsigned int NSector_;  //Number of sectors
     double rcrit_;          //critical radius that defines the sector
 

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -163,7 +163,7 @@ private:
   std::ofstream asciiEventOut_;
 
   // settings containing various constants for the tracklet processing
-  trklet::Settings settings;
+  trklet::Settings settings_;
 
   // event processor for the tracklet track finding
   trklet::TrackletEventProcessor eventProcessor;
@@ -262,28 +262,28 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   // set options in Settings based on inputs from configuration files
   // --------------------------------------------------------------------------------
 
-  settings.setExtended(extended_);
-  settings.setReduced(reduced_);
-  settings.setNHelixPar(nHelixPar_);
+  settings_.setExtended(extended_);
+  settings_.setReduced(reduced_);
+  settings_.setNHelixPar(nHelixPar_);
 
-  settings.setFitPatternFile(fitPatternFile.fullPath());
-  settings.setProcessingModulesFile(processingModulesFile.fullPath());
-  settings.setMemoryModulesFile(memoryModulesFile.fullPath());
-  settings.setWiresFile(wiresFile.fullPath());
+  settings_.setFitPatternFile(fitPatternFile.fullPath());
+  settings_.setProcessingModulesFile(processingModulesFile.fullPath());
+  settings_.setMemoryModulesFile(memoryModulesFile.fullPath());
+  settings_.setWiresFile(wiresFile.fullPath());
 
-  settings.setFakefit(iConfig.getParameter<bool>("Fakefit"));
-  settings.setStoreTrackBuilderOutput(iConfig.getParameter<bool>("StoreTrackBuilderOutput"));
-  settings.setRemovalType(iConfig.getParameter<string>("RemovalType"));
-  settings.setDoMultipleMatches(iConfig.getParameter<bool>("DoMultipleMatches"));
+  settings_.setFakefit(iConfig.getParameter<bool>("Fakefit"));
+  settings_.setStoreTrackBuilderOutput(iConfig.getParameter<bool>("StoreTrackBuilderOutput"));
+  settings_.setRemovalType(iConfig.getParameter<string>("RemovalType"));
+  settings_.setDoMultipleMatches(iConfig.getParameter<bool>("DoMultipleMatches"));
 
   if (extended_) {
-    settings.setTableTEDFile(tableTEDFile.fullPath());
-    settings.setTableTREFile(tableTREFile.fullPath());
+    settings_.setTableTEDFile(tableTEDFile.fullPath());
+    settings_.setTableTREFile(tableTREFile.fullPath());
 
     //FIXME: The TED and TRE tables are currently disabled by default, so we
     //need to allow for the additional tracklets that will eventually be
     //removed by these tables, once they are finalized
-    settings.setNbitstrackletindex(10);
+    settings_.setNbitstrackletindex(10);
   }
 
   eventnum = 0;
@@ -291,7 +291,7 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
     asciiEventOut_.open(asciiEventOutName_.c_str());
   }
 
-  if (settings.debugTracklet()) {
+  if (settings_.debugTracklet()) {
     edm::LogVerbatim("Tracklet") << "fit pattern :     " << fitPatternFile.fullPath()
                                  << "\n process modules : " << processingModulesFile.fullPath()
                                  << "\n memory modules :  " << memoryModulesFile.fullPath()
@@ -306,12 +306,12 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   if (trackQuality_) {
     trackQualityModel_ = std::make_unique<TrackQuality>(iConfig.getParameter<edm::ParameterSet>("TrackQualityPSet"));
   }
-  if (settings.storeTrackBuilderOutput() && (settings.doMultipleMatches() || settings.removalType() != "")) {
+  if (settings_.storeTrackBuilderOutput() && (settings_.doMultipleMatches() || settings_.removalType() != "")) {
     cms::Exception exception("ConfigurationNotSupported.");
     exception.addContext("L1FPGATrackProducer::produce");
-    if (settings.doMultipleMatches())
+    if (settings_.doMultipleMatches())
       exception << "Storing of TrackBuilder output does not support doMultipleMatches.";
-    if (settings.removalType() != "")
+    if (settings_.removalType() != "")
       exception << "Storing of TrackBuilder output does not support duplicate removal.";
     throw exception;
   }
@@ -338,12 +338,12 @@ void L1FPGATrackProducer::beginRun(const edm::Run& run, const edm::EventSetup& i
   iSetup.get<IdealMagneticFieldRecord>().get(magneticFieldHandle);
   const MagneticField* theMagneticField = magneticFieldHandle.product();
   double mMagneticFieldStrength = theMagneticField->inTesla(GlobalPoint(0, 0, 0)).z();
-  settings.setBfield(mMagneticFieldStrength);
+  settings_.setBfield(mMagneticFieldStrength);
 
   setup_ = iSetup.getData(esGetToken_);
   channelAssignment_ = &iSetup.getData(esGetTokenChannelAssignment_);
   // initialize the tracklet event processing (this sets all the processing & memory modules, wiring, etc)
-  eventProcessor.init(settings, channelAssignment_);
+  eventProcessor.init(settings_, channelAssignment_);
 }
 
 //////////
@@ -447,20 +447,14 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   /// READ DTC STUB INFORMATION ///
   /////////////////////////////////
 
-  // Process stubs in each region and channel within that region
+  // Process stubs in each region and channel within that tracking region
   for (const int& region : handleDTC->tfpRegions()) {
     for (const int& channel : handleDTC->tfpChannels()) {
       // Get the DTC name form the channel
-
-      static string dtcbasenames[12] = {
-          "PS10G_1", "PS10G_2", "PS10G_3", "PS10G_4", "PS_1", "PS_2", "2S_1", "2S_2", "2S_3", "2S_4", "2S_5", "2S_6"};
-
-      string dtcname = dtcbasenames[channel % 12];
-
-      if (channel % 24 >= 12)
-        dtcname = "neg" + dtcname;
-
-      dtcname += (channel < 24) ? "_A" : "_B";
+      unsigned int atcaSlot = channel % 12;
+      string dtcname = settings_.slotToDTCname(atcaSlot);
+      if (channel % 24 >= 12) dtcname = "neg" + dtcname;
+      dtcname += (channel < 24) ? "_A" : "_B"; // which detector region
 
       // Get the stubs from the DTC
       const tt::StreamStub& streamFromDTC{handleDTC->stream(region, channel)};
@@ -612,11 +606,11 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     ntracks++;
 
     // this is where we create the TTTrack object
-    double tmp_rinv = track.rinv(settings);
-    double tmp_phi = track.phi0(settings);
-    double tmp_tanL = track.tanL(settings);
-    double tmp_z0 = track.z0(settings);
-    double tmp_d0 = track.d0(settings);
+    double tmp_rinv = track.rinv(settings_);
+    double tmp_phi = track.phi0(settings_);
+    double tmp_tanL = track.tanL(settings_);
+    double tmp_z0 = track.z0(settings_);
+    double tmp_d0 = track.d0(settings_);
     double tmp_chi2rphi = track.chisqrphi();
     double tmp_chi2rz = track.chisqrz();
     unsigned int tmp_hit = track.hitpattern();
@@ -632,8 +626,8 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
                                            0,
                                            0,
                                            tmp_hit,
-                                           settings.nHelixPar(),
-                                           settings.bfield());
+                                           settings_.nHelixPar(),
+                                           settings_.bfield());
 
     unsigned int trksector = track.sector();
     unsigned int trkseed = (unsigned int)abs(track.seed());
@@ -661,7 +655,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
     // pt consistency
     aTrack.setStubPtConsistency(
-        StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings.bfield(), settings.nHelixPar()));
+        StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar()));
 
     // set TTTrack word
     aTrack.setTrackWordBits();

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -452,10 +452,6 @@ std::string TrackletConfigBuilder::STName(unsigned int l1,
          iRegStr(ireg3, iseed) + "_" + numStr(count);
 }
 
-std::string TrackletConfigBuilder::TCNAme(unsigned int iseed, unsigned int iTC) const {
-  return "TC_" + iSeedStr(iseed) + iTCStr(iTC);
-}
-
 void TrackletConfigBuilder::writeSPMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
   if (combinedmodules_)
     return;
@@ -479,7 +475,7 @@ void TrackletConfigBuilder::writeSPMemories(std::ostream& os, std::ostream& memo
 
         os << SPName(l1, TE1 / NVMTE_[iSeed].first, TE1, l2, TE2 / NVMTE_[iSeed].second, TE2, iSeed) << " input=> "
            << TEName(l1, TE1 / NVMTE_[iSeed].first, TE1, l2, TE2 / NVMTE_[iSeed].second, TE2, iSeed)
-           << ".stubpairout output=> " << TCNAme(iSeed, iTC) << ".stubpairin" << std::endl;
+           << ".stubpairout output=> " << TCName(iSeed, iTC) << ".stubpairin" << std::endl;
       }
     }
   }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -1061,6 +1061,7 @@ void TrackletConfigBuilder::writeCTMemories(std::ostream& os, std::ostream& memo
 
 void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
   //FIXME these should not be hardcoded - but for now wanted to avoid reading file
+  //Possible solution  https://github.com/tomalin/cmssw/blob/ian_TxtFiles/TrackFindingTrackletHLS/src/TxtFileWriter.cc#L28
   constexpr unsigned int nSize = 52;
   string dtcname[nSize];
   unsigned int layerdisk[nSize];

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -285,7 +285,7 @@ double TrackletConfigBuilder::rinv(double r1, double phi1, double r2, double phi
   return 2 * sin(deltaphi) / sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
 }
 
-std::string TrackletConfigBuilder::iSeedStr(unsigned int iSeed) {
+std::string TrackletConfigBuilder::iSeedStr(unsigned int iSeed) const {
   static std::string name[8] = {"L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1"};
 
   assert(iSeed < 8);
@@ -300,14 +300,14 @@ std::string TrackletConfigBuilder::numStr(unsigned int i) {
   return num[i];
 }
 
-std::string TrackletConfigBuilder::iTCStr(unsigned int iTC) {
+std::string TrackletConfigBuilder::iTCStr(unsigned int iTC) const {
   static std::string name[12] = {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"};
 
   assert(iTC < 12);
   return name[iTC];
 }
 
-std::string TrackletConfigBuilder::iRegStr(unsigned int iReg, unsigned int iSeed) {
+std::string TrackletConfigBuilder::iRegStr(unsigned int iReg, unsigned int iSeed) const {
   static std::string name[8] = {"A", "B", "C", "D", "E", "F", "G", "H"};
 
   static std::string nameOverlap[8] = {"X", "Y", "Z", "W", "Q", "R", "S", "T"};
@@ -326,7 +326,7 @@ std::string TrackletConfigBuilder::iRegStr(unsigned int iReg, unsigned int iSeed
   return name[iReg];
 }
 
-std::string TrackletConfigBuilder::TCName(unsigned int iSeed, unsigned int iTC) {
+std::string TrackletConfigBuilder::TCName(unsigned int iSeed, unsigned int iTC) const {
   if (combinedmodules_) {
     return "TP_" + iSeedStr(iSeed) + iTCStr(iTC);
   } else {
@@ -341,11 +341,11 @@ std::string TrackletConfigBuilder::LayerName(unsigned int ilayer) {
 std::string TrackletConfigBuilder::TPROJName(unsigned int iSeed,
                                              unsigned int iTC,
                                              unsigned int ilayer,
-                                             unsigned int ireg) {
+                                             unsigned int ireg) const {
   return "TPROJ_" + iSeedStr(iSeed) + iTCStr(iTC) + "_" + LayerName(ilayer) + "PHI" + iTCStr(ireg);
 }
 
-std::string TrackletConfigBuilder::PRName(unsigned int ilayer, unsigned int ireg) {
+std::string TrackletConfigBuilder::PRName(unsigned int ilayer, unsigned int ireg) const {
   if (combinedmodules_) {
     return "MP_" + LayerName(ilayer) + "PHI" + iTCStr(ireg);
   } else {
@@ -376,7 +376,7 @@ std::string TrackletConfigBuilder::SPName(unsigned int l1,
                                           unsigned int l2,
                                           unsigned int ireg2,
                                           unsigned int ivm2,
-                                          unsigned int iseed) {
+                                          unsigned int iseed) const {
   return "SP_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
          iRegStr(ireg2, iseed) + numStr(ivm2);
 }
@@ -390,7 +390,7 @@ std::string TrackletConfigBuilder::SPDName(unsigned int l1,
                                            unsigned int l3,
                                            unsigned int ireg3,
                                            unsigned int ivm3,
-                                           unsigned int iseed) {
+                                           unsigned int iseed) const {
   return "SPD_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
          iRegStr(ireg2, iseed) + numStr(ivm2) + "_" + LayerName(l3) + "PHI" + iRegStr(ireg3, iseed) + numStr(ivm3);
 }
@@ -401,7 +401,7 @@ std::string TrackletConfigBuilder::TEName(unsigned int l1,
                                           unsigned int l2,
                                           unsigned int ireg2,
                                           unsigned int ivm2,
-                                          unsigned int iseed) {
+                                          unsigned int iseed) const {
   return "TE_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
          iRegStr(ireg2, iseed) + numStr(ivm2);
 }
@@ -412,31 +412,31 @@ std::string TrackletConfigBuilder::TEDName(unsigned int l1,
                                            unsigned int l2,
                                            unsigned int ireg2,
                                            unsigned int ivm2,
-                                           unsigned int iseed) {
+                                           unsigned int iseed) const {
   return "TED_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
          iRegStr(ireg2, iseed) + numStr(ivm2);
 }
 
-std::string TrackletConfigBuilder::TParName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc) {
+std::string TrackletConfigBuilder::TParName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc) const {
   return "TPAR_" + LayerName(l1) + LayerName(l2) + LayerName(l3) + iTCStr(itc);
 }
 
-std::string TrackletConfigBuilder::TCDName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc) {
+std::string TrackletConfigBuilder::TCDName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc) const {
   return "TCD_" + LayerName(l1) + LayerName(l2) + LayerName(l3) + iTCStr(itc);
 }
 
 std::string TrackletConfigBuilder::TPROJName(
-    unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc, unsigned int projlayer, unsigned int projreg) {
+    unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc, unsigned int projlayer, unsigned int projreg) const {
   return "TPROJ_" + LayerName(l1) + LayerName(l2) + LayerName(l3) + iTCStr(itc) + "_" + LayerName(projlayer) + "PHI" +
          iTCStr(projreg);
 }
 
-std::string TrackletConfigBuilder::FTName(unsigned int l1, unsigned int l2, unsigned int l3) {
+std::string TrackletConfigBuilder::FTName(unsigned int l1, unsigned int l2, unsigned int l3) const {
   return "FT_" + LayerName(l1) + LayerName(l2) + LayerName(l3);
 }
 
 std::string TrackletConfigBuilder::TREName(
-    unsigned int l1, unsigned int ireg1, unsigned int l2, unsigned int ireg2, unsigned int iseed, unsigned int count) {
+    unsigned int l1, unsigned int ireg1, unsigned int l2, unsigned int ireg2, unsigned int iseed, unsigned int count) const {
   return "TRE_" + LayerName(l1) + iRegStr(ireg1, iseed) + LayerName(l2) + iRegStr(ireg2, iseed) + "_" + numStr(count);
 }
 
@@ -447,12 +447,12 @@ std::string TrackletConfigBuilder::STName(unsigned int l1,
                                           unsigned int l3,
                                           unsigned int ireg3,
                                           unsigned int iseed,
-                                          unsigned int count) {
+                                          unsigned int count) const {
   return "ST_" + LayerName(l1) + iRegStr(ireg1, iseed) + LayerName(l2) + iRegStr(ireg2, iseed) + "_" + LayerName(l3) +
          iRegStr(ireg3, iseed) + "_" + numStr(count);
 }
 
-std::string TrackletConfigBuilder::TCNAme(unsigned int iseed, unsigned int iTC) {
+std::string TrackletConfigBuilder::TCNAme(unsigned int iseed, unsigned int iTC) const {
   return "TC_" + iSeedStr(iseed) + iTCStr(iTC);
 }
 
@@ -1061,10 +1061,11 @@ void TrackletConfigBuilder::writeCTMemories(std::ostream& os, std::ostream& memo
 
 void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
   //FIXME these should not be hardcoded - but for now wanted to avoid reading file
-  string dtcname[52];
-  unsigned int layerdisk[52];
-  double phimin[52];
-  double phimax[52];
+  constexpr unsigned int nSize = 52;
+  string dtcname[nSize];
+  unsigned int layerdisk[nSize];
+  double phimin[nSize];
+  double phimax[nSize];
 
   dtcname[0] = "PS10G_1";
   layerdisk[0] = 0;
@@ -1278,7 +1279,7 @@ void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memo
   double dphi = 0.5 * dphisectorHG_ - M_PI / NSector_;
 
   string olddtc = "";
-  for (unsigned int i = 0; i < 52; i++) {
+  for (unsigned int i = 0; i < nSize; i++) {
     if (olddtc != dtcname[i]) {
       modules << "InputRouter: IR_" << dtcname[i] << "_A" << std::endl;
       modules << "InputRouter: IR_" << dtcname[i] << "_B" << std::endl;
@@ -1292,7 +1293,7 @@ void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memo
     olddtc = dtcname[i];
   }
 
-  for (unsigned int i = 0; i < 52; i++) {
+  for (unsigned int i = 0; i < nSize; i++) {
     double phimintmp = phimin[i] + dphi;
     double phimaxtmp = phimax[i] + dphi;
 


### PR DESCRIPTION
Cosmetic changes:

1) Constants used to get DTC name from ATCA slot number moved from L1FPGATrackProducer.cc to Settngs.h. Also put underscore at end of name of L1FPGATrackProducer data member "settings" to match usual CMSSW style.
2) Functions in TrackletConfigBuilder declared "const", if they don't change class data members. (CMSSW style requirement)
3) Added comments to Settings.h to make clear which params have their values overridden by python cfg.
4) Removed duplicate function TCNAme() in TrackletConfigBuilder