### PR TITLE
Remove obsolete FWCore functions

### DIFF
--- a/L1Trigger/TrackTrigger/test/AnalyzerClusterStub.cc
+++ b/L1Trigger/TrackTrigger/test/AnalyzerClusterStub.cc
@@ -8,7 +8,7 @@
  */
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
@@ -29,7 +29,7 @@
 #include <TH1D.h>
 #include <TH2D.h>
 
-class AnalyzerClusterStub : public edm::EDAnalyzer {
+class AnalyzerClusterStub : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
   /// Public methods
 public:
   /// Constructor/destructor
@@ -38,6 +38,8 @@ public:
   // Typical methods used on Loops over events
   void beginJob() override;
   void endJob() override;
+  void beginRun(const edm::Run& iEvent, const edm::EventSetup& iSetup) override {}
+  void endRun(const edm::Run& iEvent, const edm::EventSetup& iSetup) override {}
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   /// Private methods and variables
@@ -180,6 +182,7 @@ private:
 // CONSTRUCTOR
 AnalyzerClusterStub::AnalyzerClusterStub(edm::ParameterSet const& iConfig) : config(iConfig) {
   /// Insert here what you need to initialize
+  usesResource("TFileService");
   DebugMode = iConfig.getParameter<bool>("DebugMode");
 }
 

--- a/L1Trigger/TrackTrigger/test/AnalyzerPrintGeomInfo.cc
+++ b/L1Trigger/TrackTrigger/test/AnalyzerPrintGeomInfo.cc
@@ -6,7 +6,7 @@
 //////////////////////////////
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
@@ -28,7 +28,7 @@
 //                          //
 //////////////////////////////
 
-class AnalyzerPrintGeomInfo : public edm::EDAnalyzer {
+class AnalyzerPrintGeomInfo : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
   /// Public methods
 public:
   /// Constructor/destructor
@@ -37,6 +37,8 @@ public:
   // Typical methods used on Loops over events
   void beginJob() override;
   void endJob() override;
+  void beginRun(const edm::Run& iEvent, const edm::EventSetup& iSetup) override {}
+  void endRun(const edm::Run& iEvent, const edm::EventSetup& iSetup) override {}
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   /// Private methods and variables
@@ -93,6 +95,7 @@ private:
 // CONSTRUCTOR
 AnalyzerPrintGeomInfo::AnalyzerPrintGeomInfo(edm::ParameterSet const& iConfig) : config(iConfig) {
   /// Insert here what you need to initialize
+  usesResource("TFileService");
   TextOutput = iConfig.getParameter<std::string>("TextOutput");
   DebugMode = iConfig.getParameter<bool>("DebugMode");
 

--- a/L1Trigger/TrackTrigger/test/AnalyzerSimHitMaps.cc
+++ b/L1Trigger/TrackTrigger/test/AnalyzerSimHitMaps.cc
@@ -6,7 +6,7 @@
 ////////////////////////////
 
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
@@ -26,7 +26,7 @@
 //                          //
 //////////////////////////////
 
-class AnalyzerSimHitMaps : public edm::EDAnalyzer {
+class AnalyzerSimHitMaps : public edm::one::EDAnalyzer<edm::one::WatchRuns, edm::one::SharedResources> {
   /// Public methods
 public:
   /// Constructor/destructor
@@ -35,10 +35,14 @@ public:
   // Typical methods used on Loops over events
   void beginJob() override;
   void endJob() override;
+  void beginRun(const edm::Run& iEvent, const edm::EventSetup& iSetup) override {}
+  void endRun(const edm::Run& iEvent, const edm::EventSetup& iSetup) override {}
   void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   /// Private methods and variables
 private:
+  edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> getTokenTrackerGeometry_;
+
   /// Global Position of SimHits
   TH2D* hSimHit_Barrel_XY;
   TH2D* hSimHit_Barrel_XY_Zoom;
@@ -60,8 +64,10 @@ private:
 
 //////////////
 // CONSTRUCTOR
-AnalyzerSimHitMaps::AnalyzerSimHitMaps(edm::ParameterSet const& iConfig) {
+AnalyzerSimHitMaps::AnalyzerSimHitMaps(edm::ParameterSet const& iConfig)
+    : getTokenTrackerGeometry_(esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>()) {
   /// Insert here what you need to initialize
+  usesResource("TFileService");
 }
 
 /////////////
@@ -161,13 +167,8 @@ void AnalyzerSimHitMaps::beginJob() {
 // ANALYZE
 void AnalyzerSimHitMaps::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   /// Geometry handles etc
-  edm::ESHandle<TrackerGeometry> geometryHandle;
-  const TrackerGeometry* theGeometry;
-
-  /// Geometry setup
-  /// Set pointers to Geometry
-  iSetup.get<TrackerDigiGeometryRecord>().get(geometryHandle);
-  theGeometry = &(*geometryHandle);
+  edm::ESHandle<TrackerGeometry> geometryHandle = iSetup.getHandle(getTokenTrackerGeometry_);
+  const TrackerGeometry* theGeometry = &(*geometryHandle);
 
   //////////////////
   // GET SIM HITS //


### PR DESCRIPTION
#### PR description:

Updated L1 track related EDAnalyzers by eliminating calls to obsolete FWCore classes or functions.