### PR TITLE
Fix stub order bug

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
@@ -16,7 +16,7 @@ FullMatchMemory::FullMatchMemory(string name, Settings const& settings) : Memory
 }
 
 void FullMatchMemory::addMatch(Tracklet* tracklet, const Stub* stub) {
-  if (!settings_.doKF() || !settings_.doMultipleMatches()) {  
+  if (!settings_.doKF() || !settings_.doMultipleMatches()) {
     // When allowing only one stub per track per layer (or no KF implying same).
     for (auto& match : matches_) {
       if (match.first == tracklet) {  //Better match: replace existing one

--- a/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
@@ -16,9 +16,10 @@ FullMatchMemory::FullMatchMemory(string name, Settings const& settings) : Memory
 }
 
 void FullMatchMemory::addMatch(Tracklet* tracklet, const Stub* stub) {
-  if (!settings_.doKF() || !settings_.doMultipleMatches()) {  //When using KF we allow multiple matches
+  if (!settings_.doKF() || !settings_.doMultipleMatches()) {  
+    // When allowing only one stub per track per layer (or no KF implying same).
     for (auto& match : matches_) {
-      if (match.first == tracklet) {  //Better match, replace
+      if (match.first == tracklet) {  //Better match: replace existing one
         match.second = stub;
         return;
       }

--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -235,7 +235,7 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
 
       bool keep = true;
       if (!settings_.doKF() || !settings_.doMultipleMatches()) {
-        // Case of allowing only one stub per track per layer (or no KF which implies the same).        
+        // Case of allowing only one stub per track per layer (or no KF which implies the same).
         if (imatch && tracklet->match(layerdisk_)) {
           // Veto match if is not the best one for this tracklet (in given layer)
           auto res = tracklet->resid(layerdisk_);
@@ -245,10 +245,9 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
       }
 
       if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << getName() << " imatch = " << imatch << " keep = " << keep 
-                                     <<" ideltaphi cut " << ideltaphi << " "
-                                     << phimatchcuttable_.lookup(seedindex) << " ideltaz*fact cut " << ideltaz * fact_
-                                     << " " << zmatchcuttable_.lookup(seedindex);
+        edm::LogVerbatim("Tracklet") << getName() << " imatch = " << imatch << " keep = " << keep << " ideltaphi cut "
+                                     << ideltaphi << " " << phimatchcuttable_.lookup(seedindex) << " ideltaz*fact cut "
+                                     << ideltaz * fact_ << " " << zmatchcuttable_.lookup(seedindex);
       }
 
       if (imatch) {
@@ -409,21 +408,22 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
 
       bool keep = true;
       if (!settings_.doKF() || !settings_.doMultipleMatches()) {
-        // Case of allowing only one stub per track per layer (or no KF which implies the same).        
-        if(imatch && tracklet->match(layerdisk_)) {
+        // Case of allowing only one stub per track per layer (or no KF which implies the same).
+        if (imatch && tracklet->match(layerdisk_)) {
           // Veto match if is not the best one for this tracklet (in given layer)
           auto res = tracklet->resid(layerdisk_);
           keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
           imatch = keep;
         }
       }
-      if (not keep) match = false; // FIX: should calc keep with float point here.
+      if (not keep)
+        match = false;  // FIX: should calc keep with float point here.
 
       if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "imatch match disk: " << imatch << " " << match << " keep = " << keep 
-                                     << " " << std::abs(ideltaphi)
-                                     << " " << drphicut / (settings_.kphi() * stub->r()) << " " << std::abs(ideltar)
-                                     << " " << drcut / settings_.krprojshiftdisk() << " r = " << stub->r();
+        edm::LogVerbatim("Tracklet") << "imatch match disk: " << imatch << " " << match << " keep = " << keep << " "
+                                     << std::abs(ideltaphi) << " " << drphicut / (settings_.kphi() * stub->r()) << " "
+                                     << std::abs(ideltar) << " " << drcut / settings_.krprojshiftdisk()
+                                     << " r = " << stub->r();
       }
 
       if (imatch) {

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -532,6 +532,17 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
                                          << endl;
     }
 
+    bool keep = true;
+    if (!settings_.doKF() || !settings_.doMultipleMatches()) {
+      // Case of allowing only one stub per track per layer (or no KF which implies the same).
+      if (imatch && tracklet->match(layerdisk_)) {
+        // Veto match if is not the best one for this tracklet (in given layer)
+        auto res = tracklet->resid(layerdisk_);
+        keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
+        imatch = keep;
+      }
+    }
+
     if (imatch) {
       tracklet->addMatch(layerdisk_,
                          ideltaphi,
@@ -682,6 +693,19 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
                                    << " " << drphicut / (settings_.kphi() * stub->r()) << " " << std::abs(ideltar)
                                    << " " << drcut / settings_.krprojshiftdisk() << " r = " << stub->r();
     }
+
+    bool keep = true;
+    if (!settings_.doKF() || !settings_.doMultipleMatches()) {
+      // Case of allowing only one stub per track per layer (or no KF which implies the same).
+      if (imatch && tracklet->match(layerdisk_)) {
+        // Veto match if is not the best one for this tracklet (in given layer)
+        auto res = tracklet->resid(layerdisk_);
+        keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
+        imatch = keep;
+      }
+    }
+    if (not keep)
+      match = false;  // FIX: should calc keep with float point here.
 
     if (imatch) {
       if (settings_.debugTracklet()) {

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -96,8 +96,7 @@ public:
   // Mandatory methods
   void beginJob() override;
   void endJob() override;
-  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
-override;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
   void beginRun(const Run& iEvent, const EventSetup& iSetup) override {}
   void endRun(const Run& iEvent, const EventSetup& iSetup) override {}
 

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -8,7 +8,8 @@
 // FRAMEWORK HEADERS
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -86,7 +87,7 @@ using namespace edm;
 //                          //
 //////////////////////////////
 
-class L1TrackNtupleMaker : public edm::EDAnalyzer {
+class L1TrackNtupleMaker : public one::EDAnalyzer<one::WatchRuns> {
 public:
   // Constructor/destructor
   explicit L1TrackNtupleMaker(const edm::ParameterSet& iConfig);
@@ -95,7 +96,10 @@ public:
   // Mandatory methods
   void beginJob() override;
   void endJob() override;
-  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) 
+override;
+  void beginRun(const Run& iEvent, const EventSetup& iSetup) override {}
+  void endRun(const Run& iEvent, const EventSetup& iSetup) override {}
 
 protected:
 private:


### PR DESCRIPTION
This fixes the wrong stub order bug in the tracklet pattern reco code reported in https://github.com/cms-L1TK/cmssw/issues/156 .

The MatchCalculator fix comes from Brent Yates, with an additional correction from Ian Tomalin: (1) to apply fix also to endcap; to apply  the fix also to the MatchProcessor. (3) to disable it if multiple stubs per track per layer are allowed in the config;

When running HYBRID with "combined" modules on 1k ttbar200PU events, with DoMultipleMatches = False, the tracking efficiency goes up from 93.71% to 93.96% with this fix.

Also sneaked in unrelated 3-line change to L1TrackNtupleMaker.cc, to update it to inherit from one::EDAnalyzer, since the classic EDAnalyzer will be soon obsolete.