### PR TITLE
Added tilted and endcap module ring no. to L1TStub

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/L1TStub.h
+++ b/L1Trigger/TrackFindingTracklet/interface/L1TStub.h
@@ -22,6 +22,8 @@ namespace trklet {
             int isPSmodule,
             int isFlipped,
             bool tiltedBarrel,
+            unsigned int tiltedRingId,
+            unsigned int endcapRingId,
             unsigned int detId,
             double x,
             double y,
@@ -96,7 +98,11 @@ namespace trklet {
 
     bool isTilted() const { return tiltedBarrel_; }  // Tilted barrel
 
-    unsigned int detId() const { return detId_; }  // Lower sensor in module
+    // Tilted module ring no. (Increasing 1 to 12 as |z| increases).
+    unsigned int tiltedRingId() const { return tiltedRingId_; }
+    // Endcap disk module ring number (1-15 as r increases).
+    unsigned int endcapRingId() const { return endcapRingId_; }
+    unsigned int detId() const { return detId_; }  // Of lower sensor in module
 
     bool tpmatch(int tp) const;
     bool tpmatch2(int tp) const;
@@ -128,10 +134,11 @@ namespace trklet {
     double pt_;
     double bend_;
     unsigned int allstubindex_;
-
     unsigned int isPSmodule_;
     unsigned int isFlipped_;
     bool tiltedBarrel_;
+    unsigned int tiltedRingId_;
+    unsigned int endcapRingId_;
     unsigned int detId_;
   };
 };  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/interface/SLHCEvent.h
+++ b/L1Trigger/TrackFindingTracklet/interface/SLHCEvent.h
@@ -38,6 +38,8 @@ namespace trklet {
                  int isPSmodule,
                  int isFlipped,
                  bool tiltedBarrel,
+                 unsigned int tiltedRingId,
+                 unsigned int endcapRingId,
                  unsigned int detId,
                  double x,
                  double y,

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -588,7 +588,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         if (tiltedBarrel) {
           tiltedRingId = tTopo->tobRod(innerDetId);
           if (type == tiltedMinus) {
-            unsigned int layp1 = 1 + layerdisk; // Setup counts from 1
+            unsigned int layp1 = 1 + layerdisk;  // Setup counts from 1
             unsigned int nTilted = setup_->numTiltedLayerRing(layp1);
             tiltedRingId = 1 + nTilted - tiltedRingId;
           }

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -583,6 +583,18 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         enum TypeBarrel { nonBarrel = 0, tiltedMinus = 1, tiltedPlus = 2, flat = 3 };
         const TypeBarrel type = static_cast<TypeBarrel>(tTopo->tobSide(innerDetId));
         bool tiltedBarrel = barrel && (type == tiltedMinus || type == tiltedPlus);
+        unsigned int tiltedRingId = 0;
+        // Tilted module ring no. (Increasing 1 to 12 as |z| increases).
+        if (tiltedBarrel) {
+          tiltedRingId = tTopo->tobRod(innerDetId);
+          if (type == tiltedMinus) {
+            unsigned int layp1 = 1 + layerdisk; // Setup counts from 1
+            unsigned int nTilted = setup_->numTiltedLayerRing(layp1);
+            tiltedRingId = 1 + nTilted - tiltedRingId;
+          }
+        }
+        // Endcap module ring number (1-15) in endcap disks.
+        unsigned int endcapRingId = barrel ? 0 : tTopo->tidRing(innerDetId);
 
         const unsigned int intDetId = innerDetId.rawId();
 
@@ -593,6 +605,8 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
                    setup_->psModule(dtcId),
                    isFlipped,
                    tiltedBarrel,
+                   tiltedRingId,
+                   endcapRingId,
                    intDetId,
                    ttPos.x(),
                    ttPos.y(),

--- a/L1Trigger/TrackFindingTracklet/src/L1TStub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/L1TStub.cc
@@ -12,6 +12,8 @@ L1TStub::L1TStub(std::string DTClink,
                  int isPSmodule,
                  int isFlipped,
                  bool tiltedBarrel,
+                 unsigned int tiltedRingId,
+                 unsigned int endcapRingId,
                  unsigned int detId,
                  double x,
                  double y,
@@ -45,6 +47,8 @@ L1TStub::L1TStub(std::string DTClink,
   isPSmodule_ = isPSmodule;
   isFlipped_ = isFlipped;
   tiltedBarrel_ = tiltedBarrel;
+  tiltedRingId_ = tiltedRingId;
+  endcapRingId_ = endcapRingId;
   detId_ = detId;
 
   allstubindex_ = 999;

--- a/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
+++ b/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
@@ -17,6 +17,8 @@ bool SLHCEvent::addStub(string DTClink,
                         int isPSmodule,
                         int isFlipped,
                         bool tiltedBarrel,
+                        unsigned int tiltedRingId,
+                        unsigned int endcapRingId,
                         unsigned int detId,
                         double x,
                         double y,
@@ -24,8 +26,7 @@ bool SLHCEvent::addStub(string DTClink,
                         double bend,
                         double strip,
                         vector<int> tps) {
-  L1TStub stub(
-      DTClink, region, layerdisk, stubword, isPSmodule, isFlipped, tiltedBarrel, detId, x, y, z, bend, strip, tps);
+  L1TStub stub(DTClink, region, layerdisk, stubword, isPSmodule, isFlipped, tiltedBarrel, tiltedRingId, endcapRingId, detId, x, y, z, bend, strip, tps);
 
   stubs_.push_back(stub);
   return true;
@@ -97,6 +98,8 @@ SLHCEvent::SLHCEvent(istream& in) {
 
     // TO FIX: READ THESE FROM INPUT FILE
     bool tiltedBarrel = false;
+    unsigned int tiltedRingId = 999999;
+    unsigned int endcapRingId = 999999;
     unsigned int detId = 999999;  // Lower sensor in module
 
     for (unsigned int itps = 0; itps < ntps; itps++) {
@@ -105,8 +108,7 @@ SLHCEvent::SLHCEvent(istream& in) {
       tps.push_back(tp);
     }
 
-    L1TStub stub(
-        DTClink, region, layerdisk, stubword, isPSmodule, isFlipped, tiltedBarrel, detId, x, y, z, bend, strip, tps);
+    L1TStub stub(DTClink, region, layerdisk, stubword, isPSmodule, isFlipped, tiltedBarrel, tiltedRingId, endcapRingId, detId, x, y, z, bend, strip, tps);
 
     in >> tmp;
 

--- a/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
+++ b/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
@@ -26,7 +26,22 @@ bool SLHCEvent::addStub(string DTClink,
                         double bend,
                         double strip,
                         vector<int> tps) {
-  L1TStub stub(DTClink, region, layerdisk, stubword, isPSmodule, isFlipped, tiltedBarrel, tiltedRingId, endcapRingId, detId, x, y, z, bend, strip, tps);
+  L1TStub stub(DTClink,
+               region,
+               layerdisk,
+               stubword,
+               isPSmodule,
+               isFlipped,
+               tiltedBarrel,
+               tiltedRingId,
+               endcapRingId,
+               detId,
+               x,
+               y,
+               z,
+               bend,
+               strip,
+               tps);
 
   stubs_.push_back(stub);
   return true;
@@ -108,7 +123,22 @@ SLHCEvent::SLHCEvent(istream& in) {
       tps.push_back(tp);
     }
 
-    L1TStub stub(DTClink, region, layerdisk, stubword, isPSmodule, isFlipped, tiltedBarrel, tiltedRingId, endcapRingId, detId, x, y, z, bend, strip, tps);
+    L1TStub stub(DTClink,
+                 region,
+                 layerdisk,
+                 stubword,
+                 isPSmodule,
+                 isFlipped,
+                 tiltedBarrel,
+                 tiltedRingId,
+                 endcapRingId,
+                 detId,
+                 x,
+                 y,
+                 z,
+                 bend,
+                 strip,
+                 tps);
 
     in >> tmp;
 


### PR DESCRIPTION
Added functions to access ring number of modules in tilted barrel and endcap disks to L1TStub.
These new functions are however currently not used during L1 tracking.
N.B. These return dummy numbers if the tracking code is run stand-alone. Class SLHCEvent.cc would need modifying to get this working for stand-alone. 