### PR TITLE
Debug print of digitisation data format

### DIFF
--- a/L1Trigger/TrackerTFP/src/DataFormats.cc
+++ b/L1Trigger/TrackerTFP/src/DataFormats.cc
@@ -69,6 +69,11 @@ namespace trackerTFP {
     numStreamsTracks_ = vector<int>(+Process::end, 0);
     numStreamsTracks_[+Process::kfin] = numStreams_[+Process::kf];
     numStreamsTracks_[+Process::kf] = numStreams_[+Process::kf];
+    // Print digi data format of all variables of any specified algo step
+    //for (const Variable v : tracks_[+Process::kf]) {
+    //  const DataFormat& f = format(v, Process::kf);
+    //  cout <<" KF "<< f.base() << " " << f.range() << " " << f.width() << endl;
+    //}
   }
 
   // constructs data formats of all unique used variables and flavours


### PR DESCRIPTION
#### PR description:

Adds 5 commented-out lines to DataFormat class, which if uncommented can be used to print the digitisation format (#bits, granularity, range) of all variables in the KF, KFin etc.

This is useful for checking that our C++ is consistent with https://twiki.cern.ch/twiki/bin/view/CMS/HybridDataFormat .