### PR TITLE
Removal of dependencies of ChannelAssignement

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h
+++ b/L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h
@@ -52,8 +52,6 @@ namespace trklet {
     int channelId(int seedType, int layerId) const;
     // max number of seeding layers
     int numSeedingLayers() const { return numSeedingLayers_; }
-    // max number of projection layers
-    int numProjectionLayers() const { return numProjectionLayers_; }
 
   private:
     // helper class to store configurations
@@ -82,8 +80,6 @@ namespace trklet {
     std::vector<int> offsetsStubs_;
     // max number of seeding layers
     int numSeedingLayers_;
-    // max number of projection layers
-    int numProjectionLayers_;
   };
 
 }  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h
+++ b/L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h
@@ -28,6 +28,8 @@ namespace trklet {
     int numChannelsTrack() const { return numChannelsTrack_; }
     // number of used channels for stubs
     int numChannelsStub() const { return numChannelsStub_; }
+    // number of used seed types in tracklet algorithm
+    int numSeedTypes() const { return numSeedTypes_; }
     // sets layerId (0-7 in sequence the seed type projects to) of given TTStubRef and seedType, returns false if seeed stub
     bool layerId(int seedType, const TTStubRef& ttStubRef, int& layerId) const;
     // return tracklet layerId (barrel: [0-5], endcap: [6-10]) for given TTStubRef

--- a/L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h
+++ b/L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h
@@ -36,12 +36,14 @@ namespace trklet {
     int trackletLayerId(const TTStubRef& ttStubRef) const;
     // number layers a given seed type projects to
     int numProjectionLayers(int seedType) const { return (int)seedTypesProjectionLayers_.at(seedType).size(); }
+    // max. no. layers that any seed type projects to
+    int maxNumProjectionLayers() const { return maxNumProjectionLayers_; }
     // map of used DTC tfp channels in InputRouter
-    std::vector<int> channelEncoding() const { return channelEncoding_; }
+    const std::vector<int>& channelEncoding() const { return channelEncoding_; }
     // index of first stub channel belonging to given track channel
     int offsetStub(int channelTrack) const;
     // seed layers for given seed type id
-    std::vector<int> seedingLayers(int seedType) const { return seedTypesSeedLayers_.at(seedType); }
+    const std::vector<int>& seedingLayers(int seedType) const { return seedTypesSeedLayers_.at(seedType); }
     //
     tt::SensorModule::Type type(const TTStubRef& ttStubRef) const { return setup_->type(ttStubRef); }
     //
@@ -70,6 +72,8 @@ namespace trklet {
     std::vector<std::vector<int>> seedTypesSeedLayers_;
     // layers a seed types can project to using default layer id [barrel: 1-6, discs: 11-15]
     std::vector<std::vector<int>> seedTypesProjectionLayers_;
+    // max. number of layers to which any seed type projects
+    int maxNumProjectionLayers_;
     // map of used DTC tfp channels in InputRouter
     std::vector<int> channelEncoding_;
     // accumulated number of projections layer from seed 0 to vector index

--- a/L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h
+++ b/L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h
@@ -52,6 +52,8 @@ namespace trklet {
     int channelId(int seedType, int layerId) const;
     // max number of seeding layers
     int numSeedingLayers() const { return numSeedingLayers_; }
+    // max number of projection layers
+    int numProjectionLayers() const { return numProjectionLayers_; }
 
   private:
     // helper class to store configurations
@@ -80,6 +82,8 @@ namespace trklet {
     std::vector<int> offsetsStubs_;
     // max number of seeding layers
     int numSeedingLayers_;
+    // max number of projection layers
+    int numProjectionLayers_;
   };
 
 }  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/interface/FitTrack.h
+++ b/L1Trigger/TrackFindingTracklet/interface/FitTrack.h
@@ -6,6 +6,7 @@
 #include "L1Trigger/TrackFindingTracklet/interface/FullMatchMemory.h"
 #include "L1Trigger/TrackFindingTracklet/interface/TrackFitMemory.h"
 #include "L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h"
+#include "L1Trigger/TrackFindingTracklet/interface/StubStreamData.h"
 
 #include <vector>
 #include <deque>
@@ -15,7 +16,6 @@ namespace trklet {
   class Settings;
   class Globals;
   class Stub;
-  class L1TStub;
 
   class FitTrack : public ProcessBase {
   public:
@@ -43,6 +43,8 @@ namespace trklet {
     void execute(const ChannelAssignment* channelAssignment,
                  std::deque<tt::Frame>& streamTrack,
                  std::vector<std::deque<tt::FrameStub>>& streamsStub,
+		 std::vector<std::string>& trackStream,
+		 std::vector<std::vector<StubStreamData>>& stubStream,
                  unsigned int iSector);
 
   private:

--- a/L1Trigger/TrackFindingTracklet/interface/FitTrack.h
+++ b/L1Trigger/TrackFindingTracklet/interface/FitTrack.h
@@ -8,6 +8,7 @@
 #include "L1Trigger/TrackFindingTracklet/interface/StubStreamData.h"
 
 #include <vector>
+#include <deque>
 
 namespace trklet {
 
@@ -38,8 +39,8 @@ namespace trklet {
 
     std::vector<Tracklet*> orderedMatches(std::vector<FullMatchMemory*>& fullmatch);
 
-    void execute(std::vector<std::string>& streamTrackRaw,
-                 std::vector<std::vector<StubStreamData>>& stubStream,
+    void execute(std::deque<std::string>& streamTrackRaw,
+                 std::vector<std::deque<StubStreamData>>& stubStream,
                  unsigned int iSector);
 
   private:

--- a/L1Trigger/TrackFindingTracklet/interface/FitTrack.h
+++ b/L1Trigger/TrackFindingTracklet/interface/FitTrack.h
@@ -38,7 +38,7 @@ namespace trklet {
 
     std::vector<Tracklet*> orderedMatches(std::vector<FullMatchMemory*>& fullmatch);
 
-    void execute(std::vector<std::string>& trackStream,
+    void execute(std::vector<std::string>& streamTrackRaw,
                  std::vector<std::vector<StubStreamData>>& stubStream,
                  unsigned int iSector);
 

--- a/L1Trigger/TrackFindingTracklet/interface/FitTrack.h
+++ b/L1Trigger/TrackFindingTracklet/interface/FitTrack.h
@@ -5,11 +5,9 @@
 #include "L1Trigger/TrackFindingTracklet/interface/TrackletParametersMemory.h"
 #include "L1Trigger/TrackFindingTracklet/interface/FullMatchMemory.h"
 #include "L1Trigger/TrackFindingTracklet/interface/TrackFitMemory.h"
-#include "L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h"
 #include "L1Trigger/TrackFindingTracklet/interface/StubStreamData.h"
 
 #include <vector>
-#include <deque>
 
 namespace trklet {
 
@@ -40,10 +38,14 @@ namespace trklet {
 
     std::vector<Tracklet*> orderedMatches(std::vector<FullMatchMemory*>& fullmatch);
 
+<<<<<<< HEAD
     void execute(const ChannelAssignment* channelAssignment,
                  std::deque<tt::Frame>& streamTrack,
                  std::vector<std::deque<tt::FrameStub>>& streamsStub,
 		 std::vector<std::string>& trackStream,
+=======
+    void execute(std::vector<std::string>& trackStream,
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
 		 std::vector<std::vector<StubStreamData>>& stubStream,
                  unsigned int iSector);
 

--- a/L1Trigger/TrackFindingTracklet/interface/FitTrack.h
+++ b/L1Trigger/TrackFindingTracklet/interface/FitTrack.h
@@ -38,15 +38,8 @@ namespace trklet {
 
     std::vector<Tracklet*> orderedMatches(std::vector<FullMatchMemory*>& fullmatch);
 
-<<<<<<< HEAD
-    void execute(const ChannelAssignment* channelAssignment,
-                 std::deque<tt::Frame>& streamTrack,
-                 std::vector<std::deque<tt::FrameStub>>& streamsStub,
-		 std::vector<std::string>& trackStream,
-=======
     void execute(std::vector<std::string>& trackStream,
->>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
-		 std::vector<std::vector<StubStreamData>>& stubStream,
+                 std::vector<std::vector<StubStreamData>>& stubStream,
                  unsigned int iSector);
 
   private:

--- a/L1Trigger/TrackFindingTracklet/interface/L1TStub.h
+++ b/L1Trigger/TrackFindingTracklet/interface/L1TStub.h
@@ -2,7 +2,6 @@
 #define L1Trigger_TrackFindingTracklet_interface_L1TStub_h
 
 #include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
-#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
 #include <iostream>
 #include <fstream>
@@ -27,8 +26,7 @@ namespace trklet {
             double z,
             double bend,
             double strip,
-            std::vector<int> tps,
-            const TTStubRef& ttStubRef);
+            std::vector<int> tps);
 
     ~L1TStub() = default;
 
@@ -109,8 +107,6 @@ namespace trklet {
 
     const std::string& stubword() const { return stubword_; }
 
-    TTStubRef ttStubRef() const { return ttStubRef_; }
-
   private:
     int layerdisk_;
     std::string DTClink_;
@@ -135,7 +131,7 @@ namespace trklet {
 
     unsigned int isPSmodule_;
     unsigned int isFlipped_;
-    TTStubRef ttStubRef_;
+
   };
 };  // namespace trklet
 #endif

--- a/L1Trigger/TrackFindingTracklet/interface/L1TStub.h
+++ b/L1Trigger/TrackFindingTracklet/interface/L1TStub.h
@@ -131,7 +131,6 @@ namespace trklet {
 
     unsigned int isPSmodule_;
     unsigned int isFlipped_;
-
   };
 };  // namespace trklet
 #endif

--- a/L1Trigger/TrackFindingTracklet/interface/SLHCEvent.h
+++ b/L1Trigger/TrackFindingTracklet/interface/SLHCEvent.h
@@ -39,8 +39,7 @@ namespace trklet {
                  double z,
                  double bend,
                  double strip,
-                 std::vector<int> tpstt,
-                 const TTStubRef& ttStubRef);
+                 std::vector<int> tpstt);
 
     const L1TStub& lastStub() const { return stubs_.back(); }
 

--- a/L1Trigger/TrackFindingTracklet/interface/Sector.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Sector.h
@@ -4,7 +4,6 @@
 
 #include "L1Trigger/TrackFindingTracklet/interface/L1TStub.h"
 #include "L1Trigger/TrackFindingTracklet/interface/SLHCEvent.h"
-#include "L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h"
 #include "L1Trigger/TrackFindingTracklet/interface/StubStreamData.h"
 
 #include <string>
@@ -116,8 +115,13 @@ namespace trklet {
     void executeME();
     void executeMC();
     void executeMP();
+<<<<<<< HEAD
     void executeFT(std::vector<std::vector<std::string> >& tracksStream,
 		   std::vector<std::vector<StubStreamData>>& stubsStream);
+=======
+    void executeFT(std::vector<std::vector<std::string>>& tracksStream,
+                   std::vector<std::vector<StubStreamData>>& stubsStream);
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
     void executePD(std::vector<Track>& tracks);
 
     std::vector<Tracklet*> getAllTracklets() const;

--- a/L1Trigger/TrackFindingTracklet/interface/Sector.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Sector.h
@@ -115,13 +115,8 @@ namespace trklet {
     void executeME();
     void executeMC();
     void executeMP();
-<<<<<<< HEAD
-    void executeFT(std::vector<std::vector<std::string> >& tracksStream,
-		   std::vector<std::vector<StubStreamData>>& stubsStream);
-=======
     void executeFT(std::vector<std::vector<std::string>>& tracksStream,
                    std::vector<std::vector<StubStreamData>>& stubsStream);
->>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
     void executePD(std::vector<Track>& tracks);
 
     std::vector<Tracklet*> getAllTracklets() const;

--- a/L1Trigger/TrackFindingTracklet/interface/Sector.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Sector.h
@@ -115,8 +115,8 @@ namespace trklet {
     void executeME();
     void executeMC();
     void executeMP();
-    void executeFT(std::vector<std::vector<std::string>>& tracksStream,
-                   std::vector<std::vector<StubStreamData>>& stubsStream);
+    void executeFT(std::vector<std::vector<std::string>>& streamsTrackRaw,
+                   std::vector<std::vector<StubStreamData>>& streamsStubRaw);
     void executePD(std::vector<Track>& tracks);
 
     std::vector<Tracklet*> getAllTracklets() const;

--- a/L1Trigger/TrackFindingTracklet/interface/Sector.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Sector.h
@@ -128,14 +128,14 @@ namespace trklet {
     double phimax() const { return phimax_; }
 
     template <typename TV, typename... Args>
-    void addMemToVec(std::vector<std::unique_ptr<TV> >& memvec, const std::string& memName, Args&... args) {
+    void addMemToVec(std::vector<std::unique_ptr<TV>>& memvec, const std::string& memName, Args&... args) {
       memvec.push_back(std::make_unique<TV>(memName, std::forward<Args>(args)...));
       Memories_[memName] = memvec.back().get();
       MemoriesV_.push_back(memvec.back().get());
     }
 
     template <typename TV, typename... Args>
-    void addProcToVec(std::vector<std::unique_ptr<TV> >& procvec, const std::string& procName, Args&... args) {
+    void addProcToVec(std::vector<std::unique_ptr<TV>>& procvec, const std::string& procName, Args&... args) {
       procvec.push_back(std::make_unique<TV>(procName, std::forward<Args>(args)...));
       Processes_[procName] = procvec.back().get();
     }
@@ -149,39 +149,39 @@ namespace trklet {
 
     std::map<std::string, MemoryBase*> Memories_;
     std::vector<MemoryBase*> MemoriesV_;
-    std::vector<std::unique_ptr<DTCLinkMemory> > DL_;
-    std::vector<std::unique_ptr<InputLinkMemory> > IL_;
-    std::vector<std::unique_ptr<AllStubsMemory> > AS_;
-    std::vector<std::unique_ptr<AllInnerStubsMemory> > AIS_;
-    std::vector<std::unique_ptr<VMStubsTEMemory> > VMSTE_;
-    std::vector<std::unique_ptr<VMStubsMEMemory> > VMSME_;
-    std::vector<std::unique_ptr<StubPairsMemory> > SP_;
-    std::vector<std::unique_ptr<StubTripletsMemory> > ST_;
-    std::vector<std::unique_ptr<TrackletParametersMemory> > TPAR_;
-    std::vector<std::unique_ptr<TrackletProjectionsMemory> > TPROJ_;
-    std::vector<std::unique_ptr<AllProjectionsMemory> > AP_;
-    std::vector<std::unique_ptr<VMProjectionsMemory> > VMPROJ_;
-    std::vector<std::unique_ptr<CandidateMatchMemory> > CM_;
-    std::vector<std::unique_ptr<FullMatchMemory> > FM_;
-    std::vector<std::unique_ptr<TrackFitMemory> > TF_;
-    std::vector<std::unique_ptr<CleanTrackMemory> > CT_;
+    std::vector<std::unique_ptr<DTCLinkMemory>> DL_;
+    std::vector<std::unique_ptr<InputLinkMemory>> IL_;
+    std::vector<std::unique_ptr<AllStubsMemory>> AS_;
+    std::vector<std::unique_ptr<AllInnerStubsMemory>> AIS_;
+    std::vector<std::unique_ptr<VMStubsTEMemory>> VMSTE_;
+    std::vector<std::unique_ptr<VMStubsMEMemory>> VMSME_;
+    std::vector<std::unique_ptr<StubPairsMemory>> SP_;
+    std::vector<std::unique_ptr<StubTripletsMemory>> ST_;
+    std::vector<std::unique_ptr<TrackletParametersMemory>> TPAR_;
+    std::vector<std::unique_ptr<TrackletProjectionsMemory>> TPROJ_;
+    std::vector<std::unique_ptr<AllProjectionsMemory>> AP_;
+    std::vector<std::unique_ptr<VMProjectionsMemory>> VMPROJ_;
+    std::vector<std::unique_ptr<CandidateMatchMemory>> CM_;
+    std::vector<std::unique_ptr<FullMatchMemory>> FM_;
+    std::vector<std::unique_ptr<TrackFitMemory>> TF_;
+    std::vector<std::unique_ptr<CleanTrackMemory>> CT_;
 
     std::map<std::string, ProcessBase*> Processes_;
-    std::vector<std::unique_ptr<InputRouter> > IR_;
-    std::vector<std::unique_ptr<VMRouter> > VMR_;
-    std::vector<std::unique_ptr<VMRouterCM> > VMRCM_;
-    std::vector<std::unique_ptr<TrackletEngine> > TE_;
-    std::vector<std::unique_ptr<TrackletEngineDisplaced> > TED_;
-    std::vector<std::unique_ptr<TripletEngine> > TRE_;
-    std::vector<std::unique_ptr<TrackletProcessor> > TP_;
-    std::vector<std::unique_ptr<TrackletCalculator> > TC_;
-    std::vector<std::unique_ptr<TrackletCalculatorDisplaced> > TCD_;
-    std::vector<std::unique_ptr<ProjectionRouter> > PR_;
-    std::vector<std::unique_ptr<MatchEngine> > ME_;
-    std::vector<std::unique_ptr<MatchCalculator> > MC_;
-    std::vector<std::unique_ptr<MatchProcessor> > MP_;
-    std::vector<std::unique_ptr<FitTrack> > FT_;
-    std::vector<std::unique_ptr<PurgeDuplicate> > PD_;
+    std::vector<std::unique_ptr<InputRouter>> IR_;
+    std::vector<std::unique_ptr<VMRouter>> VMR_;
+    std::vector<std::unique_ptr<VMRouterCM>> VMRCM_;
+    std::vector<std::unique_ptr<TrackletEngine>> TE_;
+    std::vector<std::unique_ptr<TrackletEngineDisplaced>> TED_;
+    std::vector<std::unique_ptr<TripletEngine>> TRE_;
+    std::vector<std::unique_ptr<TrackletProcessor>> TP_;
+    std::vector<std::unique_ptr<TrackletCalculator>> TC_;
+    std::vector<std::unique_ptr<TrackletCalculatorDisplaced>> TCD_;
+    std::vector<std::unique_ptr<ProjectionRouter>> PR_;
+    std::vector<std::unique_ptr<MatchEngine>> ME_;
+    std::vector<std::unique_ptr<MatchCalculator>> MC_;
+    std::vector<std::unique_ptr<MatchProcessor>> MP_;
+    std::vector<std::unique_ptr<FitTrack>> FT_;
+    std::vector<std::unique_ptr<PurgeDuplicate>> PD_;
   };
 };  // namespace trklet
 #endif

--- a/L1Trigger/TrackFindingTracklet/interface/Sector.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Sector.h
@@ -5,6 +5,7 @@
 #include "L1Trigger/TrackFindingTracklet/interface/L1TStub.h"
 #include "L1Trigger/TrackFindingTracklet/interface/SLHCEvent.h"
 #include "L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h"
+#include "L1Trigger/TrackFindingTracklet/interface/StubStreamData.h"
 
 #include <string>
 #include <map>
@@ -115,7 +116,8 @@ namespace trklet {
     void executeME();
     void executeMC();
     void executeMP();
-    void executeFT(const ChannelAssignment* channelAssignment, tt::Streams& streamsTrack, tt::StreamsStub& streamsStub);
+    void executeFT(std::vector<std::vector<std::string> >& tracksStream,
+		   std::vector<std::vector<StubStreamData>>& stubsStream);
     void executePD(std::vector<Track>& tracks);
 
     std::vector<Tracklet*> getAllTracklets() const;

--- a/L1Trigger/TrackFindingTracklet/interface/StubStreamData.h
+++ b/L1Trigger/TrackFindingTracklet/interface/StubStreamData.h
@@ -1,0 +1,32 @@
+#ifndef L1Trigger_TrackFindingTracklet_interface_StubStreamData_h
+#define L1Trigger_TrackFindingTracklet_interface_StubStreamData_h
+
+#include "L1Trigger/TrackFindingTracklet/interface/L1TStub.h"
+
+#include <string>
+
+namespace trklet {
+
+  class L1TStub;
+
+  class StubStreamData {
+  public:
+    StubStreamData() {}
+    
+    StubStreamData(int iSeed, const L1TStub& stub, const std::string& residuals):
+       iSeed_(iSeed), stub_(stub), residuals_(residuals) {}
+
+    ~StubStreamData() = default;
+
+    int iSeed() const {return iSeed_;}
+    const L1TStub& stub() const {return stub_;}
+    const std::string& residuals() const {return residuals_;}
+
+  private:
+    int iSeed_{-1};
+    L1TStub stub_;
+    std::string residuals_{""};
+   
+  };
+};  // namespace trklet
+#endif

--- a/L1Trigger/TrackFindingTracklet/interface/StubStreamData.h
+++ b/L1Trigger/TrackFindingTracklet/interface/StubStreamData.h
@@ -5,7 +5,7 @@
 
 #include <string>
 
-// Used to generate bit-accurate stub stream from TrackBuilder output
+// Represents an element of the bit-accurate stub stream from TrackBuilder output
 // (This class only needed to support stand-alone running of this code).
 
 namespace trklet {
@@ -16,21 +16,21 @@ namespace trklet {
   public:
     StubStreamData() {}
 
-    StubStreamData(int iSeed, const L1TStub& stub, const std::string& residuals)
-        : iSeed_(iSeed), stub_(stub), residuals_(residuals) {}
+    StubStreamData(int iSeed, const L1TStub& stub, const std::string& dataBits)
+        : iSeed_(iSeed), stub_(stub), dataBits_(dataBits) {}
 
     ~StubStreamData() = default;
 
     int iSeed() const { return iSeed_; }          // Seed type
     bool valid() const { return (iSeed_ >= 0); }  // Valid stub
     const L1TStub& stub() const { return stub_; }
-    // String containing valid bit + r coordinate + phi residual + r or z residual.
-    const std::string& residuals() const { return residuals_; }
+    // String with bits of valid bit + r coordinate + phi residual + r or z residual.
+    const std::string& dataBits() const { return dataBits_; }
 
   private:
     int iSeed_{-1};
     L1TStub stub_;
-    std::string residuals_{""};
+    std::string dataBits_{""};
   };
 };  // namespace trklet
 #endif

--- a/L1Trigger/TrackFindingTracklet/interface/StubStreamData.h
+++ b/L1Trigger/TrackFindingTracklet/interface/StubStreamData.h
@@ -5,6 +5,8 @@
 
 #include <string>
 
+// Used to generate bit-accurate stub stream from TrackBuilder output
+
 namespace trklet {
 
   class L1TStub;
@@ -18,8 +20,9 @@ namespace trklet {
 
     ~StubStreamData() = default;
 
-    int iSeed() const {return iSeed_;}
+    int iSeed() const {return iSeed_;} // Seed type
     const L1TStub& stub() const {return stub_;}
+    // String containing valid bit + r coordinate + phi residual + r or z residual.
     const std::string& residuals() const {return residuals_;}
 
   private:

--- a/L1Trigger/TrackFindingTracklet/interface/StubStreamData.h
+++ b/L1Trigger/TrackFindingTracklet/interface/StubStreamData.h
@@ -14,24 +14,23 @@ namespace trklet {
 
   class StubStreamData {
   public:
-    StubStreamData() {} 
-    
-    StubStreamData(int iSeed, const L1TStub& stub, const std::string& residuals):
-       iSeed_(iSeed), stub_(stub), residuals_(residuals) {}
+    StubStreamData() {}
+
+    StubStreamData(int iSeed, const L1TStub& stub, const std::string& residuals)
+        : iSeed_(iSeed), stub_(stub), residuals_(residuals) {}
 
     ~StubStreamData() = default;
 
-    int iSeed() const {return iSeed_;} // Seed type
-    bool valid() const {return (iSeed_ >= 0);} // Valid stub
-    const L1TStub& stub() const {return stub_;}
+    int iSeed() const { return iSeed_; }          // Seed type
+    bool valid() const { return (iSeed_ >= 0); }  // Valid stub
+    const L1TStub& stub() const { return stub_; }
     // String containing valid bit + r coordinate + phi residual + r or z residual.
-    const std::string& residuals() const {return residuals_;}
+    const std::string& residuals() const { return residuals_; }
 
   private:
     int iSeed_{-1};
     L1TStub stub_;
     std::string residuals_{""};
-   
   };
 };  // namespace trklet
 #endif

--- a/L1Trigger/TrackFindingTracklet/interface/StubStreamData.h
+++ b/L1Trigger/TrackFindingTracklet/interface/StubStreamData.h
@@ -6,6 +6,7 @@
 #include <string>
 
 // Used to generate bit-accurate stub stream from TrackBuilder output
+// (This class only needed to support stand-alone running of this code).
 
 namespace trklet {
 
@@ -13,7 +14,7 @@ namespace trklet {
 
   class StubStreamData {
   public:
-    StubStreamData() {}
+    StubStreamData() {} 
     
     StubStreamData(int iSeed, const L1TStub& stub, const std::string& residuals):
        iSeed_(iSeed), stub_(stub), residuals_(residuals) {}
@@ -21,6 +22,7 @@ namespace trklet {
     ~StubStreamData() = default;
 
     int iSeed() const {return iSeed_;} // Seed type
+    bool valid() const {return (iSeed_ >= 0);} // Valid stub
     const L1TStub& stub() const {return stub_;}
     // String containing valid bit + r coordinate + phi residual + r or z residual.
     const std::string& residuals() const {return residuals_;}

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
@@ -23,7 +23,7 @@ namespace trklet {
   class Sector;
   class HistBase;
   class Track;
-  class ChannelAssignment;
+  class StubStreamData;
 
   class TrackletEventProcessor {
   public:
@@ -35,7 +35,9 @@ namespace trklet {
               const ChannelAssignment* channelAssignment,
               const tt::Setup* setup = nullptr);
 
-    void event(SLHCEvent& ev);
+    void event(SLHCEvent& ev,
+	       std::vector<std::vector<std::string>>& tracksStream,
+	       std::vector<std::vector<StubStreamData>>& stubsStream);
 
     void printSummary();
 
@@ -47,7 +49,6 @@ namespace trklet {
     void configure(std::istream& inwire, std::istream& inmem, std::istream& inproc);
 
     const Settings* settings_{nullptr};
-    const ChannelAssignment* channelAssignment_{nullptr};
 
     std::unique_ptr<Globals> globals_;
 
@@ -75,8 +76,6 @@ namespace trklet {
     Timer PDTimer_;
 
     std::vector<Track> tracks_;
-    tt::Streams streamsTrack_;
-    tt::StreamsStub streamsStub_;
   };
 
 };  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
@@ -34,8 +34,8 @@ namespace trklet {
               const tt::Setup* setup = nullptr);
 
     void event(SLHCEvent& ev,
-	       std::vector<std::vector<std::string>>& tracksStream,
-	       std::vector<std::vector<StubStreamData>>& stubsStream);
+	       std::vector<std::vector<std::string>>& streamsTrackRaw,
+	       std::vector<std::vector<StubStreamData>>& streamsStubRaw);
 
     void printSummary();
 

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
@@ -30,12 +30,11 @@ namespace trklet {
 
     ~TrackletEventProcessor();
 
-    void init(Settings const& theSettings,
-              const tt::Setup* setup = nullptr);
+    void init(Settings const& theSettings, const tt::Setup* setup = nullptr);
 
     void event(SLHCEvent& ev,
-	       std::vector<std::vector<std::string>>& streamsTrackRaw,
-	       std::vector<std::vector<StubStreamData>>& streamsStubRaw);
+               std::vector<std::vector<std::string>>& streamsTrackRaw,
+               std::vector<std::vector<StubStreamData>>& streamsStubRaw);
 
     void printSummary();
 

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
@@ -3,7 +3,10 @@
 #define L1Trigger_TrackFindingTracklet_interface_TrackletEventProcessor_h
 
 #include "L1Trigger/TrackFindingTracklet/interface/Timer.h"
+<<<<<<< HEAD
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+=======
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
 
 #include <map>
 #include <memory>
@@ -31,9 +34,13 @@ namespace trklet {
 
     ~TrackletEventProcessor();
 
+<<<<<<< HEAD
     void init(Settings const& theSettings,
               const ChannelAssignment* channelAssignment,
               const tt::Setup* setup = nullptr);
+=======
+    void init(Settings const& theSettings);
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
 
     void event(SLHCEvent& ev,
 	       std::vector<std::vector<std::string>>& tracksStream,
@@ -42,8 +49,6 @@ namespace trklet {
     void printSummary();
 
     const std::vector<Track>& tracks() const { return tracks_; }
-
-    void produce(tt::Streams& streamsTrack, tt::StreamsStub& streamsStub);
 
   private:
     void configure(std::istream& inwire, std::istream& inmem, std::istream& inproc);

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletEventProcessor.h
@@ -3,10 +3,6 @@
 #define L1Trigger_TrackFindingTracklet_interface_TrackletEventProcessor_h
 
 #include "L1Trigger/TrackFindingTracklet/interface/Timer.h"
-<<<<<<< HEAD
-#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
-=======
->>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
 
 #include <map>
 #include <memory>
@@ -34,13 +30,8 @@ namespace trklet {
 
     ~TrackletEventProcessor();
 
-<<<<<<< HEAD
     void init(Settings const& theSettings,
-              const ChannelAssignment* channelAssignment,
               const tt::Setup* setup = nullptr);
-=======
-    void init(Settings const& theSettings);
->>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
 
     void event(SLHCEvent& ev,
 	       std::vector<std::vector<std::string>>& tracksStream,

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -717,10 +717,6 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     for(unsigned int itk=0; itk<streamsTrackRaw[chanTrk].size(); itk++) {
       std::string bitsTrk = streamsTrackRaw[chanTrk][itk];
       int iSeed = chanTrk%channelAssignment_->numChannelsTrack(); // seed type
-      // TO DO: CHECK -- THESE LINES NO LONGER NEEDED AS FITTRACK ADDS VALID+SEED TO trackStream.
-      //if (bitsTrk != "0") 
-      //  bitsTrk="1" + TTBV(iSeed, settings_.nbitsseed()).str()+bitsTrk;
-      //}
       streamsTrack[chanTrk].emplace_back(bitsTrk);
 
       const unsigned int chanStubOffsetIn = chanTrk*maxNumProjectionLayers;

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -612,12 +612,12 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
   const std::vector<trklet::Track>& tracks = eventProcessor.tracks();
 
+  const unsigned int maxNumProjectionLayers = channelAssignment_->maxNumProjectionLayers();
   // number of track channels
   const unsigned int numStreamsTrack = N_SECTOR * channelAssignment_->numChannelsTrack();
   // number of stub channels
   const unsigned int numStreamsStub = N_SECTOR * channelAssignment_->numChannelsStub();
   // number of stub channels if all seed types streams padded to have same number of stub channels (for coding simplicity)
-  const unsigned int maxNumProjectionLayers = channelAssignment_->maxNumProjectionLayers();
   const unsigned int numStreamsStubRaw = numStreamsTrack * maxNumProjectionLayers;
 
   // Streams formatted to allow this code to run outside CMSSW.

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -744,27 +744,6 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     }    
   }
   
-  static ofstream out("streamdata.txt");
-  
-  out << "# trackstreams : "<<streamsTrack.size()<<endl;
-  for(unsigned int i=0; i<streamsTrack.size(); i++) {
-    out << "# tracks : " << streamsTrack[i].size()<<endl; 
-    for(unsigned int j=0;j<streamsTrack[i].size(); j++) {
-      out << "Track : " << streamsTrack[i][j] << endl;
-    }
-  }
-  
-
-  out << "# stub streams : "<<streamsStub.size()<<endl;
-  for(unsigned int i=0; i<streamsStub.size(); i++) {
-    out << "# stubs : " << streamsStub[i].size()<<endl; 
-    for(unsigned int j=0;j<streamsStub[i].size(); j++) {
-      out << "Stub : " << streamsStub[i][j].second << endl;
-    }
-  }
-
-  
-
   iEvent.emplace(edPutTokenTracks_, move(streamsTrack));
   iEvent.emplace(edPutTokenStubs_, move(streamsStub));
 

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -617,11 +617,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   // number of stub channels
   const unsigned int numStreamsStub = N_SECTOR * channelAssignment_->numChannelsStub();
   // number of stub channels if all seed types streams padded to have same number of stub channels (for coding simplicity)
-  unsigned int maxNumProjectionLayers = 0;
-  for (int iSeedType = 0; iSeedType < channelAssignment_->numSeedTypes(); iSeedType++) {
-    maxNumProjectionLayers =
-        max(maxNumProjectionLayers, (unsigned int)channelAssignment_->numProjectionLayers(iSeedType));
-  }
+  const unsigned int maxNumProjectionLayers = channelAssignment_->maxNumProjectionLayers();
   const unsigned int numStreamsStubRaw = numStreamsTrack * maxNumProjectionLayers;
 
   // Streams formatted to allow this code to run outside CMSSW.
@@ -734,7 +730,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
           if (!channelAssignment_->layerId(stubdata.iSeed(), ttStubRef, layerId))
             continue;
           hitMap.set(layerId);
-          streamsStub[chanStubOffsetOut + layerId].emplace_back(ttStubRef, stubdata.residuals());
+          streamsStub[chanStubOffsetOut + layerId].emplace_back(ttStubRef, stubdata.dataBits());
         }
       }
       for (int layerId : hitMap.ids(false)) {  // invalid stubs

--- a/L1Trigger/TrackFindingTracklet/src/ChannelAssignment.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ChannelAssignment.cc
@@ -30,6 +30,10 @@ namespace trklet {
       seedTypesSeedLayers_.emplace_back(pSetSeedTypesSeedLayers.getParameter<vector<int>>(s));
       seedTypesProjectionLayers_.emplace_back(pSetSeedTypesProjectionLayers.getParameter<vector<int>>(s));
     }
+    maxNumProjectionLayers_ = 0;
+    for (const auto& v : seedTypesProjectionLayers_) {
+      maxNumProjectionLayers_ = max(maxNumProjectionLayers_, (int) v.size());
+    }
     auto acc = [](int& sum, vector<int> ints) { return sum += (int)ints.size(); };
     numChannelsStub_ = accumulate(seedTypesProjectionLayers_.begin(), seedTypesProjectionLayers_.end(), 0, acc);
     offsetsStubs_.reserve(numSeedTypes_);

--- a/L1Trigger/TrackFindingTracklet/src/ChannelAssignment.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ChannelAssignment.cc
@@ -114,6 +114,8 @@ namespace trklet {
     }
     auto bigger = [](const vector<int>& lhs, const vector<int>& rhs) { return lhs.size() < rhs.size(); };
     numSeedingLayers_ = max_element(seedTypesSeedLayers_.begin(), seedTypesSeedLayers_.end(), bigger)->size();
+    numProjectionLayers_ =
+        max_element(seedTypesProjectionLayers_.begin(), seedTypesProjectionLayers_.end(), bigger)->size();
   }
 
   // sets channelId of given TTTrackRef, return false if track outside pt range

--- a/L1Trigger/TrackFindingTracklet/src/ChannelAssignment.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ChannelAssignment.cc
@@ -30,10 +30,6 @@ namespace trklet {
       seedTypesSeedLayers_.emplace_back(pSetSeedTypesSeedLayers.getParameter<vector<int>>(s));
       seedTypesProjectionLayers_.emplace_back(pSetSeedTypesProjectionLayers.getParameter<vector<int>>(s));
     }
-    maxNumProjectionLayers_ = 0;
-    for (const auto& v : seedTypesProjectionLayers_) {
-      maxNumProjectionLayers_ = max(maxNumProjectionLayers_, (int) v.size());
-    }
     auto acc = [](int& sum, vector<int> ints) { return sum += (int)ints.size(); };
     numChannelsStub_ = accumulate(seedTypesProjectionLayers_.begin(), seedTypesProjectionLayers_.end(), 0, acc);
     offsetsStubs_.reserve(numSeedTypes_);
@@ -114,7 +110,7 @@ namespace trklet {
     }
     auto bigger = [](const vector<int>& lhs, const vector<int>& rhs) { return lhs.size() < rhs.size(); };
     numSeedingLayers_ = max_element(seedTypesSeedLayers_.begin(), seedTypesSeedLayers_.end(), bigger)->size();
-    numProjectionLayers_ =
+    maxNumProjectionLayers_ =
         max_element(seedTypesProjectionLayers_.begin(), seedTypesProjectionLayers_.end(), bigger)->size();
   }
 

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -1066,8 +1066,6 @@ void FitTrack::execute(vector<string>& streamTrackRaw,
           const string& rz = resid.fpgarzresid().str();
           const L1TStub* stub = resid.stubptr()->l1tstub();
           static constexpr int widthDisk2Sidentifier = 8;
-          // TO DO: Check if this correctly translates Thomas's code for endcap 2S r coordinate
-          //if (channelAssignment->type(ttStubRef) == tt::SensorModule::Disk2S)
           bool disk2S = (stub->disk() != 0) && (stub->isPSmodule() == 0);
           if (disk2S) r = string(widthDisk2Sidentifier, '0') + r;
           // store seed, L1TStub, and bit accurate 64 bit word in clock accurate output

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -1056,7 +1056,7 @@ void FitTrack::execute(vector<string>& streamTrackRaw,
       streamTrackRaw.emplace_back(valid + seed + rinv + phi0 + z0 + t);
 
       unsigned int ihit(0);
-      for(unsigned int ilayer = 0 ; ilayer < N_LAYER + N_DISK ; ilayer++){
+      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
         if (bestTracklet->match(ilayer)) {
           const Residual& resid = bestTracklet->resid(ilayer);
           // create bit accurate 64 bit word
@@ -1067,13 +1067,14 @@ void FitTrack::execute(vector<string>& streamTrackRaw,
           const L1TStub* stub = resid.stubptr()->l1tstub();
           static constexpr int widthDisk2Sidentifier = 8;
           bool disk2S = (stub->disk() != 0) && (stub->isPSmodule() == 0);
-          if (disk2S) r = string(widthDisk2Sidentifier, '0') + r;
+          if (disk2S)
+            r = string(widthDisk2Sidentifier, '0') + r;
           // store seed, L1TStub, and bit accurate 64 bit word in clock accurate output
-          streamsStubRaw[ihit++].emplace_back(StubStreamData(seedType,*stub,valid + r + phi + rz));
+          streamsStubRaw[ihit++].emplace_back(StubStreamData(seedType, *stub, valid + r + phi + rz));
         }
       }
       // fill all layer with no stubs with gaps
-      while (ihit<streamsStubRaw.size()) {
+      while (ihit < streamsStubRaw.size()) {
         streamsStubRaw[ihit++].emplace_back(StubStreamData());
       }
     }

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -869,6 +869,7 @@ std::vector<Tracklet*> FitTrack::orderedMatches(vector<FullMatchMemory*>& fullma
   return tmp;
 }
 
+<<<<<<< HEAD
 // Adds the fitted track to the output memories to be used by pure Tracklet algo.
 // (Also used by Hybrid algo with non-exact Old KF emulation)
 // Also create output streams, that bypass these memories, (so can include gaps in time),
@@ -878,6 +879,9 @@ void FitTrack::execute(const ChannelAssignment* channelAssignment,
                        deque<tt::Frame>& streamTrack,
                        vector<deque<tt::FrameStub>>& streamsStub,
 		       vector<string>& trackStream,
+=======
+void FitTrack::execute(vector<string>& trackStream,
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
 		       vector<vector<StubStreamData>>& stubStream,
                        unsigned int iSector) {
   // merge
@@ -1039,26 +1043,26 @@ void FitTrack::execute(const ChannelAssignment* channelAssignment,
     }
 
     // store bit and clock accurate TB output
+<<<<<<< HEAD
     if (settings_.storeTrackBuilderOutput() && bestTracklet) {
+=======
+
+    if (settings_.emulateTB() && bestTracklet) {
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
       // add gap if enough layer to form track
       if (!bestTracklet->fit()) {
-        streamTrack.emplace_back(tt::Frame());
 	static const string invalid = "0";
 	trackStream.emplace_back(invalid);
-        for (auto& stream : streamsStub)
-          stream.emplace_back(tt::FrameStub());
         for (auto& stream : stubStream)
           stream.emplace_back(StubStreamData());
         continue;
       }
       // convert Track word
-      const int seedType = bestTracklet->getISeed();
-      static const string valid = "1";
-      const string seed = TTBV(seedType, settings_.nbitsseed()).str();
       const string rinv = bestTracklet->fpgarinv().str();
       const string phi0 = bestTracklet->fpgaphi0().str();
       const string z0 = bestTracklet->fpgaz0().str();
       const string t = bestTracklet->fpgat().str();
+<<<<<<< HEAD
       streamTrack.emplace_back(valid + seed + rinv + phi0 + z0 + t);
       trackStream.emplace_back(valid + seed + rinv + phi0 + z0 + t);
       // hitMap used to remember whcih layer had no stub to fill them with gaps
@@ -1092,48 +1096,30 @@ void FitTrack::execute(const ChannelAssignment* channelAssignment,
       for (int layer : hitMap.ids(false)) {
         streamsStub[layer].emplace_back(tt::FrameStub());
       }
+=======
+      trackStream.emplace_back(rinv + phi0 + z0 + t);
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
 
+      const int seedType = bestTracklet->getISeed();
       unsigned int ihit(0);
-      //TTBV hitMap2(0, channelAssignment->maxNumProjectionLayers());
-      cout << "Here020" << endl;
-      //for (const auto& stub : bestTracklet->getL1Stubs()) {
+
       for(unsigned int ilayer = 0 ; ilayer < N_LAYER + N_DISK ; ilayer++){
-        // get TTStubRef of this stub
-        //const TTStubRef& ttStubRef = stub->ttStubRef();
-        // get layerId and skip over seeding layer
-        //int layerId(-1);
-        //if (!channelAssignment->layerId(seedType, ttStubRef, layerId))
-        //  continue;
-        // mark layerId
-        //hitMap2.set(layerId);
-        // tracklet layerId
-        //const int trackletLayerId = channelAssignment->trackletLayerId(ttStubRef);
-        // get stub Residual
 	if (!bestTracklet->match(ilayer))
 	  continue;
         const Residual& resid = bestTracklet->resid(ilayer);
         // create bit accurate 64 bit word
+        const string valid("1");
         const string& r = resid.stubptr()->r().str();
         const string& phi = resid.fpgaphiresid().str();
         const string& rz = resid.fpgarzresid().str();
 	const L1TStub* stub = resid.stubptr()->l1tstub();
-        // store TTStubRef and bit accurate 64 bit word in clock accurate output
-	cout << "ihit size : "<<ihit<<" "<<stubStream.size()<<endl;
-	cout << "seed stub.z stub "<<seedType<<" "<<stub->z()<<" "<<stub<<endl;
-        if (seedType==0) {
-	  assert(fabs(stub->z())<250.0);
-	}
+        // store seed, L1TStub, and bit accurate 64 bit word in clock accurate output
 	stubStream[ihit++].emplace_back(StubStreamData(seedType,*stub,valid + r + phi + rz));
       }
-
-      cout << "Here999" << endl;
-
       // fill all layer with no stubs with gaps
       while (ihit<stubStream.size()) {
         stubStream[ihit++].emplace_back(StubStreamData());
       }
-
-
     }
 
   } while (bestTracklet != nullptr && countAll < settings_.maxStep("TB"));

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -874,8 +874,8 @@ std::vector<Tracklet*> FitTrack::orderedMatches(vector<FullMatchMemory*>& fullma
 // Also create output streams, that bypass these memories, (so can include gaps in time),
 // to be used by Hybrid case with exact New KF emulation.
 
-void FitTrack::execute(vector<string>& trackStream,
-                       vector<vector<StubStreamData>>& stubStream,
+void FitTrack::execute(vector<string>& streamTrackRaw,
+                       vector<vector<StubStreamData>>& streamsStubRaw,
                        unsigned int iSector) {
   // merge
   const std::vector<Tracklet*>& matches1 = orderedMatches(fullmatch1_);
@@ -1040,8 +1040,8 @@ void FitTrack::execute(vector<string>& trackStream,
       // add gap if enough layer to form track
       if (!bestTracklet->fit()) {
         static const string invalid = "0";
-        trackStream.emplace_back(invalid);
-        for (auto& stream : stubStream)
+        streamTrackRaw.emplace_back(invalid);
+        for (auto& stream : streamsStubRaw)
           stream.emplace_back(StubStreamData());
         continue;
       }
@@ -1053,7 +1053,7 @@ void FitTrack::execute(vector<string>& trackStream,
       const int seedType = bestTracklet->getISeed();
       const string seed = TTBV(seedType, settings_.nbitsseed()).str();
       const string valid("1");
-      trackStream.emplace_back(valid + seed + rinv + phi0 + z0 + t);
+      streamTrackRaw.emplace_back(valid + seed + rinv + phi0 + z0 + t);
 
       unsigned int ihit(0);
       for(unsigned int ilayer = 0 ; ilayer < N_LAYER + N_DISK ; ilayer++){
@@ -1071,12 +1071,12 @@ void FitTrack::execute(vector<string>& trackStream,
           bool disk2S = (stub->disk() != 0) && (stub->isPSmodule() == 0);
           if (disk2S) r = string(widthDisk2Sidentifier, '0') + r;
           // store seed, L1TStub, and bit accurate 64 bit word in clock accurate output
-          stubStream[ihit++].emplace_back(StubStreamData(seedType,*stub,valid + r + phi + rz));
+          streamsStubRaw[ihit++].emplace_back(StubStreamData(seedType,*stub,valid + r + phi + rz));
         }
       }
       // fill all layer with no stubs with gaps
-      while (ihit<stubStream.size()) {
-        stubStream[ihit++].emplace_back(StubStreamData());
+      while (ihit<streamsStubRaw.size()) {
+        streamsStubRaw[ihit++].emplace_back(StubStreamData());
       }
     }
 

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -874,8 +874,8 @@ std::vector<Tracklet*> FitTrack::orderedMatches(vector<FullMatchMemory*>& fullma
 // Also create output streams, that bypass these memories, (so can include gaps in time),
 // to be used by Hybrid case with exact New KF emulation.
 
-void FitTrack::execute(vector<string>& streamTrackRaw,
-                       vector<vector<StubStreamData>>& streamsStubRaw,
+void FitTrack::execute(deque<string>& streamTrackRaw,
+                       vector<deque<StubStreamData>>& streamsStubRaw,
                        unsigned int iSector) {
   // merge
   const std::vector<Tracklet*>& matches1 = orderedMatches(fullmatch1_);
@@ -1070,12 +1070,12 @@ void FitTrack::execute(vector<string>& streamTrackRaw,
           if (disk2S)
             r = string(widthDisk2Sidentifier, '0') + r;
           // store seed, L1TStub, and bit accurate 64 bit word in clock accurate output
-          streamsStubRaw[ihit++].emplace_back(StubStreamData(seedType, *stub, valid + r + phi + rz));
+          streamsStubRaw[ihit++].emplace_back(seedType, *stub, valid + r + phi + rz);
         }
       }
       // fill all layer with no stubs with gaps
       while (ihit < streamsStubRaw.size()) {
-        streamsStubRaw[ihit++].emplace_back(StubStreamData());
+        streamsStubRaw[ihit++].emplace_back();
       }
     }
 

--- a/L1Trigger/TrackFindingTracklet/src/L1TStub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/L1TStub.cc
@@ -16,9 +16,7 @@ L1TStub::L1TStub(std::string DTClink,
                  double z,
                  double bend,
                  double strip,
-                 std::vector<int> tps,
-                 const TTStubRef& ttStubRef)
-    : ttStubRef_(ttStubRef) {
+                 std::vector<int> tps) {
   DTClink_ = DTClink;
   layerdisk_ = layerdisk;
   region_ = region;

--- a/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
+++ b/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
@@ -21,9 +21,8 @@ bool SLHCEvent::addStub(string DTClink,
                         double z,
                         double bend,
                         double strip,
-                        vector<int> tps,
-                        const TTStubRef& ttStubRef) {
-  L1TStub stub(DTClink, region, layerdisk, stubword, isPSmodule, isFlipped, x, y, z, bend, strip, tps, ttStubRef);
+                        vector<int> tps) {
+  L1TStub stub(DTClink, region, layerdisk, stubword, isPSmodule, isFlipped, x, y, z, bend, strip, tps);
 
   stubs_.push_back(stub);
   return true;
@@ -99,7 +98,7 @@ SLHCEvent::SLHCEvent(istream& in) {
       tps.push_back(tp);
     }
 
-    L1TStub stub(DTClink, region, layerdisk, stubword, isPSmodule, isFlipped, x, y, z, bend, strip, tps, TTStubRef());
+    L1TStub stub(DTClink, region, layerdisk, stubword, isPSmodule, isFlipped, x, y, z, bend, strip, tps);
 
     in >> tmp;
 

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -419,7 +419,7 @@ void Sector::executeMP() {
 
 void Sector::executeFT(vector<vector<string>>& streamsTrackRaw, vector<vector<StubStreamData>>& streamsStubRaw) {
   const int numChannels = streamsTrackRaw.size() / N_SECTOR;
-  const int maxNumProjectionLayers = streamsStubRaw.size()/streamsTrackRaw.size();
+  const int maxNumProjectionLayers = streamsStubRaw.size() / streamsTrackRaw.size();
   const int offsetTrack = isector_ * numChannels;
   int channelTrack(0);
 

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -425,17 +425,17 @@ void Sector::executeFT(vector<vector<string>>& streamsTrackRaw, vector<vector<St
 
   for (auto& i : FT_) {
     // Temporary streams for a single TrackBuilder (i.e. seed type)
-    vector<string> streamTrackTmp;
-    vector<vector<StubStreamData>> streamsStubTmp(maxNumProjectionLayers);
+    deque<string> streamTrackTmp;
+    vector<deque<StubStreamData>> streamsStubTmp(maxNumProjectionLayers);
     i->execute(streamTrackTmp, streamsStubTmp, isector_);
     if (!settings_.storeTrackBuilderOutput())
       continue;
     const int offsetStub = (offsetTrack + channelTrack) * maxNumProjectionLayers;
-    streamsTrackRaw[offsetTrack + channelTrack] = streamTrackTmp;
+    streamsTrackRaw[offsetTrack + channelTrack] = vector<string>(streamTrackTmp.begin(), streamTrackTmp.end());
     channelTrack++;
     int channelStub(0);
     for (auto& stream : streamsStubTmp)
-      streamsStubRaw[offsetStub + channelStub++] = stream;
+      streamsStubRaw[offsetStub + channelStub++] = vector<StubStreamData>(stream.begin(), stream.end());
   }
 }
 

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -417,32 +417,20 @@ void Sector::executeMP() {
 // If using Hybrid, then PurgeDuplicates runs both duplicate removal & KF steps.
 // (unless duplicate removal disabled, in which case FitTrack runs KF).
 
-<<<<<<< HEAD
 void Sector::executeFT(vector<vector<string>>& tracksStream, vector<vector<StubStreamData>>& stubsStream) {
-  int numChannels = tracksStream.size() / N_SECTOR;
-  int maxNumProjectionLayers = stubsStream.size()/tracksStream.size();
-=======
-
-void Sector::executeFT(vector<vector<string>>& tracksStream, vector<vector<StubStreamData>>& stubsStream) {
-
-  int numChannels = tracksStream.size() / N_SECTOR;
-  int maxNumProjectionLayers = stubsStream.size()/tracksStream.size();
-
->>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
+  const int numChannels = tracksStream.size() / N_SECTOR;
+  const int maxNumProjectionLayers = stubsStream.size()/tracksStream.size();
   const int offsetTrack = isector_ * numChannels;
   int channelTrack(0);
 
   for (auto& i : FT_) {
+    // Temporary streams for a single TrackBuilder (i.e. seed type)
     vector<string> trackStreamTmp;
     vector<vector<StubStreamData>> stubStreamTmp(maxNumProjectionLayers);
     i->execute(trackStreamTmp, stubStreamTmp, isector_);
-    if (!settings_.emulateTB())
+    if (!settings_.storeTrackBuilderOutput())
       continue;
-<<<<<<< HEAD
-    const int offsetStub = (offsetTrack + channelTrack) * maxNumProjectionsLayers;
-=======
     const int offsetStub = (offsetTrack + channelTrack) * maxNumProjectionLayers;
->>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
     tracksStream[offsetTrack + channelTrack] = trackStreamTmp;
     channelTrack++;
     int channelStub(0);

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -417,9 +417,18 @@ void Sector::executeMP() {
 // If using Hybrid, then PurgeDuplicates runs both duplicate removal & KF steps.
 // (unless duplicate removal disabled, in which case FitTrack runs KF).
 
+<<<<<<< HEAD
 void Sector::executeFT(vector<vector<string>>& tracksStream, vector<vector<StubStreamData>>& stubsStream) {
   int numChannels = tracksStream.size() / N_SECTOR;
   int maxNumProjectionLayers = stubsStream.size()/tracksStream.size();
+=======
+
+void Sector::executeFT(vector<vector<string>>& tracksStream, vector<vector<StubStreamData>>& stubsStream) {
+
+  int numChannels = tracksStream.size() / N_SECTOR;
+  int maxNumProjectionLayers = stubsStream.size()/tracksStream.size();
+
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
   const int offsetTrack = isector_ * numChannels;
   int channelTrack(0);
 
@@ -429,13 +438,14 @@ void Sector::executeFT(vector<vector<string>>& tracksStream, vector<vector<StubS
     i->execute(trackStreamTmp, stubStreamTmp, isector_);
     if (!settings_.emulateTB())
       continue;
+<<<<<<< HEAD
     const int offsetStub = (offsetTrack + channelTrack) * maxNumProjectionsLayers;
+=======
+    const int offsetStub = (offsetTrack + channelTrack) * maxNumProjectionLayers;
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
     tracksStream[offsetTrack + channelTrack] = trackStreamTmp;
     channelTrack++;
     int channelStub(0);
-    for (deque<tt::FrameStub>& stream : streamsStubTmp)
-      streamsStub[offsetStub + channelStub++] = tt::StreamStub(stream.begin(), stream.end());
-    channelStub = 0;
     for (auto& stream : stubStreamTmp)
       stubsStream[offsetStub + channelStub++] = stream;
   }

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -417,25 +417,25 @@ void Sector::executeMP() {
 // If using Hybrid, then PurgeDuplicates runs both duplicate removal & KF steps.
 // (unless duplicate removal disabled, in which case FitTrack runs KF).
 
-void Sector::executeFT(vector<vector<string>>& tracksStream, vector<vector<StubStreamData>>& stubsStream) {
-  const int numChannels = tracksStream.size() / N_SECTOR;
-  const int maxNumProjectionLayers = stubsStream.size()/tracksStream.size();
+void Sector::executeFT(vector<vector<string>>& streamsTrackRaw, vector<vector<StubStreamData>>& streamsStubRaw) {
+  const int numChannels = streamsTrackRaw.size() / N_SECTOR;
+  const int maxNumProjectionLayers = streamsStubRaw.size()/streamsTrackRaw.size();
   const int offsetTrack = isector_ * numChannels;
   int channelTrack(0);
 
   for (auto& i : FT_) {
     // Temporary streams for a single TrackBuilder (i.e. seed type)
-    vector<string> trackStreamTmp;
-    vector<vector<StubStreamData>> stubStreamTmp(maxNumProjectionLayers);
-    i->execute(trackStreamTmp, stubStreamTmp, isector_);
+    vector<string> streamTrackTmp;
+    vector<vector<StubStreamData>> streamsStubTmp(maxNumProjectionLayers);
+    i->execute(streamTrackTmp, streamsStubTmp, isector_);
     if (!settings_.storeTrackBuilderOutput())
       continue;
     const int offsetStub = (offsetTrack + channelTrack) * maxNumProjectionLayers;
-    tracksStream[offsetTrack + channelTrack] = trackStreamTmp;
+    streamsTrackRaw[offsetTrack + channelTrack] = streamTrackTmp;
     channelTrack++;
     int channelStub(0);
-    for (auto& stream : stubStreamTmp)
-      stubsStream[offsetStub + channelStub++] = stream;
+    for (auto& stream : streamsStubTmp)
+      streamsStubRaw[offsetStub + channelStub++] = stream;
   }
 }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -175,8 +175,8 @@ void TrackletEventProcessor::configure(istream& inwire, istream& inmem, istream&
 }
 
 void TrackletEventProcessor::event(SLHCEvent& ev,
-				   vector<vector<string>>& tracksStream,
-				   vector<vector<StubStreamData>>& stubsStream) {
+				   vector<vector<string>>& streamsTrackRaw,
+				   vector<vector<StubStreamData>>& streamsStubRaw) {
   globals_->event() = &ev;
 
   tracks_.clear();
@@ -367,7 +367,7 @@ void TrackletEventProcessor::event(SLHCEvent& ev,
 
     // fit track
     FTTimer_.start();
-    sector_->executeFT(tracksStream, stubsStream);
+    sector_->executeFT(streamsTrackRaw, streamsStubRaw);
     if ((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) {
       sector_->writeTF(first);
     }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -25,15 +25,9 @@ TrackletEventProcessor::~TrackletEventProcessor() {
   }
 }
 
-<<<<<<< HEAD
 void TrackletEventProcessor::init(Settings const& theSettings,
                                   const tt::Setup* setup) {
   settings_ = &theSettings;
-
-=======
-void TrackletEventProcessor::init(Settings const& theSettings) {
-  settings_ = &theSettings;
->>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
   globals_ = make_unique<Globals>(*settings_);
 
   //Verify consistency
@@ -451,7 +445,3 @@ void TrackletEventProcessor::printSummary() {
                                << setprecision(3) << PDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
                                << PDTimer_.tottime();
 }
-<<<<<<< HEAD
-=======
-
->>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -25,10 +25,15 @@ TrackletEventProcessor::~TrackletEventProcessor() {
   }
 }
 
+<<<<<<< HEAD
 void TrackletEventProcessor::init(Settings const& theSettings,
                                   const tt::Setup* setup) {
   settings_ = &theSettings;
 
+=======
+void TrackletEventProcessor::init(Settings const& theSettings) {
+  settings_ = &theSettings;
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit
   globals_ = make_unique<Globals>(*settings_);
 
   //Verify consistency
@@ -181,8 +186,6 @@ void TrackletEventProcessor::event(SLHCEvent& ev,
   globals_->event() = &ev;
 
   tracks_.clear();
-  for (tt::StreamStub& streamStub : streamsStub_)
-    streamStub.clear();
 
   eventnum_++;
   bool first = (eventnum_ == 1);
@@ -448,3 +451,7 @@ void TrackletEventProcessor::printSummary() {
                                << setprecision(3) << PDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
                                << PDTimer_.tottime();
 }
+<<<<<<< HEAD
+=======
+
+>>>>>>> Remove code for old calculation of stream data - keeping the debug print out in this commit

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -25,8 +25,7 @@ TrackletEventProcessor::~TrackletEventProcessor() {
   }
 }
 
-void TrackletEventProcessor::init(Settings const& theSettings,
-                                  const tt::Setup* setup) {
+void TrackletEventProcessor::init(Settings const& theSettings, const tt::Setup* setup) {
   settings_ = &theSettings;
   globals_ = make_unique<Globals>(*settings_);
 
@@ -175,8 +174,8 @@ void TrackletEventProcessor::configure(istream& inwire, istream& inmem, istream&
 }
 
 void TrackletEventProcessor::event(SLHCEvent& ev,
-				   vector<vector<string>>& streamsTrackRaw,
-				   vector<vector<StubStreamData>>& streamsStubRaw) {
+                                   vector<vector<string>>& streamsTrackRaw,
+                                   vector<vector<StubStreamData>>& streamsStubRaw) {
   globals_->event() = &ev;
 
   tracks_.clear();

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -121,7 +121,7 @@ void VMRouterCM::addInput(MemoryBase* memory, string input) {
   throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
 }
 
-void VMRouterCM::execute(unsigned int iSector) {
+void VMRouterCM::execute(unsigned int) {
   unsigned int allStubCounter = 0;
 
   //bool print = getName() == "VMR_D1PHIB" && iSector == 3;

--- a/L1Trigger/TrackFindingTracklet/test/fpga.cc
+++ b/L1Trigger/TrackFindingTracklet/test/fpga.cc
@@ -209,8 +209,8 @@ int main(const int argc, const char **argv) {
     edm::LogVerbatim("Tracklet") << "Process event: " << eventnum << " with " << ev.nstubs() << " stubs and "
                                  << ev.nsimtracks() << " simtracks";
 
-    std::vector<std::vector<std::string>> tracksStream(N_SECTOR*8);
-    std::vector<std::vector<StubStreamData>> stubsStream(N_SECTOR*8*8);
+    std::vector<std::vector<std::string>> tracksStream(N_SECTOR * 8);
+    std::vector<std::vector<StubStreamData>> stubsStream(N_SECTOR * 8 * 8);
 
     eventProcessor.event(ev, tracksStream, stubsStream);
 

--- a/L1Trigger/TrackFindingTracklet/test/fpga.cc
+++ b/L1Trigger/TrackFindingTracklet/test/fpga.cc
@@ -26,6 +26,7 @@
 #include "../interface/SLHCEvent.h"
 #include "../interface/Track.h"
 #include "../interface/Settings.h"
+#include "../interface/StubStreamData.h"
 #include "../interface/TrackletEventProcessor.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -208,7 +209,10 @@ int main(const int argc, const char **argv) {
     edm::LogVerbatim("Tracklet") << "Process event: " << eventnum << " with " << ev.nstubs() << " stubs and "
                                  << ev.nsimtracks() << " simtracks";
 
-    eventProcessor.event(ev);
+    std::vector<std::vector<std::string>> tracksStream(N_SECTOR*8);
+    std::vector<std::vector<StubStreamData>> stubsStream(N_SECTOR*8*8);
+
+    eventProcessor.event(ev, tracksStream, stubsStream);
 
     const std::vector<Track> &tracks = eventProcessor.tracks();
 

--- a/L1Trigger/TrackFindingTracklet/test/fpga.cc
+++ b/L1Trigger/TrackFindingTracklet/test/fpga.cc
@@ -209,8 +209,14 @@ int main(const int argc, const char **argv) {
     edm::LogVerbatim("Tracklet") << "Process event: " << eventnum << " with " << ev.nstubs() << " stubs and "
                                  << ev.nsimtracks() << " simtracks";
 
-    std::vector<std::vector<std::string>> tracksStream(N_SECTOR * 8);
-    std::vector<std::vector<StubStreamData>> stubsStream(N_SECTOR * 8 * 8);
+    // Output track streams per nonant from track-builders.
+    constexpr unsigned int numStubStreamsPerTrack = settings.extended() ? N_SEED : N_SEED_PROMPT;
+    // Max. number of projection layers for any tracklet seed.
+    constexpr unsigned int maxNumProjectionLayers = 8;
+    constexpr unsigned int numStreamsTrack = N_SECTOR * numStubStreamsTrack;
+    constexpr unsigned int numStreamsStub = numStreamsTrack * maxNumProjectionLayers;
+    std::vector<std::vector<std::string>> tracksStream(numStreamsTrack);
+    std::vector<std::vector<StubStreamData>> stubsStream(numStreamsStub);
 
     eventProcessor.event(ev, tracksStream, stubsStream);
 


### PR DESCRIPTION
This removes the CMSSWS dependencies from recent PRs by Thomas Schuh, so as to allow the tracklet pattern reco to be run outside CMSSW again.

Validation:
Tracking performance unchanged with both HYBRID_NEWKF & HYBRID_REDUCED OPTIONS
Dump of bit strings from output streamsStub & streamsTrack EDProducts, were unchanged.