### PR TITLE
Find best MC match

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -124,7 +124,7 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
 
   std::vector<std::pair<std::pair<Tracklet*, int>, const Stub*> > mergedMatches = mergeMatches(matches_);
 
-  // Number of clock cycles the pipeline in HLS takes to process the projection merging to 
+  // Number of clock cycles the pipeline in HLS takes to process the projection merging to
   // produce the first projectio
   unsigned int mergedepth = 3;
 
@@ -202,12 +202,13 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
       double dzapprox = z - (proj.rzprojapprox() + dr * proj.rzprojderapprox());
 
       int seedindex = tracklet->getISeed();
-      unsigned int projindex = mergedMatches[j].first.second;               // Allproj index
+      unsigned int projindex = mergedMatches[j].first.second;  // Allproj index
       curr_projid = next_projid;
       next_projid = projindex;
 
       bool newtracklet = (j == 0 || projindex != curr_projid);
-      if (j == 0)  best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1)); // Set to the maximum possible
+      if (j == 0)
+        best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
       if (newtracklet) {
         best_ideltaphi_barrel = (int)phimatchcuttable_.lookup(seedindex);
         best_ideltaz_barrel = (int)zmatchcuttable_.lookup(seedindex);
@@ -247,10 +248,8 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
             << zmatchcuttable_.lookup(seedindex) * settings_.kz() << endl;
       }
 
-
-      bool imatch = (std::abs(ideltaphi) <= best_ideltaphi_barrel) &&
-                    (ideltaz * fact_ < best_ideltaz_barrel) &&
-                    (ideltaz * fact_ >= - best_ideltaz_barrel);
+      bool imatch = (std::abs(ideltaphi) <= best_ideltaphi_barrel) && (ideltaz * fact_ < best_ideltaz_barrel) &&
+                    (ideltaz * fact_ >= -best_ideltaz_barrel);
       if (imatch) {
         best_ideltaphi_barrel = std::abs(ideltaphi);
         best_ideltaz_barrel = std::abs(ideltaz * fact_);
@@ -393,11 +392,12 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
         idrcut = rcut2Stable_.lookup(seedindex);
       }
 
-      unsigned int projindex = mergedMatches[j].first.second;               // Allproj index
+      unsigned int projindex = mergedMatches[j].first.second;  // Allproj index
       curr_projid = next_projid;
       next_projid = projindex;
       bool newtracklet = (j == 0 || projindex != curr_projid);
-      if (j == 0)  best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1)); // Set to the maximum possible
+      if (j == 0)
+        best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
       if (newtracklet) {
         best_ideltaphi_disk = idrphicut;
         best_ideltar_disk = idrcut;

--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -138,7 +138,7 @@ void MatchCalculator::execute(unsigned int iSector, double phioffset) {
 
   unsigned int maxProc = std::min(settings_.maxStep("MC") - mergedepth, (unsigned int)mergedMatches.size());
 
-  # Pick some initial large values
+  // Pick some initial large values
   int best_ideltaphi_barrel = 0xFFFF;
   int best_ideltaz_barrel = 0xFFFF;
   int best_ideltaphi_disk = 0xFFFF;

--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -26,11 +26,7 @@ MatchCalculator::MatchCalculator(string name, Settings const& settings, Globals*
       rphicutPStable_(settings),
       rphicut2Stable_(settings),
       rcutPStable_(settings),
-      rcut2Stable_(settings),
-      alphainner_(settings),
-      alphaouter_(settings),
-      rSSinner_(settings),
-      rSSouter_(settings) {
+      rcut2Stable_(settings) {
   phiregion_ = name[8] - 'A';
   layerdisk_ = initLayerDisk(3);
 
@@ -65,10 +61,6 @@ MatchCalculator::MatchCalculator(string name, Settings const& settings, Globals*
     rphicut2Stable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::disk2Sphi, region);
     rcutPStable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::diskPSr, region);
     rcut2Stable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::disk2Sr, region);
-    alphainner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphainner, region);
-    alphaouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphaouter, region);
-    rSSinner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSinner, region);
-    rSSouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSouter, region);
   }
 
   for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {


### PR DESCRIPTION
PR description:
This PR adds a better implementation of the ability to find better FullMatch memories. The code is similar to the HLS implementation, where for a particular tracklet, the best values are stored, and new stubs are only matched if their delta values (z, r, phi depending on barrel or disk matches) are better than the current best.

PR validation:
We were already seeing full agreement with 100 events in the barrel. However, while developing and testing the HLS MC disk implementation, I've seen this gives more correct matches (the HLS implementation is stull under development so not all matches agree yet).