### PR TITLE
Fix to set nbits_ for the VMRME/TE files

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -1100,10 +1100,12 @@ void TrackletLUT::initVMRTable(unsigned int layerdisk, VMRTableType type, int re
 
   if (settings_.combined()) {
     if (type == VMRTableType::me) {
+      nbits_ = 2 * settings_.NLONGVMBITS();
       positive_ = false;
       name_ = "VMRME_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
     }
     if (type == VMRTableType::disk) {
+      nbits_ = 2 * settings_.NLONGVMBITS();
       positive_ = false;
       name_ = "VMRTE_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
     }


### PR DESCRIPTION
#### PR description:

A mistake was introduced earlier where nbits_ was not set when writing the VMR ME/TE LUTs for the combined modules. This cased a crash (segv) when trying to write the LUTs when running the combined modules.

#### PR validation:

This has been tested to write the LUTs for a combined module barrel project

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A

