### PR TITLE
Change binning method used by track quality

### DIFF
--- a/L1Trigger/TrackTrigger/src/TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/TrackQuality.cc
@@ -123,48 +123,17 @@ std::vector<float> TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDigi_
     tmp_trk_dtot += hitpattern_expanded_binary[i];
   }
 
-  // bin bendchi2 variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
+  // binned bendchi2 variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
   float tmp_trk_bendchi2 = aTrack.stubPtConsistency();
-  std::array<float, 8> bendchi2_bins{{0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
-  int n_bendchi2 = static_cast<int>(bendchi2_bins.size());
-  float tmp_trk_bendchi2_bin = -1;
-  for (int i = 0; i < n_bendchi2; i++) {
-    if (tmp_trk_bendchi2 >= bendchi2_bins[i] && tmp_trk_bendchi2 < bendchi2_bins[i + 1]) {
-      tmp_trk_bendchi2_bin = i;
-      break;
-    }
-  }
-  if (tmp_trk_bendchi2_bin < 0)
-    tmp_trk_bendchi2_bin = n_bendchi2;
-
+  int tmp_trk_bendchi2_bin = aTrack.getBendChi2Bits();
+  
   // bin chi2rphi variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
-  float tmp_trk_chi2rphi = aTrack.chi2XYRed();
-  std::array<float, 16> chi2rphi_bins{
-      {0, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 10.0, 15.0, 20.0, 35.0, 60.0, 200.0}};
-  int n_chi2rphi = static_cast<int>(chi2rphi_bins.size());
-  float tmp_trk_chi2rphi_bin = -1;
-  for (int i = 0; i < n_chi2rphi; i++) {
-    if (tmp_trk_chi2rphi >= chi2rphi_bins[i] && tmp_trk_chi2rphi < chi2rphi_bins[i + 1]) {
-      tmp_trk_chi2rphi_bin = i;
-      break;
-    }
-  }
-  if (tmp_trk_chi2rphi_bin < 0)
-    tmp_trk_chi2rphi_bin = n_chi2rphi;
+  float tmp_trk_chi2rphi = aTrack.chi2XY();
+  int tmp_trk_chi2rphi_bin = aTrack.getChi2RPhiBits();  
 
   // bin chi2rz variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
-  float tmp_trk_chi2rz = aTrack.chi2ZRed();
-  std::array<float, 16> chi2rz_bins{{0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 8.0, 10.0, 20.0, 50.0}};
-  int n_chi2rz = static_cast<int>(chi2rz_bins.size());
-  float tmp_trk_chi2rz_bin = -1;
-  for (int i = 0; i < n_chi2rz; i++) {
-    if (tmp_trk_chi2rz >= chi2rz_bins[i] && tmp_trk_chi2rz < chi2rz_bins[i + 1]) {
-      tmp_trk_chi2rz_bin = i;
-      break;
-    }
-  }
-  if (tmp_trk_chi2rz_bin < 0)
-    tmp_trk_chi2rz_bin = n_chi2rz;
+  float tmp_trk_chi2rz = aTrack.chi2Z();
+  int tmp_trk_chi2rz_bin = aTrack.getChi2RZBits();  
 
   // get the nstub
   std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>> stubRefs =


### PR DESCRIPTION
#### PR description:

This PR updates the binning method in the track quality class with the chi2 variables. These variables are now taken directly from the TTTrack word.

#### PR validation:

I have tested to make sure that the old binning method produced the exact same results as the bins pulled directly from the TTTrack word. Therefore, this does not affect the performance of the classifier at all.
