### PR TITLE
DTC phi range hard-wired constants removed

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -501,6 +501,8 @@ namespace trklet {
          {{3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2, 2}},
          {{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1}}}};
 
+    // FIX: There should be 3 PS10G slots & 3 PS (5G) ones.
+    // (Will change output files used by HLS).
     std::vector<std::string> slotToDTCname_{"PS10G_1","PS10G_2","PS10G_3","PS10G_4","PS_1","PS_2","2S_1","2S_2","2S_3","2S_4","2S_5","2S_6"};
 
     std::map<std::string, std::vector<int> > dtclayers_{{"PS10G_1", {0, 6, 8, 10}},

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -287,6 +287,7 @@ namespace trklet {
     void setNbitsseed(unsigned int nbitsseed) { nbitsseed_ = nbitsseed; }
     void setNbitsseedextended(unsigned int nbitsseed) { nbitsseedextended_ = nbitsseed; }
 
+    // Phi width of nonant including overlaps (at widest point).
     double dphisectorHG() const {
       //These values are used in the DTC emulation code.
       double rsectmin = 21.8;

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
@@ -129,7 +129,7 @@ namespace trklet {
                        unsigned int ivm2,
                        unsigned int iseed) const;
 
-    //StubPaur displaced name
+    //StubPair displaced name
     std::string SPDName(unsigned int l1,
                         unsigned int ireg1,
                         unsigned int ivm1,

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
@@ -258,10 +258,10 @@ namespace trklet {
     std::pair<std::vector<std::pair<double, double> >, std::vector<std::pair<double, double> > >
         VMStubsTE_[N_SEED_PROMPT];
 
-    //List of the TEs and the VM bins for each TE
+    // VM bin in inner/outer seeding layer of each TE.
     std::vector<std::pair<unsigned int, unsigned int> > TE_[N_SEED_PROMPT];
 
-    //The TCs for each seeding combination
+    //The ID of all TE that send data to TCs for each seeding combination
     std::vector<std::vector<unsigned int> > TC_[N_SEED_PROMPT];
 
     //The projections to each layer/disk from a seed and TC

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
@@ -9,18 +9,21 @@
 #include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
 
 #include <vector>
+#include <list>
 #include <utility>
 #include <set>
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
 
+namespace tt {class Setup;}
+
 namespace trklet {
 
   class TrackletConfigBuilder {
   public:
     //Builds the configuration for the tracklet based track finding
-    TrackletConfigBuilder(const Settings& settings);
+    TrackletConfigBuilder(const Settings& settings, const tt::Setup* setup = nullptr);
 
     //This method writes out the configuration as files
     void writeAll(std::ostream& wires, std::ostream& memories, std::ostream& modules);
@@ -74,6 +77,17 @@ namespace trklet {
     // Finds the projections needed for each seeding combination
     //
     void buildProjections();
+
+#ifdef CMSSW_GIT_HASH
+    // Calculate phi range of modules read by each DTC.
+    void setDTCphirange(const tt::Setup* setup);
+
+    // Write DTC phi ranges to dtcphirange.txt for stand-alone emulation.
+    void writeDTCphirange() const;
+#else
+    // Set phi ranges after reading them from dtcphirange.txt
+    void setDTCphirange(const tt::Setup* setup = nullptr);
+#endif
 
     //
     // Helper function to determine if a pair of VM memories form valid TE
@@ -263,6 +277,9 @@ namespace trklet {
                                                        {1, -1, -1, -1, -1, -1, 2, 3, -1, -1, 4},   //D3D4
                                                        {-1, -1, -1, -1, -1, -1, -1, 1, 2, 3, 4},   //L1D1
                                                        {1, -1, -1, -1, -1, -1, -1, 2, 3, 4, -1}};  //L2D1
+
+    struct DTCinfo {std::string name; int layer; float phimin; float phimax;};
+    std::list<DTCinfo> vecDTCinfo_;
 
     //Settings
     const Settings& settings_;

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
@@ -85,7 +85,7 @@ namespace trklet {
     // Write DTC phi ranges to dtcphirange.txt for stand-alone emulation.
     void writeDTCphirange() const;
 #else
-    // Set phi ranges after reading them from dtcphirange.txt
+    // Set phi ranges after reading them from dtcphirange.txt (stand-alone emulation)
     void setDTCphirange(const tt::Setup* setup = nullptr);
 #endif
 

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
@@ -3,13 +3,15 @@
 #define L1Trigger_TrackFindingTracklet_interface_TrackletEventProcessor_h
 
 #include "L1Trigger/TrackFindingTracklet/interface/Timer.h"
-#include "L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
 #include <map>
 #include <memory>
 #include <vector>
 #include <deque>
 #include <string>
+
+namespace tt {class Setup;}
 
 namespace trklet {
 
@@ -19,6 +21,7 @@ namespace trklet {
   class Sector;
   class HistBase;
   class Track;
+  class ChannelAssignment;
 
   class TrackletEventProcessor {
   public:
@@ -26,7 +29,7 @@ namespace trklet {
 
     ~TrackletEventProcessor();
 
-    void init(Settings const& theSettings, const ChannelAssignment* channelAssignment);
+    void init(Settings const& theSettings, const ChannelAssignment* channelAssignment, const tt::Setup* setup = nullptr);
 
     void event(SLHCEvent& ev);
 

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -343,7 +343,7 @@ void L1FPGATrackProducer::beginRun(const edm::Run& run, const edm::EventSetup& i
   setup_ = iSetup.getData(esGetToken_);
   channelAssignment_ = &iSetup.getData(esGetTokenChannelAssignment_);
   // initialize the tracklet event processing (this sets all the processing & memory modules, wiring, etc)
-  eventProcessor.init(settings_, channelAssignment_);
+  eventProcessor.init(settings_, channelAssignment_, &setup_);
 }
 
 //////////

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -1217,11 +1217,33 @@ void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memo
   for (const DTCinfo& info : vecDTCinfo_) {
     string dtcname = info.name;
     int layerdisk = info.layer;
-    double phiminDTC = info.phimin; // Phi range of each DTC.
-    double phimaxDTC = info.phimax;
 
     for (unsigned int iReg = 0; iReg < NRegions_[layerdisk]; iReg++) {
-      if (allStubs_[layerdisk][iReg].first > phimaxDTC && allStubs_[layerdisk][iReg].second < phiminDTC)
+//--- Ian Tomalin's proposed bug fix
+      double phiminDTC_A = info.phimin - M_PI/N_SECTOR; // Phi range of each DTC.
+      double phimaxDTC_A = info.phimax - M_PI/N_SECTOR;
+      double phiminDTC_B = info.phimin + M_PI/N_SECTOR; // Phi range of each DTC.
+      double phimaxDTC_B = info.phimax + M_PI/N_SECTOR;
+      if (allStubs_[layerdisk][iReg].second > phiminDTC_A && allStubs_[layerdisk][iReg].first < phimaxDTC_A) {
+        memories << "InputLink: IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_A"
+                 << " [36]" << std::endl;
+        os << "IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_A"
+           << " input=> IR_" << dtcname << "_A.stubout output=> VMR_" << LayerName(layerdisk) << "PHI"
+           << iTCStr(iReg) << ".stubin" << std::endl;
+      }
+      if (allStubs_[layerdisk][iReg].second > phiminDTC_B && allStubs_[layerdisk][iReg].first < phimaxDTC_B) {
+        memories << "InputLink: IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_B"
+                 << " [36]" << std::endl;
+        os << "IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_B"
+           << " input=> IR_" << dtcname << "_B.stubout output=> VMR_" << LayerName(layerdisk) << "PHI"
+           << iTCStr(iReg) << ".stubin" << std::endl;
+      }
+//--- Original (buggy) code
+/*
+      double phiminDTC = info.phimin; // Phi range of each DTC.
+      double phimaxDTC = info.phimax;
+
+      if (allStubs_[layerdisk][iReg].first > phimaxDTC && allStubs_[layerdisk][iReg].second < phiminDTC) 
         continue;
 
       // Phi region range must be entirely contained in this DTC to keep this connection.
@@ -1240,6 +1262,7 @@ void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memo
            << " input=> IR_" << dtcname << "_B.stubout output=> VMR_" << LayerName(layerdisk) << "PHI"
            << iTCStr(iReg) << ".stubin" << std::endl;
       }
+*/
     }
   }
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <cstdlib>
 #include <cassert>
 #include <mutex>
@@ -150,10 +151,10 @@ void TrackletConfigBuilder::writeDTCphirange() const {
     std::ofstream out;
     openfile(out, first, dirName, fileName, __FILE__, __LINE__);
     if (first) {
-      out<<"// phi ranges of modules read by each DTC"<<endl;
+      out<<"// layer & phi ranges of modules read by each DTC"<<endl;
       out<<"// (Used by stand-alone emulation)"<<endl;
     }
-    out<<"vecDTCinfo_.push_back( {"""<<info.name<<""", "<<info.layer<<", "<<info.phimin<<", "<<info.phimax<<"} );"<<endl;
+    out<<info.name<<" "<<info.layer<<" "<<info.phimin<<" "<<info.phimax<<endl;
     out.close();
     first = false;
   }
@@ -161,8 +162,24 @@ void TrackletConfigBuilder::writeDTCphirange() const {
 
 #else
 
+//--- Set DTC phi ranges from .txt file (stand-alone operation only)
+
 void TrackletConfigBuilder::setDTCphirange(const tt::Setup* setup) {
-#include "L1Trigger/TrackFindingTracklet/data/dtcphirange.txt"
+  // This file previously written by writeDTCphirange().
+  const string fname="../data/dtcphirange.txt";
+  if (vecDTCinfo_.empty()) { // Only run once per thread.
+    std::ifstream str_dtc;
+    str_dtc.open(fname);
+    assert(str_dtc.good());
+    string line;
+    while (ifstream, getline(line)) {
+      std::istringstream iss(line);
+      DTCinfo info;
+      iss >> info.name >> info.layer >> info.phimin >> info.phimax;
+      vecDTCinfo_.push_back(info);
+    } 
+    str_dtc.close();
+  }
 }
 
 #endif

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -100,7 +100,7 @@ void TrackletConfigBuilder::setDTCphirange(const tt::Setup* setup) {
         float phiMin = sm->phi() - 0.5*sm->numRows()*sm->pitchRow() / r;
         float phiMax = sm->phi() + 0.5*sm->numRows()*sm->pitchRow() / r;
         // Hybrid measures phi w.r.t. lower edge of tracker nonant.
-        const float phiOffsetHybrid = M_PI/N_SECTOR;
+        const float phiOffsetHybrid = 0.5 * dphisectorHG_;
         phiMin += phiOffsetHybrid;
         phiMax += phiOffsetHybrid;
         if (dtcPhiRange.find(layer) == dtcPhiRange.end()) {
@@ -1214,20 +1214,18 @@ void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memo
     olddtc = dtcname;
   }
 
-  const double dphi = 0.5 * dphisectorHG_ - M_PI / NSector_;
-
   for (const DTCinfo& info : vecDTCinfo_) {
     string dtcname = info.name;
     int layerdisk = info.layer;
-    double phimintmp = info.phimin + dphi; // Phi range of each DTC.
-    double phimaxtmp = info.phimax + dphi;
+    double phiminDTC = info.phimin; // Phi range of each DTC.
+    double phimaxDTC = info.phimax;
 
     for (unsigned int iReg = 0; iReg < NRegions_[layerdisk]; iReg++) {
-      if (allStubs_[layerdisk][iReg].first > phimaxtmp && allStubs_[layerdisk][iReg].second < phimintmp)
+      if (allStubs_[layerdisk][iReg].first > phimaxDTC && allStubs_[layerdisk][iReg].second < phiminDTC)
         continue;
 
       // Phi region range must be entirely contained in this DTC to keep this connection.
-      if (allStubs_[layerdisk][iReg].second < phimaxtmp) {
+      if (allStubs_[layerdisk][iReg].second < phimaxDTC) {
         memories << "InputLink: IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_A"
                  << " [36]" << std::endl;
         os << "IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_A"
@@ -1235,7 +1233,7 @@ void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memo
            << iTCStr(iReg) << ".stubin" << std::endl;
       }
 
-      if (allStubs_[layerdisk][iReg].first > phimintmp) {
+      if (allStubs_[layerdisk][iReg].first > phiminDTC) {
         memories << "InputLink: IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_B"
                  << " [36]" << std::endl;
         os << "IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_B"

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -7,6 +7,7 @@
 #include "L1Trigger/TrackFindingTracklet/interface/Track.h"
 #include "L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h"
 #include "L1Trigger/TrackFindingTracklet/interface/IMATH_TrackletCalculator.h"
+#include "L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h"
 
 #include "DataFormats/Math/interface/deltaPhi.h"
 
@@ -24,7 +25,7 @@ TrackletEventProcessor::~TrackletEventProcessor() {
   }
 }
 
-void TrackletEventProcessor::init(Settings const& theSettings, const ChannelAssignment* channelAssignment) {
+void TrackletEventProcessor::init(Settings const& theSettings, const ChannelAssignment* channelAssignment, const tt::Setup* setup) {
   settings_ = &theSettings;
   channelAssignment_ = channelAssignment;
   // number of track channel
@@ -100,7 +101,7 @@ void TrackletEventProcessor::init(Settings const& theSettings, const ChannelAssi
     configure(inwire, inmem, inproc);
 
   } else {
-    TrackletConfigBuilder config(*settings_);
+    TrackletConfigBuilder config(*settings_, setup);
 
     //Write configurations to file.
     if (settings_->writeConfig()) {

--- a/L1Trigger/TrackTrigger/interface/Setup.h
+++ b/L1Trigger/TrackTrigger/interface/Setup.h
@@ -318,6 +318,8 @@ namespace tt {
     int numRegions() const { return numRegions_; }
     // number of regions a reconstructable particles may cross
     int numOverlappingRegions() const { return numOverlappingRegions_; }
+    // number of Tracker boards per ATCA crate.
+    int numATCASlots() const { return numATCASlots_;}
     // number of DTC boards used to readout a detector region, likely constructed to be an integerer multiple of NumSlots_
     int numDTCsPerRegion() const { return numDTCsPerRegion_; }
     // max number of sensor modules connected to one DTC board


### PR DESCRIPTION
This eliminates the array of hard-wired constants from TrackletConfigBuilder that specified the phi ranges of modules read by each DTC. Instead these constants are determined at start of run from the CMS geometry DB. This is done by new function setDTCphirange().

Two additional functions are added, which are only needed to support stand-alone emulation, since it can't access the DB. writeDTCphirange() can optionally, when running within CMSSW, write the calculated DTC phi ranges to file dtcphirange.txt ; and setDTCphirange() can, when running stand-alone, read in dtcphirange.txt to avoid needing the DB.

The pragma CMSSW_GIT_HASH is used to switch between these depending on whether running standalone or not.

In addition, the calculation of the DTC phi ranges is now correct in the tilted barrel modules. Though this doesn't change the wiring map.

The file dtcphiranges.txt has been added to https://github.com/cms-L1TK/L1Trigger-TrackFindingTracklet .

Validation: I've checked that wires.dat etc. are unaffected.

P.S. I realized after that the only place that uses the DTC phi ranges is writeILMemories(), which added this offset to them all https://github.com/cms-L1TK/cmssw/blob/L1TK-dev-12_0_0_pre4/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc#L1276 before using them. The only reason this was needed is that the DTC phi ranges had not been converted correctly from DTC to Tracklet format. I've now updated the DTC phi range calculation in setDTCphirange() to fix this, so the offset in writeILMemories() has been removed. This means that the calculated phi values are now all offset with respect to the original ones.