### PR TITLE
Add possibility to invent seeding stubs coordinates before DR 

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/L1TStub.h
+++ b/L1Trigger/TrackFindingTracklet/interface/L1TStub.h
@@ -81,8 +81,10 @@ namespace trklet {
     std::vector<int> tps() const { return tps_; }
 
     void setAllStubIndex(unsigned int index) { allstubindex_ = index; }
+    void setUniqueIndex(unsigned int index) { uniqueindex_ = index; }
 
     unsigned int allStubIndex() const { return allstubindex_; }
+    unsigned int uniqueIndex() const { return uniqueindex_; }
 
     unsigned int strip() const { return strip_; }
 
@@ -134,6 +136,7 @@ namespace trklet {
     double pt_;
     double bend_;
     unsigned int allstubindex_;
+    unsigned int uniqueindex_;
     unsigned int isPSmodule_;
     unsigned int isFlipped_;
     bool tiltedBarrel_;

--- a/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
+++ b/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
@@ -37,13 +37,13 @@ namespace trklet {
 
   private:
     double getPhiRes(Tracklet* curTracklet, const Stub* curStub);
-    bool isSeedingStub(int , int , int );
+    bool isSeedingStub(int, int, int);
     std::string l1tinfo(const L1TStub*, std::string);
-    std::pair<int,int> findLayerDisk(const Stub*);
+    std::pair<int, int> findLayerDisk(const Stub*);
     std::vector<double> getInventedCoords(unsigned int, const Stub*, Tracklet*);
     std::vector<double> getInventedCoordsExtended(unsigned int, const Stub*, Tracklet*);
-    std::vector<const Stub*> seedStubCoordsFromTracklet (unsigned int, Tracklet* , std::vector<const Stub*>  );
-    
+    std::vector<const Stub*> seedStubCoordsFromTracklet(unsigned int, Tracklet*, std::vector<const Stub*>);
+
     std::vector<Track*> inputtracks_;
     std::vector<std::vector<const Stub*>> inputstublists_;
     std::vector<std::vector<std::pair<int, int>>> inputstubidslists_;

--- a/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
+++ b/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
@@ -37,7 +37,13 @@ namespace trklet {
 
   private:
     double getPhiRes(Tracklet* curTracklet, const Stub* curStub);
-
+    bool isSeedingStub(int , int , int );
+    std::string l1tinfo(const L1TStub*, std::string);
+    std::pair<int,int> findLayerDisk(const Stub*);
+    std::vector<double> getInventedCoords(unsigned int, const Stub*, Tracklet*);
+    std::vector<double> getInventedCoordsExtended(unsigned int, const Stub*, Tracklet*);
+    std::vector<const Stub*> seedStubCoordsFromTracklet (unsigned int, Tracklet* , std::vector<const Stub*>  );
+    
     std::vector<Track*> inputtracks_;
     std::vector<std::vector<const Stub*>> inputstublists_;
     std::vector<std::vector<std::pair<int, int>>> inputstubidslists_;

--- a/L1Trigger/TrackFindingTracklet/interface/SLHCEvent.h
+++ b/L1Trigger/TrackFindingTracklet/interface/SLHCEvent.h
@@ -46,7 +46,8 @@ namespace trklet {
                  double z,
                  double bend,
                  double strip,
-                 std::vector<int> tpstt);
+                 std::vector<int> tpstt,
+                 int stubindex);
 
     const L1TStub& lastStub() const { return stubs_.back(); }
 

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -258,6 +258,8 @@ namespace trklet {
     void setCombined(bool combined) { combined_ = combined; }
     bool reduced() const { return reduced_; }
     void setReduced(bool reduced) { reduced_ = reduced; }
+    bool inventStubs() const { return inventStubs_; }
+    void setInventStubs(bool inventStubs) { inventStubs_ = inventStubs; }
 
     double bfield() const { return bfield_; }
     void setBfield(double bfield) { bfield_ = bfield; }
@@ -944,6 +946,7 @@ namespace trklet {
     unsigned int nHelixPar_{4};  // 4 or 5 param helix fit
     bool extended_{false};       // turn on displaced tracking
     bool reduced_{false};        // use reduced (Summer Chain) config
+    bool inventStubs_{false}; // invent seeding stub coordinates based on tracklet traj
 
     bool combined_{false};  // use combined TP (TE+TC) and MP (PR+ME+MC) configuration
 

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -946,7 +946,7 @@ namespace trklet {
     unsigned int nHelixPar_{4};  // 4 or 5 param helix fit
     bool extended_{false};       // turn on displaced tracking
     bool reduced_{false};        // use reduced (Summer Chain) config
-    bool inventStubs_{false}; // invent seeding stub coordinates based on tracklet traj
+    bool inventStubs_{false};    // invent seeding stub coordinates based on tracklet traj
 
     bool combined_{false};  // use combined TP (TE+TC) and MP (PR+ME+MC) configuration
 

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -372,7 +372,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       stubMapType;
   typedef std::map<unsigned int,
                    edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
-      stubIndexMapType;    
+      stubIndexMapType;
   typedef edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>
       TTClusterRef;
 
@@ -709,10 +709,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       itIndex = stubIndexMap.find(itstubs.uniqueIndex());
       if (itIndex != stubIndexMap.end()) {
         aTrack.addStubRef(itIndex->second);
-        countStubs = countStubs+1;
-//       it = stubMap.find(itstubs);
-//       if (it != stubMap.end()) {
-//         aTrack.addStubRef(it->second);
+        countStubs = countStubs + 1;
       } else {
         // could not find stub in stub map
       }

--- a/L1Trigger/TrackFindingTracklet/python/Tracklet_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/Tracklet_cfi.py
@@ -13,6 +13,7 @@ TTTracksFromTrackletEmulation = cms.EDProducer("L1FPGATrackProducer",
                                                asciiFileName = cms.untracked.string(""),
                                                Extended = cms.bool(False),
                                                Reduced = cms.bool(False),
+                                               InventStubs = cms.bool(False),
                                                Hnpar = cms.uint32(4),
                                                # (if running on CRAB use "../../fitpattern.txt" etc instead)
                                                fitPatternFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/fitpattern.txt'),
@@ -31,6 +32,7 @@ TTTracksFromTrackletEmulation = cms.EDProducer("L1FPGATrackProducer",
 TTTracksFromExtendedTrackletEmulation = TTTracksFromTrackletEmulation.clone(
                                                Extended = cms.bool(True),
                                                Reduced = cms.bool(False),
+                                               InventStubs = cms.bool(False),
                                                Hnpar = cms.uint32(5),
                                                # specifying where the TrackletEngineDisplaced(TED)/TripletEngine(TRE) tables are located
                                                tableTEDFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/table_TED/table_TED_D1PHIA1_D2PHIA1.txt'),

--- a/L1Trigger/TrackFindingTracklet/src/L1TStub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/L1TStub.cc
@@ -52,6 +52,7 @@ L1TStub::L1TStub(std::string DTClink,
   detId_ = detId;
 
   allstubindex_ = 999;
+  uniqueindex_ = 99999;
 }
 
 void L1TStub::write(ofstream& out) {

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -172,6 +172,12 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
     if (inputtracklets_.empty())
       return;
     unsigned int numStublists = inputstublists_.size();
+    
+    if ( settings_.inventStubs()){
+      for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
+        inputstublists_[itrk] = seedStubCoordsFromTracklet ( iSector, inputtracklets_[itrk], inputstublists_[itrk] );
+      }
+    }
 
     // Initialize all-false 2D array of tracks being duplicates to other tracks
     bool dupMap[numStublists][numStublists];  // Ends up symmetric
@@ -292,29 +298,38 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
 
           // Get a merged stub list
           std::vector<const Stub*> newStubList;
-          std::vector<const Stub*> stubsTrk1 = inputstublists_[rejetrk];
-          std::vector<const Stub*> stubsTrk2 = inputstublists_[preftrk];
+          std::vector<const Stub*> stubsTrk1 = inputstublists_[preftrk];
+          std::vector<const Stub*> stubsTrk2 = inputstublists_[rejetrk];
+          std::vector<unsigned int> stubsTrk1indices;
+          std::vector<unsigned int> stubsTrk2indices;
+          for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
+            stubsTrk1indices.push_back(stubsTrk1[stub1it]->l1tstub()->uniqueIndex());
+          }          
+          for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
+            stubsTrk2indices.push_back(stubsTrk2[stub2it]->l1tstub()->uniqueIndex());
+          }          
           newStubList = stubsTrk1;
           for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
-            if (find(stubsTrk1.begin(), stubsTrk1.end(), stubsTrk2[stub2it]) == stubsTrk1.end()) {
+            if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) == stubsTrk1indices.end()) {
               newStubList.push_back(stubsTrk2[stub2it]);
             }
           }
-          // Overwrite stublist of preferred track with merged list
+          //   Overwrite stublist of preferred track with merged list
           inputstublists_[preftrk] = newStubList;
-
+  
           std::vector<std::pair<int, int>> newStubidsList;
-          std::vector<std::pair<int, int>> stubidsTrk1 = mergedstubidslists_[rejetrk];
-          std::vector<std::pair<int, int>> stubidsTrk2 = mergedstubidslists_[preftrk];
+          std::vector<std::pair<int, int>> stubidsTrk1 = mergedstubidslists_[preftrk];
+          std::vector<std::pair<int, int>> stubidsTrk2 = mergedstubidslists_[rejetrk];
           newStubidsList = stubidsTrk1;
-          for (unsigned int stub2it = 0; stub2it < stubidsTrk2.size(); stub2it++) {
-            if (find(stubidsTrk1.begin(), stubidsTrk1.end(), stubidsTrk2[stub2it]) == stubidsTrk1.end()) {
+
+          for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
+            if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) == stubsTrk1indices.end()) {
               newStubidsList.push_back(stubidsTrk2[stub2it]);
             }
           }
           // Overwrite stubidslist of preferred track with merged list
           mergedstubidslists_[preftrk] = newStubidsList;
-
+          
           // Mark that rejected track has been merged into another track
           trackInfo[rejetrk].second = true;
         }
@@ -497,15 +512,7 @@ double PurgeDuplicate::getPhiRes(Tracklet* curTracklet, const Stub* curStub) {
   // Get phi projection of tracklet
   int seedindex = curTracklet->seedIndex();
   // If this stub is a seed stub, set projection=phi, so that res=0
-  if ((seedindex == 0 && (Layer == 1 || Layer == 2)) || (seedindex == 1 && (Layer == 2 || Layer == 3)) ||
-      (seedindex == 2 && (Layer == 3 || Layer == 4)) || (seedindex == 3 && (Layer == 5 || Layer == 6)) ||
-      (seedindex == 4 && (abs(Disk) == 1 || abs(Disk) == 2)) ||
-      (seedindex == 5 && (abs(Disk) == 3 || abs(Disk) == 4)) || (seedindex == 6 && (Layer == 1 || abs(Disk) == 1)) ||
-      (seedindex == 7 && (Layer == 2 || abs(Disk) == 1)) ||
-      (seedindex == 8 && (Layer == 2 || Layer == 3 || Layer == 4)) ||
-      (seedindex == 9 && (Layer == 4 || Layer == 5 || Layer == 6)) ||
-      (seedindex == 10 && (Layer == 2 || Layer == 3 || abs(Disk) == 1)) ||
-      (seedindex == 11 && (Layer == 2 || abs(Disk) == 1 || abs(Disk) == 2))) {
+  if (isSeedingStub(seedindex, Layer, Disk)){
     phiproj = stubphi;
     // Otherwise, get projection of tracklet
   } else {
@@ -514,4 +521,194 @@ double PurgeDuplicate::getPhiRes(Tracklet* curTracklet, const Stub* curStub) {
   // Calculate residual
   phires = std::abs(stubphi - phiproj);
   return phires;
+}
+
+
+// Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7
+bool PurgeDuplicate::isSeedingStub(int seedindex, int Layer, int Disk){
+  if ((seedindex == 0 && (Layer == 1 || Layer == 2)) || 
+      (seedindex == 1 && (Layer == 2 || Layer == 3)) ||
+      (seedindex == 2 && (Layer == 3 || Layer == 4)) || 
+      (seedindex == 3 && (Layer == 5 || Layer == 6)) ||
+      (seedindex == 4 && (abs(Disk) == 1 || abs(Disk) == 2)) ||
+      (seedindex == 5 && (abs(Disk) == 3 || abs(Disk) == 4)) || 
+      (seedindex == 6 && (Layer == 1 || abs(Disk) == 1)) ||
+      (seedindex == 7 && (Layer == 2 || abs(Disk) == 1)) ||
+      (seedindex == 8 && (Layer == 2 || Layer == 3 || Layer == 4)) ||
+      (seedindex == 9 && (Layer == 4 || Layer == 5 || Layer == 6)) ||
+      (seedindex == 10 && (Layer == 2 || Layer == 3 || abs(Disk) == 1)) ||
+      (seedindex == 11 && (Layer == 2 || abs(Disk) == 1 || abs(Disk) == 2))) 
+      return true;
+
+  return false;
+}
+
+std::pair<int,int> PurgeDuplicate::findLayerDisk(const Stub* st){
+
+    std::pair<int,int> layer_disk;
+    layer_disk.first = st->layerdisk() + 1;
+    if (layer_disk.first > N_LAYER) {
+        layer_disk.first = 0;
+    }
+    layer_disk.second = st->layerdisk() - (N_LAYER - 1);
+    if (layer_disk.second < 0) {
+        layer_disk.second = 0;
+    }
+    return layer_disk;
+}
+
+
+std::string PurgeDuplicate::l1tinfo(const L1TStub* L1stub, std::string str=""){
+    std::string thestr = Form("\t %s stub info:  r/z/phi:\t%f\t%f\t%f\t%d\t%f\t%d", str.c_str(), L1stub->r(), L1stub->z(), L1stub->phi(), L1stub->iphi(), L1stub->bend(),  L1stub->layerdisk()   );
+    return thestr;                        
+}
+
+
+std::vector<double> PurgeDuplicate::getInventedCoords(unsigned int iSector, const Stub* st, Tracklet* tracklet){     
+
+  int stubLayer = (findLayerDisk(st)).first;
+  int stubDisk = (findLayerDisk(st)).second;
+
+  double stub_phi  = -99;
+  double stub_z    = -99;
+  double stub_r    = -99;
+
+  double tracklet_rinv = tracklet->rinv();
+
+  if (st->isBarrel()){
+      stub_r = settings_.rmean(stubLayer-1);
+      stub_phi  = tracklet->phi0() - std::asin(stub_r*tracklet_rinv/2);
+      stub_phi  = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+      stub_phi  = reco::reduceRange(stub_phi);
+      stub_z  = tracklet->z0() + 2 * tracklet->t() * 1 / tracklet_rinv * std::asin(stub_r*tracklet_rinv/2);
+  }
+  else{
+      stub_z = settings_.zmean(stubDisk-1)*tracklet->disk()/abs(tracklet->disk());
+      stub_phi  = tracklet->phi0() - (stub_z - tracklet->z0())*tracklet_rinv/2/tracklet->t();
+      stub_phi  = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+      stub_phi  = reco::reduceRange(stub_phi);
+      stub_r  = 2/tracklet_rinv * std::sin ((stub_z - tracklet->z0())*tracklet_rinv/2/tracklet->t());
+  }
+
+  std::vector invented_coords{stub_r, stub_z, stub_phi};
+  return invented_coords;
+}
+
+
+std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSector, const Stub* st, Tracklet* tracklet){     
+
+  int stubLayer = (findLayerDisk(st)).first;
+  int stubDisk = (findLayerDisk(st)).second;
+
+
+  double stub_phi  = -99;
+  double stub_z    = -99;
+  double stub_r    = -99;
+
+  double rho = 1/tracklet->rinv();
+  double rho_minus_d0 = rho + tracklet->d0(); // should be -, but otherwise does not work
+
+  // exact helix
+  if (st->isBarrel()){
+      stub_r = settings_.rmean(stubLayer-1);
+
+      double sin_val = (stub_r*stub_r + rho_minus_d0*rho_minus_d0 - rho*rho) / (2 * stub_r * rho_minus_d0) ;
+      stub_phi = tracklet->phi0() - std::asin(sin_val);
+      stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+      stub_phi = reco::reduceRange(stub_phi);
+
+      double beta =  std::acos((rho*rho + rho_minus_d0*rho_minus_d0 - stub_r*stub_r) / (2 * rho * rho_minus_d0) );
+      stub_z = tracklet->z0() + tracklet->t() * std::abs(rho * beta);
+  }
+  else {
+      stub_z = settings_.zmean(stubDisk-1)*tracklet->disk()/abs(tracklet->disk());
+
+      double beta = (stub_z - tracklet->z0()) / (tracklet->t() * std::abs(rho)); // maybe rho should be abs value
+      double r_square = -2 * rho * rho_minus_d0 * std::cos(beta) + rho*rho + rho_minus_d0*rho_minus_d0;
+      stub_r = sqrt(r_square);
+
+      double sin_val = (stub_r*stub_r + rho_minus_d0*rho_minus_d0 - rho*rho) / (2 * stub_r * rho_minus_d0) ;
+      stub_phi = tracklet->phi0() - std::asin(sin_val);
+      stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+      stub_phi = reco::reduceRange(stub_phi);
+  }
+
+  // TMP: for displaced tracking, exclude one of the 3 seeding stubs
+  // to be discussed
+  int seed = tracklet->seedIndex();
+  if ( (seed == 8 && stubLayer == 4) ||\
+       (seed == 9 && stubLayer == 5) ||\
+       (seed == 10 && stubLayer == 3) ||\
+       (seed == 11 && abs(stubDisk) == 1)
+     ){
+    stub_phi  = st->l1tstub()->phi();
+    stub_z    = st->l1tstub()->z();
+    stub_r    = st->l1tstub()->r();
+  }
+
+  std::vector invented_coords{stub_r, stub_z, stub_phi};
+  return invented_coords;
+}
+
+std::vector<const Stub*> PurgeDuplicate::seedStubCoordsFromTracklet (unsigned int iSector, Tracklet* tracklet, std::vector<const Stub*> originalStubsList ){
+
+  std::vector<const Stub*> newStubList;
+
+  for (unsigned int stubit = 0; stubit < originalStubsList.size(); stubit++) {
+    const Stub* thisStub = originalStubsList[stubit];
+
+    if ( isSeedingStub(tracklet->seedIndex(), (findLayerDisk(thisStub)).first, (findLayerDisk(thisStub)).second)) {
+      // get a vector containing r, z, phi
+      std::vector<double> inv_r_z_phi;
+      if (!settings_.extended())
+        inv_r_z_phi = getInventedCoords(iSector, thisStub, tracklet );
+      else  {
+        inv_r_z_phi = getInventedCoordsExtended(iSector, thisStub, tracklet );
+      }      
+      double stub_x_invent = inv_r_z_phi[0] * std::cos(inv_r_z_phi[2]);
+      double stub_y_invent = inv_r_z_phi[0] * std::sin(inv_r_z_phi[2]);
+      double stub_z_invent = inv_r_z_phi[1];
+
+      Stub* invent_stub_ptr = new Stub(*thisStub) ;
+      const L1TStub* L1stub = thisStub->l1tstub();
+
+      L1TStub invent_L1stub ( L1stub->DTClink(),
+                              L1stub->region(),
+                              L1stub->layerdisk(),
+                              L1stub->stubword(),
+                              L1stub->isPSmodule(),
+                              L1stub->isFlipped(),
+                              L1stub->isTilted(),
+                              L1stub->tiltedRingId(),
+                              L1stub->endcapRingId(),
+                              L1stub->detId(),
+                              stub_x_invent,
+                              stub_y_invent,
+                              stub_z_invent,
+                              L1stub->bend(),
+                              L1stub->strip(),
+                              L1stub->tps()
+//                               L1stub->ttStubRef()	
+                            );
+
+      invent_stub_ptr->setl1tstub(new L1TStub(invent_L1stub));
+      invent_stub_ptr->l1tstub()->setAllStubIndex(L1stub->allStubIndex());
+      invent_stub_ptr->l1tstub()->setUniqueIndex(L1stub->uniqueIndex());
+
+      newStubList.push_back(invent_stub_ptr);  
+
+      // to enable comparison output file                  
+//       std::cout << invent_stub_ptr->isBarrel()<< "\t" << l1tinfo(&invent_L1stub, "invent").c_str() << "\t" <<  l1tinfo(L1stub, "original").c_str() 
+//                 << "\tdr\t"    << abs(invent_L1stub.r()-L1stub->r())  
+//                 << "\tdz\t"    << abs(invent_L1stub.z()-L1stub->z()) 
+//                 << "\tdphi\t"  << abs(invent_L1stub.phi()-L1stub->phi()) 
+//                 << "\tisPS\t"  << L1stub->isPSmodule() 
+// //                 << "\tisTilted\t"  << L1stub->isTilted() 
+//                 << std::endl;
+    }
+    else{
+      newStubList.push_back(thisStub);
+    }
+  }
+  return newStubList;
 }

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -172,10 +172,10 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
     if (inputtracklets_.empty())
       return;
     unsigned int numStublists = inputstublists_.size();
-    
-    if ( settings_.inventStubs()){
+
+    if (settings_.inventStubs()) {
       for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-        inputstublists_[itrk] = seedStubCoordsFromTracklet ( iSector, inputtracklets_[itrk], inputstublists_[itrk] );
+        inputstublists_[itrk] = seedStubCoordsFromTracklet(iSector, inputtracklets_[itrk], inputstublists_[itrk]);
       }
     }
 
@@ -304,32 +304,34 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
           std::vector<unsigned int> stubsTrk2indices;
           for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
             stubsTrk1indices.push_back(stubsTrk1[stub1it]->l1tstub()->uniqueIndex());
-          }          
+          }
           for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
             stubsTrk2indices.push_back(stubsTrk2[stub2it]->l1tstub()->uniqueIndex());
-          }          
+          }
           newStubList = stubsTrk1;
           for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
-            if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) == stubsTrk1indices.end()) {
+            if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) ==
+                stubsTrk1indices.end()) {
               newStubList.push_back(stubsTrk2[stub2it]);
             }
           }
           //   Overwrite stublist of preferred track with merged list
           inputstublists_[preftrk] = newStubList;
-  
+
           std::vector<std::pair<int, int>> newStubidsList;
           std::vector<std::pair<int, int>> stubidsTrk1 = mergedstubidslists_[preftrk];
           std::vector<std::pair<int, int>> stubidsTrk2 = mergedstubidslists_[rejetrk];
           newStubidsList = stubidsTrk1;
 
           for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
-            if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) == stubsTrk1indices.end()) {
+            if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) ==
+                stubsTrk1indices.end()) {
               newStubidsList.push_back(stubidsTrk2[stub2it]);
             }
           }
           // Overwrite stubidslist of preferred track with merged list
           mergedstubidslists_[preftrk] = newStubidsList;
-          
+
           // Mark that rejected track has been merged into another track
           trackInfo[rejetrk].second = true;
         }
@@ -512,7 +514,7 @@ double PurgeDuplicate::getPhiRes(Tracklet* curTracklet, const Stub* curStub) {
   // Get phi projection of tracklet
   int seedindex = curTracklet->seedIndex();
   // If this stub is a seed stub, set projection=phi, so that res=0
-  if (isSeedingStub(seedindex, Layer, Disk)){
+  if (isSeedingStub(seedindex, Layer, Disk)) {
     phiproj = stubphi;
     // Otherwise, get projection of tracklet
   } else {
@@ -523,190 +525,175 @@ double PurgeDuplicate::getPhiRes(Tracklet* curTracklet, const Stub* curStub) {
   return phires;
 }
 
-
 // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7
-bool PurgeDuplicate::isSeedingStub(int seedindex, int Layer, int Disk){
-  if ((seedindex == 0 && (Layer == 1 || Layer == 2)) || 
-      (seedindex == 1 && (Layer == 2 || Layer == 3)) ||
-      (seedindex == 2 && (Layer == 3 || Layer == 4)) || 
-      (seedindex == 3 && (Layer == 5 || Layer == 6)) ||
+bool PurgeDuplicate::isSeedingStub(int seedindex, int Layer, int Disk) {
+  if ((seedindex == 0 && (Layer == 1 || Layer == 2)) || (seedindex == 1 && (Layer == 2 || Layer == 3)) ||
+      (seedindex == 2 && (Layer == 3 || Layer == 4)) || (seedindex == 3 && (Layer == 5 || Layer == 6)) ||
       (seedindex == 4 && (abs(Disk) == 1 || abs(Disk) == 2)) ||
-      (seedindex == 5 && (abs(Disk) == 3 || abs(Disk) == 4)) || 
-      (seedindex == 6 && (Layer == 1 || abs(Disk) == 1)) ||
+      (seedindex == 5 && (abs(Disk) == 3 || abs(Disk) == 4)) || (seedindex == 6 && (Layer == 1 || abs(Disk) == 1)) ||
       (seedindex == 7 && (Layer == 2 || abs(Disk) == 1)) ||
       (seedindex == 8 && (Layer == 2 || Layer == 3 || Layer == 4)) ||
       (seedindex == 9 && (Layer == 4 || Layer == 5 || Layer == 6)) ||
       (seedindex == 10 && (Layer == 2 || Layer == 3 || abs(Disk) == 1)) ||
-      (seedindex == 11 && (Layer == 2 || abs(Disk) == 1 || abs(Disk) == 2))) 
-      return true;
+      (seedindex == 11 && (Layer == 2 || abs(Disk) == 1 || abs(Disk) == 2)))
+    return true;
 
   return false;
 }
 
-std::pair<int,int> PurgeDuplicate::findLayerDisk(const Stub* st){
-
-    std::pair<int,int> layer_disk;
-    layer_disk.first = st->layerdisk() + 1;
-    if (layer_disk.first > N_LAYER) {
-        layer_disk.first = 0;
-    }
-    layer_disk.second = st->layerdisk() - (N_LAYER - 1);
-    if (layer_disk.second < 0) {
-        layer_disk.second = 0;
-    }
-    return layer_disk;
+std::pair<int, int> PurgeDuplicate::findLayerDisk(const Stub* st) {
+  std::pair<int, int> layer_disk;
+  layer_disk.first = st->layerdisk() + 1;
+  if (layer_disk.first > N_LAYER) {
+    layer_disk.first = 0;
+  }
+  layer_disk.second = st->layerdisk() - (N_LAYER - 1);
+  if (layer_disk.second < 0) {
+    layer_disk.second = 0;
+  }
+  return layer_disk;
 }
 
-
-std::string PurgeDuplicate::l1tinfo(const L1TStub* L1stub, std::string str=""){
-    std::string thestr = Form("\t %s stub info:  r/z/phi:\t%f\t%f\t%f\t%d\t%f\t%d", str.c_str(), L1stub->r(), L1stub->z(), L1stub->phi(), L1stub->iphi(), L1stub->bend(),  L1stub->layerdisk()   );
-    return thestr;                        
+std::string PurgeDuplicate::l1tinfo(const L1TStub* L1stub, std::string str = "") {
+  std::string thestr = Form("\t %s stub info:  r/z/phi:\t%f\t%f\t%f\t%d\t%f\t%d",
+                            str.c_str(),
+                            L1stub->r(),
+                            L1stub->z(),
+                            L1stub->phi(),
+                            L1stub->iphi(),
+                            L1stub->bend(),
+                            L1stub->layerdisk());
+  return thestr;
 }
 
-
-std::vector<double> PurgeDuplicate::getInventedCoords(unsigned int iSector, const Stub* st, Tracklet* tracklet){     
-
+std::vector<double> PurgeDuplicate::getInventedCoords(unsigned int iSector, const Stub* st, Tracklet* tracklet) {
   int stubLayer = (findLayerDisk(st)).first;
   int stubDisk = (findLayerDisk(st)).second;
 
-  double stub_phi  = -99;
-  double stub_z    = -99;
-  double stub_r    = -99;
+  double stub_phi = -99;
+  double stub_z = -99;
+  double stub_r = -99;
 
   double tracklet_rinv = tracklet->rinv();
 
-  if (st->isBarrel()){
-      stub_r = settings_.rmean(stubLayer-1);
-      stub_phi  = tracklet->phi0() - std::asin(stub_r*tracklet_rinv/2);
-      stub_phi  = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-      stub_phi  = reco::reduceRange(stub_phi);
-      stub_z  = tracklet->z0() + 2 * tracklet->t() * 1 / tracklet_rinv * std::asin(stub_r*tracklet_rinv/2);
-  }
-  else{
-      stub_z = settings_.zmean(stubDisk-1)*tracklet->disk()/abs(tracklet->disk());
-      stub_phi  = tracklet->phi0() - (stub_z - tracklet->z0())*tracklet_rinv/2/tracklet->t();
-      stub_phi  = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-      stub_phi  = reco::reduceRange(stub_phi);
-      stub_r  = 2/tracklet_rinv * std::sin ((stub_z - tracklet->z0())*tracklet_rinv/2/tracklet->t());
+  if (st->isBarrel()) {
+    stub_r = settings_.rmean(stubLayer - 1);
+    stub_phi = tracklet->phi0() - std::asin(stub_r * tracklet_rinv / 2);
+    stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+    stub_phi = reco::reduceRange(stub_phi);
+    stub_z = tracklet->z0() + 2 * tracklet->t() * 1 / tracklet_rinv * std::asin(stub_r * tracklet_rinv / 2);
+  } else {
+    stub_z = settings_.zmean(stubDisk - 1) * tracklet->disk() / abs(tracklet->disk());
+    stub_phi = tracklet->phi0() - (stub_z - tracklet->z0()) * tracklet_rinv / 2 / tracklet->t();
+    stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+    stub_phi = reco::reduceRange(stub_phi);
+    stub_r = 2 / tracklet_rinv * std::sin((stub_z - tracklet->z0()) * tracklet_rinv / 2 / tracklet->t());
   }
 
   std::vector invented_coords{stub_r, stub_z, stub_phi};
   return invented_coords;
 }
 
-
-std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSector, const Stub* st, Tracklet* tracklet){     
-
+std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSector,
+                                                              const Stub* st,
+                                                              Tracklet* tracklet) {
   int stubLayer = (findLayerDisk(st)).first;
   int stubDisk = (findLayerDisk(st)).second;
 
+  double stub_phi = -99;
+  double stub_z = -99;
+  double stub_r = -99;
 
-  double stub_phi  = -99;
-  double stub_z    = -99;
-  double stub_r    = -99;
-
-  double rho = 1/tracklet->rinv();
-  double rho_minus_d0 = rho + tracklet->d0(); // should be -, but otherwise does not work
+  double rho = 1 / tracklet->rinv();
+  double rho_minus_d0 = rho + tracklet->d0();  // should be -, but otherwise does not work
 
   // exact helix
-  if (st->isBarrel()){
-      stub_r = settings_.rmean(stubLayer-1);
+  if (st->isBarrel()) {
+    stub_r = settings_.rmean(stubLayer - 1);
 
-      double sin_val = (stub_r*stub_r + rho_minus_d0*rho_minus_d0 - rho*rho) / (2 * stub_r * rho_minus_d0) ;
-      stub_phi = tracklet->phi0() - std::asin(sin_val);
-      stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-      stub_phi = reco::reduceRange(stub_phi);
+    double sin_val = (stub_r * stub_r + rho_minus_d0 * rho_minus_d0 - rho * rho) / (2 * stub_r * rho_minus_d0);
+    stub_phi = tracklet->phi0() - std::asin(sin_val);
+    stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+    stub_phi = reco::reduceRange(stub_phi);
 
-      double beta =  std::acos((rho*rho + rho_minus_d0*rho_minus_d0 - stub_r*stub_r) / (2 * rho * rho_minus_d0) );
-      stub_z = tracklet->z0() + tracklet->t() * std::abs(rho * beta);
-  }
-  else {
-      stub_z = settings_.zmean(stubDisk-1)*tracklet->disk()/abs(tracklet->disk());
+    double beta = std::acos((rho * rho + rho_minus_d0 * rho_minus_d0 - stub_r * stub_r) / (2 * rho * rho_minus_d0));
+    stub_z = tracklet->z0() + tracklet->t() * std::abs(rho * beta);
+  } else {
+    stub_z = settings_.zmean(stubDisk - 1) * tracklet->disk() / abs(tracklet->disk());
 
-      double beta = (stub_z - tracklet->z0()) / (tracklet->t() * std::abs(rho)); // maybe rho should be abs value
-      double r_square = -2 * rho * rho_minus_d0 * std::cos(beta) + rho*rho + rho_minus_d0*rho_minus_d0;
-      stub_r = sqrt(r_square);
+    double beta = (stub_z - tracklet->z0()) / (tracklet->t() * std::abs(rho));  // maybe rho should be abs value
+    double r_square = -2 * rho * rho_minus_d0 * std::cos(beta) + rho * rho + rho_minus_d0 * rho_minus_d0;
+    stub_r = sqrt(r_square);
 
-      double sin_val = (stub_r*stub_r + rho_minus_d0*rho_minus_d0 - rho*rho) / (2 * stub_r * rho_minus_d0) ;
-      stub_phi = tracklet->phi0() - std::asin(sin_val);
-      stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-      stub_phi = reco::reduceRange(stub_phi);
+    double sin_val = (stub_r * stub_r + rho_minus_d0 * rho_minus_d0 - rho * rho) / (2 * stub_r * rho_minus_d0);
+    stub_phi = tracklet->phi0() - std::asin(sin_val);
+    stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+    stub_phi = reco::reduceRange(stub_phi);
   }
 
   // TMP: for displaced tracking, exclude one of the 3 seeding stubs
   // to be discussed
   int seed = tracklet->seedIndex();
-  if ( (seed == 8 && stubLayer == 4) ||\
-       (seed == 9 && stubLayer == 5) ||\
-       (seed == 10 && stubLayer == 3) ||\
-       (seed == 11 && abs(stubDisk) == 1)
-     ){
-    stub_phi  = st->l1tstub()->phi();
-    stub_z    = st->l1tstub()->z();
-    stub_r    = st->l1tstub()->r();
+  if ((seed == 8 && stubLayer == 4) || (seed == 9 && stubLayer == 5) || (seed == 10 && stubLayer == 3) ||
+      (seed == 11 && abs(stubDisk) == 1)) {
+    stub_phi = st->l1tstub()->phi();
+    stub_z = st->l1tstub()->z();
+    stub_r = st->l1tstub()->r();
   }
 
   std::vector invented_coords{stub_r, stub_z, stub_phi};
   return invented_coords;
 }
 
-std::vector<const Stub*> PurgeDuplicate::seedStubCoordsFromTracklet (unsigned int iSector, Tracklet* tracklet, std::vector<const Stub*> originalStubsList ){
-
+std::vector<const Stub*> PurgeDuplicate::seedStubCoordsFromTracklet(unsigned int iSector,
+                                                                    Tracklet* tracklet,
+                                                                    std::vector<const Stub*> originalStubsList) {
   std::vector<const Stub*> newStubList;
 
   for (unsigned int stubit = 0; stubit < originalStubsList.size(); stubit++) {
     const Stub* thisStub = originalStubsList[stubit];
 
-    if ( isSeedingStub(tracklet->seedIndex(), (findLayerDisk(thisStub)).first, (findLayerDisk(thisStub)).second)) {
+    if (isSeedingStub(tracklet->seedIndex(), (findLayerDisk(thisStub)).first, (findLayerDisk(thisStub)).second)) {
       // get a vector containing r, z, phi
       std::vector<double> inv_r_z_phi;
       if (!settings_.extended())
-        inv_r_z_phi = getInventedCoords(iSector, thisStub, tracklet );
-      else  {
-        inv_r_z_phi = getInventedCoordsExtended(iSector, thisStub, tracklet );
-      }      
+        inv_r_z_phi = getInventedCoords(iSector, thisStub, tracklet);
+      else {
+        inv_r_z_phi = getInventedCoordsExtended(iSector, thisStub, tracklet);
+      }
       double stub_x_invent = inv_r_z_phi[0] * std::cos(inv_r_z_phi[2]);
       double stub_y_invent = inv_r_z_phi[0] * std::sin(inv_r_z_phi[2]);
       double stub_z_invent = inv_r_z_phi[1];
 
-      Stub* invent_stub_ptr = new Stub(*thisStub) ;
+      Stub* invent_stub_ptr = new Stub(*thisStub);
       const L1TStub* L1stub = thisStub->l1tstub();
 
-      L1TStub invent_L1stub ( L1stub->DTClink(),
-                              L1stub->region(),
-                              L1stub->layerdisk(),
-                              L1stub->stubword(),
-                              L1stub->isPSmodule(),
-                              L1stub->isFlipped(),
-                              L1stub->isTilted(),
-                              L1stub->tiltedRingId(),
-                              L1stub->endcapRingId(),
-                              L1stub->detId(),
-                              stub_x_invent,
-                              stub_y_invent,
-                              stub_z_invent,
-                              L1stub->bend(),
-                              L1stub->strip(),
-                              L1stub->tps()
-//                               L1stub->ttStubRef()	
-                            );
+      L1TStub invent_L1stub(L1stub->DTClink(),
+                            L1stub->region(),
+                            L1stub->layerdisk(),
+                            L1stub->stubword(),
+                            L1stub->isPSmodule(),
+                            L1stub->isFlipped(),
+                            L1stub->isTilted(),
+                            L1stub->tiltedRingId(),
+                            L1stub->endcapRingId(),
+                            L1stub->detId(),
+                            stub_x_invent,
+                            stub_y_invent,
+                            stub_z_invent,
+                            L1stub->bend(),
+                            L1stub->strip(),
+                            L1stub->tps()
+                            //                               L1stub->ttStubRef()
+      );
 
       invent_stub_ptr->setl1tstub(new L1TStub(invent_L1stub));
       invent_stub_ptr->l1tstub()->setAllStubIndex(L1stub->allStubIndex());
       invent_stub_ptr->l1tstub()->setUniqueIndex(L1stub->uniqueIndex());
 
-      newStubList.push_back(invent_stub_ptr);  
+      newStubList.push_back(invent_stub_ptr);
 
-      // to enable comparison output file                  
-//       std::cout << invent_stub_ptr->isBarrel()<< "\t" << l1tinfo(&invent_L1stub, "invent").c_str() << "\t" <<  l1tinfo(L1stub, "original").c_str() 
-//                 << "\tdr\t"    << abs(invent_L1stub.r()-L1stub->r())  
-//                 << "\tdz\t"    << abs(invent_L1stub.z()-L1stub->z()) 
-//                 << "\tdphi\t"  << abs(invent_L1stub.phi()-L1stub->phi()) 
-//                 << "\tisPS\t"  << L1stub->isPSmodule() 
-// //                 << "\tisTilted\t"  << L1stub->isTilted() 
-//                 << std::endl;
-    }
-    else{
+    } else {
       newStubList.push_back(thisStub);
     }
   }

--- a/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
+++ b/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
@@ -25,7 +25,8 @@ bool SLHCEvent::addStub(string DTClink,
                         double z,
                         double bend,
                         double strip,
-                        vector<int> tps) {
+                        vector<int> tps,
+                        int stubindex) {
   L1TStub stub(DTClink,
                region,
                layerdisk,
@@ -43,6 +44,7 @@ bool SLHCEvent::addStub(string DTClink,
                strip,
                tps);
 
+  stub.setUniqueIndex(stubindex);
   stubs_.push_back(stub);
   return true;
 }


### PR DESCRIPTION
#### PR description:

Include code to enable the setting of seeding stubs coordinates to those inferred from the tracklet trajectory, before the DR step.
Performance shown [here](https://indico.cern.ch/event/1170133/#51-invented-seed-stubs-from-tr).