### PR TITLE
Reduce L1 tracking CPU

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/imath.h
+++ b/L1Trigger/TrackFindingTracklet/interface/imath.h
@@ -225,7 +225,7 @@ namespace trklet {
                     const std::map<const VarBase *, std::set<std::string> > *const previous_cut_strings = nullptr) const;
     void add_cut(VarCut *cut, const bool call_set_cut_var = true);
     VarBase *cut_var();
-
+    // observed range of fval_ (only filled if debug_level > 0)
     double minval() const { return minval_; }
     double maxval() const { return maxval_; }
     void analyze();
@@ -250,8 +250,7 @@ namespace trklet {
     int step() const { return step_; }
     int latency() const { return latency_; }
     void add_latency(unsigned int l) { latency_ += l; }  //only call before using the variable in calculation!
-    bool calculate(int debug_level);
-    bool calculate() { return calculate(0); }
+    bool calculate(int debug_level = 0);
     virtual void local_calculate() {}
     void calcDebug(int debug_level, long int ival_prev, bool &all_ok);
     virtual void print(std::ofstream &fs, Verilog, int l1 = 0, int l2 = 0, int l3 = 0) {

--- a/L1Trigger/TrackFindingTracklet/interface/imath.h
+++ b/L1Trigger/TrackFindingTracklet/interface/imath.h
@@ -253,6 +253,7 @@ namespace trklet {
     bool calculate(int debug_level);
     bool calculate() { return calculate(0); }
     virtual void local_calculate() {}
+    void calcDebug(int debug_level, long int ival_prev, bool &all_ok);
     virtual void print(std::ofstream &fs, Verilog, int l1 = 0, int l2 = 0, int l3 = 0) {
       fs << "// VarBase here. Soemthing is wrong!! " << l1 << ", " << l2 << ", " << l3 << "\n";
     }

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -351,7 +351,7 @@ void L1FPGATrackProducer::beginRun(const edm::Run& run, const edm::EventSetup& i
   setup_ = &iSetup.getData(esGetToken_);
   setupHPH_ = &iSetup.getData(esGetTokenHPH_);
   if (trackQuality_) {
-    trackQualityModel_->setHPHSetup(setupHPH_);
+    trackQualityModel_->beginRun(setupHPH_);
   }
   // Tracklet pattern reco output channel info.
   channelAssignment_ = &iSetup.getData(esGetTokenChannelAssignment_);

--- a/L1Trigger/TrackFindingTracklet/src/imath_calculate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath_calculate.cc
@@ -15,15 +15,10 @@ bool VarBase::calculate(int debug_level) {
   if (p3_)
     ok3 = p3_->calculate(debug_level);
 
-  long int ival_prev = ival_;
-  local_calculate();
-
   bool all_ok = debug_level && ok1 && ok2 && ok3;
+  long int ival_prev = ival_;
 
-  if (fval_ > maxval_)
-    maxval_ = fval_;
-  if (fval_ < minval_)
-    minval_ = fval_;
+  local_calculate();
 
   val_ = ival_ * K_;
 
@@ -53,6 +48,12 @@ bool VarBase::calculate(int debug_level) {
 }
 
 void VarBase::calcDebug(int debug_level, long int ival_prev, bool &all_ok) {
+
+  if (fval_ > maxval_)
+    maxval_ = fval_;
+  if (fval_ < minval_)
+    minval_ = fval_;
+
   bool todump = false;
   int nmax = sizeof(long int) * 8;
   int ns = nmax - nbits_;

--- a/L1Trigger/TrackFindingTracklet/src/imath_calculate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath_calculate.cc
@@ -48,7 +48,6 @@ bool VarBase::calculate(int debug_level) {
 }
 
 void VarBase::calcDebug(int debug_level, long int ival_prev, bool &all_ok) {
-
   if (fval_ > maxval_)
     maxval_ = fval_;
   if (fval_ < minval_)

--- a/L1Trigger/TrackFindingTracklet/src/imath_calculate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath_calculate.cc
@@ -18,12 +18,15 @@ bool VarBase::calculate(int debug_level) {
   long int ival_prev = ival_;
   local_calculate();
 
-  bool all_ok = ok1 && ok2 && ok3 && debug_level;
+  bool all_ok = debug_level && ok1 && ok2 && ok3;
 
   if (fval_ > maxval_)
     maxval_ = fval_;
   if (fval_ < minval_)
     minval_ = fval_;
+
+  val_ = ival_ * K_;
+
 #ifdef IMATH_ROOT
   if (globals_->use_root) {
     if (h_ == 0) {
@@ -43,6 +46,13 @@ bool VarBase::calculate(int debug_level) {
   }
 #endif
 
+  if (debug_level)
+    calcDebug(debug_level, ival_prev, all_ok);
+
+  return all_ok;
+}
+
+void VarBase::calcDebug(int debug_level, long int ival_prev, bool &all_ok) {
   bool todump = false;
   int nmax = sizeof(long int) * 8;
   int ns = nmax - nbits_;
@@ -57,7 +67,6 @@ bool VarBase::calculate(int debug_level) {
     all_ok = false;
   }
 
-  val_ = ival_ * K_;
   float ftest = val_;
   float tolerance = 0.1 * std::abs(fval_);
   if (tolerance < 2 * K_)
@@ -71,11 +80,8 @@ bool VarBase::calculate(int debug_level) {
     }
     all_ok = false;
   }
-
   if (todump)
     edm::LogVerbatim("Tracklet") << dump();
-
-  return all_ok;
 }
 
 void VarFlag::calculate_step() {

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1097,7 +1097,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         // ----------------------------------------------------------------------------------------------
         // get d0/z0 propagated back to the IP
 
-        float tmp_matchtp_t = tan(2.0 * atan(1.0) - 2.0 * atan(exp(-tmp_matchtp_eta)));
+        float tmp_matchtp_t = 1.0 / tan(2.0 * atan(exp(-tmp_matchtp_eta)));
 
         float delx = -tmp_matchtp_vx;
         float dely = -tmp_matchtp_vy;
@@ -1205,10 +1205,13 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float tmp_tp_z0_prod = tmp_tp_vz;
     float tmp_tp_d0_prod = tmp_tp_vx * sin(tmp_tp_phi) - tmp_tp_vy * cos(tmp_tp_phi);
 
+    if (tmp_tp_pt < TP_minPt)  // Save CPU by applying this cut early.
+      continue;
+
     // ----------------------------------------------------------------------------------------------
     // get d0/z0 propagated back to the IP
 
-    float tmp_tp_t = tan(2.0 * atan(1.0) - 2.0 * atan(exp(-tmp_tp_eta)));
+    float tmp_tp_t = 1.0 / tan(2.0 * atan(exp(-tmp_tp_eta)));
     float tmp_tp_charge = iterTP->charge();
 
     float delx = -tmp_tp_vx;
@@ -1239,8 +1242,6 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     if ((MyProcess == 6 || MyProcess == 15 || MyProcess == 211) && abs(tmp_tp_pdgid) != 211)
       continue;
 
-    if (tmp_tp_pt < TP_minPt)
-      continue;
     if (std::abs(tmp_tp_eta) > TP_maxEta)
       continue;
     if (std::abs(tmp_tp_z0) > TP_maxZ0)

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1202,17 +1202,21 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float tmp_tp_vx = iterTP->vx();
     float tmp_tp_vy = iterTP->vy();
     int tmp_tp_pdgid = iterTP->pdgId();
+    float tmp_tp_charge = iterTP->charge();
     float tmp_tp_z0_prod = tmp_tp_vz;
     float tmp_tp_d0_prod = tmp_tp_vx * sin(tmp_tp_phi) - tmp_tp_vy * cos(tmp_tp_phi);
 
-    if (tmp_tp_pt < TP_minPt)  // Save CPU by applying this cut early.
+    if (tmp_tp_pt < TP_minPt)  // Save CPU by applying these cuts here.
+      continue;
+    if (tmp_tp_charge == 0.)
+      continue;
+    if (std::abs(tmp_tp_eta) > TP_maxEta)
       continue;
 
     // ----------------------------------------------------------------------------------------------
     // get d0/z0 propagated back to the IP
 
     float tmp_tp_t = 1.0 / tan(2.0 * atan(exp(-tmp_tp_eta)));
-    float tmp_tp_charge = iterTP->charge();
 
     float delx = -tmp_tp_vx;
     float dely = -tmp_tp_vy;
@@ -1242,8 +1246,6 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     if ((MyProcess == 6 || MyProcess == 15 || MyProcess == 211) && abs(tmp_tp_pdgid) != 211)
       continue;
 
-    if (std::abs(tmp_tp_eta) > TP_maxEta)
-      continue;
     if (std::abs(tmp_tp_z0) > TP_maxZ0)
       continue;
 

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -304,7 +304,7 @@ L1TrackNtupleMaker::L1TrackNtupleMaker(edm::ParameterSet const& iConfig) : confi
   ttStubMCTruthToken_ = consumes<TTStubAssociationMap<Ref_Phase2TrackerDigi_> >(MCTruthStubInputTag);
 
   TrackingParticleToken_ = consumes<std::vector<TrackingParticle> >(TrackingParticleInputTag);
-  TrackingVertexToken_ = consumes<std::vector<TrackingVertex> >(TrackingVertexInputTag);
+  //TrackingVertexToken_ = consumes<std::vector<TrackingVertex> >(TrackingVertexInputTag);
   GenJetToken_ = consumes<std::vector<reco::GenJet> >(GenJetInputTag);
 
   getTokenTrackerGeom_ = esConsumes<TrackerGeometry, TrackerDigiGeometryRecord>();
@@ -713,7 +713,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
   edm::Handle<std::vector<TrackingParticle> > TrackingParticleHandle;
   edm::Handle<std::vector<TrackingVertex> > TrackingVertexHandle;
   iEvent.getByToken(TrackingParticleToken_, TrackingParticleHandle);
-  iEvent.getByToken(TrackingVertexToken_, TrackingVertexHandle);
+  //iEvent.getByToken(TrackingVertexToken_, TrackingVertexHandle);
 
   // -----------------------------------------------------------------------------------------------
   // more for TTStubs
@@ -1196,15 +1196,8 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       continue;  //only care about tracking particles from the primary interaction (except for MyProcess==1, i.e. looking at all TPs)
 
     float tmp_tp_pt = iterTP->pt();
-    float tmp_tp_eta = iterTP->eta();
-    float tmp_tp_phi = iterTP->phi();
-    float tmp_tp_vz = iterTP->vz();
-    float tmp_tp_vx = iterTP->vx();
-    float tmp_tp_vy = iterTP->vy();
-    int tmp_tp_pdgid = iterTP->pdgId();
     float tmp_tp_charge = iterTP->charge();
-    float tmp_tp_z0_prod = tmp_tp_vz;
-    float tmp_tp_d0_prod = tmp_tp_vx * sin(tmp_tp_phi) - tmp_tp_vy * cos(tmp_tp_phi);
+    float tmp_tp_eta = iterTP->eta();
 
     if (tmp_tp_pt < TP_minPt)  // Save CPU by applying these cuts here.
       continue;
@@ -1212,6 +1205,14 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       continue;
     if (std::abs(tmp_tp_eta) > TP_maxEta)
       continue;
+
+    float tmp_tp_phi = iterTP->phi();
+    float tmp_tp_vz = iterTP->vz();
+    float tmp_tp_vx = iterTP->vx();
+    float tmp_tp_vy = iterTP->vy();
+    int tmp_tp_pdgid = iterTP->pdgId();
+    float tmp_tp_z0_prod = tmp_tp_vz;
+    float tmp_tp_d0_prod = tmp_tp_vx * sin(tmp_tp_phi) - tmp_tp_vy * cos(tmp_tp_phi);
 
     // ----------------------------------------------------------------------------------------------
     // get d0/z0 propagated back to the IP

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackQualityPlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackQualityPlot.C
@@ -2,7 +2,7 @@
 // Basic example ROOT script for making tracking performance plots using the ntuples produced by L1TrackNtupleMaker.cc
 //
 // e.g. in ROOT do: [0] .L L1TrackQualityPlot.C++
-//                  [1] L1TrackQualityPlot("TTbar_PU200_D49")
+//                  [1] L1TrackQualityPlot("TTbar_PU200_D76")
 //
 // By Claire Savard, July 2020
 // Based off of L1TrackNtuplePlot.C

--- a/L1Trigger/TrackFindingTracklet/test/makeHists.csh
+++ b/L1Trigger/TrackFindingTracklet/test/makeHists.csh
@@ -1,16 +1,16 @@
 #!/bin/tcsh
-###########################################################################
-# Create L1 track histograms & print summary of tracking performance,     #
-# by running ROOT macro L1TrackNtuplePlot.C on .root file                 #
-# from L1TrackNtupleMaker_cfg.py                                          #                     
-#                                                                         #
-# To use:                                                                 #
-#   makeHists.csh  rootFileName                                           #
-#                                                                         #
-# (where rootFileName is the name of the input .root file,                #
-#  including its directory name, if its not in the current one.           #
-#  If rootFileName not specified, it defaults to TTbar_PU200_hybrid.root) #
-###########################################################################
+########################################################################
+# Create L1 track histograms & print summary of tracking performance,  #
+# by running ROOT macros L1TrackNtuplePlot.C & L1TrackQualityPlot.C    #
+# on the .root file from L1TrackNtupleMaker_cfg.py .                   # #                                                                      #
+#                                                                      #
+# To use:                                                              #
+#   makeHists.csh  rootFileName                                        #
+#                                                                      #
+# (where rootFileName is the name of the input .root file,             #
+#  including its directory name, if its not in the current one.        #
+#  If rootFileName not specified, it defaults to TTbar_PU200_D76.root) #
+########################################################################
 
 if ($#argv == 0) then
   set inputFullFileName = "TTbar_PU200_D76.root"
@@ -32,20 +32,20 @@ set fileName = `basename $inputFullFileName`
 # Get stem of filename, removing ".root".
 set inputFileStem = `echo $fileName | awk -F . '{print $1;}'`
 
-# Find plotting macro
 eval `scramv1 runtime -csh`
+
+# Run track quality MVA plotting macro
+set plotMacro = $CMSSW_BASE/src/L1Trigger/TrackFindingTracklet/test/L1TrackQualityPlot.C
+if (-e MVA_plots) rm -r MVA_plots
+\root -b -q ${plotMacro}'("'${inputFileStem}'","'${dirName}'")' 
+echo "MVA track quality Histograms written to MVA_plots/"  
+
+# Run track performance plotting macro
 set plotMacro = $CMSSW_BASE/src/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
-if ( -e $plotMacro ) then
-  # Run plotting macro
-  if (-e TrkPlots) rm -r TrkPlots
-  \root -b -q ${plotMacro}'("'${inputFileStem}'","'${dirName}'")' | tail -n 19 >! results.out 
-  cat results.out
-  echo "Tracking performance summary written to results.out"
-  echo "Histograms written to TrkPlots/"  
-else if ( -e ../L1TrackNtuplePlot.C ) then
-else
-  echo "ERROR: $plotMacro not found"
-  exit(2)
-endif
+if (-e TrkPlots) rm -r TrkPlots
+\root -b -q ${plotMacro}'("'${inputFileStem}'","'${dirName}'")' | tail -n 19 >! results.out 
+cat results.out
+echo "Tracking performance summary written to results.out"
+echo "Track performance histograms written to TrkPlots/"  
 
 exit

--- a/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
+++ b/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
@@ -21,8 +21,8 @@ C.Brown 28/07/20
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 #include "L1Trigger/TrackTrigger/interface/HitPatternHelper.h"
-
-#include "L1Trigger/TrackTrigger/interface/HitPatternHelper.h"
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+#include <memory>
 
 class L1TrackQuality {
 public:
@@ -74,5 +74,6 @@ private:
   int nStubsmin_;
   const hph::Setup* setupHPH_;
   bool useHPH_;
+  std::unique_ptr<cms::Ort::ONNXRuntime> runTime_;
 };
 #endif

--- a/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
+++ b/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
@@ -58,7 +58,7 @@ public:
                     std::string const& ONNXInputName,
                     std::vector<std::string> const& featureNames);
 
-  void setHPHSetup(const hph::Setup* setup);
+  void beginRun(const hph::Setup* setup);
 
 private:
   // Private Member Data
@@ -72,7 +72,7 @@ private:
   float bendchi2Max_;
   float minPt_;
   int nStubsmin_;
-  const hph::Setup* setup_;
-  bool useHPH;
+  const hph::Setup* setupHPH_;
+  bool useHPH_;
 };
 #endif

--- a/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
@@ -11,7 +11,7 @@ C.Brown & C.Savard 07/2020
 
 L1TrackQuality::L1TrackQuality() {}
 
-L1TrackQuality::L1TrackQuality(const edm::ParameterSet& qualityParams) : setup_(), useHPH(false) {
+L1TrackQuality::L1TrackQuality(const edm::ParameterSet& qualityParams) : setupHPH_(), useHPH_(false) {
   std::string AlgorithmString = qualityParams.getParameter<std::string>("qualityAlgorithm");
   // Unpacks EDM parameter set itself to save unecessary processing within TrackProducers
   if (AlgorithmString == "Cut") {
@@ -68,8 +68,8 @@ std::vector<float> L1TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDig
   int tmp_trk_chi2rz_bin = aTrack.getChi2RZBits();
 
   // Extra variables from HitPatternHelper don't improve performance, so commented out.
-  //if (useHPH) {
-  //  hph::HitPatternHelper hph(setup_, tmp_trk_hitpattern, tmp_trk_tanL, tmp_trk_z0);
+  //if (useHPH_) {
+  //  hph::HitPatternHelper hph(setupHPH_, tmp_trk_hitpattern, tmp_trk_tanL, tmp_trk_z0);
   //  hitpattern_expanded_binary = hph.binary();
   //  tmp_trk_nlaymiss_PS = hph.numMissingPS();
   //  tmp_trk_nlaymiss_2S = hph.numMissing2S();
@@ -197,7 +197,8 @@ void L1TrackQuality::setONNXModel(std::string const& AlgorithmString,
   featureNames_ = featureNames;
 }
 
-void L1TrackQuality::setHPHSetup(const hph::Setup* setup) {
-  setup_ = setup;
-  useHPH = true;
+void L1TrackQuality::beginRun(const hph::Setup* setupHPH) {
+  // Initialize helper for decoding hit patterns.
+  setupHPH_ = setupHPH;
+  useHPH_ = true;
 }


### PR DESCRIPTION
#### PR description:

This reduces the CPU used by L1FPGATrackProducer::produce() by 63%. This is achieved by:
1) Removing a call to SLHCEvent::layersHit() from TrackletEventProcessor.cc during normal running. This call is only needed when producing debug output.
2) The call to cms::Ort::ONNXRuntime from L1TrackQuality is now called only in the L1TrackQuality constructor (start of job) instead of for every track of every event.
3) Expensive calculation done in the IMATH code VarBase::calculate(), which are not needed with the default debug_level=0 have been swithched off. This function is called by the TrackletCalculator and dominates its CPU use.

This PR also reduces by 50% the CPU use of L1TrackNtupleMaker.cc by moving earlier in a loop over TP the cuts on Pt & eta, and rejecting also neutral TP. Remaining CPU use is dominated by the HitPatternHelper.

P.S. Also sneaked in a few trivial style improvements too.

Validation:

Checked tracking performance unchanged on 10 ttbar+200PU events. And output txt files for HLS unchanged.