### PR TITLE
MP disk projection LUT

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/MatchEngineUnit.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MatchEngineUnit.h
@@ -108,13 +108,13 @@ namespace trklet {
     //Various manually pipelined variables
     //Each _ represents a layer of pipelining
     //e.g., good__ is set and one iteration later good___ is updated
-    VMStubME vmstub__, vmstub___;
-    bool isPSseed__, isPSseed___;
-    bool good__, good___;
-    int projfinerz__, projfinerz___;
-    int projfinephi__, projfinephi___;
-    int projrinv__, projrinv___;
-    Tracklet *proj__, *proj___;
+    VMStubME vmstub__, vmstub__t, vmstub___;
+    bool isPSseed__, isPSseed__t, isPSseed___;
+    bool good__, good__t, good___;
+    int projfinerz__, projfinerz__t, projfinerz___;
+    int projfinephi__, projfinephi__t, projfinephi___;
+    int projrinv__, projrinv__t, projrinv___;
+    Tracklet *proj__, *proj__t, *proj___;
 
     //save the candidate matches
     CircularBuffer<std::pair<Tracklet*, const Stub*>> candmatches_;

--- a/L1Trigger/TrackFindingTracklet/interface/MatchProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MatchProcessor.h
@@ -63,8 +63,13 @@ namespace trklet {
     TrackletLUT rSSinner_;
     TrackletLUT rSSouter_;
 
+    TrackletLUT diskRadius_;
+
     int nrbits_;
     int nphiderbits_;
+
+    //Number of r bits for the projection to use in LUT for disk
+    int nrprojbits_;
 
     AllStubsMemory* allstubs_;
     std::vector<VMStubsMEMemory*> vmstubs_;

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h
@@ -79,6 +79,8 @@ namespace trklet {
 
     void initBendMatch(unsigned int layerdisk);
 
+    void initProjectionDiskRadius(int nrbits);
+
     enum VMRTableType { me, disk, inner, inneroverlap, innerthird };
 
     //region only used for name - should be removed

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -16,6 +16,7 @@ MatchEngineUnit::MatchEngineUnit(const Settings& settings,
   barrel_ = barrel;
   layerdisk_ = layerdisk;
   good__ = false;
+  good__t = false;
   good___ = false;
 }
 
@@ -154,13 +155,21 @@ void MatchEngineUnit::processPipeline() {
     }
   }
 
-  proj___ = proj__;
-  projfinephi___ = projfinephi__;
-  projfinerz___ = projfinerz__;
-  projrinv___ = projrinv__;
-  isPSseed___ = isPSseed__;
-  good___ = good__;
-  vmstub___ = vmstub__;
+  proj___ = proj__t;
+  projfinephi___ = projfinephi__t;
+  projfinerz___ = projfinerz__t;
+  projrinv___ = projrinv__t;
+  isPSseed___ = isPSseed__t;
+  good___ = good__t;
+  vmstub___ = vmstub__t;
+
+  proj__t = proj__;
+  projfinephi__t = projfinephi__;
+  projfinerz__t = projfinerz__;
+  projrinv__t = projrinv__;
+  isPSseed__t = isPSseed__;
+  good__t = good__;
+  vmstub__t = vmstub__;
 }
 
 void MatchEngineUnit::reset() {
@@ -168,6 +177,7 @@ void MatchEngineUnit::reset() {
   idle_ = true;
   istub_ = 0;
   good__ = false;
+  good__t = false;
   good___ = false;
 }
 
@@ -178,6 +188,10 @@ int MatchEngineUnit::TCID() const {
 
   if (good___) {
     return proj___->TCID();
+  }
+
+  if (good__t) {
+    return proj__t->TCID();
   }
 
   if (good__) {

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -403,23 +403,24 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
         unsigned int projfinephi =
             (fpgaphi.value() >> (fpgaphi.nbits() - (nvmbits_ + NFINEPHIBITS))) & ((1 << NFINEPHIBITS) - 1);
 
-	unsigned int slot;
-	bool second;
-	int projfinerz;
-       
-	if (barrel_) {
-	  slot = proj->proj(layerdisk_).fpgarzbin1projvm().value();
-	  second = proj->proj(layerdisk_).fpgarzbin2projvm().value();
-	  projfinerz = proj->proj(layerdisk_).fpgafinerzvm().value();
-	} else {
-	  //The -1 here is due to not using the full range of bits. Should be fixed.
-	  unsigned int ir = proj->proj(layerdisk_).fpgarzproj().value() >> (proj->proj(layerdisk_).fpgarzproj().nbits() - nrprojbits_ - 1);
-	  unsigned int word = diskRadius_.lookup(ir);
+        unsigned int slot;
+        bool second;
+        int projfinerz;
 
-	  slot = (word>>1)&((1<<N_RZBITS)-1);
-          if (proj->proj(layerdisk_).fpgarzprojder().value()<0) {
-	    slot += (1<<N_RZBITS);
-	  }
+        if (barrel_) {
+          slot = proj->proj(layerdisk_).fpgarzbin1projvm().value();
+          second = proj->proj(layerdisk_).fpgarzbin2projvm().value();
+          projfinerz = proj->proj(layerdisk_).fpgafinerzvm().value();
+        } else {
+          //The -1 here is due to not using the full range of bits. Should be fixed.
+          unsigned int ir = proj->proj(layerdisk_).fpgarzproj().value() >>
+                            (proj->proj(layerdisk_).fpgarzproj().nbits() - nrprojbits_ - 1);
+          unsigned int word = diskRadius_.lookup(ir);
+
+          slot = (word >> 1) & ((1 << N_RZBITS) - 1);
+          if (proj->proj(layerdisk_).fpgarzprojder().value() < 0) {
+            slot += (1 << N_RZBITS);
+          }
           second = word & 1;
           projfinerz = word >> 4;
         }

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -37,6 +37,7 @@ MatchProcessor::MatchProcessor(string name, Settings const& settings, Globals* g
       alphaouter_(settings),
       rSSinner_(settings),
       rSSouter_(settings),
+      diskRadius_(settings),
       fullmatches_(12),
       rinvbendlut_(settings),
       luttable_(settings),
@@ -63,6 +64,8 @@ MatchProcessor::MatchProcessor(string name, Settings const& settings, Globals* g
   nrbits_ = 5;
   nphiderbits_ = 6;
 
+  nrprojbits_ = 8;
+
   if (!barrel_) {
     rinvbendlut_.initProjectionBend(
         global->ITC_L1L2()->der_phiD_final.K(), layerdisk_ - N_LAYER, nrbits_, nphiderbits_);
@@ -85,6 +88,7 @@ MatchProcessor::MatchProcessor(string name, Settings const& settings, Globals* g
     alphaouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphaouter, region);
     rSSinner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSinner, region);
     rSSouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSouter, region);
+    diskRadius_.initProjectionDiskRadius(nrprojbits_);
   }
 
   for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
@@ -396,12 +400,29 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
         }
         assert(projrinv >= 0);
 
-        unsigned int slot = proj->proj(layerdisk_).fpgarzbin1projvm().value();
-        bool second = proj->proj(layerdisk_).fpgarzbin2projvm().value();
-
         unsigned int projfinephi =
             (fpgaphi.value() >> (fpgaphi.nbits() - (nvmbits_ + NFINEPHIBITS))) & ((1 << NFINEPHIBITS) - 1);
-        int projfinerz = proj->proj(layerdisk_).fpgafinerzvm().value();
+
+	unsigned int slot;
+	bool second;
+	int projfinerz;
+       
+	if (barrel_) {
+	  slot = proj->proj(layerdisk_).fpgarzbin1projvm().value();
+	  second = proj->proj(layerdisk_).fpgarzbin2projvm().value();
+	  projfinerz = proj->proj(layerdisk_).fpgafinerzvm().value();
+	} else {
+	  //The -1 here is due to not using the full range of bits. Should be fixed.
+	  unsigned int ir = proj->proj(layerdisk_).fpgarzproj().value() >> (proj->proj(layerdisk_).fpgarzproj().nbits() - nrprojbits_ - 1);
+	  unsigned int word = diskRadius_.lookup(ir);
+
+	  slot = (word>>1)&((1<<N_RZBITS)-1);
+          if (proj->proj(layerdisk_).fpgarzprojder().value()<0) {
+	    slot += (1<<N_RZBITS);
+	  }
+          second = word & 1;
+          projfinerz = word >> 4;
+        }
 
         bool isPSseed = proj->PSseed();
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -478,53 +478,42 @@ void TrackletLUT::initProjectionBend(double k_phider,
   writeTable();
 }
 
-void TrackletLUT::initProjectionDiskRadius(int nrbits){
-
+void TrackletLUT::initProjectionDiskRadius(int nrbits) {
   double roffset = 3.0;
 
-  for(unsigned int ir = 0; ir < (1u<<nrbits); ir++) {
+  for (unsigned int ir = 0; ir < (1u << nrbits); ir++) {
+    double r = ir * settings_.rmaxdisk() / (1u << nrbits);
 
-    double r = ir*settings_.rmaxdisk()/(1u<<nrbits);
-    
-    int rbin1 = 8.0 * (r - roffset - settings_.rmindiskvm()) /
-      (settings_.rmaxdisk() - settings_.rmindiskvm());
-    int rbin2 = 8.0 * (r + roffset - settings_.rmindiskvm()) /
-      (settings_.rmaxdisk() - settings_.rmindiskvm());
+    int rbin1 = 8.0 * (r - roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
+    int rbin2 = 8.0 * (r + roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
 
     if (rbin1 < 0) {
       rbin1 = 0;
     }
     rbin2 = clamp(rbin2, 0, 7);
-    
+
     assert(rbin1 <= rbin2);
     assert(rbin2 - rbin1 <= 1);
 
     int d = rbin1 != rbin2;
 
-    int finer = 64 *
-      ((r - settings_.rmindiskvm()) -
-       rbin1 * (settings_.rmaxdisk() - settings_.rmindiskvm()) / 8.0) /
-      (settings_.rmaxdisk() - settings_.rmindiskvm());
-    
+    int finer = 64 * ((r - settings_.rmindiskvm()) - rbin1 * (settings_.rmaxdisk() - settings_.rmindiskvm()) / 8.0) /
+                (settings_.rmaxdisk() - settings_.rmindiskvm());
+
     finer = clamp(finer, 0, 15);
 
     //Pack the data in a 8 bit word (ffffrrrd) where f is finer, r is rbin1, and d is difference
 
-    int word = (finer<<4) + (rbin1<<1) + d;
-    
+    int word = (finer << 4) + (rbin1 << 1) + d;
+
     table_.push_back(word);
-    
   }
-  
+
   nbits_ = 10;
   positive_ = true;
   name_ = "ProjectionDiskRadius.tab";
   writeTable();
-  
 }
-
-
-
 
 void TrackletLUT::initBendMatch(unsigned int layerdisk) {
   unsigned int nrinv = NRINVBITS;

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -478,6 +478,54 @@ void TrackletLUT::initProjectionBend(double k_phider,
   writeTable();
 }
 
+void TrackletLUT::initProjectionDiskRadius(int nrbits){
+
+  double roffset = 3.0;
+
+  for(unsigned int ir = 0; ir < (1u<<nrbits); ir++) {
+
+    double r = ir*settings_.rmaxdisk()/(1u<<nrbits);
+    
+    int rbin1 = 8.0 * (r - roffset - settings_.rmindiskvm()) /
+      (settings_.rmaxdisk() - settings_.rmindiskvm());
+    int rbin2 = 8.0 * (r + roffset - settings_.rmindiskvm()) /
+      (settings_.rmaxdisk() - settings_.rmindiskvm());
+
+    if (rbin1 < 0) {
+      rbin1 = 0;
+    }
+    rbin2 = clamp(rbin2, 0, 7);
+    
+    assert(rbin1 <= rbin2);
+    assert(rbin2 - rbin1 <= 1);
+
+    int d = rbin1 != rbin2;
+
+    int finer = 64 *
+      ((r - settings_.rmindiskvm()) -
+       rbin1 * (settings_.rmaxdisk() - settings_.rmindiskvm()) / 8.0) /
+      (settings_.rmaxdisk() - settings_.rmindiskvm());
+    
+    finer = clamp(finer, 0, 15);
+
+    //Pack the data in a 8 bit word (ffffrrrd) where f is finer, r is rbin1, and d is difference
+
+    int word = (finer<<4) + (rbin1<<1) + d;
+    
+    table_.push_back(word);
+    
+  }
+  
+  nbits_ = 10;
+  positive_ = true;
+  name_ = "ProjectionDiskRadius.tab";
+  writeTable();
+  
+}
+
+
+
+
 void TrackletLUT::initBendMatch(unsigned int layerdisk) {
   unsigned int nrinv = NRINVBITS;
   double rinvhalf = 0.5 * ((1 << nrinv) - 1);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -505,7 +505,7 @@ void TrackletLUT::initProjectionDiskRadius(int nrbits) {
     //Pack the data in a 8 bit word (ffffrrrd) where f is finer, r is rbin1, and d is difference
     int N_DIFF_FLAG = 1;  // Single bit for bool flag
 
-    int word = (finer << (N_RZBITS+N_DIFF_FLAG) + (rbin1 << N_DIFF_FLAG) + d;
+    int word = (finer << (N_RZBITS+N_DIFF_FLAG)) + (rbin1 << N_DIFF_FLAG) + d;
 
     table_.push_back(word);
   }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -505,7 +505,7 @@ void TrackletLUT::initProjectionDiskRadius(int nrbits) {
     //Pack the data in a 8 bit word (ffffrrrd) where f is finer, r is rbin1, and d is difference
     int N_DIFF_FLAG = 1;  // Single bit for bool flag
 
-    int word = (finer << (N_RZBITS+N_DIFF_FLAG)) + (rbin1 << N_DIFF_FLAG) + d;
+    int word = (finer << (N_RZBITS + N_DIFF_FLAG)) + (rbin1 << N_DIFF_FLAG) + d;
 
     table_.push_back(word);
   }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -490,7 +490,7 @@ void TrackletLUT::initProjectionDiskRadius(int nrbits) {
     if (rbin1 < 0) {
       rbin1 = 0;
     }
-    rbin2 = clamp(rbin2, 0, 7);
+    rbin2 = clamp(rbin2, 0, ((1 << N_RZBITS) - 1));
 
     assert(rbin1 <= rbin2);
     assert(rbin2 - rbin1 <= 1);
@@ -500,11 +500,12 @@ void TrackletLUT::initProjectionDiskRadius(int nrbits) {
     int finer = 64 * ((r - settings_.rmindiskvm()) - rbin1 * (settings_.rmaxdisk() - settings_.rmindiskvm()) / 8.0) /
                 (settings_.rmaxdisk() - settings_.rmindiskvm());
 
-    finer = clamp(finer, 0, 15);
+    finer = clamp(finer, 0, ((1 << (NFINERZBITS + 1)) - 1));
 
     //Pack the data in a 8 bit word (ffffrrrd) where f is finer, r is rbin1, and d is difference
+    int N_DIFF_FLAG = 1;  // Single bit for bool flag
 
-    int word = (finer << 4) + (rbin1 << 1) + d;
+    int word = (finer << (N_RZBITS+N_DIFF_FLAG) + (rbin1 << N_DIFF_FLAG) + d;
 
     table_.push_back(word);
   }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -479,13 +479,18 @@ void TrackletLUT::initProjectionBend(double k_phider,
 }
 
 void TrackletLUT::initProjectionDiskRadius(int nrbits) {
+
+  //When a projection to a disk is considered this offset and added and subtracted to calculate
+  //the bin the projection is pointing to. This is to account for resolution effects such that 
+  //projections that are near a bin boundary will be assigned to both bins. The value (3 cm) should
+  //cover the uncertanty in the resolution.
   double roffset = 3.0;
 
   for (unsigned int ir = 0; ir < (1u << nrbits); ir++) {
     double r = ir * settings_.rmaxdisk() / (1u << nrbits);
 
-    int rbin1 = 8.0 * (r - roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
-    int rbin2 = 8.0 * (r + roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
+    int rbin1 = (1 << N_RZBITS) * (r - roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
+    int rbin2 = (1 << N_RZBITS) * (r + roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
 
     if (rbin1 < 0) {
       rbin1 = 0;
@@ -497,7 +502,7 @@ void TrackletLUT::initProjectionDiskRadius(int nrbits) {
 
     int d = rbin1 != rbin2;
 
-    int finer = 64 * ((r - settings_.rmindiskvm()) - rbin1 * (settings_.rmaxdisk() - settings_.rmindiskvm()) / 8.0) /
+    int finer = (1 << (N_RZBITS + NFINERZBITS)) * ((r - settings_.rmindiskvm()) - rbin1 * (settings_.rmaxdisk() - settings_.rmindiskvm()) / (1 << N_RZBITS)) /
                 (settings_.rmaxdisk() - settings_.rmindiskvm());
 
     finer = clamp(finer, 0, ((1 << (NFINERZBITS + 1)) - 1));
@@ -510,7 +515,8 @@ void TrackletLUT::initProjectionDiskRadius(int nrbits) {
     table_.push_back(word);
   }
 
-  nbits_ = 10;
+  //Size of the data word from above (8 bits)
+  nbits_ = NFINERZBITS + 1 + N_RZBITS + 1;
   positive_ = true;
   name_ = "ProjectionDiskRadius.tab";
   writeTable();

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -479,9 +479,8 @@ void TrackletLUT::initProjectionBend(double k_phider,
 }
 
 void TrackletLUT::initProjectionDiskRadius(int nrbits) {
-
   //When a projection to a disk is considered this offset and added and subtracted to calculate
-  //the bin the projection is pointing to. This is to account for resolution effects such that 
+  //the bin the projection is pointing to. This is to account for resolution effects such that
   //projections that are near a bin boundary will be assigned to both bins. The value (3 cm) should
   //cover the uncertanty in the resolution.
   double roffset = 3.0;
@@ -489,8 +488,10 @@ void TrackletLUT::initProjectionDiskRadius(int nrbits) {
   for (unsigned int ir = 0; ir < (1u << nrbits); ir++) {
     double r = ir * settings_.rmaxdisk() / (1u << nrbits);
 
-    int rbin1 = (1 << N_RZBITS) * (r - roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
-    int rbin2 = (1 << N_RZBITS) * (r + roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
+    int rbin1 =
+        (1 << N_RZBITS) * (r - roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
+    int rbin2 =
+        (1 << N_RZBITS) * (r + roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
 
     if (rbin1 < 0) {
       rbin1 = 0;
@@ -502,8 +503,10 @@ void TrackletLUT::initProjectionDiskRadius(int nrbits) {
 
     int d = rbin1 != rbin2;
 
-    int finer = (1 << (N_RZBITS + NFINERZBITS)) * ((r - settings_.rmindiskvm()) - rbin1 * (settings_.rmaxdisk() - settings_.rmindiskvm()) / (1 << N_RZBITS)) /
-                (settings_.rmaxdisk() - settings_.rmindiskvm());
+    int finer =
+        (1 << (N_RZBITS + NFINERZBITS)) *
+        ((r - settings_.rmindiskvm()) - rbin1 * (settings_.rmaxdisk() - settings_.rmindiskvm()) / (1 << N_RZBITS)) /
+        (settings_.rmaxdisk() - settings_.rmindiskvm());
 
     finer = clamp(finer, 0, ((1 << (NFINERZBITS + 1)) - 1));
 


### PR DESCRIPTION

#### PR description:

These changes implements a LUT as function of the radial projection in the disks to determine which r bins needs to be searched - and the finer position within the r bin. It produces an 8-bit word (`ffffrrrd`) where `f` is `fine r`, `r` is `rbin1`, and `d` is difference (`rbin1 != rbin2`)

It also includes an additional pipeline step to match the HLS implementation.

#### PR validation:

Designed for HLS [WIP] PR #[242](https://github.com/cms-L1TK/firmware-hls/pull/242)