### PR TITLE
Atownse2 calc bend cuts

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -14,7 +14,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-namespace tt{
+namespace tt {
   class Setup;
 }
 
@@ -281,7 +281,7 @@ namespace trklet {
     void setStripPitch_PS(double stripPitch_PS) { stripPitch_PS_ = stripPitch_PS; }
     void setStripPitch_2S(double stripPitch_2S) { stripPitch_2S_ = stripPitch_2S; }
 
-    double sensorSpacing2S() const { return sensorSpacing_2S_;}
+    double sensorSpacing2S() const { return sensorSpacing_2S_; }
 
     double stripLength(bool isPSmodule) const { return isPSmodule ? stripLength_PS_ : stripLength_2S_; }
     void setStripLength_PS(double stripLength_PS) { stripLength_PS_ = stripLength_PS; }
@@ -819,7 +819,7 @@ namespace trklet {
          {{2.5, 1.5, 1.5, 2.0, 2.0, 2.0, 2.0, 2.0, 99.9, 2.0, 2.0, 2.0, 2.0, 2.0, 1.5, 1.5}},          //D4 2S
          {{2.5, 1.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 99.9, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.5}}}};        //D5 2S
 
-    double FEbendcut = sqrt(1/6.0);
+    double FEbendcut = sqrt(1 / 6.0);
 
     double bendcutTE_[N_SEED_PROMPT][2] = {{2.2 * FEbendcut, 2.5 * FEbendcut},   //L1L2
                                            {2.0 * FEbendcut, 2.0 * FEbendcut},   //L2L3
@@ -1028,7 +1028,6 @@ namespace trklet {
     double stripLength_2S_{5.0250};
 
     double sensorSpacing_2S_{0.18};
-
   };
 
   constexpr unsigned int N_TILTED_RINGS = 12;  // # of tilted rings per half-layer in TBPS layers

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -456,8 +456,7 @@ namespace trklet {
     }
 
     bool useCalcBendCuts = false;
-    unsigned int nzbinsPhiCorr = 2; // 1, 2, or 13 (2 = (Flat, Tilted), 13 = (Flat, TR1, ..., TR12))
-                                    // TODO Test 13 bin version
+    unsigned int nzbinsPhiCorr = 1; // 1, 2, or 13 (2 = (Flat, Tilted), 13 = (Flat, TR1, ..., TR12)) Only marginal improvments for > 1 z bin
 
     double bendcutTE(unsigned int seed, bool inner) const { 
       if (inner){

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -64,7 +64,7 @@ namespace trklet {
     ~Settings() = default;
 
     void passSetup(const tt::Setup* setup) { setup_ = setup; }
-    const tt::Setup* setup() const {return setup_; }
+    const tt::Setup* setup() const { return setup_; }
 
     // processing & memory modules, wiring, etc.
     std::string const& fitPatternFile() const { return fitPatternFile_; }
@@ -172,8 +172,8 @@ namespace trklet {
     double zmax(unsigned int iDisk) const { return zmean(iDisk) + dzmax(); }
     double zmin(unsigned int iDisk) const { return zmean(iDisk) - dzmax(); }
 
-    double zmindisk(unsigned int iDisk) const { return zmean(iDisk) - zsepdisk_/2;}
-    double zmaxdisk(unsigned int iDisk) const { return zmean(iDisk) + zsepdisk_/2;}
+    double zmindisk(unsigned int iDisk) const { return zmean(iDisk) - zsepdisk_ / 2; }
+    double zmaxdisk(unsigned int iDisk) const { return zmean(iDisk) + zsepdisk_ / 2; }
 
     double rDSSinner(unsigned int iBin) const {
       return rDSSinner_mod_[iBin / 2] + halfstrip_ * ((iBin % 2 == 0) ? -1 : 1);
@@ -455,25 +455,23 @@ namespace trklet {
       return fact * bendcut(ibend, layerdisk, isPSmodule);
     }
 
-    bool useCalcBendCuts = false;
-    unsigned int nzbinsPhiCorr = 1; // 1, 2, or 13 (2 = (Flat, Tilted), 13 = (Flat, TR1, ..., TR12)) Only marginal improvments for > 1 z bin
+    bool useCalcBendCuts = true;
+    unsigned int nzbinsPhiCorr = 1;  // 1, 2, or 13 (2 = (Flat, Tilted), 13 = (Flat, TR1, ..., TR12))
 
-    double bendcutTE(unsigned int seed, bool inner) const { 
-      if (inner){
+    double bendcutTE(unsigned int seed, bool inner) const {
+      if (inner) {
         return bendcutTE_[seed][0];
-      } 
-      else{
+      } else {
         return bendcutTE_[seed][1];
       }
     }
 
-    double bendcutME(unsigned int layerdisk, bool isPSmodule) const { 
+    double bendcutME(unsigned int layerdisk, bool isPSmodule) const {
       if (layerdisk >= N_LAYER && (!isPSmodule))
         layerdisk += N_DISK;
 
-      return bendcutME_[layerdisk]; 
+      return bendcutME_[layerdisk];
     }
-
 
     //layers/disks used by each seed
     std::array<std::array<int, 3>, N_SEED> seedlayers() const { return seedlayers_; }
@@ -485,7 +483,6 @@ namespace trklet {
     std::array<std::array<unsigned int, N_DISK>, N_SEED> projdisks() const { return projdisks_; }
 
   private:
-
     const tt::Setup* setup_;
 
     std::string fitPatternFile_;
@@ -570,7 +567,7 @@ namespace trklet {
     double rmaxdisk_{120.0};
     double rmindisk_{20.0};
 
-    double zsepdisk_{1.5}; //cm
+    double zsepdisk_{1.5};  //cm
 
     double half2SmoduleWidth_{4.57};
 
@@ -818,34 +815,33 @@ namespace trklet {
          {{2.5, 1.5, 1.5, 2.0, 2.0, 2.0, 2.0, 2.0, 99.9, 2.0, 2.0, 2.0, 2.0, 2.0, 1.5, 1.5}},          //D4 2S
          {{2.5, 1.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 99.9, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.5}}}};        //D5 2S
 
+    double FEbendcut = 0.4;  // ~sqrt(1/6)
 
-    double FEbendcut = 0.4; // ~sqrt(1/6)
-    double bendcutTE_[N_SEED_PROMPT][2] = {{2.2*FEbendcut, 2.5*FEbendcut}, //L1L2 
-                                        {2.0*FEbendcut, 2.0*FEbendcut}, //L2L3 
-                                        {2.0*FEbendcut, 2.6*FEbendcut}, //L3L4 
-                                        {2.4*FEbendcut, 2.4*FEbendcut}, //L5L6 
-                                        {2.5*FEbendcut, 2.2*FEbendcut}, //D1D2 PS
-                                        {2.0*FEbendcut, 2.0*FEbendcut}, //D3D4 PS
-                                        {2.0*FEbendcut, 2.4*FEbendcut}, //L1D1 PS
-                                        {2.2*FEbendcut, 2.2*FEbendcut}};//L2D1 PS
- 
-    double bendcutME_[N_LAYER+2*N_DISK] = {2.0*FEbendcut, //0  L1
-                                           2.5*FEbendcut, //1  L2
-                                           2.0*FEbendcut, //2  L3
-                                           2.5*FEbendcut, //3  L4
-                                           2.2*FEbendcut, //4  L5
-                                           2.3*FEbendcut, //5  L6
-                                           4.0*FEbendcut, //6  D1 PS
-                                           3.5*FEbendcut, //7  D2 PS
-                                           3.5*FEbendcut, //8  D3 PS
-                                           3.5*FEbendcut, //9  D4 PS
-                                           2.7*FEbendcut, //10 D5 PS
-                                           3.5*FEbendcut, //11 D1 2S
-                                           3.4*FEbendcut, //12 D2 2S
-                                           3.5*FEbendcut, //13 D3 2S
-                                           3.7*FEbendcut, //14 D4 2S
-                                           3.5*FEbendcut};//15 D5 2S
+    double bendcutTE_[N_SEED_PROMPT][2] = {{2.2 * FEbendcut, 2.5 * FEbendcut},   //L1L2
+                                           {2.0 * FEbendcut, 2.0 * FEbendcut},   //L2L3
+                                           {2.0 * FEbendcut, 2.6 * FEbendcut},   //L3L4
+                                           {2.4 * FEbendcut, 2.4 * FEbendcut},   //L5L6
+                                           {2.5 * FEbendcut, 2.2 * FEbendcut},   //D1D2 PS
+                                           {2.0 * FEbendcut, 2.0 * FEbendcut},   //D3D4 PS
+                                           {2.0 * FEbendcut, 2.4 * FEbendcut},   //L1D1 PS
+                                           {2.2 * FEbendcut, 2.2 * FEbendcut}};  //L2D1 PS
 
+    double bendcutME_[N_LAYER + 2 * N_DISK] = {2.0 * FEbendcut,   //0  L1
+                                               2.5 * FEbendcut,   //1  L2
+                                               2.0 * FEbendcut,   //2  L3
+                                               2.5 * FEbendcut,   //3  L4
+                                               2.2 * FEbendcut,   //4  L5
+                                               2.3 * FEbendcut,   //5  L6
+                                               4.0 * FEbendcut,   //6  D1 PS
+                                               3.5 * FEbendcut,   //7  D2 PS
+                                               3.5 * FEbendcut,   //8  D3 PS
+                                               3.5 * FEbendcut,   //9  D4 PS
+                                               2.7 * FEbendcut,   //10 D5 PS
+                                               3.5 * FEbendcut,   //11 D1 2S
+                                               3.4 * FEbendcut,   //12 D2 2S
+                                               3.5 * FEbendcut,   //13 D3 2S
+                                               3.7 * FEbendcut,   //14 D4 2S
+                                               3.5 * FEbendcut};  //15 D5 2S
 
     // Offset to the maximum number of steps in each processing step:
     // Set to 0 (default) means standard truncation

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -13,7 +13,10 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include "L1Trigger/TrackTrigger/interface/Setup.h"
+
+namespace tt{
+  class Setup;
+}
 
 namespace trklet {
 
@@ -278,6 +281,8 @@ namespace trklet {
     void setStripPitch_PS(double stripPitch_PS) { stripPitch_PS_ = stripPitch_PS; }
     void setStripPitch_2S(double stripPitch_2S) { stripPitch_2S_ = stripPitch_2S; }
 
+    double sensorSpacing2S() const { return sensorSpacing_2S_;}
+
     double stripLength(bool isPSmodule) const { return isPSmodule ? stripLength_PS_ : stripLength_2S_; }
     void setStripLength_PS(double stripLength_PS) { stripLength_PS_ = stripLength_PS; }
     void setStripLength_2S(double stripLength_2S) { stripLength_2S_ = stripLength_2S; }
@@ -455,8 +460,7 @@ namespace trklet {
       return fact * bendcut(ibend, layerdisk, isPSmodule);
     }
 
-    bool useCalcBendCuts = false;
-    unsigned int nzbinsPhiCorr = 1;  // 1, 2, or 13 (2 = (Flat, Tilted), 13 = (Flat, TR1, ..., TR12))
+    bool useCalcBendCuts = true;
 
     double bendcutTE(unsigned int seed, bool inner) const {
       if (inner) {
@@ -815,7 +819,7 @@ namespace trklet {
          {{2.5, 1.5, 1.5, 2.0, 2.0, 2.0, 2.0, 2.0, 99.9, 2.0, 2.0, 2.0, 2.0, 2.0, 1.5, 1.5}},          //D4 2S
          {{2.5, 1.5, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 99.9, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 1.5}}}};        //D5 2S
 
-    double FEbendcut = 0.4;  // ~sqrt(1/6)
+    double FEbendcut = sqrt(1/6.0);
 
     double bendcutTE_[N_SEED_PROMPT][2] = {{2.2 * FEbendcut, 2.5 * FEbendcut},   //L1L2
                                            {2.0 * FEbendcut, 2.0 * FEbendcut},   //L2L3
@@ -1022,6 +1026,9 @@ namespace trklet {
 
     double stripLength_PS_{0.1467};
     double stripLength_2S_{5.0250};
+
+    double sensorSpacing_2S_{0.18};
+
   };
 
   constexpr unsigned int N_TILTED_RINGS = 12;  // # of tilted rings per half-layer in TBPS layers

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -455,7 +455,7 @@ namespace trklet {
       return fact * bendcut(ibend, layerdisk, isPSmodule);
     }
 
-    bool useCalcBendCuts = true;
+    bool useCalcBendCuts = false;
     unsigned int nzbinsPhiCorr = 1;  // 1, 2, or 13 (2 = (Flat, Tilted), 13 = (Flat, TR1, ..., TR12))
 
     double bendcutTE(unsigned int seed, bool inner) const {

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <string>
 
+#include "L1Trigger/TrackTrigger/interface/Setup.h"
+
 namespace trklet {
 
   class Settings;
@@ -77,12 +79,33 @@ namespace trklet {
     unsigned int size() const { return table_.size(); }
 
   private:
+    const Settings& settings_;
+    const tt::Setup* setup_;
+
+
+    //Determine bend/bend cuts in LUT regions
+    std::vector<const tt::SensorModule*> getSensorModules(unsigned int layerdisk, 
+                                                          bool isPS,
+                                                          std::array<double, 2> tan_range = {{-1,-1}},
+                                                          unsigned int nzbins = 1,
+                                                          unsigned int zbin = 0);
+
+    std::array<double, 2> getTanRange(const std::vector<const tt::SensorModule*>& sensorModules );
+
+    std::vector<double> getBendAverage(unsigned int layerdisk, 
+                                       const std::vector<const tt::SensorModule*>& sensorModules, 
+                                       bool isPS, 
+                                       std::string bend_type);
+
+    std::vector<std::array<double, 2>> getBendCut(unsigned int layerdisk, 
+                                                  const std::vector<const tt::SensorModule*>& sensorModules, 
+                                                  bool isPS, 
+                                                  double FEbendcut = 0);
+
     int getphiCorrValue(
-        unsigned int layerdisk, unsigned int ibend, unsigned int irbin, double rmean, double dr, double drmax) const;
+        unsigned int layerdisk, double bend, unsigned int irbin, double rmean, double dr, double drmax) const;
 
     int getVMRLookup(unsigned int layerdisk, double z, double r, double dz, double dr, int iseed = -1) const;
-
-    const Settings& settings_;
 
     std::string name_;
 

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
@@ -7,6 +7,8 @@
 
 #include "L1Trigger/TrackTrigger/interface/Setup.h"
 
+class Setup;
+
 namespace trklet {
 
   class Settings;

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
@@ -91,11 +91,6 @@ namespace trklet {
 
     std::array<double, 2> getTanRange(const std::vector<const tt::SensorModule*>& sensorModules);
 
-    std::vector<double> getBendAverage(unsigned int layerdisk,
-                                       const std::vector<const tt::SensorModule*>& sensorModules,
-                                       bool isPS,
-                                       std::string bend_type);
-
     std::vector<std::array<double, 2>> getBendCut(unsigned int layerdisk,
                                                   const std::vector<const tt::SensorModule*>& sensorModules,
                                                   bool isPS,

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
@@ -82,24 +82,23 @@ namespace trklet {
     const Settings& settings_;
     const tt::Setup* setup_;
 
-
     //Determine bend/bend cuts in LUT regions
-    std::vector<const tt::SensorModule*> getSensorModules(unsigned int layerdisk, 
+    std::vector<const tt::SensorModule*> getSensorModules(unsigned int layerdisk,
                                                           bool isPS,
-                                                          std::array<double, 2> tan_range = {{-1,-1}},
+                                                          std::array<double, 2> tan_range = {{-1, -1}},
                                                           unsigned int nzbins = 1,
                                                           unsigned int zbin = 0);
 
-    std::array<double, 2> getTanRange(const std::vector<const tt::SensorModule*>& sensorModules );
+    std::array<double, 2> getTanRange(const std::vector<const tt::SensorModule*>& sensorModules);
 
-    std::vector<double> getBendAverage(unsigned int layerdisk, 
-                                       const std::vector<const tt::SensorModule*>& sensorModules, 
-                                       bool isPS, 
+    std::vector<double> getBendAverage(unsigned int layerdisk,
+                                       const std::vector<const tt::SensorModule*>& sensorModules,
+                                       bool isPS,
                                        std::string bend_type);
 
-    std::vector<std::array<double, 2>> getBendCut(unsigned int layerdisk, 
-                                                  const std::vector<const tt::SensorModule*>& sensorModules, 
-                                                  bool isPS, 
+    std::vector<std::array<double, 2>> getBendCut(unsigned int layerdisk,
+                                                  const std::vector<const tt::SensorModule*>& sensorModules,
+                                                  bool isPS,
                                                   double FEbendcut = 0);
 
     int getphiCorrValue(

--- a/L1Trigger/TrackFindingTracklet/interface/Util.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Util.h
@@ -46,6 +46,24 @@ namespace trklet {
     return bend;
   }
 
+  inline double convertFEBend( double FEbend, double sensorSep, double CF, bool barrel, double r = 0){
+    double bend = 0.18*CF*FEbend/sensorSep;
+    return bend; 
+  }
+
+  inline double tan_theta( double r, double z, double z0, bool z0_max ){
+    //Calculates tan(theta) = z_displaced/r 
+    //measure tan theta at different points to account for displaced tracks 
+    double tan;
+    if (z0_max)
+      tan = (z-z0)/r;
+    else
+      tan = (z+z0)/r;
+
+    return tan;
+  }
+
+
   inline double rinv(double phi1, double phi2, double r1, double r2) {
     assert(r1 < r2);  //Can not form tracklet should not call function with r2<=r1
 

--- a/L1Trigger/TrackFindingTracklet/interface/Util.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Util.h
@@ -39,15 +39,19 @@ namespace trklet {
     return str;
   }
 
-  inline double bendstrip(double r, double rinv, double stripPitch) {
-    constexpr double dr = 0.18;
-    double delta = r * dr * 0.5 * rinv;
+  inline double bendstrip(double r, double rinv, double stripPitch, double sensorSpacing) {
+    double delta = r * sensorSpacing * 0.5 * rinv;
     double bend = delta / stripPitch;
     return bend;
   }
 
-  inline double convertFEBend(double FEbend, double sensorSep, double CF, bool barrel, double r = 0) {
-    double bend = 0.18 * CF * FEbend / sensorSep;
+  inline double convertFEBend(double FEbend, 
+                              double sensorSep, 
+                              double sensorSpacing, 
+                              double CF, 
+                              bool barrel, 
+                              double r = 0) {
+    double bend = sensorSpacing*CF*FEbend/sensorSep;
     return bend;
   }
 

--- a/L1Trigger/TrackFindingTracklet/interface/Util.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Util.h
@@ -46,23 +46,22 @@ namespace trklet {
     return bend;
   }
 
-  inline double convertFEBend( double FEbend, double sensorSep, double CF, bool barrel, double r = 0){
-    double bend = 0.18*CF*FEbend/sensorSep;
-    return bend; 
+  inline double convertFEBend(double FEbend, double sensorSep, double CF, bool barrel, double r = 0) {
+    double bend = 0.18 * CF * FEbend / sensorSep;
+    return bend;
   }
 
-  inline double tan_theta( double r, double z, double z0, bool z0_max ){
-    //Calculates tan(theta) = z_displaced/r 
-    //measure tan theta at different points to account for displaced tracks 
+  inline double tan_theta(double r, double z, double z0, bool z0_max) {
+    //Calculates tan(theta) = z_displaced/r
+    //measure tan theta at different points to account for displaced tracks
     double tan;
     if (z0_max)
-      tan = (z-z0)/r;
+      tan = (z - z0) / r;
     else
-      tan = (z+z0)/r;
+      tan = (z + z0) / r;
 
     return tan;
   }
-
 
   inline double rinv(double phi1, double phi2, double r1, double r2) {
     assert(r1 < r2);  //Can not form tracklet should not call function with r2<=r1

--- a/L1Trigger/TrackFindingTracklet/interface/Util.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Util.h
@@ -45,13 +45,9 @@ namespace trklet {
     return bend;
   }
 
-  inline double convertFEBend(double FEbend, 
-                              double sensorSep, 
-                              double sensorSpacing, 
-                              double CF, 
-                              bool barrel, 
-                              double r = 0) {
-    double bend = sensorSpacing*CF*FEbend/sensorSep;
+  inline double convertFEBend(
+      double FEbend, double sensorSep, double sensorSpacing, double CF, bool barrel, double r = 0) {
+    double bend = sensorSpacing * CF * FEbend / sensorSep;
     return bend;
   }
 

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -350,7 +350,6 @@ void L1FPGATrackProducer::beginRun(const edm::Run& run, const edm::EventSetup& i
 
   setup_ = &iSetup.getData(esGetToken_);
 
-  //getBendCut
   settings_.passSetup(setup_);
 
   setupHPH_ = &iSetup.getData(esGetTokenHPH_);

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -349,6 +349,10 @@ void L1FPGATrackProducer::beginRun(const edm::Run& run, const edm::EventSetup& i
   settings_.setBfield(mMagneticFieldStrength);
 
   setup_ = &iSetup.getData(esGetToken_);
+
+  //getBendCut
+  settings_.passSetup(setup_);
+
   setupHPH_ = &iSetup.getData(esGetTokenHPH_);
   if (trackQuality_) {
     trackQualityModel_->setHPHSetup(setupHPH_);

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -83,8 +83,26 @@ bool Sector::addStub(L1TStub stub, string dtc) {
     FPGAWord r = fpgastub.r();
     int bendbin = fpgastub.bend().value();
     int rbin = (r.value() + (1 << (r.nbits() - 1))) >> (r.nbits() - 3);
+
     const TrackletLUT& phiCorrTable = *globals_->phiCorr(layerdisk);
-    int iphicorr = phiCorrTable.lookup(bendbin * (1 << 3) + rbin);
+
+    int zbin = 0;
+
+    if (layerdisk < 3 and settings_.useCalcBendCuts ){
+      if (settings_.nzbinsPhiCorr > 1){ 
+        if (settings_.nzbinsPhiCorr == 2)
+          zbin = (stub.tiltedRingId() == 0) ? 0: 1;
+        else if (settings_.nzbinsPhiCorr == 13)
+          zbin = stub.tiltedRingId();
+      }
+    }
+    
+    int nrbits = 3;
+    int bendbits = fpgastub.bend().nbits();
+
+    int index = (zbin<<(nrbits+bendbits)) + (bendbin<<nrbits) + rbin;
+
+    int iphicorr = phiCorrTable.lookup(index);
     fpgastub.setPhiCorr(iphicorr);
   }
 

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -88,19 +88,19 @@ bool Sector::addStub(L1TStub stub, string dtc) {
 
     int zbin = 0;
 
-    if (layerdisk < 3 and settings_.useCalcBendCuts ){
-      if (settings_.nzbinsPhiCorr > 1){ 
+    if (layerdisk < 3 and settings_.useCalcBendCuts) {
+      if (settings_.nzbinsPhiCorr > 1) {
         if (settings_.nzbinsPhiCorr == 2)
-          zbin = (stub.tiltedRingId() == 0) ? 0: 1;
+          zbin = (stub.tiltedRingId() == 0) ? 0 : 1;
         else if (settings_.nzbinsPhiCorr == 13)
           zbin = stub.tiltedRingId();
       }
     }
-    
+
     int nrbits = 3;
     int bendbits = fpgastub.bend().nbits();
 
-    int index = (zbin<<(nrbits+bendbits)) + (bendbin<<nrbits) + rbin;
+    int index = (zbin << (nrbits + bendbits)) + (bendbin << nrbits) + rbin;
 
     int iphicorr = phiCorrTable.lookup(index);
     fpgastub.setPhiCorr(iphicorr);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngine.cc
@@ -104,7 +104,7 @@ void TrackletEngine::execute() {
 
         if (iSeed_ >= 4) {  //Also use r-position
           int ir = ((ibin & 3) << 1) + (rzbin >> 2);
-          index = (index << 3) + ir;
+          index += (ir << (outerphibits_ + innerphibits_));
         }
 
         if (start != ibin)

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngine.cc
@@ -95,7 +95,7 @@ void TrackletEngine::execute() {
         countall++;
         const VMStubTE& outervmstub = outervmstubs_->getVMStubTEBinned(ibin, j);
 
-        int rzbin = outervmstub.vmbits().bits(0, 3);
+        int rzbin = outervmstub.vmbits().bits(0, N_RZBITS);
 
         FPGAWord iphiinnerbin = innervmstub.finephi();
         FPGAWord iphiouterbin = outervmstub.finephi();
@@ -103,12 +103,16 @@ void TrackletEngine::execute() {
         unsigned int index = (iphiinnerbin.value() << outerphibits_) + iphiouterbin.value();
 
         if (iSeed_ >= 4) {  //Also use r-position
-          int ir = ((ibin & 3) << 1) + (rzbin >> 2);
+  
+          int nrbits = 3; // Number of bits used for r position in disk LUT
+          int ibinmask = (1 << (nrbits-1)) - 1; // Mask of two least significant bits
+
+          int ir = ((ibin & ibinmask) << 1 ) + (rzbin >> (N_RZBITS-1));
           index += (ir << (outerphibits_ + innerphibits_));
         }
 
         if (start != ibin)
-          rzbin += 8;
+          rzbin += (1 << N_RZBITS);
         if ((rzbin < rzbinfirst) || (rzbin - rzbinfirst > rzdiffmax)) {
           continue;
         }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngine.cc
@@ -103,11 +103,11 @@ void TrackletEngine::execute() {
         unsigned int index = (iphiinnerbin.value() << outerphibits_) + iphiouterbin.value();
 
         if (iSeed_ >= 4) {  //Also use r-position
-  
-          int nrbits = 3; // Number of bits used for r position in disk LUT
-          int ibinmask = (1 << (nrbits-1)) - 1; // Mask of two least significant bits
 
-          int ir = ((ibin & ibinmask) << 1 ) + (rzbin >> (N_RZBITS-1));
+          int nrbits = 3;                          // Number of bits used for r position in disk LUT
+          int ibinmask = (1 << (nrbits - 1)) - 1;  // Mask of two least significant bits
+
+          int ir = ((ibin & ibinmask) << 1) + (rzbin >> (N_RZBITS - 1));
           index += (ir << (outerphibits_ + innerphibits_));
         }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -63,8 +63,7 @@ std::vector<const tt::SensorModule*> TrackletLUT::getSensorModules(
         if (sm.ringId(setup_) == zbin)
           sensorModules.push_back(&sm);
       } else {
-        edm::LogVerbatim("Tracklet") << "Unspecified number of z bins";
-        throw exception();
+        throw cms::Exception("Unspecified number of z bins");
       }
     } else {
       sensorModules.push_back(&sm);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -8,7 +8,187 @@
 using namespace std;
 using namespace trklet;
 
-TrackletLUT::TrackletLUT(const Settings& settings) : settings_(settings) {}
+TrackletLUT::TrackletLUT(const Settings& settings) : settings_(settings), setup_(settings.setup()) {}
+
+
+std::vector<const tt::SensorModule*> TrackletLUT::getSensorModules(unsigned int layerdisk, 
+                                                                   bool isPS,
+                                                                   std::array<double, 2> tan_range,
+                                                                   unsigned int nzbins,
+                                                                   unsigned int zbin){ 
+  
+  //Returns a vector of SensorModules using T. Schuh's Setup and SensorModule classes.
+  //Can be used 3 ways:
+  //Default: No specified tan_range or nzbins, returns all SensorModules in specified layerdisk (unique in |z|)
+  //tan_range: Returns modules in given tan range, where the min and max tan(theta) are measured from 0 -/+ z0 to account for displaced tracks
+  //zbins: Returns modules in specified z bin (2 zbins = (Flat, Tilted), 13 zbins = (Flat, TR1, ..., TR12). Only for tilted barrel
+
+  bool use_tan_range = !(tan_range[0] == -1 and tan_range[1] == -1);
+  bool use_zbins = (nzbins > 1);
+
+  bool barrel = layerdisk < N_LAYER;
+
+  int layerId = barrel? layerdisk+1: layerdisk+N_LAYER-1; 
+
+  std::vector<const tt::SensorModule*> sensorModules;
+
+  double z0 = settings_.z0cut();
+
+  for (auto& sm : setup_->sensorModules()){
+    if (sm.layerId() != layerId || sm.z() < 0 || sm.psModule() != isPS){
+      continue;
+    }
+    
+    if (use_tan_range){
+      double rmin = sm.r() - (sm.numColumns()/2 - 0.5)*sm.pitchCol()*std::abs(sm.sinTilt());
+      double rmax = sm.r() + (sm.numColumns()/2 - 0.5)*sm.pitchCol()*std::abs(sm.sinTilt());
+
+      double zmin = std::abs(sm.z()) - (sm.numColumns()/2 - 0.5)*sm.pitchCol()*std::abs(sm.cosTilt()); 
+      double zmax = std::abs(sm.z()) + (sm.numColumns()/2 - 0.5)*sm.pitchCol()*std::abs(sm.cosTilt());
+
+      double mod_tan_max = tan_theta(rmin, zmax, z0, false); //z0_max is swapped here so that the comparison down 4 lines is from same origin (+/- z0)
+
+      double mod_tan_min = tan_theta(rmax, zmin, z0, true);
+
+      if ( mod_tan_max >= tan_range[0] && mod_tan_min <= tan_range[1] ){
+        sensorModules.push_back(&sm);    
+      }
+    } else if (use_zbins){
+      assert(layerdisk<3);
+
+      if (nzbins == 2){ 
+        bool useFlat = (zbin == 0);
+        bool isFlat = (sm.tilt() == 0);
+
+        if (useFlat and isFlat)
+          sensorModules.push_back(&sm);
+        else if (!useFlat and !isFlat)
+          sensorModules.push_back(&sm);
+      } else if (nzbins == 13){ 
+        if (sm.ringId(setup_) == zbin)
+          sensorModules.push_back(&sm);    
+      } else {
+        edm::LogVerbatim("Tracklet") << "Unspecified number of z bins";
+        throw exception();
+      }
+    } else {
+      sensorModules.push_back(&sm);
+    } 
+  }
+
+  //Remove Duplicate Modules
+  static constexpr double delta = 1.e-3;
+  auto smallerR = [](const tt::SensorModule* lhs, const tt::SensorModule* rhs) { return lhs->r() < rhs->r(); };
+  auto smallerZ = [](const tt::SensorModule* lhs, const tt::SensorModule* rhs) { return lhs->z() < rhs->z(); };
+  auto equalRZ  = [](const tt::SensorModule* lhs, const tt::SensorModule* rhs) {
+    return abs(lhs->r() - rhs->r()) < delta && abs(lhs->z() - rhs->z()) < delta;
+  };
+  stable_sort(sensorModules.begin(), sensorModules.end(), smallerR);
+  stable_sort(sensorModules.begin(), sensorModules.end(), smallerZ);
+  sensorModules.erase(unique(sensorModules.begin(), sensorModules.end(), equalRZ), sensorModules.end());
+
+  return sensorModules;
+}
+
+std::array<double, 2> TrackletLUT::getTanRange( const std::vector<const tt::SensorModule*>& sensorModules ){ 
+  //Given a set of modules returns a range in tan(theta), the angle is measured in the r-z(+/-z0) plane from the r-axis 
+
+  std::array<double, 2> tan_range = {{2147483647, 0}}; //(tan_min, tan_max)
+
+  double z0 = settings_.z0cut();
+
+  for (auto sm : sensorModules){
+
+    double rmin = sm->r() - (sm->numColumns()/2 - 0.5)*sm->pitchCol()*std::abs(sm->sinTilt());
+    double rmax = sm->r() + (sm->numColumns()/2 - 0.5)*sm->pitchCol()*std::abs(sm->sinTilt());
+
+    double zmin = std::abs(sm->z()) - (sm->numColumns()/2 - 0.5)*sm->pitchCol()*sm->cosTilt(); 
+    double zmax = std::abs(sm->z()) + (sm->numColumns()/2 - 0.5)*sm->pitchCol()*sm->cosTilt();
+
+    double mod_tan_max = tan_theta(rmin, zmax, z0, true); //(r, z, z0, bool z0_max), z0_max measures from +/- z0
+    double mod_tan_min = tan_theta(rmax, zmin, z0, false);
+
+    if (mod_tan_min < tan_range[0])
+      tan_range[0] = mod_tan_min;
+    if (mod_tan_max > tan_range[1])
+      tan_range[1] = mod_tan_max;
+  }
+  return tan_range;
+}
+
+std::vector<std::array<double, 2>> TrackletLUT::getBendCut(unsigned int layerdisk, 
+                                                           const std::vector<const tt::SensorModule*>& sensorModules, 
+                                                           bool isPS, 
+                                                           double FEbendcut){
+  //Finds range of bendstrip for given SensorModules as a function of the encoded bend. Returns in format (mid, half_range).
+  //This uses the stub windows provided by T. Schuh's SensorModule class to determine the bend encoding. TODO test changes in stub windows
+  //Any other change to the bend encoding requires changes here, perhaps a function that given (FEbend, isPS, stub window) and outputs an encoded bend
+  //would be useful for consistency.
+
+  unsigned int bendbits = isPS ? 3 : 4;
+
+  std::vector<std::array<double, 2>>  bendpars; // mid, cut
+  std::vector<std::array<double, 2>>  bendminmax; // min, max
+
+  //Initialize array
+  for (int i=0; i<1<<bendbits; i++){
+    bendpars.push_back({{99,0}});
+    bendminmax.push_back({{99,-99}});
+  }
+
+  //Loop over modules
+  for (auto sm : sensorModules){
+    int window = sm->windowSize() ; //Half-strip units 
+    const vector<double>& encodingBend = setup_->encodingBend(window, isPS);
+
+    //Loop over FEbends
+    for ( int ibend = 0; ibend <= 2*window; ibend++){ 
+      int FEbend = ibend - window; //Half-strip units
+      double BEbend = setup_->stubAlgorithm()->degradeBend( isPS, window, FEbend) ; //Full strip units
+
+      const auto pos = std::find(encodingBend.begin(), encodingBend.end(), std::abs(BEbend));
+      int bend = std::signbit(BEbend) ? (1<<bendbits) - distance(encodingBend.begin(),pos) : distance(encodingBend.begin(),pos); //Encoded bend
+
+      double bendmin = FEbend/2.0 - FEbendcut; //Full Strip units
+      double bendmax = FEbend/2.0 + FEbendcut;
+
+      //Convert to bendstrip, calculate at module edges (z min, r max) and  (z max, r min)
+      vector<double> z_mod;
+  
+      z_mod.push_back( std::abs(sm->z()) + (sm->numColumns()/2 - 0.5)*sm->pitchCol()*sm->cosTilt()); //z max
+      z_mod.push_back( std::abs(sm->z()) - (sm->numColumns()/2 - 0.5)*sm->pitchCol()*sm->cosTilt()); //z min
+
+      vector<double> r_mod;
+      
+      r_mod.push_back( sm->r() - (sm->numColumns()/2 - 0.5)*sm->pitchCol()*std::abs(sm->sinTilt())); //r min    
+      r_mod.push_back( sm->r() + (sm->numColumns()/2 - 0.5)*sm->pitchCol()*std::abs(sm->sinTilt())); //r max
+
+      for (int i = 0; i < 2; i++){ // 2 points to cover range in tan(theta) = z/r
+        double CF = std::abs(sm->sinTilt())*( z_mod[i] /r_mod[i]) + sm->cosTilt();
+
+        double cbendmin = convertFEBend(bendmin, sm->sep(), CF, (layerdisk < N_LAYER), r_mod[i]);
+        double cbendmax = convertFEBend(bendmax, sm->sep(), CF, (layerdisk < N_LAYER), r_mod[i]);
+
+        if (cbendmin < bendminmax[bend][0])
+          bendminmax.at(bend)[0] = cbendmin;
+        if (cbendmax > bendminmax[bend][1])
+          bendminmax.at(bend)[1] = cbendmax;
+      }
+    }
+  }
+  //Convert min, max to mid, cut for ease of use
+  for (int i=0; i<1<<bendbits; i++){
+    double mid = (bendminmax[i][1] + bendminmax[i][0])/2;
+    double cut = (bendminmax[i][1] - bendminmax[i][0])/2;
+
+    bendpars[i][0] = mid;
+    bendpars[i][1] = cut;
+  }
+
+  return bendpars;
+}
+
+
 
 void TrackletLUT::initmatchcut(unsigned int layerdisk, MatchType type, unsigned int region) {
   char cregion = 'A' + region;
@@ -273,36 +453,98 @@ void TrackletLUT::initteptlut(bool fillInner,
     nbendbitsouter = 4;
   }
 
+  bool isPSinner = nbendbitsinner == 3;
+  bool isPSouter = nbendbitsouter == 3;
+
   if (fillTEMem) {
     if (fillInner) {
       table_.resize((1 << nbendbitsinner), false);
     } else {
-      table_.resize((1 << nbendbitsouter), false);
+      table_.resize((1 << nbendbitsouter ), false);
     }
   }
 
-  for (int iphiinnerbin = 0; iphiinnerbin < innerphibins; iphiinnerbin++) {
-    phiinner[0] = innerphimin + iphiinnerbin * (innerphimax - innerphimin) / innerphibins;
-    phiinner[1] = innerphimin + (iphiinnerbin + 1) * (innerphimax - innerphimin) / innerphibins;
-    for (int iphiouterbin = 0; iphiouterbin < outerphibins; iphiouterbin++) {
-      phiouter[0] = outerphimin + iphiouterbin * (outerphimax - outerphimin) / outerphibins;
-      phiouter[1] = outerphimin + (iphiouterbin + 1) * (outerphimax - outerphimin) / outerphibins;
-      for (int irouterbin = 0; irouterbin < outerrbins; irouterbin++) {
-        if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4 || iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
-          router[0] =
-              settings_.rmindiskvm() + irouterbin * (settings_.rmaxdiskvm() - settings_.rmindiskvm()) / outerrbins;
-          router[1] = settings_.rmindiskvm() +
-                      (irouterbin + 1) * (settings_.rmaxdiskvm() - settings_.rmindiskvm()) / outerrbins;
-        } else {
-          router[0] = settings_.rmean(layerdisk2);
-          router[1] = settings_.rmean(layerdisk2);
-        }
+  double z0 = settings_.z0cut();
+
+  for (int irouterbin = 0; irouterbin < outerrbins; irouterbin++) {
+    if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4 || iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
+      router[0] = settings_.rmindiskvm() + irouterbin *      (settings_.rmaxdiskvm() - settings_.rmindiskvm()) / outerrbins;
+      router[1] = settings_.rmindiskvm() +(irouterbin + 1) * (settings_.rmaxdiskvm() - settings_.rmindiskvm()) / outerrbins;
+    } else {
+      router[0] = settings_.rmean(layerdisk2);
+      router[1] = settings_.rmean(layerdisk2);
+    }
+
+    //Determine bend cuts using geometry
+    std::vector<std::array<double, 2>> bend_cuts_inner;
+    std::vector<std::array<double, 2>> bend_cuts_outer;
+
+    //Find all rings in LUT r/z bin
+    if (settings_.useCalcBendCuts){
+      std::vector<const tt::SensorModule*> sminner; 
+      std::vector<const tt::SensorModule*> smouter;
+
+      if (iSeed == Seed::L1L2 || iSeed == Seed::L2L3 || iSeed == Seed::L3L4 || iSeed == Seed::L5L6){
+
+        double outer_tan_max = tan_theta(settings_.rmean(layerdisk2), settings_.zlength(), z0, true);
+        std::array<double, 2> tan_range = {{0, outer_tan_max}};
+
+        smouter = getSensorModules( layerdisk2, isPSouter, tan_range);
+        sminner = getSensorModules( layerdisk1, isPSinner, tan_range); 
+
+      } else if (iSeed == Seed::L1D1 || iSeed == Seed::L2D1){
+
+        double outer_tan_min = tan_theta(router[1], settings_.zmindisk(layerdisk2-N_LAYER), z0, false);
+        double outer_tan_max = tan_theta(router[0], settings_.zmaxdisk(layerdisk2-N_LAYER), z0, true);
+
+        smouter = getSensorModules( layerdisk2, isPSouter, {{outer_tan_min, outer_tan_max}});
+        std::array<double, 2> tan_range = getTanRange(smouter);
+        sminner = getSensorModules( layerdisk1, isPSinner, tan_range); 
+
+      } else{ // D1D2 D3D4
+
+        double outer_tan_min = tan_theta(router[1], settings_.zmindisk(layerdisk2-N_LAYER), z0, false);
+        double outer_tan_max = tan_theta(router[0], settings_.zmaxdisk(layerdisk2-N_LAYER), z0, true);
+
+      
+        smouter = getSensorModules( layerdisk2, isPSouter, {{outer_tan_min, outer_tan_max}});
+
+        std::array<double, 2> tan_range = getTanRange(smouter);
+        sminner = getSensorModules( layerdisk1, isPSinner, tan_range);
+      }
+
+      bend_cuts_inner = getBendCut(layerdisk1, sminner, isPSinner, settings_.bendcutTE(iSeed, true));
+      bend_cuts_outer = getBendCut(layerdisk2, smouter, isPSouter, settings_.bendcutTE(iSeed, false));
+    
+    } else {
+      for (int ibend = 0; ibend < (1 << nbendbitsinner); ibend++) {
+        double mid = settings_.benddecode(ibend, layerdisk1, nbendbitsinner == 3);
+        double cut = settings_.bendcutte( ibend, layerdisk1, nbendbitsinner == 3);
+        bend_cuts_inner.push_back({{mid, cut}}); 
+      }
+      for (int ibend = 0; ibend < (1 << nbendbitsouter); ibend++) {
+        double mid = settings_.benddecode(ibend, layerdisk2, nbendbitsouter == 3);
+        double cut = settings_.bendcutte( ibend, layerdisk2, nbendbitsouter == 3);
+        bend_cuts_outer.push_back({{mid, cut}}); 
+      }
+    }
+
+
+    for (int iphiinnerbin = 0; iphiinnerbin < innerphibins; iphiinnerbin++) {
+      phiinner[0] = innerphimin + iphiinnerbin * (innerphimax - innerphimin) / innerphibins;
+      phiinner[1] = innerphimin + (iphiinnerbin + 1) * (innerphimax - innerphimin) / innerphibins;
+      for (int iphiouterbin = 0; iphiouterbin < outerphibins; iphiouterbin++) {
+        phiouter[0] = outerphimin + iphiouterbin * (outerphimax - outerphimin) / outerphibins;
+        phiouter[1] = outerphimin + (iphiouterbin + 1) * (outerphimax - outerphimin) / outerphibins;
 
         double bendinnermin = 20.0;
         double bendinnermax = -20.0;
         double bendoutermin = 20.0;
         double bendoutermax = -20.0;
         double rinvmin = 1.0;
+        double rinvmax = -1.0;
+        double absrinvmin = 1.0;
+
         for (int i1 = 0; i1 < 2; i1++) {
           for (int i2 = 0; i2 < 2; i2++) {
             for (int i3 = 0; i3 < 2; i3++) {
@@ -312,13 +554,21 @@ void TrackletLUT::initteptlut(bool fillInner,
               } else {
                 rinner = settings_.rmean(layerdisk1);
               }
+
+              if (settings_.useCalcBendCuts){
+                if (rinner >= router[i3])
+                  continue;
+              }
+
               double rinv1 = (rinner < router[i3]) ? -rinv(phiinner[i1], phiouter[i2], rinner, router[i3]) : -20.0;
               double pitchinner =
                   (rinner < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
               double pitchouter =
                   (router[i3] < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
+
               double abendinner = bendstrip(rinner, rinv1, pitchinner);
               double abendouter = bendstrip(router[i3], rinv1, pitchouter);
+
               if (abendinner < bendinnermin)
                 bendinnermin = abendinner;
               if (abendinner > bendinnermax)
@@ -327,40 +577,63 @@ void TrackletLUT::initteptlut(bool fillInner,
                 bendoutermin = abendouter;
               if (abendouter > bendoutermax)
                 bendoutermax = abendouter;
-              if (std::abs(rinv1) < rinvmin) {
-                rinvmin = std::abs(rinv1);
-              }
+              if (std::abs(rinv1) < absrinvmin)
+                absrinvmin = std::abs(rinv1);
+              if (rinv1 > rinvmax)
+                rinvmax = rinv1;
+              if (rinv1 < rinvmin)
+                rinvmin = rinv1; 
             }
           }
         }
 
-        bool passptcut = rinvmin < settings_.rinvcutte();
+        double lowrinvcutte = 0.002;
+
+        bool passptcut;
+        double bendfac;
+
+        if (settings_.useCalcBendCuts){
+          passptcut = rinvmin < settings_.rinvcutte() and rinvmax > -settings_.rinvcutte();
+          bendfac = (rinvmin < lowrinvcutte and rinvmax > -lowrinvcutte) ? 1.05 : 1.0; // Better acceptance for high pt
+        } else {
+          passptcut = absrinvmin < settings_.rinvcutte();
+          bendfac = 1.0;
+        }
 
         if (fillInner) {
           for (int ibend = 0; ibend < (1 << nbendbitsinner); ibend++) {
-            double bend = settings_.benddecode(ibend, layerdisk1, nbendbitsinner == 3);
 
-            bool passinner = bend > bendinnermin - settings_.bendcutte(ibend, layerdisk1, nbendbitsinner == 3) &&
-                             bend < bendinnermax + settings_.bendcutte(ibend, layerdisk1, nbendbitsinner == 3);
+            double bendminfac = (isPSinner and (ibend == 2 or ibend == 3)) ? bendfac: 1.0;
+            double bendmaxfac = (isPSinner and (ibend == 6 or ibend == 5)) ? bendfac: 1.0;
+
+            double mid = bend_cuts_inner.at(ibend)[0]; 
+            double cut = bend_cuts_inner.at(ibend)[1];
+
+            bool passinner = mid + cut*bendmaxfac  > bendinnermin &&
+                             mid - cut*bendminfac  < bendinnermax ;
 
             if (fillTEMem) {
-              if (passinner) {
+              if (passinner)        
                 table_[ibend] = 1;
-              }
             } else {
               table_.push_back(passinner && passptcut);
             }
           }
         } else {
           for (int ibend = 0; ibend < (1 << nbendbitsouter); ibend++) {
-            double bend = settings_.benddecode(ibend, layerdisk2, nbendbitsouter == 3);
 
-            bool passouter = bend > bendoutermin - settings_.bendcutte(ibend, layerdisk2, nbendbitsouter == 3) &&
-                             bend < bendoutermax + settings_.bendcutte(ibend, layerdisk2, nbendbitsouter == 3);
+            double bendminfac = (isPSouter and (ibend == 2 or ibend == 3)) ? bendfac: 1.0;
+            double bendmaxfac = (isPSouter and (ibend == 6 or ibend == 5)) ? bendfac: 1.0;
+
+            double mid = bend_cuts_outer.at(ibend)[0];
+            double cut = bend_cuts_outer.at(ibend)[1];
+          
+            bool passouter = mid + cut*bendmaxfac  > bendoutermin &&
+                             mid - cut*bendminfac  < bendoutermax ;
+
             if (fillTEMem) {
-              if (passouter) {
+              if (passouter)
                 table_[ibend] = 1;
-              }
             } else {
               table_.push_back(passouter && passptcut);
             }
@@ -386,9 +659,9 @@ void TrackletLUT::initteptlut(bool fillInner,
       name_ += "_stubptoutercut.tab";
     }
   }
-
   writeTable();
 }
+
 
 void TrackletLUT::initProjectionBend(double k_phider,
                                      unsigned int idisk,
@@ -447,36 +720,92 @@ void TrackletLUT::initBendMatch(unsigned int layerdisk) {
   double rinvhalf = 0.5 * ((1 << nrinv) - 1);
 
   bool barrel = layerdisk < N_LAYER;
-  bool isPSmodule = layerdisk < N_PSLAYER;
-  double stripPitch = settings_.stripPitch(isPSmodule);
 
   if (barrel) {
+    bool isPSmodule = layerdisk < N_PSLAYER;
+    double stripPitch = settings_.stripPitch(isPSmodule); 
     unsigned int nbits = isPSmodule ? N_BENDBITS_PS : N_BENDBITS_2S;
+
+    std::vector<std::array<double, 2>> bend_cuts;
+
+    if (settings_.useCalcBendCuts){
+      double bendcutFE = settings_.bendcutME(layerdisk, isPSmodule);
+      std::vector<const tt::SensorModule*> sm = getSensorModules( layerdisk, isPSmodule);
+      bend_cuts = getBendCut(layerdisk, sm, isPSmodule, bendcutFE);
+ 
+    } else {
+      for (unsigned int ibend = 0; ibend < (1u << nbits); ibend++) {
+        double mid = settings_.benddecode(ibend, layerdisk, isPSmodule);
+        double cut = settings_.bendcutte( ibend, layerdisk, isPSmodule);
+        bend_cuts.push_back({{mid, cut}}); 
+      }
+    }
 
     for (unsigned int irinv = 0; irinv < (1u << nrinv); irinv++) {
       double rinv = (irinv - rinvhalf) * (1 << (settings_.nbitsrinv() - nrinv)) * settings_.krinvpars();
 
       double projbend = bendstrip(settings_.rmean(layerdisk), rinv, stripPitch);
       for (unsigned int ibend = 0; ibend < (1u << nbits); ibend++) {
-        double stubbend = settings_.benddecode(ibend, layerdisk, isPSmodule);
-        bool pass = std::abs(stubbend - projbend) < settings_.bendcutme(ibend, layerdisk, isPSmodule);
+
+        double mid = bend_cuts[ibend][0];
+        double cut = bend_cuts[ibend][1];
+
+        double pass = mid + cut  > projbend &&
+                      mid - cut  < projbend;
+
         table_.push_back(pass);
       }
     }
   } else {
+    std::vector<std::array<double, 2>> bend_cuts_2S;
+    std::vector<std::array<double, 2>> bend_cuts_PS;   
+
+    if (settings_.useCalcBendCuts){
+      double bendcutFE2S = settings_.bendcutME(layerdisk, false);
+      std::vector<const tt::SensorModule*> sm2S = getSensorModules( layerdisk, false);
+      bend_cuts_2S = getBendCut(layerdisk, sm2S, false, bendcutFE2S); 
+
+      double bendcutFEPS = settings_.bendcutME(layerdisk, true);
+      std::vector<const tt::SensorModule*> smPS = getSensorModules( layerdisk, true);
+      bend_cuts_PS = getBendCut(layerdisk, smPS, true , bendcutFEPS);
+
+    } else {
+      for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_2S); ibend++) {
+        double mid = settings_.benddecode(ibend, layerdisk, false);
+        double cut = settings_.bendcutme( ibend, layerdisk, false);
+        bend_cuts_2S.push_back({{mid, cut}}); 
+      }
+      for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_PS); ibend++) {
+        double mid = settings_.benddecode(ibend, layerdisk, true);
+        double cut = settings_.bendcutme( ibend, layerdisk, true);
+        bend_cuts_PS.push_back({{mid, cut}}); 
+      }
+    }
+
+
     for (unsigned int iprojbend = 0; iprojbend < (1u << nrinv); iprojbend++) {
       double projbend = 0.5 * (iprojbend - rinvhalf);
       for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_2S); ibend++) {
-        double stubbend = settings_.benddecode(ibend, layerdisk, false);
-        bool pass = std::abs(stubbend - projbend) < settings_.bendcutme(ibend, layerdisk, false);
+
+        double mid = bend_cuts_2S[ibend][0];
+        double cut = bend_cuts_2S[ibend][1];
+
+        double pass = mid + cut  > projbend &&
+                      mid - cut  < projbend;
+
         table_.push_back(pass);
       }
     }
-    for (unsigned int iprojbend = 0; iprojbend < (1u << nrinv); iprojbend++) {
+    for (unsigned int iprojbend = 0; iprojbend < (1u << nrinv); iprojbend++) { //Should this be binned in r?
       double projbend = 0.5 * (iprojbend - rinvhalf);
       for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_PS); ibend++) {
-        double stubbend = settings_.benddecode(ibend, layerdisk, true);
-        bool pass = std::abs(stubbend - projbend) < settings_.bendcutme(ibend, layerdisk, true);
+
+        double mid = bend_cuts_PS[ibend][0];
+        double cut = bend_cuts_PS[ibend][1];
+
+        double pass = mid + cut  > projbend &&
+                      mid - cut  < projbend;
+
         table_.push_back(pass);
       }
     }
@@ -834,15 +1163,34 @@ void TrackletLUT::initPhiCorrTable(unsigned int layerdisk, unsigned int rbits) {
 
   double dr = 2.0 * drmax / rbins;
 
-  unsigned int bendbins = (1 << bendbits);
+  unsigned int zbins = (settings_.useCalcBendCuts and layerdisk<3) ? settings_.nzbinsPhiCorr: 1;
 
-  for (unsigned int ibend = 0; ibend < bendbins; ibend++) {
-    for (unsigned int irbin = 0; irbin < rbins; irbin++) {
-      int value = getphiCorrValue(layerdisk, ibend, irbin, rmean, dr, drmax);
-      table_.push_back(value);
+  for (unsigned int izbin = 0; izbin < zbins; izbin++){
+    std::vector<std::array<double, 2>> bend_vals;
+
+    if (settings_.useCalcBendCuts){
+      std::vector<const tt::SensorModule*> sm;
+      if (layerdisk < 3)
+        sm = getSensorModules(layerdisk, psmodule, {{-1,-1}}, settings_.nzbinsPhiCorr, izbin);
+      else
+        sm = getSensorModules(layerdisk, psmodule);
+
+      bend_vals = getBendCut(layerdisk, sm, psmodule);
+
+    } else {
+      for (int ibend = 0; ibend < 1<<bendbits; ibend++) {
+        bend_vals.push_back({{settings_.benddecode(ibend, layerdisk, layerdisk < N_PSLAYER), 0}});
+      }
+    }
+
+    for (int ibend = 0; ibend < 1<<bendbits; ibend++) {
+      for (unsigned int irbin = 0; irbin < rbins; irbin++) {
+        double bend = -bend_vals[ibend][0];
+        int value = getphiCorrValue(layerdisk, bend, irbin, rmean, dr, drmax);
+        table_.push_back(value);
+      }
     }
   }
-
   name_ = "VMPhiCorrL" + std::to_string(layerdisk + 1) + ".tab";
   nbits_ = 14;
   positive_ = false;
@@ -851,10 +1199,9 @@ void TrackletLUT::initPhiCorrTable(unsigned int layerdisk, unsigned int rbits) {
 }
 
 int TrackletLUT::getphiCorrValue(
-    unsigned int layerdisk, unsigned int ibend, unsigned int irbin, double rmean, double dr, double drmax) const {
-  bool psmodule = layerdisk < N_PSLAYER;
+    unsigned int layerdisk, double bend, unsigned int irbin, double rmean, double dr, double drmax) const {
 
-  double bend = -settings_.benddecode(ibend, layerdisk, psmodule);
+  bool psmodule = layerdisk < N_PSLAYER;
 
   //for the rbin - calculate the distance to the nominal layer radius
   double Delta = (irbin + 0.5) * dr - drmax;

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -160,10 +160,10 @@ std::vector<std::array<double, 2>> TrackletLUT::getBendCut(unsigned int layerdis
       for (int i = 0; i < 2; i++) {  // 2 points to cover range in tan(theta) = z/r
         double CF = std::abs(sm->sinTilt()) * (z_mod[i] / r_mod[i]) + sm->cosTilt();
 
-        double cbendmin = convertFEBend(bendmin, sm->sep(), settings_.sensorSpacing2S(), 
-                                        CF, (layerdisk < N_LAYER), r_mod[i]);
-        double cbendmax = convertFEBend(bendmax, sm->sep(), settings_.sensorSpacing2S(), 
-                                        CF, (layerdisk < N_LAYER), r_mod[i]);
+        double cbendmin =
+            convertFEBend(bendmin, sm->sep(), settings_.sensorSpacing2S(), CF, (layerdisk < N_LAYER), r_mod[i]);
+        double cbendmax =
+            convertFEBend(bendmax, sm->sep(), settings_.sensorSpacing2S(), CF, (layerdisk < N_LAYER), r_mod[i]);
 
         if (cbendmin < bendminmax[bend][0])
           bendminmax.at(bend)[0] = cbendmin;
@@ -263,7 +263,7 @@ void TrackletLUT::initTPlut(bool fillInner,
     isPSouter = false;
   } else if (iSeed == Seed::L5L6) {
     isPSinner = false;
-    isPSouter = false;   
+    isPSouter = false;
   } else {
     isPSinner = true;
     isPSouter = true;
@@ -393,9 +393,12 @@ void TrackletLUT::initTPlut(bool fillInner,
       double rinvcutte = settings_.rinvcutte();
 
       if (settings_.useCalcBendCuts) {
-        double lowrinvcutte = rinvcutte/3; //Somewhat arbitrary value, allows for better acceptance in bins with low rinv (high pt)
+        double lowrinvcutte =
+            rinvcutte / 3;  //Somewhat arbitrary value, allows for better acceptance in bins with low rinv (high pt)
         passptcut = rinvmin < rinvcutte and rinvmax > -rinvcutte;
-        bendfac = (rinvmin < lowrinvcutte and rinvmax > -lowrinvcutte) ? 1.05 : 1.0;  //Somewhat arbirary value, bend cuts are 5% larger in bins with low rinv (high pt)
+        bendfac = (rinvmin < lowrinvcutte and rinvmax > -lowrinvcutte)
+                      ? 1.05
+                      : 1.0;  //Somewhat arbirary value, bend cuts are 5% larger in bins with low rinv (high pt)
       } else {
         passptcut = absrinvmin < rinvcutte;
         bendfac = 1.0;
@@ -534,7 +537,7 @@ void TrackletLUT::initteptlut(bool fillInner,
     isPSouter = false;
   } else if (iSeed == Seed::L5L6) {
     isPSinner = false;
-    isPSouter = false;   
+    isPSouter = false;
   } else {
     isPSinner = true;
     isPSouter = true;

--- a/L1Trigger/TrackTrigger/interface/SensorModule.h
+++ b/L1Trigger/TrackTrigger/interface/SensorModule.h
@@ -69,6 +69,8 @@ namespace tt {
     int windowSize() const { return windowSize_; }
     //
     double tiltCorrection(double cot) const { return abs(tiltCorrectionSlope_ * cot) + tiltCorrectionIntercept_; }
+  
+    unsigned int ringId(const Setup* setup) const;
 
   private:
     enum TypeTilt { nonBarrel = 0, tiltedMinus = 1, tiltedPlus = 2, flat = 3 };

--- a/L1Trigger/TrackTrigger/interface/SensorModule.h
+++ b/L1Trigger/TrackTrigger/interface/SensorModule.h
@@ -69,7 +69,7 @@ namespace tt {
     int windowSize() const { return windowSize_; }
     //
     double tiltCorrection(double cot) const { return abs(tiltCorrectionSlope_ * cot) + tiltCorrectionIntercept_; }
-  
+
     unsigned int ringId(const Setup* setup) const;
 
   private:

--- a/L1Trigger/TrackTrigger/interface/Setup.h
+++ b/L1Trigger/TrackTrigger/interface/Setup.h
@@ -510,6 +510,9 @@ namespace tt {
     // internal memory depth
     int drDepthMemory() const { return drDepthMemory_; }
 
+    //getBendCut
+    const StubAlgorithmOfficial* stubAlgorithm() const { return stubAlgorithm_; }
+
   private:
     // checks consitency between history and current configuration for a specific module
     void checkHistory(const edm::ProcessHistory&,

--- a/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
@@ -19,21 +19,35 @@ TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_of
    #Number of tilted rings per side in barrel layers (for tilted geom only)
    NTiltedRings = cms.vdouble( 0., 12., 12., 12., 0., 0., 0.), 
    # PU200 tight tuning, optimized for muons
-   BarrelCut    = cms.vdouble( 0, 2, 2.5, 3.5, 4.5, 5.5, 7),
-   TiltedBarrelCutSet = cms.VPSet(
-        cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 3, 3, 2.5, 3, 3, 2.5, 2.5, 2, 1.5, 1.5, 1, 1) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 3.5, 3, 3, 3, 3, 2.5, 2.5, 3, 3, 2.5, 2.5, 2.5) ),
-        cms.PSet( TiltedCut = cms.vdouble( 0, 4, 4, 4, 3.5, 3.5, 3.5, 3.5, 3, 3, 3, 3, 3) ),
-	),
-   EndcapCutSet = cms.VPSet(
-        cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 2.5, 3, 2.5, 3, 3.5, 4, 4, 4.5, 3.5, 4, 4.5, 5, 5.5) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2.5, 2.5, 3, 2.5, 3, 3, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5, 5) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 3, 3, 2.5, 3.5, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 3, 2.5, 3.5, 3, 3, 3.5, 3.5, 3.5, 4, 4) ),
-        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2.5, 3.5, 3, 3, 3.5, 4, 3.5, 4, 3.5) ),
-        )
+   #BarrelCut    = cms.vdouble( 0, 2, 2.5, 3.5, 4.5, 5.5, 7),
+   #TiltedBarrelCutSet = cms.VPSet(
+   #     cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
+   #     cms.PSet( TiltedCut = cms.vdouble( 0, 3, 3, 2.5, 3, 3, 2.5, 2.5, 2, 1.5, 1.5, 1, 1) ),
+   #     cms.PSet( TiltedCut = cms.vdouble( 0, 3.5, 3, 3, 3, 3, 2.5, 2.5, 3, 3, 2.5, 2.5, 2.5) ),
+   #     cms.PSet( TiltedCut = cms.vdouble( 0, 4, 4, 4, 3.5, 3.5, 3.5, 3.5, 3, 3, 3, 3, 3) ),
+   #	),
+   #EndcapCutSet = cms.VPSet(
+   #     cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
+   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 2.5, 3, 2.5, 3, 3.5, 4, 4, 4.5, 3.5, 4, 4.5, 5, 5.5) ),
+   #     cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2.5, 2.5, 3, 2.5, 3, 3, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5, 5) ),
+   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1, 3, 3, 2.5, 3.5, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5) ),
+   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 3, 2.5, 3.5, 3, 3, 3.5, 3.5, 3.5, 4, 4) ),
+   #     cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2.5, 3.5, 3, 3, 3.5, 4, 3.5, 4, 3.5) ),
+   #     )
+  BarrelCut    = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5),
+  TiltedBarrelCutSet = cms.VPSet(         
+      cms.PSet( TiltedCut = cms.vdouble( 0 ) ),         
+      cms.PSet( TiltedCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ), 
+      cms.PSet( TiltedCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
+      cms.PSet( TiltedCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
+      ), 
+  EndcapCutSet = cms.VPSet( cms.PSet( EndcapCut = cms.vdouble( 0 ) ), 
+      cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ), 
+      cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
+      cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
+      cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
+      cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
+      )
 
    # PU200 loose tuning, optimized for robustness (uncomment if you want to use it)
    #BarrelCut    = cms.vdouble( 0, 2.0, 3, 4.5, 6, 6.5, 7.0),

--- a/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TTStubAlgorithmRegister_cfi.py
@@ -19,35 +19,21 @@ TTStubAlgorithm_official_Phase2TrackerDigi_ = cms.ESProducer("TTStubAlgorithm_of
    #Number of tilted rings per side in barrel layers (for tilted geom only)
    NTiltedRings = cms.vdouble( 0., 12., 12., 12., 0., 0., 0.), 
    # PU200 tight tuning, optimized for muons
-   #BarrelCut    = cms.vdouble( 0, 2, 2.5, 3.5, 4.5, 5.5, 7),
-   #TiltedBarrelCutSet = cms.VPSet(
-   #     cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
-   #     cms.PSet( TiltedCut = cms.vdouble( 0, 3, 3, 2.5, 3, 3, 2.5, 2.5, 2, 1.5, 1.5, 1, 1) ),
-   #     cms.PSet( TiltedCut = cms.vdouble( 0, 3.5, 3, 3, 3, 3, 2.5, 2.5, 3, 3, 2.5, 2.5, 2.5) ),
-   #     cms.PSet( TiltedCut = cms.vdouble( 0, 4, 4, 4, 3.5, 3.5, 3.5, 3.5, 3, 3, 3, 3, 3) ),
-   #	),
-   #EndcapCutSet = cms.VPSet(
-   #     cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
-   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 2.5, 3, 2.5, 3, 3.5, 4, 4, 4.5, 3.5, 4, 4.5, 5, 5.5) ),
-   #     cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2.5, 2.5, 3, 2.5, 3, 3, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5, 5) ),
-   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1, 3, 3, 2.5, 3.5, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5) ),
-   #     cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 3, 2.5, 3.5, 3, 3, 3.5, 3.5, 3.5, 4, 4) ),
-   #     cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2.5, 3.5, 3, 3, 3.5, 4, 3.5, 4, 3.5) ),
-   #     )
-  BarrelCut    = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5),
-  TiltedBarrelCutSet = cms.VPSet(         
-      cms.PSet( TiltedCut = cms.vdouble( 0 ) ),         
-      cms.PSet( TiltedCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ), 
-      cms.PSet( TiltedCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
-      cms.PSet( TiltedCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
-      ), 
-  EndcapCutSet = cms.VPSet( cms.PSet( EndcapCut = cms.vdouble( 0 ) ), 
-      cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ), 
-      cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
-      cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
-      cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
-      cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5) ),
-      )
+   BarrelCut    = cms.vdouble( 0, 2, 2.5, 3.5, 4.5, 5.5, 7),
+   TiltedBarrelCutSet = cms.VPSet(
+        cms.PSet( TiltedCut = cms.vdouble( 0 ) ),
+        cms.PSet( TiltedCut = cms.vdouble( 0, 3, 3, 2.5, 3, 3, 2.5, 2.5, 2, 1.5, 1.5, 1, 1) ),
+        cms.PSet( TiltedCut = cms.vdouble( 0, 3.5, 3, 3, 3, 3, 2.5, 2.5, 3, 3, 2.5, 2.5, 2.5) ),
+        cms.PSet( TiltedCut = cms.vdouble( 0, 4, 4, 4, 3.5, 3.5, 3.5, 3.5, 3, 3, 3, 3, 3) ),
+   	),
+   EndcapCutSet = cms.VPSet(
+        cms.PSet( EndcapCut = cms.vdouble( 0 ) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 2.5, 3, 2.5, 3, 3.5, 4, 4, 4.5, 3.5, 4, 4.5, 5, 5.5) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 2.5, 2.5, 3, 2.5, 3, 3, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5, 5) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 3, 3, 2.5, 3.5, 3.5, 3.5, 4, 3.5, 3.5, 4, 4.5) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 1, 2.5, 3, 2.5, 3.5, 3, 3, 3.5, 3.5, 3.5, 4, 4) ),
+        cms.PSet( EndcapCut = cms.vdouble( 0, 0.5, 1.5, 3, 2.5, 3.5, 3, 3, 3.5, 4, 3.5, 4, 3.5) ),
+        )
 
    # PU200 loose tuning, optimized for robustness (uncomment if you want to use it)
    #BarrelCut    = cms.vdouble( 0, 2.0, 3, 4.5, 6, 6.5, 7.0),

--- a/L1Trigger/TrackTrigger/src/SensorModule.cc
+++ b/L1Trigger/TrackTrigger/src/SensorModule.cc
@@ -119,7 +119,7 @@ namespace tt {
     }
   }
 
-  unsigned int SensorModule::ringId(const Setup* setup) const{
+  unsigned int SensorModule::ringId(const Setup* setup) const {
     // In barrel PS: Tilted module ring no. (Increasing 1 to 12 as |z| increases)
     // In barrel 2S: 0
     // In disk: Endcap module ring number (1-15) in endcap disks
@@ -138,8 +138,8 @@ namespace tt {
         unsigned int nTilted = setup->numTiltedLayerRing(layp1);
         ringId = 1 + nTilted - ringId;
       }
-    } else{
-    ringId = barrel_ ? 0 : trackerTopology->tidRing(detId_);
+    } else {
+      ringId = barrel_ ? 0 : trackerTopology->tidRing(detId_);
     }
     return ringId;
   }

--- a/L1Trigger/TrackTrigger/src/SensorModule.cc
+++ b/L1Trigger/TrackTrigger/src/SensorModule.cc
@@ -119,4 +119,29 @@ namespace tt {
     }
   }
 
+  unsigned int SensorModule::ringId(const Setup* setup) const{
+    // In barrel PS: Tilted module ring no. (Increasing 1 to 12 as |z| increases)
+    // In barrel 2S: 0
+    // In disk: Endcap module ring number (1-15) in endcap disks
+
+    // See  https://github.com/cms-sw/cmssw/tree/master/Geometry/TrackerNumberingBuilder
+    const TrackerTopology* trackerTopology = setup->trackerTopology();
+    enum TypeBarrel { nonBarrel = 0, tiltedMinus = 1, tiltedPlus = 2, flat = 3 };
+    const TypeBarrel type = static_cast<TypeBarrel>(trackerTopology->tobSide(detId_));
+    bool tiltedBarrel = barrel_ && (type == tiltedMinus || type == tiltedPlus);
+    unsigned int ringId = 0;
+    // Tilted module ring no. (Increasing 1 to 12 as |z| increases).
+    if (tiltedBarrel) {
+      ringId = trackerTopology->tobRod(detId_);
+      if (type == tiltedMinus) {
+        unsigned int layp1 = trackerTopology->layer(detId_);
+        unsigned int nTilted = setup->numTiltedLayerRing(layp1);
+        ringId = 1 + nTilted - ringId;
+      }
+    } else{
+    ringId = barrel_ ? 0 : trackerTopology->tidRing(detId_);
+    }
+    return ringId;
+  }
+
 }  // namespace tt


### PR DESCRIPTION
#### PR description:

This PR allows the bend decoding to be a function of the FE stub bend windows.

#### PR validation:

All tests are using TTbar_200PU events. The name "L1TK" refers to the default code and "CalcBendCuts" refers to the version with the proposed changes.

In the TrackletLUT::initPhiCorrTable I added the option of using z bins in the tilted layers, the options below show the comparison of 1, 2, and 13 z bins. Also shown is the output when the flag useCalcBendCuts is set to false (changes off).

Edit: Because there is no definite performance difference between 1, 2, and 13 z bins in the PhiCorrTable, to simplify the code only 1 z bin is used.

<img width="861" alt="Screen Shot 2022-07-12 at 2 16 06 PM" src="https://user-images.githubusercontent.com/47793576/178565584-8d32f808-9f15-41db-bae4-fc873ff8cfdc.png">

Using more that one z bin would require changes in firmware to calculate the z bin of a stub in the tilted barrel, because of this and the lack of substantial improvement I would recommend using just one z bin here. Later versions shown will be using only one z bin in the PhiCorrTable.


To validate that this code does indeed use the FE stub windows, I compare the output of running both versions with modified stub windows. These tunes are the result of work done by Reza Goldouzian (reza.goldouzian@cern.ch). The validation done here is only to show that this code can adapt to modified FE stub bend windows.

The tunes ["newTight", "newLoose"] are similar to ["tight", "loose"] ; ["0p5", "7p0"] are tunes where the FE stub bend windows are all set to the same value, 0.5 and 7.0 respectively.

<img width="1120" alt="Screen Shot 2022-07-12 at 2 43 38 PM" src="https://user-images.githubusercontent.com/47793576/178570527-5d8f13ed-a563-4490-bd38-fb642134da84.png">


Also tested is the combined version, using TrackletProcessor instead of TrackletEngine+TrackletCalculator.

<img width="863" alt="Screen Shot 2022-07-12 at 2 45 29 PM" src="https://user-images.githubusercontent.com/47793576/178570768-09bb7063-d076-4d9b-bec5-11bf78fe56d4.png">


In L1Trigger/TrackFindingTracklet/interface/Settings.h I define "bendcut" parameters that are found through a process of optimizing for several metrics in the TE (ME), including pass rate of tp matched tracklets (matches), rate of truncation, and pass rate of fake (not tp matched) tracklets (matches).

Some plots of this are shown here: https://indico.cern.ch/event/1161122/contributions/4897597/attachments/2453548/4204791/L1TK%20Update%20053122.pdf


Before submitting your pull requests, make sure you followed this checklist:
- [x] verify that the PR is really intended for the chosen 
- [x] verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- [x] verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

[runall-report-step123-L1TK.log](https://github.com/cms-L1TK/cmssw/files/9104745/runall-report-step123-L1TK.log)
[runall-report-step123-CalcBendCuts.log](https://github.com/cms-L1TK/cmssw/files/9104754/runall-report-step123-CalcBendCuts.log)

