### PR TITLE
Update track quality chi2 bins

### DIFF
--- a/L1Trigger/TrackTrigger/src/TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/TrackQuality.cc
@@ -125,7 +125,7 @@ std::vector<float> TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDigi_
 
   // bin bendchi2 variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
   float tmp_trk_bendchi2 = aTrack.stubPtConsistency();
-  std::array<float, 8> bendchi2_bins{{0, 0.5, 1.25, 2, 3, 5, 10, 50}};
+  std::array<float, 8> bendchi2_bins{{0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
   int n_bendchi2 = static_cast<int>(bendchi2_bins.size());
   float tmp_trk_bendchi2_bin = -1;
   for (int i = 0; i < n_bendchi2; i++) {
@@ -139,7 +139,7 @@ std::vector<float> TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDigi_
 
   // bin chi2rphi variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
   float tmp_trk_chi2rphi = aTrack.chi2XY();
-  std::array<float, 16> chi2rphi_bins{{0, 0.25, 0.5, 1, 2, 3, 5, 7, 10, 20, 40, 100, 200, 500, 1000, 3000}};
+  std::array<float, 16> chi2rphi_bins{{0, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 10.0, 15.0, 20.0, 35.0, 60.0, 200.0}};
   int n_chi2rphi = static_cast<int>(chi2rphi_bins.size());
   float tmp_trk_chi2rphi_bin = -1;
   for (int i = 0; i < n_chi2rphi; i++) {
@@ -153,7 +153,7 @@ std::vector<float> TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDigi_
 
   // bin chi2rz variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
   float tmp_trk_chi2rz = aTrack.chi2Z();
-  std::array<float, 16> chi2rz_bins{{0, 0.25, 0.5, 1, 2, 3, 5, 7, 10, 20, 40, 100, 200, 500, 1000, 3000}};
+  std::array<float, 16> chi2rz_bins{{0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 8.0, 10.0, 20.0, 50.0}};
   int n_chi2rz = static_cast<int>(chi2rz_bins.size());
   float tmp_trk_chi2rz_bin = -1;
   for (int i = 0; i < n_chi2rz; i++) {

--- a/L1Trigger/TrackTrigger/src/TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/TrackQuality.cc
@@ -138,7 +138,7 @@ std::vector<float> TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDigi_
     tmp_trk_bendchi2_bin = n_bendchi2;
 
   // bin chi2rphi variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
-  float tmp_trk_chi2rphi = aTrack.chi2XY();
+  float tmp_trk_chi2rphi = aTrack.chi2XYRed();
   std::array<float, 16> chi2rphi_bins{{0, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 10.0, 15.0, 20.0, 35.0, 60.0, 200.0}};
   int n_chi2rphi = static_cast<int>(chi2rphi_bins.size());
   float tmp_trk_chi2rphi_bin = -1;
@@ -152,7 +152,7 @@ std::vector<float> TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDigi_
     tmp_trk_chi2rphi_bin = n_chi2rphi;
 
   // bin chi2rz variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
-  float tmp_trk_chi2rz = aTrack.chi2Z();
+  float tmp_trk_chi2rz = aTrack.chi2ZRed();
   std::array<float, 16> chi2rz_bins{{0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 8.0, 10.0, 20.0, 50.0}};
   int n_chi2rz = static_cast<int>(chi2rz_bins.size());
   float tmp_trk_chi2rz_bin = -1;


### PR DESCRIPTION
#### PR description:

This PR updates the chi2rz, chi2rphi, and bendchi2 binnings used by the track quality classifier. These binning were proposed by Emily MacDonald and are the current accepted bins used by the L1TK group, and I have previously shown [here](https://indico.cern.ch/event/1058340/contributions/4456095/attachments/2287755/3888672/L1T_7_27_21.pdf) that updating these bins in the track quality classifier does not effect the classifier performance. This PR is correlated to a [PR](https://github.com/cms-data/L1Trigger-TrackTrigger/pull/2) made to cms-data to update the default classifier to one trained on the new binning.

#### PR validation:

I have checked that the python implementation and CMSSW implementation of the new classifier with these chi2 bin changes have matching output. I have also verified that the overall performance of this new classifier almost exactly matches the performance of the old classifier in CMSSW, just like what I showed in the python implementations [here](https://indico.cern.ch/event/1058340/contributions/4456095/attachments/2287755/3888672/L1T_7_27_21.pdf).
