### PR TITLE
Clean building

### DIFF
--- a/L1Trigger/TrackFindingTMTT/plugins/BuildFile.xml
+++ b/L1Trigger/TrackFindingTMTT/plugins/BuildFile.xml
@@ -1,7 +1,8 @@
-<use name="L1Trigger/TrackFindingTMTT"/>
-<use name="MagneticField/Engine"/>
-<use name="MagneticField/Records"/>
-
-<flags CXXFLAGS="-g -Wno-unused-variable -Wno-misleading-indentation"/>
-<flags EDM_PLUGIN="1"/>
+<library file="*.cc" name="TrackFindingTMTTPlugins">
+  <use name="L1Trigger/TrackFindingTMTT"/>
+  <use name="MagneticField/Engine"/>
+  <use name="MagneticField/Records"/>
+  <flags CXXFLAGS="-g -Wno-unused-variable -Wno-misleading-indentation"/>
+  <flags EDM_PLUGIN="1"/>
+</library>
 

--- a/L1Trigger/TrackFindingTracklet/BuildFile.xml
+++ b/L1Trigger/TrackFindingTracklet/BuildFile.xml
@@ -3,9 +3,9 @@
 <use name="root"/>
 <use name="rootrflx"/>
 <use name="xerces-c"/>
-<use name="DataFormats/L1TrackTrigger"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
+<use name="L1Trigger/L1TrackTrigger"/>
 <use name="L1Trigger/TrackFindingTMTT"/>
 <use name="L1Trigger/TrackerTFP"/>
 <flags CXXFLAGS="-DUSEHYBRID"/>

--- a/L1Trigger/TrackFindingTracklet/BuildFile.xml
+++ b/L1Trigger/TrackFindingTracklet/BuildFile.xml
@@ -5,7 +5,7 @@
 <use name="xerces-c"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
-<use name="L1Trigger/L1TrackTrigger"/>
+<use name="L1Trigger/TrackTrigger"/>
 <use name="L1Trigger/TrackFindingTMTT"/>
 <use name="L1Trigger/TrackerTFP"/>
 <flags CXXFLAGS="-DUSEHYBRID"/>

--- a/L1Trigger/TrackFindingTracklet/plugins/BuildFile.xml
+++ b/L1Trigger/TrackFindingTracklet/plugins/BuildFile.xml
@@ -1,10 +1,6 @@
 <library file="*.cc" name="TrackFindingTrackletPlugins">
   <use name="hepmc"/>
-  <use name="root"/>
-  <use name="DataFormats/L1TrackTrigger"/>
   <use name="L1Trigger/TrackFindingTracklet"/>
-  <use name="L1Trigger/TrackTrigger"/>
-  <use name="L1Trigger/TrackerDTC"/>
   <use name="MagneticField/Engine"/>
   <use name="MagneticField/Records"/>
   <flags EDM_PLUGIN="1"/>

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -783,4 +783,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
 // ///////////////////////////
 // // DEFINE THIS AS A PLUG-IN
-DEFINE_FWK_MODULE(trklet::L1FPGATrackProducer);
+// workaround for bug in framework dealing with namespaces?
+//DEFINE_FWK_MODULE(trklet::L1FPGATrackProducer);
+using namespace trklet;
+DEFINE_FWK_MODULE(L1FPGATrackProducer);

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -126,660 +126,663 @@ using namespace tt;
 
 namespace trklet {
 
-struct L1TStubCompare {
-public:
-  bool operator()(const trklet::L1TStub& a, const trklet::L1TStub& b) const {
-    if (a.x() != b.x())
-      return (b.x() > a.x());
-    else if (a.y() != b.y())
-      return (b.y() > a.y());
-    else if (a.z() != b.z())
-      return (a.z() > b.z());
-    else
-      return a.bend() > b.bend();
-  }
-};
+  struct L1TStubCompare {
+  public:
+    bool operator()(const trklet::L1TStub& a, const trklet::L1TStub& b) const {
+      if (a.x() != b.x())
+        return (b.x() > a.x());
+      else if (a.y() != b.y())
+        return (b.y() > a.y());
+      else if (a.z() != b.z())
+        return (a.z() > b.z());
+      else
+        return a.bend() > b.bend();
+    }
+  };
 
-class L1FPGATrackProducer : public edm::one::EDProducer<edm::one::WatchRuns> {
-public:
-  /// Constructor/destructor
-  explicit L1FPGATrackProducer(const edm::ParameterSet& iConfig);
-  ~L1FPGATrackProducer() override;
+  class L1FPGATrackProducer : public edm::one::EDProducer<edm::one::WatchRuns> {
+  public:
+    /// Constructor/destructor
+    explicit L1FPGATrackProducer(const edm::ParameterSet& iConfig);
+    ~L1FPGATrackProducer() override;
 
-private:
-  int eventnum;
+  private:
+    int eventnum;
 
-  /// Containers of parameters passed by python configuration file
-  edm::ParameterSet config;
+    /// Containers of parameters passed by python configuration file
+    edm::ParameterSet config;
 
-  bool readMoreMcTruth_;
+    bool readMoreMcTruth_;
 
-  /// File path for configuration files
-  edm::FileInPath fitPatternFile;
-  edm::FileInPath memoryModulesFile;
-  edm::FileInPath processingModulesFile;
-  edm::FileInPath wiresFile;
+    /// File path for configuration files
+    edm::FileInPath fitPatternFile;
+    edm::FileInPath memoryModulesFile;
+    edm::FileInPath processingModulesFile;
+    edm::FileInPath wiresFile;
 
-  edm::FileInPath tableTEDFile;
-  edm::FileInPath tableTREFile;
+    edm::FileInPath tableTEDFile;
+    edm::FileInPath tableTREFile;
 
-  string asciiEventOutName_;
-  std::ofstream asciiEventOut_;
+    string asciiEventOutName_;
+    std::ofstream asciiEventOut_;
 
-  // settings containing various constants for the tracklet processing
-  trklet::Settings settings_;
+    // settings containing various constants for the tracklet processing
+    trklet::Settings settings_;
 
-  // event processor for the tracklet track finding
-  trklet::TrackletEventProcessor eventProcessor;
+    // event processor for the tracklet track finding
+    trklet::TrackletEventProcessor eventProcessor;
 
-  unsigned int nHelixPar_;
-  bool extended_;
-  bool reduced_;
+    unsigned int nHelixPar_;
+    bool extended_;
+    bool reduced_;
 
-  bool trackQuality_;
-  std::unique_ptr<L1TrackQuality> trackQualityModel_;
+    bool trackQuality_;
+    std::unique_ptr<L1TrackQuality> trackQualityModel_;
 
-  std::map<string, vector<int>> dtclayerdisk;
+    std::map<string, vector<int>> dtclayerdisk;
 
-  edm::InputTag MCTruthClusterInputTag;
-  edm::InputTag MCTruthStubInputTag;
-  edm::InputTag TrackingParticleInputTag;
+    edm::InputTag MCTruthClusterInputTag;
+    edm::InputTag MCTruthStubInputTag;
+    edm::InputTag TrackingParticleInputTag;
 
-  const edm::EDGetTokenT<reco::BeamSpot> getTokenBS_;
-  const edm::EDGetTokenT<TTDTC> getTokenDTC_;
-  edm::EDGetTokenT<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> getTokenTTClusterMCTruth_;
-  edm::EDGetTokenT<std::vector<TrackingParticle>> getTokenTrackingParticle_;
+    const edm::EDGetTokenT<reco::BeamSpot> getTokenBS_;
+    const edm::EDGetTokenT<TTDTC> getTokenDTC_;
+    edm::EDGetTokenT<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> getTokenTTClusterMCTruth_;
+    edm::EDGetTokenT<std::vector<TrackingParticle>> getTokenTrackingParticle_;
 
-  // ED output token for clock and bit accurate tracks
-  const edm::EDPutTokenT<Streams> putTokenTracks_;
-  // ED output token for clock and bit accurate stubs
-  const edm::EDPutTokenT<StreamsStub> putTokenStubs_;
-  // ChannelAssignment token
-  const ESGetToken<ChannelAssignment, ChannelAssignmentRcd> esGetTokenChannelAssignment_;
-  // helper class to assign tracks to channel
-  const ChannelAssignment* channelAssignment_;
+    // ED output token for clock and bit accurate tracks
+    const edm::EDPutTokenT<Streams> putTokenTracks_;
+    // ED output token for clock and bit accurate stubs
+    const edm::EDPutTokenT<StreamsStub> putTokenStubs_;
+    // ChannelAssignment token
+    const ESGetToken<ChannelAssignment, ChannelAssignmentRcd> esGetTokenChannelAssignment_;
+    // helper class to assign tracks to channel
+    const ChannelAssignment* channelAssignment_;
 
-  // helper class to store DTC configuration
-  const Setup* setup_;
-  // helper class to store configuration needed by HitPatternHelper
-  const hph::Setup* setupHPH_;
+    // helper class to store DTC configuration
+    const Setup* setup_;
+    // helper class to store configuration needed by HitPatternHelper
+    const hph::Setup* setupHPH_;
 
-  // Setup token
-  const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> esGetTokenBfield_;
-  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> esGetTokenTGeom_;
-  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> esGetTokenTTopo_;
-  const edm::ESGetToken<tt::Setup, tt::SetupRcd> esGetToken_;
-  const edm::ESGetToken<hph::Setup, hph::SetupRcd> esGetTokenHPH_;
+    // Setup token
+    const edm::ESGetToken<MagneticField, IdealMagneticFieldRecord> esGetTokenBfield_;
+    const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> esGetTokenTGeom_;
+    const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> esGetTokenTTopo_;
+    const edm::ESGetToken<tt::Setup, tt::SetupRcd> esGetToken_;
+    const edm::ESGetToken<hph::Setup, hph::SetupRcd> esGetTokenHPH_;
 
-  /// ///////////////// ///
-  /// MANDATORY METHODS ///
-  void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
-  void endRun(edm::Run const&, edm::EventSetup const&) override;
-  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
-};
+    /// ///////////////// ///
+    /// MANDATORY METHODS ///
+    void beginRun(const edm::Run& run, const edm::EventSetup& iSetup) override;
+    void endRun(edm::Run const&, edm::EventSetup const&) override;
+    void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+  };
 
-//////////////
-// CONSTRUCTOR
-L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
-    : config(iConfig),
-      readMoreMcTruth_(iConfig.getParameter<bool>("readMoreMcTruth")),
-      MCTruthClusterInputTag(readMoreMcTruth_ ? config.getParameter<edm::InputTag>("MCTruthClusterInputTag")
-                                              : edm::InputTag()),
-      MCTruthStubInputTag(readMoreMcTruth_ ? config.getParameter<edm::InputTag>("MCTruthStubInputTag")
-                                           : edm::InputTag()),
-      TrackingParticleInputTag(readMoreMcTruth_ ? iConfig.getParameter<edm::InputTag>("TrackingParticleInputTag")
+  //////////////
+  // CONSTRUCTOR
+  L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
+      : config(iConfig),
+        readMoreMcTruth_(iConfig.getParameter<bool>("readMoreMcTruth")),
+        MCTruthClusterInputTag(readMoreMcTruth_ ? config.getParameter<edm::InputTag>("MCTruthClusterInputTag")
                                                 : edm::InputTag()),
-      // book ED products
-      getTokenBS_(consumes<reco::BeamSpot>(config.getParameter<edm::InputTag>("BeamSpotSource"))),
-      getTokenDTC_(consumes<TTDTC>(edm::InputTag(iConfig.getParameter<edm::InputTag>("InputTagTTDTC")))),
-      // book ED output token for clock and bit accurate tracks
-      putTokenTracks_(produces<Streams>("Level1TTTracks")),
-      // book ED output token for clock and bit accurate stubs
-      putTokenStubs_(produces<StreamsStub>("Level1TTTracks")),
-      // book ES products
-      esGetTokenChannelAssignment_(esConsumes<ChannelAssignment, ChannelAssignmentRcd, Transition::BeginRun>()),
-      esGetTokenBfield_(esConsumes<edm::Transition::BeginRun>()),
-      esGetTokenTGeom_(esConsumes()),
-      esGetTokenTTopo_(esConsumes()),
-      esGetToken_(esConsumes<tt::Setup, tt::SetupRcd, edm::Transition::BeginRun>()),
-      esGetTokenHPH_(esConsumes<hph::Setup, hph::SetupRcd, edm::Transition::BeginRun>()) {
-  if (readMoreMcTruth_) {
-    getTokenTTClusterMCTruth_ = consumes<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>(MCTruthClusterInputTag);
-    getTokenTrackingParticle_ = consumes<std::vector<TrackingParticle>>(TrackingParticleInputTag);
-  }
+        MCTruthStubInputTag(readMoreMcTruth_ ? config.getParameter<edm::InputTag>("MCTruthStubInputTag")
+                                             : edm::InputTag()),
+        TrackingParticleInputTag(readMoreMcTruth_ ? iConfig.getParameter<edm::InputTag>("TrackingParticleInputTag")
+                                                  : edm::InputTag()),
+        // book ED products
+        getTokenBS_(consumes<reco::BeamSpot>(config.getParameter<edm::InputTag>("BeamSpotSource"))),
+        getTokenDTC_(consumes<TTDTC>(edm::InputTag(iConfig.getParameter<edm::InputTag>("InputTagTTDTC")))),
+        // book ED output token for clock and bit accurate tracks
+        putTokenTracks_(produces<Streams>("Level1TTTracks")),
+        // book ED output token for clock and bit accurate stubs
+        putTokenStubs_(produces<StreamsStub>("Level1TTTracks")),
+        // book ES products
+        esGetTokenChannelAssignment_(esConsumes<ChannelAssignment, ChannelAssignmentRcd, Transition::BeginRun>()),
+        esGetTokenBfield_(esConsumes<edm::Transition::BeginRun>()),
+        esGetTokenTGeom_(esConsumes()),
+        esGetTokenTTopo_(esConsumes()),
+        esGetToken_(esConsumes<tt::Setup, tt::SetupRcd, edm::Transition::BeginRun>()),
+        esGetTokenHPH_(esConsumes<hph::Setup, hph::SetupRcd, edm::Transition::BeginRun>()) {
+    if (readMoreMcTruth_) {
+      getTokenTTClusterMCTruth_ = consumes<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>>(MCTruthClusterInputTag);
+      getTokenTrackingParticle_ = consumes<std::vector<TrackingParticle>>(TrackingParticleInputTag);
+    }
 
-  produces<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>("Level1TTTracks").setBranchAlias("Level1TTTracks");
+    produces<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>("Level1TTTracks").setBranchAlias("Level1TTTracks");
 
-  asciiEventOutName_ = iConfig.getUntrackedParameter<string>("asciiFileName", "");
+    asciiEventOutName_ = iConfig.getUntrackedParameter<string>("asciiFileName", "");
 
-  fitPatternFile = iConfig.getParameter<edm::FileInPath>("fitPatternFile");
-  processingModulesFile = iConfig.getParameter<edm::FileInPath>("processingModulesFile");
-  memoryModulesFile = iConfig.getParameter<edm::FileInPath>("memoryModulesFile");
-  wiresFile = iConfig.getParameter<edm::FileInPath>("wiresFile");
+    fitPatternFile = iConfig.getParameter<edm::FileInPath>("fitPatternFile");
+    processingModulesFile = iConfig.getParameter<edm::FileInPath>("processingModulesFile");
+    memoryModulesFile = iConfig.getParameter<edm::FileInPath>("memoryModulesFile");
+    wiresFile = iConfig.getParameter<edm::FileInPath>("wiresFile");
 
-  extended_ = iConfig.getParameter<bool>("Extended");
-  reduced_ = iConfig.getParameter<bool>("Reduced");
-  nHelixPar_ = iConfig.getParameter<unsigned int>("Hnpar");
+    extended_ = iConfig.getParameter<bool>("Extended");
+    reduced_ = iConfig.getParameter<bool>("Reduced");
+    nHelixPar_ = iConfig.getParameter<unsigned int>("Hnpar");
 
-  if (extended_) {
-    tableTEDFile = iConfig.getParameter<edm::FileInPath>("tableTEDFile");
-    tableTREFile = iConfig.getParameter<edm::FileInPath>("tableTREFile");
-  }
-
-  // initial ES products
-  channelAssignment_ = nullptr;
-  setup_ = nullptr;
-
-  // --------------------------------------------------------------------------------
-  // set options in Settings based on inputs from configuration files
-  // --------------------------------------------------------------------------------
-
-  settings_.setExtended(extended_);
-  settings_.setReduced(reduced_);
-  settings_.setNHelixPar(nHelixPar_);
-
-  settings_.setFitPatternFile(fitPatternFile.fullPath());
-  settings_.setProcessingModulesFile(processingModulesFile.fullPath());
-  settings_.setMemoryModulesFile(memoryModulesFile.fullPath());
-  settings_.setWiresFile(wiresFile.fullPath());
-
-  settings_.setFakefit(iConfig.getParameter<bool>("Fakefit"));
-  settings_.setStoreTrackBuilderOutput(iConfig.getParameter<bool>("StoreTrackBuilderOutput"));
-  settings_.setRemovalType(iConfig.getParameter<string>("RemovalType"));
-  settings_.setDoMultipleMatches(iConfig.getParameter<bool>("DoMultipleMatches"));
-
-  if (extended_) {
-    settings_.setTableTEDFile(tableTEDFile.fullPath());
-    settings_.setTableTREFile(tableTREFile.fullPath());
-
-    //FIXME: The TED and TRE tables are currently disabled by default, so we
-    //need to allow for the additional tracklets that will eventually be
-    //removed by these tables, once they are finalized
-    settings_.setNbitstrackletindex(15);
-  }
-
-  eventnum = 0;
-  if (not asciiEventOutName_.empty()) {
-    asciiEventOut_.open(asciiEventOutName_.c_str());
-  }
-
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "fit pattern :     " << fitPatternFile.fullPath()
-                                 << "\n process modules : " << processingModulesFile.fullPath()
-                                 << "\n memory modules :  " << memoryModulesFile.fullPath()
-                                 << "\n wires          :  " << wiresFile.fullPath();
     if (extended_) {
-      edm::LogVerbatim("Tracklet") << "table_TED    :  " << tableTEDFile.fullPath()
-                                   << "\n table_TRE    :  " << tableTREFile.fullPath();
+      tableTEDFile = iConfig.getParameter<edm::FileInPath>("tableTEDFile");
+      tableTREFile = iConfig.getParameter<edm::FileInPath>("tableTREFile");
+    }
+
+    // initial ES products
+    channelAssignment_ = nullptr;
+    setup_ = nullptr;
+
+    // --------------------------------------------------------------------------------
+    // set options in Settings based on inputs from configuration files
+    // --------------------------------------------------------------------------------
+
+    settings_.setExtended(extended_);
+    settings_.setReduced(reduced_);
+    settings_.setNHelixPar(nHelixPar_);
+
+    settings_.setFitPatternFile(fitPatternFile.fullPath());
+    settings_.setProcessingModulesFile(processingModulesFile.fullPath());
+    settings_.setMemoryModulesFile(memoryModulesFile.fullPath());
+    settings_.setWiresFile(wiresFile.fullPath());
+
+    settings_.setFakefit(iConfig.getParameter<bool>("Fakefit"));
+    settings_.setStoreTrackBuilderOutput(iConfig.getParameter<bool>("StoreTrackBuilderOutput"));
+    settings_.setRemovalType(iConfig.getParameter<string>("RemovalType"));
+    settings_.setDoMultipleMatches(iConfig.getParameter<bool>("DoMultipleMatches"));
+
+    if (extended_) {
+      settings_.setTableTEDFile(tableTEDFile.fullPath());
+      settings_.setTableTREFile(tableTREFile.fullPath());
+
+      //FIXME: The TED and TRE tables are currently disabled by default, so we
+      //need to allow for the additional tracklets that will eventually be
+      //removed by these tables, once they are finalized
+      settings_.setNbitstrackletindex(15);
+    }
+
+    eventnum = 0;
+    if (not asciiEventOutName_.empty()) {
+      asciiEventOut_.open(asciiEventOutName_.c_str());
+    }
+
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "fit pattern :     " << fitPatternFile.fullPath()
+                                   << "\n process modules : " << processingModulesFile.fullPath()
+                                   << "\n memory modules :  " << memoryModulesFile.fullPath()
+                                   << "\n wires          :  " << wiresFile.fullPath();
+      if (extended_) {
+        edm::LogVerbatim("Tracklet") << "table_TED    :  " << tableTEDFile.fullPath()
+                                     << "\n table_TRE    :  " << tableTREFile.fullPath();
+      }
+    }
+
+    trackQuality_ = iConfig.getParameter<bool>("TrackQuality");
+    if (trackQuality_) {
+      trackQualityModel_ =
+          std::make_unique<L1TrackQuality>(iConfig.getParameter<edm::ParameterSet>("TrackQualityPSet"));
+    }
+    if (settings_.storeTrackBuilderOutput() && (settings_.doMultipleMatches() || !settings_.removalType().empty())) {
+      cms::Exception exception("ConfigurationNotSupported.");
+      exception.addContext("L1FPGATrackProducer::produce");
+      if (settings_.doMultipleMatches())
+        exception << "Storing of TrackBuilder output does not support doMultipleMatches.";
+      if (!settings_.removalType().empty())
+        exception << "Storing of TrackBuilder output does not support duplicate removal.";
+      throw exception;
     }
   }
 
-  trackQuality_ = iConfig.getParameter<bool>("TrackQuality");
-  if (trackQuality_) {
-    trackQualityModel_ = std::make_unique<L1TrackQuality>(iConfig.getParameter<edm::ParameterSet>("TrackQualityPSet"));
+  /////////////
+  // DESTRUCTOR
+  L1FPGATrackProducer::~L1FPGATrackProducer() {
+    if (asciiEventOut_.is_open()) {
+      asciiEventOut_.close();
+    }
   }
-  if (settings_.storeTrackBuilderOutput() && (settings_.doMultipleMatches() || !settings_.removalType().empty())) {
-    cms::Exception exception("ConfigurationNotSupported.");
-    exception.addContext("L1FPGATrackProducer::produce");
-    if (settings_.doMultipleMatches())
-      exception << "Storing of TrackBuilder output does not support doMultipleMatches.";
-    if (!settings_.removalType().empty())
-      exception << "Storing of TrackBuilder output does not support duplicate removal.";
-    throw exception;
-  }
-}
 
-/////////////
-// DESTRUCTOR
-L1FPGATrackProducer::~L1FPGATrackProducer() {
-  if (asciiEventOut_.is_open()) {
-    asciiEventOut_.close();
-  }
-}
-
-///////END RUN
-//
-void L1FPGATrackProducer::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
-
-////////////
-// BEGIN JOB
-void L1FPGATrackProducer::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
-  ////////////////////////
-  // GET MAGNETIC FIELD //
-  const MagneticField* theMagneticField = &iSetup.getData(esGetTokenBfield_);
-  double mMagneticFieldStrength = theMagneticField->inTesla(GlobalPoint(0, 0, 0)).z();
-  settings_.setBfield(mMagneticFieldStrength);
-
-  setup_ = &iSetup.getData(esGetToken_);
-
-  settings_.passSetup(setup_);
-
-  setupHPH_ = &iSetup.getData(esGetTokenHPH_);
-  // Tracklet pattern reco output channel info.
-  channelAssignment_ = &iSetup.getData(esGetTokenChannelAssignment_);
-  // initialize the tracklet event processing (this sets all the processing & memory modules, wiring, etc)
-  eventProcessor.init(settings_, setup_);
-}
-
-//////////
-// PRODUCE
-void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  typedef std::map<trklet::L1TStub,
-                   edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>,
-                   L1TStubCompare>
-      stubMapType;
-  typedef std::map<unsigned int,
-                   edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
-      stubIndexMapType;
-  typedef edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>
-      TTClusterRef;
-
-  /// Prepare output
-  auto L1TkTracksForOutput = std::make_unique<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>();
-
-  stubMapType stubMap;
-  stubIndexMapType stubIndexMap;
+  ///////END RUN
+  //
+  void L1FPGATrackProducer::endRun(const edm::Run& run, const edm::EventSetup& iSetup) {}
 
   ////////////
-  // GET BS //
-  edm::Handle<reco::BeamSpot> beamSpotHandle;
-  iEvent.getByToken(getTokenBS_, beamSpotHandle);
-  math::XYZPoint bsPosition = beamSpotHandle->position();
+  // BEGIN JOB
+  void L1FPGATrackProducer::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
+    ////////////////////////
+    // GET MAGNETIC FIELD //
+    const MagneticField* theMagneticField = &iSetup.getData(esGetTokenBfield_);
+    double mMagneticFieldStrength = theMagneticField->inTesla(GlobalPoint(0, 0, 0)).z();
+    settings_.setBfield(mMagneticFieldStrength);
 
-  eventnum++;
-  trklet::SLHCEvent ev;
-  ev.setEventNum(eventnum);
-  ev.setIP(bsPosition.x(), bsPosition.y());
+    setup_ = &iSetup.getData(esGetToken_);
 
-  // tracking particles
-  edm::Handle<std::vector<TrackingParticle>> TrackingParticleHandle;
-  if (readMoreMcTruth_)
-    iEvent.getByToken(getTokenTrackingParticle_, TrackingParticleHandle);
+    settings_.passSetup(setup_);
 
-  // tracker topology
-  const TrackerTopology* const tTopo = &iSetup.getData(esGetTokenTTopo_);
-  const TrackerGeometry* const theTrackerGeom = &iSetup.getData(esGetTokenTGeom_);
+    setupHPH_ = &iSetup.getData(esGetTokenHPH_);
+    // Tracklet pattern reco output channel info.
+    channelAssignment_ = &iSetup.getData(esGetTokenChannelAssignment_);
+    // initialize the tracklet event processing (this sets all the processing & memory modules, wiring, etc)
+    eventProcessor.init(settings_, setup_);
+  }
 
-  ////////////////////////
-  // GET THE PRIMITIVES //
-  edm::Handle<TTDTC> handleDTC;
-  iEvent.getByToken<TTDTC>(getTokenDTC_, handleDTC);
+  //////////
+  // PRODUCE
+  void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    typedef std::map<trklet::L1TStub,
+                     edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>,
+                     L1TStubCompare>
+        stubMapType;
+    typedef std::map<unsigned int,
+                     edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
+        stubIndexMapType;
+    typedef edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>
+        TTClusterRef;
 
-  // must be defined for code to compile, even if it's not used unless readMoreMcTruth_ is true
-  map<edm::Ptr<TrackingParticle>, int> translateTP;
+    /// Prepare output
+    auto L1TkTracksForOutput = std::make_unique<std::vector<TTTrack<Ref_Phase2TrackerDigi_>>>();
 
-  // MC truth association maps
-  edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> MCTruthTTClusterHandle;
-  if (readMoreMcTruth_) {
-    iEvent.getByToken(getTokenTTClusterMCTruth_, MCTruthTTClusterHandle);
+    stubMapType stubMap;
+    stubIndexMapType stubIndexMap;
 
-    ////////////////////////////////////////////////
-    /// LOOP OVER TRACKING PARTICLES & GET SIMTRACKS
+    ////////////
+    // GET BS //
+    edm::Handle<reco::BeamSpot> beamSpotHandle;
+    iEvent.getByToken(getTokenBS_, beamSpotHandle);
+    math::XYZPoint bsPosition = beamSpotHandle->position();
 
-    int ntps = 1;  //count from 1 ; 0 will mean invalid
+    eventnum++;
+    trklet::SLHCEvent ev;
+    ev.setEventNum(eventnum);
+    ev.setIP(bsPosition.x(), bsPosition.y());
 
-    int this_tp = 0;
+    // tracking particles
+    edm::Handle<std::vector<TrackingParticle>> TrackingParticleHandle;
+    if (readMoreMcTruth_)
+      iEvent.getByToken(getTokenTrackingParticle_, TrackingParticleHandle);
+
+    // tracker topology
+    const TrackerTopology* const tTopo = &iSetup.getData(esGetTokenTTopo_);
+    const TrackerGeometry* const theTrackerGeom = &iSetup.getData(esGetTokenTGeom_);
+
+    ////////////////////////
+    // GET THE PRIMITIVES //
+    edm::Handle<TTDTC> handleDTC;
+    iEvent.getByToken<TTDTC>(getTokenDTC_, handleDTC);
+
+    // must be defined for code to compile, even if it's not used unless readMoreMcTruth_ is true
+    map<edm::Ptr<TrackingParticle>, int> translateTP;
+
+    // MC truth association maps
+    edm::Handle<TTClusterAssociationMap<Ref_Phase2TrackerDigi_>> MCTruthTTClusterHandle;
     if (readMoreMcTruth_) {
-      for (const auto& iterTP : *TrackingParticleHandle) {
-        edm::Ptr<TrackingParticle> tp_ptr(TrackingParticleHandle, this_tp);
-        this_tp++;
+      iEvent.getByToken(getTokenTTClusterMCTruth_, MCTruthTTClusterHandle);
 
-        // only keep TPs producing a cluster
-        if (MCTruthTTClusterHandle->findTTClusterRefs(tp_ptr).empty())
-          continue;
+      ////////////////////////////////////////////////
+      /// LOOP OVER TRACKING PARTICLES & GET SIMTRACKS
 
-        if (iterTP.g4Tracks().empty()) {
-          continue;
-        }
+      int ntps = 1;  //count from 1 ; 0 will mean invalid
 
-        int sim_eventid = iterTP.g4Tracks().at(0).eventId().event();
-        int sim_type = iterTP.pdgId();
-        float sim_pt = iterTP.pt();
-        float sim_eta = iterTP.eta();
-        float sim_phi = iterTP.phi();
+      int this_tp = 0;
+      if (readMoreMcTruth_) {
+        for (const auto& iterTP : *TrackingParticleHandle) {
+          edm::Ptr<TrackingParticle> tp_ptr(TrackingParticleHandle, this_tp);
+          this_tp++;
 
-        float vx = iterTP.vertex().x();
-        float vy = iterTP.vertex().y();
-        float vz = iterTP.vertex().z();
+          // only keep TPs producing a cluster
+          if (MCTruthTTClusterHandle->findTTClusterRefs(tp_ptr).empty())
+            continue;
 
-        if (sim_pt < 1.0 || std::abs(vz) > 100.0 || hypot(vx, vy) > 50.0)
-          continue;
+          if (iterTP.g4Tracks().empty()) {
+            continue;
+          }
 
-        ev.addL1SimTrack(sim_eventid, ntps, sim_type, sim_pt, sim_eta, sim_phi, vx, vy, vz);
+          int sim_eventid = iterTP.g4Tracks().at(0).eventId().event();
+          int sim_type = iterTP.pdgId();
+          float sim_pt = iterTP.pt();
+          float sim_eta = iterTP.eta();
+          float sim_phi = iterTP.phi();
 
-        translateTP[tp_ptr] = ntps;
-        ntps++;
+          float vx = iterTP.vertex().x();
+          float vy = iterTP.vertex().y();
+          float vz = iterTP.vertex().z();
 
-      }  //end loop over TPs
-    }
+          if (sim_pt < 1.0 || std::abs(vz) > 100.0 || hypot(vx, vy) > 50.0)
+            continue;
 
-  }  // end if (readMoreMcTruth_)
+          ev.addL1SimTrack(sim_eventid, ntps, sim_type, sim_pt, sim_eta, sim_phi, vx, vy, vz);
 
-  /////////////////////////////////
-  /// READ DTC STUB INFORMATION ///
-  /////////////////////////////////
+          translateTP[tp_ptr] = ntps;
+          ntps++;
 
-  // Process stubs in each region and channel within that tracking region
-  unsigned int theStubIndex = 0;
-  for (const int& region : handleDTC->tfpRegions()) {
-    for (const int& channel : handleDTC->tfpChannels()) {
-      // Get the DTC name & ID from the channel
-      unsigned int atcaSlot = channel % 12;
-      string dtcname = settings_.slotToDTCname(atcaSlot);
-      if (channel % 24 >= 12)
-        dtcname = "neg" + dtcname;
-      dtcname += (channel < 24) ? "_A" : "_B";  // which detector region
-      int dtcId = setup_->dtcId(region, channel);
+        }  //end loop over TPs
+      }
 
-      // Get the stubs from the DTC
-      const tt::StreamStub& streamFromDTC{handleDTC->stream(region, channel)};
+    }  // end if (readMoreMcTruth_)
 
-      // Prepare the DTC stubs for the IR
-      for (size_t stubIndex = 0; stubIndex < streamFromDTC.size(); ++stubIndex) {
-        const tt::FrameStub& stub{streamFromDTC[stubIndex]};
-        const TTStubRef& stubRef = stub.first;
+    /////////////////////////////////
+    /// READ DTC STUB INFORMATION ///
+    /////////////////////////////////
 
-        if (stubRef.isNull())
-          continue;
+    // Process stubs in each region and channel within that tracking region
+    unsigned int theStubIndex = 0;
+    for (const int& region : handleDTC->tfpRegions()) {
+      for (const int& channel : handleDTC->tfpChannels()) {
+        // Get the DTC name & ID from the channel
+        unsigned int atcaSlot = channel % 12;
+        string dtcname = settings_.slotToDTCname(atcaSlot);
+        if (channel % 24 >= 12)
+          dtcname = "neg" + dtcname;
+        dtcname += (channel < 24) ? "_A" : "_B";  // which detector region
+        int dtcId = setup_->dtcId(region, channel);
 
-        const GlobalPoint& ttPos = setup_->stubPos(stubRef);
+        // Get the stubs from the DTC
+        const tt::StreamStub& streamFromDTC{handleDTC->stream(region, channel)};
 
-        //Get the 2 bits for the layercode
-        string layerword = stub.second.to_string().substr(61, 2);
-        unsigned int layercode = 2 * (layerword[0] - '0') + layerword[1] - '0';
-        assert(layercode < 4);
+        // Prepare the DTC stubs for the IR
+        for (size_t stubIndex = 0; stubIndex < streamFromDTC.size(); ++stubIndex) {
+          const tt::FrameStub& stub{streamFromDTC[stubIndex]};
+          const TTStubRef& stubRef = stub.first;
 
-        //translation from the two bit layercode to the layer/disk number of each of the
-        //12 channels (dtcs)
-        // FIX: take this from DTC cabling map.
-        static const int layerdisktab[12][4] = {{0, 6, 8, 10},
-                                                {0, 7, 9, -1},
-                                                {1, 7, -1, -1},
-                                                {6, 8, 10, -1},
-                                                {2, 7, -1, -1},
-                                                {2, 9, -1, -1},
-                                                {3, 4, -1, -1},
-                                                {4, -1, -1, -1},
-                                                {5, -1, -1, -1},
-                                                {5, 8, -1, -1},
-                                                {6, 9, -1, -1},
-                                                {7, 10, -1, -1}};
+          if (stubRef.isNull())
+            continue;
 
-        int layerdisk = layerdisktab[channel % 12][layercode];
-        assert(layerdisk != -1);
+          const GlobalPoint& ttPos = setup_->stubPos(stubRef);
 
-        //Get the 36 bit word - skip the lowest 3 buts (status and layer code)
-        constexpr int DTCLinkWordSize = 64;
-        constexpr int StubWordSize = 36;
-        constexpr int LayerandStatusCodeSize = 3;
-        string stubword =
-            stub.second.to_string().substr(DTCLinkWordSize - StubWordSize - LayerandStatusCodeSize, StubWordSize);
-        string stubwordhex = "";
+          //Get the 2 bits for the layercode
+          string layerword = stub.second.to_string().substr(61, 2);
+          unsigned int layercode = 2 * (layerword[0] - '0') + layerword[1] - '0';
+          assert(layercode < 4);
 
-        //Loop over the 9 words in the 36 bit stub word
-        for (unsigned int i = 0; i < 9; i++) {
-          bitset<4> bits(stubword.substr(i * 4, 4));
-          ulong val = bits.to_ulong();
-          stubwordhex += ((val < 10) ? ('0' + val) : ('A' + val - 10));
-        }
+          //translation from the two bit layercode to the layer/disk number of each of the
+          //12 channels (dtcs)
+          // FIX: take this from DTC cabling map.
+          static const int layerdisktab[12][4] = {{0, 6, 8, 10},
+                                                  {0, 7, 9, -1},
+                                                  {1, 7, -1, -1},
+                                                  {6, 8, 10, -1},
+                                                  {2, 7, -1, -1},
+                                                  {2, 9, -1, -1},
+                                                  {3, 4, -1, -1},
+                                                  {4, -1, -1, -1},
+                                                  {5, -1, -1, -1},
+                                                  {5, 8, -1, -1},
+                                                  {6, 9, -1, -1},
+                                                  {7, 10, -1, -1}};
 
-        /// Get the Inner and Outer TTCluster
-        edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>
-            innerCluster = stub.first->clusterRef(0);
-        edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>
-            outerCluster = stub.first->clusterRef(1);
+          int layerdisk = layerdisktab[channel % 12][layercode];
+          assert(layerdisk != -1);
 
-        // -----------------------------------------------------
-        // check module orientation, if flipped, need to store that information for track fit
-        // -----------------------------------------------------
+          //Get the 36 bit word - skip the lowest 3 buts (status and layer code)
+          constexpr int DTCLinkWordSize = 64;
+          constexpr int StubWordSize = 36;
+          constexpr int LayerandStatusCodeSize = 3;
+          string stubword =
+              stub.second.to_string().substr(DTCLinkWordSize - StubWordSize - LayerandStatusCodeSize, StubWordSize);
+          string stubwordhex = "";
 
-        const DetId innerDetId = innerCluster->getDetId();
-        const GeomDetUnit* det_inner = theTrackerGeom->idToDetUnit(innerDetId);
-        const auto* theGeomDet_inner = dynamic_cast<const PixelGeomDetUnit*>(det_inner);
-        const PixelTopology* topol_inner = dynamic_cast<const PixelTopology*>(&(theGeomDet_inner->specificTopology()));
+          //Loop over the 9 words in the 36 bit stub word
+          for (unsigned int i = 0; i < 9; i++) {
+            bitset<4> bits(stubword.substr(i * 4, 4));
+            ulong val = bits.to_ulong();
+            stubwordhex += ((val < 10) ? ('0' + val) : ('A' + val - 10));
+          }
 
-        MeasurementPoint coords_inner = innerCluster->findAverageLocalCoordinatesCentered();
-        LocalPoint clustlp_inner = topol_inner->localPosition(coords_inner);
-        GlobalPoint posStub_inner = theGeomDet_inner->surface().toGlobal(clustlp_inner);
+          /// Get the Inner and Outer TTCluster
+          edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>
+              innerCluster = stub.first->clusterRef(0);
+          edm::Ref<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>, TTCluster<Ref_Phase2TrackerDigi_>>
+              outerCluster = stub.first->clusterRef(1);
 
-        const DetId outerDetId = outerCluster->getDetId();
-        const GeomDetUnit* det_outer = theTrackerGeom->idToDetUnit(outerDetId);
-        const auto* theGeomDet_outer = dynamic_cast<const PixelGeomDetUnit*>(det_outer);
-        const PixelTopology* topol_outer = dynamic_cast<const PixelTopology*>(&(theGeomDet_outer->specificTopology()));
+          // -----------------------------------------------------
+          // check module orientation, if flipped, need to store that information for track fit
+          // -----------------------------------------------------
 
-        MeasurementPoint coords_outer = outerCluster->findAverageLocalCoordinatesCentered();
-        LocalPoint clustlp_outer = topol_outer->localPosition(coords_outer);
-        GlobalPoint posStub_outer = theGeomDet_outer->surface().toGlobal(clustlp_outer);
+          const DetId innerDetId = innerCluster->getDetId();
+          const GeomDetUnit* det_inner = theTrackerGeom->idToDetUnit(innerDetId);
+          const auto* theGeomDet_inner = dynamic_cast<const PixelGeomDetUnit*>(det_inner);
+          const PixelTopology* topol_inner =
+              dynamic_cast<const PixelTopology*>(&(theGeomDet_inner->specificTopology()));
 
-        bool isFlipped = (posStub_outer.mag() < posStub_inner.mag());
+          MeasurementPoint coords_inner = innerCluster->findAverageLocalCoordinatesCentered();
+          LocalPoint clustlp_inner = topol_inner->localPosition(coords_inner);
+          GlobalPoint posStub_inner = theGeomDet_inner->surface().toGlobal(clustlp_inner);
 
-        vector<int> assocTPs;
+          const DetId outerDetId = outerCluster->getDetId();
+          const GeomDetUnit* det_outer = theTrackerGeom->idToDetUnit(outerDetId);
+          const auto* theGeomDet_outer = dynamic_cast<const PixelGeomDetUnit*>(det_outer);
+          const PixelTopology* topol_outer =
+              dynamic_cast<const PixelTopology*>(&(theGeomDet_outer->specificTopology()));
 
-        for (unsigned int iClus = 0; iClus <= 1; iClus++) {  // Loop over both clusters that make up stub.
+          MeasurementPoint coords_outer = outerCluster->findAverageLocalCoordinatesCentered();
+          LocalPoint clustlp_outer = topol_outer->localPosition(coords_outer);
+          GlobalPoint posStub_outer = theGeomDet_outer->surface().toGlobal(clustlp_outer);
 
-          const TTClusterRef& ttClusterRef = stubRef->clusterRef(iClus);
+          bool isFlipped = (posStub_outer.mag() < posStub_inner.mag());
 
-          // Now identify all TP's contributing to either cluster in stub.
-          if (readMoreMcTruth_) {
-            vector<edm::Ptr<TrackingParticle>> vecTpPtr =
-                MCTruthTTClusterHandle->findTrackingParticlePtrs(ttClusterRef);
+          vector<int> assocTPs;
 
-            for (const edm::Ptr<TrackingParticle>& tpPtr : vecTpPtr) {
-              if (translateTP.find(tpPtr) != translateTP.end()) {
-                if (iClus == 0) {
-                  assocTPs.push_back(translateTP.at(tpPtr));
+          for (unsigned int iClus = 0; iClus <= 1; iClus++) {  // Loop over both clusters that make up stub.
+
+            const TTClusterRef& ttClusterRef = stubRef->clusterRef(iClus);
+
+            // Now identify all TP's contributing to either cluster in stub.
+            if (readMoreMcTruth_) {
+              vector<edm::Ptr<TrackingParticle>> vecTpPtr =
+                  MCTruthTTClusterHandle->findTrackingParticlePtrs(ttClusterRef);
+
+              for (const edm::Ptr<TrackingParticle>& tpPtr : vecTpPtr) {
+                if (translateTP.find(tpPtr) != translateTP.end()) {
+                  if (iClus == 0) {
+                    assocTPs.push_back(translateTP.at(tpPtr));
+                  } else {
+                    assocTPs.push_back(-translateTP.at(tpPtr));
+                  }
+                  // N.B. Since not all tracking particles are stored in InputData::vTPs_, sometimes no match will be found.
                 } else {
-                  assocTPs.push_back(-translateTP.at(tpPtr));
+                  assocTPs.push_back(0);
                 }
-                // N.B. Since not all tracking particles are stored in InputData::vTPs_, sometimes no match will be found.
-              } else {
-                assocTPs.push_back(0);
               }
             }
           }
-        }
 
-        double stubbend = stubRef->bendFE();  //stubRef->rawBend()
-        if (ttPos.z() < -120) {
-          stubbend = -stubbend;
-        }
+          double stubbend = stubRef->bendFE();  //stubRef->rawBend()
+          if (ttPos.z() < -120) {
+            stubbend = -stubbend;
+          }
 
-        bool barrel = (layerdisk < N_LAYER);
-        // See  https://github.com/cms-sw/cmssw/tree/master/Geometry/TrackerNumberingBuilder
-        enum TypeBarrel { nonBarrel = 0, tiltedMinus = 1, tiltedPlus = 2, flat = 3 };
-        const TypeBarrel type = static_cast<TypeBarrel>(tTopo->tobSide(innerDetId));
-        bool tiltedBarrel = barrel && (type == tiltedMinus || type == tiltedPlus);
-        unsigned int tiltedRingId = 0;
-        // Tilted module ring no. (Increasing 1 to 12 as |z| increases).
-        if (tiltedBarrel) {
-          tiltedRingId = tTopo->tobRod(innerDetId);
-          if (type == tiltedMinus) {
-            unsigned int layp1 = 1 + layerdisk;  // Setup counts from 1
-            unsigned int nTilted = setup_->numTiltedLayerRing(layp1);
-            tiltedRingId = 1 + nTilted - tiltedRingId;
+          bool barrel = (layerdisk < N_LAYER);
+          // See  https://github.com/cms-sw/cmssw/tree/master/Geometry/TrackerNumberingBuilder
+          enum TypeBarrel { nonBarrel = 0, tiltedMinus = 1, tiltedPlus = 2, flat = 3 };
+          const TypeBarrel type = static_cast<TypeBarrel>(tTopo->tobSide(innerDetId));
+          bool tiltedBarrel = barrel && (type == tiltedMinus || type == tiltedPlus);
+          unsigned int tiltedRingId = 0;
+          // Tilted module ring no. (Increasing 1 to 12 as |z| increases).
+          if (tiltedBarrel) {
+            tiltedRingId = tTopo->tobRod(innerDetId);
+            if (type == tiltedMinus) {
+              unsigned int layp1 = 1 + layerdisk;  // Setup counts from 1
+              unsigned int nTilted = setup_->numTiltedLayerRing(layp1);
+              tiltedRingId = 1 + nTilted - tiltedRingId;
+            }
+          }
+          // Endcap module ring number (1-15) in endcap disks.
+          unsigned int endcapRingId = barrel ? 0 : tTopo->tidRing(innerDetId);
+
+          const unsigned int intDetId = innerDetId.rawId();
+
+          ev.addStub(dtcname,
+                     region,
+                     layerdisk,
+                     stubwordhex,
+                     setup_->psModule(dtcId),
+                     isFlipped,
+                     tiltedBarrel,
+                     tiltedRingId,
+                     endcapRingId,
+                     intDetId,
+                     ttPos.x(),
+                     ttPos.y(),
+                     ttPos.z(),
+                     stubbend,
+                     stubRef->innerClusterPosition(),
+                     assocTPs,
+                     theStubIndex);
+
+          const trklet::L1TStub& lastStub = ev.lastStub();
+          stubMap[lastStub] = stubRef;
+          stubIndexMap[lastStub.uniqueIndex()] = stub.first;
+          theStubIndex++;
+        }
+      }
+    }
+
+    //////////////////////////
+    // NOW RUN THE L1 tracking
+
+    if (!asciiEventOutName_.empty()) {
+      ev.write(asciiEventOut_);
+    }
+
+    const std::vector<trklet::Track>& tracks = eventProcessor.tracks();
+
+    const unsigned int maxNumProjectionLayers = channelAssignment_->maxNumProjectionLayers();
+    // number of track channels
+    const unsigned int numStreamsTrack = N_SECTOR * channelAssignment_->numChannelsTrack();
+    // number of stub channels
+    const unsigned int numStreamsStub = N_SECTOR * channelAssignment_->numChannelsStub();
+    // number of stub channels if all seed types streams padded to have same number of stub channels (for coding simplicity)
+    const unsigned int numStreamsStubRaw = numStreamsTrack * maxNumProjectionLayers;
+
+    // Streams formatted to allow this code to run outside CMSSW.
+    vector<vector<string>> streamsTrackRaw(numStreamsTrack);
+    vector<vector<StubStreamData>> streamsStubRaw(numStreamsStubRaw);
+
+    // this performs the actual tracklet event processing
+    eventProcessor.event(ev, streamsTrackRaw, streamsStubRaw);
+
+    int ntracks = 0;
+
+    for (const auto& track : tracks) {
+      if (track.duplicate())
+        continue;
+
+      ntracks++;
+
+      // this is where we create the TTTrack object
+      double tmp_rinv = track.rinv(settings_);
+      double tmp_phi = track.phi0(settings_);
+      double tmp_tanL = track.tanL(settings_);
+      double tmp_z0 = track.z0(settings_);
+      double tmp_d0 = track.d0(settings_);
+      double tmp_chi2rphi = track.chisqrphi();
+      double tmp_chi2rz = track.chisqrz();
+      unsigned int tmp_hit = track.hitpattern();
+
+      TTTrack<Ref_Phase2TrackerDigi_> aTrack(tmp_rinv,
+                                             tmp_phi,
+                                             tmp_tanL,
+                                             tmp_z0,
+                                             tmp_d0,
+                                             tmp_chi2rphi,
+                                             tmp_chi2rz,
+                                             0,
+                                             0,
+                                             0,
+                                             tmp_hit,
+                                             settings_.nHelixPar(),
+                                             settings_.bfield());
+
+      unsigned int trksector = track.sector();
+      unsigned int trkseed = (unsigned int)abs(track.seed());
+
+      aTrack.setPhiSector(trksector);
+      aTrack.setTrackSeedType(trkseed);
+
+      const vector<trklet::L1TStub>& stubptrs = track.stubs();
+      vector<trklet::L1TStub> stubs;
+
+      stubs.reserve(stubptrs.size());
+      for (const auto& stubptr : stubptrs) {
+        stubs.push_back(stubptr);
+      }
+
+      int countStubs = 0;
+      stubMapType::const_iterator it;
+      stubIndexMapType::const_iterator itIndex;
+      for (const auto& itstubs : stubs) {
+        itIndex = stubIndexMap.find(itstubs.uniqueIndex());
+        if (itIndex != stubIndexMap.end()) {
+          aTrack.addStubRef(itIndex->second);
+          countStubs = countStubs + 1;
+        } else {
+          // could not find stub in stub map
+        }
+      }
+
+      // pt consistency
+      aTrack.setStubPtConsistency(
+          StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar()));
+
+      // set TTTrack word
+      aTrack.setTrackWordBits();
+
+      if (trackQuality_) {
+        trackQualityModel_->setL1TrackQuality(aTrack);
+      }
+
+      //    hph::HitPatternHelper hph(setupHPH_, tmp_hit, tmp_tanL, tmp_z0);
+      //    if (trackQuality_) {
+      //      trackQualityModel_->setBonusFeatures(hph.bonusFeatures());
+      //    }
+
+      // test track word
+      //aTrack.testTrackWordBits();
+
+      L1TkTracksForOutput->push_back(aTrack);
+    }
+
+    iEvent.put(std::move(L1TkTracksForOutput), "Level1TTTracks");
+
+    // produce clock and bit accurate stream output tracks and stubs.
+    // from end of tracklet pattern recognition.
+    // Convertion here is from stream format that allows this code to run
+    // outside CMSSW to the EDProduct one.
+    Streams streamsTrack(numStreamsTrack);
+    StreamsStub streamsStub(numStreamsStub);
+
+    for (unsigned int chanTrk = 0; chanTrk < numStreamsTrack; chanTrk++) {
+      for (unsigned int itk = 0; itk < streamsTrackRaw[chanTrk].size(); itk++) {
+        std::string bitsTrk = streamsTrackRaw[chanTrk][itk];
+        int iSeed = chanTrk % channelAssignment_->numChannelsTrack();  // seed type
+        streamsTrack[chanTrk].emplace_back(bitsTrk);
+
+        const unsigned int chanStubOffsetIn = chanTrk * maxNumProjectionLayers;
+        const unsigned int chanStubOffsetOut = channelAssignment_->offsetStub(chanTrk);
+        const unsigned int numProjLayers = channelAssignment_->numProjectionLayers(iSeed);
+        TTBV hitMap(0, numProjLayers);
+        // remove padding from stub stream
+        for (unsigned int iproj = 0; iproj < maxNumProjectionLayers; iproj++) {
+          // FW current has one (perhaps invalid) stub per layer per track.
+          const StubStreamData& stubdata = streamsStubRaw[chanStubOffsetIn + iproj][itk];
+          const L1TStub& stub = stubdata.stub();
+          if (stubdata.valid()) {
+            const TTStubRef ttStubRef = stubMap[stub];
+            int layerId(-1);
+            if (!channelAssignment_->layerId(stubdata.iSeed(), ttStubRef, layerId))
+              continue;
+            hitMap.set(layerId);
+            streamsStub[chanStubOffsetOut + layerId].emplace_back(ttStubRef, stubdata.dataBits());
           }
         }
-        // Endcap module ring number (1-15) in endcap disks.
-        unsigned int endcapRingId = barrel ? 0 : tTopo->tidRing(innerDetId);
-
-        const unsigned int intDetId = innerDetId.rawId();
-
-        ev.addStub(dtcname,
-                   region,
-                   layerdisk,
-                   stubwordhex,
-                   setup_->psModule(dtcId),
-                   isFlipped,
-                   tiltedBarrel,
-                   tiltedRingId,
-                   endcapRingId,
-                   intDetId,
-                   ttPos.x(),
-                   ttPos.y(),
-                   ttPos.z(),
-                   stubbend,
-                   stubRef->innerClusterPosition(),
-                   assocTPs,
-                   theStubIndex);
-
-        const trklet::L1TStub& lastStub = ev.lastStub();
-        stubMap[lastStub] = stubRef;
-        stubIndexMap[lastStub.uniqueIndex()] = stub.first;
-        theStubIndex++;
-      }
-    }
-  }
-
-  //////////////////////////
-  // NOW RUN THE L1 tracking
-
-  if (!asciiEventOutName_.empty()) {
-    ev.write(asciiEventOut_);
-  }
-
-  const std::vector<trklet::Track>& tracks = eventProcessor.tracks();
-
-  const unsigned int maxNumProjectionLayers = channelAssignment_->maxNumProjectionLayers();
-  // number of track channels
-  const unsigned int numStreamsTrack = N_SECTOR * channelAssignment_->numChannelsTrack();
-  // number of stub channels
-  const unsigned int numStreamsStub = N_SECTOR * channelAssignment_->numChannelsStub();
-  // number of stub channels if all seed types streams padded to have same number of stub channels (for coding simplicity)
-  const unsigned int numStreamsStubRaw = numStreamsTrack * maxNumProjectionLayers;
-
-  // Streams formatted to allow this code to run outside CMSSW.
-  vector<vector<string>> streamsTrackRaw(numStreamsTrack);
-  vector<vector<StubStreamData>> streamsStubRaw(numStreamsStubRaw);
-
-  // this performs the actual tracklet event processing
-  eventProcessor.event(ev, streamsTrackRaw, streamsStubRaw);
-
-  int ntracks = 0;
-
-  for (const auto& track : tracks) {
-    if (track.duplicate())
-      continue;
-
-    ntracks++;
-
-    // this is where we create the TTTrack object
-    double tmp_rinv = track.rinv(settings_);
-    double tmp_phi = track.phi0(settings_);
-    double tmp_tanL = track.tanL(settings_);
-    double tmp_z0 = track.z0(settings_);
-    double tmp_d0 = track.d0(settings_);
-    double tmp_chi2rphi = track.chisqrphi();
-    double tmp_chi2rz = track.chisqrz();
-    unsigned int tmp_hit = track.hitpattern();
-
-    TTTrack<Ref_Phase2TrackerDigi_> aTrack(tmp_rinv,
-                                           tmp_phi,
-                                           tmp_tanL,
-                                           tmp_z0,
-                                           tmp_d0,
-                                           tmp_chi2rphi,
-                                           tmp_chi2rz,
-                                           0,
-                                           0,
-                                           0,
-                                           tmp_hit,
-                                           settings_.nHelixPar(),
-                                           settings_.bfield());
-
-    unsigned int trksector = track.sector();
-    unsigned int trkseed = (unsigned int)abs(track.seed());
-
-    aTrack.setPhiSector(trksector);
-    aTrack.setTrackSeedType(trkseed);
-
-    const vector<trklet::L1TStub>& stubptrs = track.stubs();
-    vector<trklet::L1TStub> stubs;
-
-    stubs.reserve(stubptrs.size());
-    for (const auto& stubptr : stubptrs) {
-      stubs.push_back(stubptr);
-    }
-
-    int countStubs = 0;
-    stubMapType::const_iterator it;
-    stubIndexMapType::const_iterator itIndex;
-    for (const auto& itstubs : stubs) {
-      itIndex = stubIndexMap.find(itstubs.uniqueIndex());
-      if (itIndex != stubIndexMap.end()) {
-        aTrack.addStubRef(itIndex->second);
-        countStubs = countStubs + 1;
-      } else {
-        // could not find stub in stub map
-      }
-    }
-
-    // pt consistency
-    aTrack.setStubPtConsistency(
-        StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar()));
-
-    // set TTTrack word
-    aTrack.setTrackWordBits();
-
-    if (trackQuality_) {
-      trackQualityModel_->setL1TrackQuality(aTrack);
-    }
-
-    //    hph::HitPatternHelper hph(setupHPH_, tmp_hit, tmp_tanL, tmp_z0);
-    //    if (trackQuality_) {
-    //      trackQualityModel_->setBonusFeatures(hph.bonusFeatures());
-    //    }
-
-    // test track word
-    //aTrack.testTrackWordBits();
-
-    L1TkTracksForOutput->push_back(aTrack);
-  }
-
-  iEvent.put(std::move(L1TkTracksForOutput), "Level1TTTracks");
-
-  // produce clock and bit accurate stream output tracks and stubs.
-  // from end of tracklet pattern recognition.
-  // Convertion here is from stream format that allows this code to run
-  // outside CMSSW to the EDProduct one.
-  Streams streamsTrack(numStreamsTrack);
-  StreamsStub streamsStub(numStreamsStub);
-
-  for (unsigned int chanTrk = 0; chanTrk < numStreamsTrack; chanTrk++) {
-    for (unsigned int itk = 0; itk < streamsTrackRaw[chanTrk].size(); itk++) {
-      std::string bitsTrk = streamsTrackRaw[chanTrk][itk];
-      int iSeed = chanTrk % channelAssignment_->numChannelsTrack();  // seed type
-      streamsTrack[chanTrk].emplace_back(bitsTrk);
-
-      const unsigned int chanStubOffsetIn = chanTrk * maxNumProjectionLayers;
-      const unsigned int chanStubOffsetOut = channelAssignment_->offsetStub(chanTrk);
-      const unsigned int numProjLayers = channelAssignment_->numProjectionLayers(iSeed);
-      TTBV hitMap(0, numProjLayers);
-      // remove padding from stub stream
-      for (unsigned int iproj = 0; iproj < maxNumProjectionLayers; iproj++) {
-        // FW current has one (perhaps invalid) stub per layer per track.
-        const StubStreamData& stubdata = streamsStubRaw[chanStubOffsetIn + iproj][itk];
-        const L1TStub& stub = stubdata.stub();
-        if (stubdata.valid()) {
-          const TTStubRef ttStubRef = stubMap[stub];
-          int layerId(-1);
-          if (!channelAssignment_->layerId(stubdata.iSeed(), ttStubRef, layerId))
-            continue;
-          hitMap.set(layerId);
-          streamsStub[chanStubOffsetOut + layerId].emplace_back(ttStubRef, stubdata.dataBits());
+        for (int layerId : hitMap.ids(false)) {  // invalid stubs
+          streamsStub[chanStubOffsetOut + layerId].emplace_back(tt::FrameStub());
         }
       }
-      for (int layerId : hitMap.ids(false)) {  // invalid stubs
-        streamsStub[chanStubOffsetOut + layerId].emplace_back(tt::FrameStub());
-      }
     }
-  }
 
-  iEvent.emplace(putTokenTracks_, move(streamsTrack));
-  iEvent.emplace(putTokenStubs_, move(streamsStub));
+    iEvent.emplace(putTokenTracks_, move(streamsTrack));
+    iEvent.emplace(putTokenStubs_, move(streamsStub));
 
-}  /// End of produce()
+  }  /// End of produce()
 
-}
+}  // namespace trklet
 
 // ///////////////////////////
 // // DEFINE THIS AS A PLUG-IN

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -113,7 +113,6 @@
 using namespace edm;
 using namespace std;
 using namespace tt;
-using namespace trklet;
 
 //////////////////////////////
 //                          //
@@ -124,6 +123,9 @@ using namespace trklet;
 /////////////////////////////////////
 // this class is needed to make a map
 // between different types of stubs
+
+namespace trklet {
+
 struct L1TStubCompare {
 public:
   bool operator()(const trklet::L1TStub& a, const trklet::L1TStub& b) const {
@@ -777,6 +779,8 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
 }  /// End of produce()
 
+}
+
 // ///////////////////////////
 // // DEFINE THIS AS A PLUG-IN
-DEFINE_FWK_MODULE(L1FPGATrackProducer);
+DEFINE_FWK_MODULE(trklet::L1FPGATrackProducer);

--- a/L1Trigger/TrackFindingTracklet/src/AllInnerStubsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/AllInnerStubsMemory.cc
@@ -7,18 +7,18 @@ using namespace std;
 
 namespace trklet {
 
-AllInnerStubsMemory::AllInnerStubsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
+  AllInnerStubsMemory::AllInnerStubsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
 
-void AllInnerStubsMemory::writeStubs(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirS = settings_.memPath() + "Stubs/";
-  openFile(first, dirS, "AllInnerStubs_");
+  void AllInnerStubsMemory::writeStubs(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirS = settings_.memPath() + "Stubs/";
+    openFile(first, dirS, "AllInnerStubs_");
 
-  for (unsigned int j = 0; j < stubs_.size(); j++) {
-    string stub = stubs_[j]->strinner();
-    out_ << hexstr(j) << " " << stub << " " << hexFormat(stub) << endl;
+    for (unsigned int j = 0; j < stubs_.size(); j++) {
+      string stub = stubs_[j]->strinner();
+      out_ << hexstr(j) << " " << stub << " " << hexFormat(stub) << endl;
+    }
+    out_.close();
   }
-  out_.close();
-}
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/AllInnerStubsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/AllInnerStubsMemory.cc
@@ -4,7 +4,8 @@
 #include <iomanip>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 AllInnerStubsMemory::AllInnerStubsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
 
@@ -18,4 +19,6 @@ void AllInnerStubsMemory::writeStubs(bool first, unsigned int iSector) {
     out_ << hexstr(j) << " " << stub << " " << hexFormat(stub) << endl;
   }
   out_.close();
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/AllProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/AllProjectionsMemory.cc
@@ -7,8 +7,9 @@
 #include <iomanip>
 #include <filesystem>
 
-using namespace trklet;
 using namespace std;
+
+namespace trklet {
 
 AllProjectionsMemory::AllProjectionsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
   initLayerDisk(3, layer_, disk_);
@@ -37,4 +38,5 @@ void AllProjectionsMemory::writeAP(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
 }

--- a/L1Trigger/TrackFindingTracklet/src/AllProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/AllProjectionsMemory.cc
@@ -11,32 +11,32 @@ using namespace std;
 
 namespace trklet {
 
-AllProjectionsMemory::AllProjectionsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
-  initLayerDisk(3, layer_, disk_);
-}
-
-void AllProjectionsMemory::writeAP(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirTP = settings_.memPath() + "TrackletProjections/";
-
-  std::ostringstream oss;
-  oss << dirTP << "AllProj_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirTP, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
-
-  for (unsigned int j = 0; j < tracklets_.size(); j++) {
-    string proj =
-        (layer_ > 0) ? tracklets_[j]->trackletprojstrlayer(layer_) : tracklets_[j]->trackletprojstrdisk(disk_);
-    out_ << hexstr(j) << " " << proj << "  " << trklet::hexFormat(proj) << endl;
+  AllProjectionsMemory::AllProjectionsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
+    initLayerDisk(3, layer_, disk_);
   }
-  out_.close();
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
-}
+  void AllProjectionsMemory::writeAP(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirTP = settings_.memPath() + "TrackletProjections/";
+
+    std::ostringstream oss;
+    oss << dirTP << "AllProj_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
+    auto const& fname = oss.str();
+
+    openfile(out_, first, dirTP, fname, __FILE__, __LINE__);
+
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+
+    for (unsigned int j = 0; j < tracklets_.size(); j++) {
+      string proj =
+          (layer_ > 0) ? tracklets_[j]->trackletprojstrlayer(layer_) : tracklets_[j]->trackletprojstrdisk(disk_);
+      out_ << hexstr(j) << " " << proj << "  " << trklet::hexFormat(proj) << endl;
+    }
+    out_.close();
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
+  }
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/AllStubsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/AllStubsMemory.cc
@@ -4,7 +4,8 @@
 #include <iomanip>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 AllStubsMemory::AllStubsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
 
@@ -18,4 +19,6 @@ void AllStubsMemory::writeStubs(bool first, unsigned int iSector) {
     out_ << hexstr(j) << " " << stub << " " << hexFormat(stub) << endl;
   }
   out_.close();
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/AllStubsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/AllStubsMemory.cc
@@ -7,18 +7,18 @@ using namespace std;
 
 namespace trklet {
 
-AllStubsMemory::AllStubsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
+  AllStubsMemory::AllStubsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
 
-void AllStubsMemory::writeStubs(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirS = settings_.memPath() + "Stubs/";
-  openFile(first, dirS, "AllStubs_");
+  void AllStubsMemory::writeStubs(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirS = settings_.memPath() + "Stubs/";
+    openFile(first, dirS, "AllStubs_");
 
-  for (unsigned int j = 0; j < stubs_.size(); j++) {
-    string stub = stubs_[j]->str();
-    out_ << hexstr(j) << " " << stub << " " << hexFormat(stub) << endl;
+    for (unsigned int j = 0; j < stubs_.size(); j++) {
+      string stub = stubs_[j]->str();
+      out_ << hexstr(j) << " " << stub << " " << hexFormat(stub) << endl;
+    }
+    out_.close();
   }
-  out_.close();
-}
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/CandidateMatchMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/CandidateMatchMemory.cc
@@ -12,51 +12,51 @@ using namespace std;
 
 namespace trklet {
 
-CandidateMatchMemory::CandidateMatchMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
+  CandidateMatchMemory::CandidateMatchMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
 
-void CandidateMatchMemory::addMatch(std::pair<Tracklet*, int> tracklet, const Stub* stub) {
-  std::pair<std::pair<Tracklet*, int>, const Stub*> tmp(tracklet, stub);
+  void CandidateMatchMemory::addMatch(std::pair<Tracklet*, int> tracklet, const Stub* stub) {
+    std::pair<std::pair<Tracklet*, int>, const Stub*> tmp(tracklet, stub);
 
-  //Check for consistency
-  for (auto& match : matches_) {
-    if (tracklet.first->TCID() < match.first.first->TCID()) {
-      throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " In " << getName() << " adding tracklet "
-                                         << tracklet.first << " with lower TCID : " << tracklet.first->TCID()
-                                         << " than earlier TCID " << match.first.first->TCID();
+    //Check for consistency
+    for (auto& match : matches_) {
+      if (tracklet.first->TCID() < match.first.first->TCID()) {
+        throw cms::Exception("LogicError")
+            << __FILE__ << " " << __LINE__ << " In " << getName() << " adding tracklet " << tracklet.first
+            << " with lower TCID : " << tracklet.first->TCID() << " than earlier TCID " << match.first.first->TCID();
+      }
     }
+    matches_.push_back(tmp);
   }
-  matches_.push_back(tmp);
-}
 
-void CandidateMatchMemory::writeCM(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirM = settings_.memPath() + "Matches/";
+  void CandidateMatchMemory::writeCM(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirM = settings_.memPath() + "Matches/";
 
-  std::ostringstream oss;
-  oss << dirM << "CandidateMatches_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1)
-      << ".dat";
-  auto const& fname = oss.str();
+    std::ostringstream oss;
+    oss << dirM << "CandidateMatches_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1)
+        << ".dat";
+    auto const& fname = oss.str();
 
-  openfile(out_, first, dirM, fname, __FILE__, __LINE__);
+    openfile(out_, first, dirM, fname, __FILE__, __LINE__);
 
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
 
-  for (unsigned int j = 0; j < matches_.size(); j++) {
-    string stubid = matches_[j].second->stubindex().str();  // stub ID
-    int projindex = matches_[j].first.second;               // Allproj index
-    FPGAWord tmp;
-    if (projindex >= (1 << 7)) {
-      projindex = (1 << 7) - 1;
+    for (unsigned int j = 0; j < matches_.size(); j++) {
+      string stubid = matches_[j].second->stubindex().str();  // stub ID
+      int projindex = matches_[j].first.second;               // Allproj index
+      FPGAWord tmp;
+      if (projindex >= (1 << 7)) {
+        projindex = (1 << 7) - 1;
+      }
+      tmp.set(projindex, 7, true, __LINE__, __FILE__);
+      out_ << hexstr(j) << " " << tmp.str() << "|" << stubid << " " << trklet::hexFormat(tmp.str() + stubid) << endl;
     }
-    tmp.set(projindex, 7, true, __LINE__, __FILE__);
-    out_ << hexstr(j) << " " << tmp.str() << "|" << stubid << " " << trklet::hexFormat(tmp.str() + stubid) << endl;
+    out_.close();
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
   }
-  out_.close();
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/CandidateMatchMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/CandidateMatchMemory.cc
@@ -9,7 +9,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 CandidateMatchMemory::CandidateMatchMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
 
@@ -56,4 +57,6 @@ void CandidateMatchMemory::writeCM(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/CleanTrackMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/CleanTrackMemory.cc
@@ -5,7 +5,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 CleanTrackMemory::CleanTrackMemory(string name, Settings const& settings, double phimin, double phimax)
     : MemoryBase(name, settings) {
@@ -59,4 +60,6 @@ void CleanTrackMemory::writeCT(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/CleanTrackMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/CleanTrackMemory.cc
@@ -8,58 +8,58 @@ using namespace std;
 
 namespace trklet {
 
-CleanTrackMemory::CleanTrackMemory(string name, Settings const& settings, double phimin, double phimax)
-    : MemoryBase(name, settings) {
-  phimin_ = phimin;
-  phimax_ = phimax;
-}
-
-void CleanTrackMemory::writeCT(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirCT = settings_.memPath() + "CleanTrack/";
-
-  std::ostringstream oss;
-  oss << dirCT << "CleanTrack_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirCT, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
-
-  for (unsigned int j = 0; j < tracks_.size(); j++) {
-    out_ << hexstr(j) << " " << tracks_[j]->trackfitstr() << " " << trklet::hexFormat(tracks_[j]->trackfitstr());
-    out_ << "\n";
+  CleanTrackMemory::CleanTrackMemory(string name, Settings const& settings, double phimin, double phimax)
+      : MemoryBase(name, settings) {
+    phimin_ = phimin;
+    phimax_ = phimax;
   }
-  out_.close();
 
-  // --------------------------------------------------------------
-  // print separately ALL cleaned tracks in single file
-  if (settings_.writeMonitorData("CT")) {
-    std::string fnameAll = "CleanTracksAll.dat";
-    if (first && getName() == "CT_L1L2" && iSector_ == 0)
-      out_.open(fnameAll);
-    else
-      out_.open(fnameAll, std::ofstream::app);
+  void CleanTrackMemory::writeCT(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirCT = settings_.memPath() + "CleanTrack/";
 
-    if (!tracks_.empty())
-      out_ << "BX= " << (bitset<3>)bx_ << " event= " << event_ << " seed= " << getName()
-           << " phisector= " << iSector_ + 1 << endl;
+    std::ostringstream oss;
+    oss << dirCT << "CleanTrack_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
+    auto const& fname = oss.str();
+
+    openfile(out_, first, dirCT, fname, __FILE__, __LINE__);
+
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
 
     for (unsigned int j = 0; j < tracks_.size(); j++) {
-      if (j < 16)
-        out_ << "0";
-      out_ << hex << j << dec << " ";
-      out_ << tracks_[j]->trackfitstr();
+      out_ << hexstr(j) << " " << tracks_[j]->trackfitstr() << " " << trklet::hexFormat(tracks_[j]->trackfitstr());
       out_ << "\n";
     }
     out_.close();
+
+    // --------------------------------------------------------------
+    // print separately ALL cleaned tracks in single file
+    if (settings_.writeMonitorData("CT")) {
+      std::string fnameAll = "CleanTracksAll.dat";
+      if (first && getName() == "CT_L1L2" && iSector_ == 0)
+        out_.open(fnameAll);
+      else
+        out_.open(fnameAll, std::ofstream::app);
+
+      if (!tracks_.empty())
+        out_ << "BX= " << (bitset<3>)bx_ << " event= " << event_ << " seed= " << getName()
+             << " phisector= " << iSector_ + 1 << endl;
+
+      for (unsigned int j = 0; j < tracks_.size(); j++) {
+        if (j < 16)
+          out_ << "0";
+        out_ << hex << j << dec << " ";
+        out_ << tracks_[j]->trackfitstr();
+        out_ << "\n";
+      }
+      out_.close();
+    }
+    // --------------------------------------------------------------
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
   }
-  // --------------------------------------------------------------
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/DTCLinkMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/DTCLinkMemory.cc
@@ -11,8 +11,9 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-using namespace trklet;
 using namespace std;
+
+namespace trklet {
 
 DTCLinkMemory::DTCLinkMemory(string name, Settings const& settings, double, double) : MemoryBase(name, settings) {}
 
@@ -66,4 +67,6 @@ void DTCLinkMemory::clean() {
     delete stub;
   }
   stubs_.clear();
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/DTCLinkMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/DTCLinkMemory.cc
@@ -15,58 +15,58 @@ using namespace std;
 
 namespace trklet {
 
-DTCLinkMemory::DTCLinkMemory(string name, Settings const& settings, double, double) : MemoryBase(name, settings) {}
+  DTCLinkMemory::DTCLinkMemory(string name, Settings const& settings, double, double) : MemoryBase(name, settings) {}
 
-void DTCLinkMemory::addStub(const L1TStub& al1stub, const Stub& stub) {
-  //Make new objects owned by the dtclink memory and save in list of stubs
-  if (stubs_.size() < settings_.maxStep("IR")) {
-    Stub* stubptr = new Stub(stub);
-    stubptr->setl1tstub(new L1TStub(al1stub));
+  void DTCLinkMemory::addStub(const L1TStub& al1stub, const Stub& stub) {
+    //Make new objects owned by the dtclink memory and save in list of stubs
+    if (stubs_.size() < settings_.maxStep("IR")) {
+      Stub* stubptr = new Stub(stub);
+      stubptr->setl1tstub(new L1TStub(al1stub));
 
-    stubs_.emplace_back(stubptr);
-  }
-}
-
-void DTCLinkMemory::writeStubs(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-
-  const string dirIS = settings_.memPath() + "InputStubs/";
-  openFile(first, dirIS, "Link_");
-
-  for (unsigned int j = 0; j < stubs_.size(); j++) {
-    string dtcname = stubs_[j]->l1tstub()->DTClink();
-    int layerdisk = stubs_[j]->l1tstub()->layerdisk();
-
-    //If the string starts with 'neg' skip the first three character
-    int start = dtcname.substr(0, 3) == "neg" ? 3 : 0;
-
-    //For the dtcbase name remove the leading 'neg' if in the name and the trailing '_A' or '_B'
-    string dtcbase = dtcname.substr(start, dtcname.size() - 2 - start);
-
-    const vector<int>& layers = settings_.dtcLayers(dtcbase);
-
-    int lcode = -1;
-    for (unsigned int index = 0; index < layers.size(); index++) {
-      if (layerdisk == layers[index]) {
-        lcode = index;
-      }
+      stubs_.emplace_back(stubptr);
     }
-    assert(lcode != -1);
-
-    FPGAWord ldcode(lcode, 2, true);
-
-    string stub = stubs_[j]->str() + "|" + ldcode.str() + "|1";
-    out_ << hexstr(j) << " " << stub << " " << trklet::hexFormat(stub) << endl;
   }
-  out_.close();
-}
 
-void DTCLinkMemory::clean() {
-  for (auto& stub : stubs_) {
-    delete stub->l1tstub();
-    delete stub;
+  void DTCLinkMemory::writeStubs(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+
+    const string dirIS = settings_.memPath() + "InputStubs/";
+    openFile(first, dirIS, "Link_");
+
+    for (unsigned int j = 0; j < stubs_.size(); j++) {
+      string dtcname = stubs_[j]->l1tstub()->DTClink();
+      int layerdisk = stubs_[j]->l1tstub()->layerdisk();
+
+      //If the string starts with 'neg' skip the first three character
+      int start = dtcname.substr(0, 3) == "neg" ? 3 : 0;
+
+      //For the dtcbase name remove the leading 'neg' if in the name and the trailing '_A' or '_B'
+      string dtcbase = dtcname.substr(start, dtcname.size() - 2 - start);
+
+      const vector<int>& layers = settings_.dtcLayers(dtcbase);
+
+      int lcode = -1;
+      for (unsigned int index = 0; index < layers.size(); index++) {
+        if (layerdisk == layers[index]) {
+          lcode = index;
+        }
+      }
+      assert(lcode != -1);
+
+      FPGAWord ldcode(lcode, 2, true);
+
+      string stub = stubs_[j]->str() + "|" + ldcode.str() + "|1";
+      out_ << hexstr(j) << " " << stub << " " << trklet::hexFormat(stub) << endl;
+    }
+    out_.close();
   }
-  stubs_.clear();
-}
 
-}
+  void DTCLinkMemory::clean() {
+    for (auto& stub : stubs_) {
+      delete stub->l1tstub();
+      delete stub;
+    }
+    stubs_.clear();
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/FPGAWord.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FPGAWord.cc
@@ -6,87 +6,86 @@ using namespace std;
 
 namespace trklet {
 
-FPGAWord::FPGAWord() {}
+  FPGAWord::FPGAWord() {}
 
-FPGAWord::FPGAWord(int value, int nbits, bool positive, int line, const char* file) {
-  set(value, nbits, positive, line, file);
-}
+  FPGAWord::FPGAWord(int value, int nbits, bool positive, int line, const char* file) {
+    set(value, nbits, positive, line, file);
+  }
 
-void FPGAWord::set(int value, int nbits, bool positive, int line, const char* file) {
-  value_ = value;
-  nbits_ = nbits;
-  positive_ = positive;
-  if (positive) {
-    if (value < 0) {
-      edm::LogProblem("Tracklet") << "FPGAWord got negative value:" << value << " (" << file << ":" << line << ")";
-    }
-    assert(value >= 0);
-  }
-  if (nbits >= 22) {
-    edm::LogPrint("Tracklet") << "FPGAWord got too many bits:" << nbits << " (" << file << ":" << line << ")";
-  }
-  assert(nbits < 22);
-  if (nbits <= 0) {
-    edm::LogPrint("Tracklet") << "FPGAWord got too few bits:" << nbits << " (" << file << ":" << line << ")";
-  }
-  assert(nbits > 0);
-  if (positive) {
-    if (value >= (1 << nbits)) {
-      if (file != nullptr) {
-        edm::LogProblem("Tracklet") << "value too large:" << value << " " << (1 << nbits) << " (" << file << ":" << line
-                                    << ")";
+  void FPGAWord::set(int value, int nbits, bool positive, int line, const char* file) {
+    value_ = value;
+    nbits_ = nbits;
+    positive_ = positive;
+    if (positive) {
+      if (value < 0) {
+        edm::LogProblem("Tracklet") << "FPGAWord got negative value:" << value << " (" << file << ":" << line << ")";
       }
+      assert(value >= 0);
     }
-    assert(value < (1 << nbits));
-  } else {
-    if (value >= (1 << (nbits - 1))) {
-      edm::LogProblem("Tracklet") << "value too large:" << value << " " << (1 << (nbits - 1)) - 1 << " (" << file << ":"
-                                  << line << ")";
+    if (nbits >= 22) {
+      edm::LogPrint("Tracklet") << "FPGAWord got too many bits:" << nbits << " (" << file << ":" << line << ")";
     }
-    assert(value < (1 << (nbits - 1)));
-    if (value < -(1 << (nbits - 1))) {
-      edm::LogProblem("Tracklet") << "value too negative:" << value << " " << -(1 << (nbits - 1)) << " (" << file << ":"
-                                  << line << ")";
+    assert(nbits < 22);
+    if (nbits <= 0) {
+      edm::LogPrint("Tracklet") << "FPGAWord got too few bits:" << nbits << " (" << file << ":" << line << ")";
     }
-    assert(value >= -(1 << (nbits - 1)));
+    assert(nbits > 0);
+    if (positive) {
+      if (value >= (1 << nbits)) {
+        if (file != nullptr) {
+          edm::LogProblem("Tracklet") << "value too large:" << value << " " << (1 << nbits) << " (" << file << ":"
+                                      << line << ")";
+        }
+      }
+      assert(value < (1 << nbits));
+    } else {
+      if (value >= (1 << (nbits - 1))) {
+        edm::LogProblem("Tracklet") << "value too large:" << value << " " << (1 << (nbits - 1)) - 1 << " (" << file
+                                    << ":" << line << ")";
+      }
+      assert(value < (1 << (nbits - 1)));
+      if (value < -(1 << (nbits - 1))) {
+        edm::LogProblem("Tracklet") << "value too negative:" << value << " " << -(1 << (nbits - 1)) << " (" << file
+                                    << ":" << line << ")";
+      }
+      assert(value >= -(1 << (nbits - 1)));
+    }
   }
-}
 
-std::string FPGAWord::str() const {
-  const int nbit = nbits_;
+  std::string FPGAWord::str() const {
+    const int nbit = nbits_;
 
-  if (!(nbit > 0 && nbit < 22))
-    edm::LogVerbatim("Tracklet") << "nbit: " << nbit;
-  if (nbit == -1)
-    return "?";
-  if (nbit == 0)
-    return "~";
+    if (!(nbit > 0 && nbit < 22))
+      edm::LogVerbatim("Tracklet") << "nbit: " << nbit;
+    if (nbit == -1)
+      return "?";
+    if (nbit == 0)
+      return "~";
 
-  int valtmp = value_;
-  string str = "";
-  for (int i = 0; i < nbit; i++) {
-    str = ((valtmp & 1) ? "1" : "0") + str;
-    valtmp >>= 1;
+    int valtmp = value_;
+    string str = "";
+    for (int i = 0; i < nbit; i++) {
+      str = ((valtmp & 1) ? "1" : "0") + str;
+      valtmp >>= 1;
+    }
+
+    return str;
   }
 
-  return str;
-}
-
-unsigned int FPGAWord::bits(unsigned int lsb, unsigned int nbit) const {
-  assert(lsb + nbit <= (unsigned int)nbits());
-  return (value_ >> lsb) & ((1 << nbit) - 1);
-}
-
-bool FPGAWord::atExtreme() const {
-  if (positive_) {
-    return (value_ == 0) || (value_ == (1 << nbits_) - 1);
+  unsigned int FPGAWord::bits(unsigned int lsb, unsigned int nbit) const {
+    assert(lsb + nbit <= (unsigned int)nbits());
+    return (value_ >> lsb) & ((1 << nbit) - 1);
   }
-  return ((value_ == (-(1 << (nbits_ - 1)))) || (value_ == ((1 << (nbits_ - 1)) - 1)));
-}
 
-bool FPGAWord::operator==(const FPGAWord& other) const {
-  return (value_ == other.value_) && (nbits_ == other.nbits_) && (positive_ == other.positive_);
-}
+  bool FPGAWord::atExtreme() const {
+    if (positive_) {
+      return (value_ == 0) || (value_ == (1 << nbits_) - 1);
+    }
+    return ((value_ == (-(1 << (nbits_ - 1)))) || (value_ == ((1 << (nbits_ - 1)) - 1)));
+  }
 
-}
+  bool FPGAWord::operator==(const FPGAWord& other) const {
+    return (value_ == other.value_) && (nbits_ == other.nbits_) && (positive_ == other.positive_);
+  }
 
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/FPGAWord.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FPGAWord.cc
@@ -3,7 +3,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 FPGAWord::FPGAWord() {}
 
@@ -86,3 +87,6 @@ bool FPGAWord::atExtreme() const {
 bool FPGAWord::operator==(const FPGAWord& other) const {
   return (value_ == other.value_) && (nbits_ == other.nbits_) && (positive_ == other.positive_);
 }
+
+}
+

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -11,7 +11,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {;
 
 FitTrack::FitTrack(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global), trackfit_(nullptr) {}
@@ -1085,4 +1086,6 @@ void FitTrack::execute(deque<string>& streamTrackRaw,
   if (settings_.writeMonitorData("FT")) {
     globals_->ofstream("fittrack.txt") << getName() << " " << countAll << " " << countFit << endl;
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -12,1080 +12,1086 @@
 
 using namespace std;
 
-namespace trklet {;
+namespace trklet {
+  ;
 
-FitTrack::FitTrack(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global), trackfit_(nullptr) {}
+  FitTrack::FitTrack(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global), trackfit_(nullptr) {}
 
-void FitTrack::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-  if (output == "trackout") {
-    TrackFitMemory* tmp = dynamic_cast<TrackFitMemory*>(memory);
-    assert(tmp != nullptr);
-    trackfit_ = tmp;
-    return;
-  }
+  void FitTrack::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
+    if (output == "trackout") {
+      TrackFitMemory* tmp = dynamic_cast<TrackFitMemory*>(memory);
+      assert(tmp != nullptr);
+      trackfit_ = tmp;
+      return;
+    }
 
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " addOutput, output = " << output << " not known";
-}
-
-void FitTrack::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input.substr(0, 4) == "tpar") {
-    auto* tmp = dynamic_cast<TrackletParametersMemory*>(memory);
-    assert(tmp != nullptr);
-    seedtracklet_.push_back(tmp);
-    return;
-  }
-  if (input.substr(0, 10) == "fullmatch1") {
-    auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
-    assert(tmp != nullptr);
-    fullmatch1_.push_back(tmp);
-    return;
-  }
-  if (input.substr(0, 10) == "fullmatch2") {
-    auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
-    assert(tmp != nullptr);
-    fullmatch2_.push_back(tmp);
-    return;
-  }
-  if (input.substr(0, 10) == "fullmatch3") {
-    auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
-    assert(tmp != nullptr);
-    fullmatch3_.push_back(tmp);
-    return;
-  }
-  if (input.substr(0, 10) == "fullmatch4") {
-    auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
-    assert(tmp != nullptr);
-    fullmatch4_.push_back(tmp);
-    return;
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " addOutput, output = " << output
+                                      << " not known";
   }
 
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " input = " << input << " not found";
-}
+  void FitTrack::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input.substr(0, 4) == "tpar") {
+      auto* tmp = dynamic_cast<TrackletParametersMemory*>(memory);
+      assert(tmp != nullptr);
+      seedtracklet_.push_back(tmp);
+      return;
+    }
+    if (input.substr(0, 10) == "fullmatch1") {
+      auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
+      assert(tmp != nullptr);
+      fullmatch1_.push_back(tmp);
+      return;
+    }
+    if (input.substr(0, 10) == "fullmatch2") {
+      auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
+      assert(tmp != nullptr);
+      fullmatch2_.push_back(tmp);
+      return;
+    }
+    if (input.substr(0, 10) == "fullmatch3") {
+      auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
+      assert(tmp != nullptr);
+      fullmatch3_.push_back(tmp);
+      return;
+    }
+    if (input.substr(0, 10) == "fullmatch4") {
+      auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
+      assert(tmp != nullptr);
+      fullmatch4_.push_back(tmp);
+      return;
+    }
+
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " input = " << input << " not found";
+  }
 
 #ifdef USEHYBRID
-void FitTrack::trackFitKF(Tracklet* tracklet,
-                          std::vector<const Stub*>& trackstublist,
-                          std::vector<std::pair<int, int>>& stubidslist) {
-  if (settings_.doKF()) {
-    // From full match lists, collect all the stubs associated with the tracklet seed
+  void FitTrack::trackFitKF(Tracklet* tracklet,
+                            std::vector<const Stub*>& trackstublist,
+                            std::vector<std::pair<int, int>>& stubidslist) {
+    if (settings_.doKF()) {
+      // From full match lists, collect all the stubs associated with the tracklet seed
 
-    // Get seed stubs first
-    trackstublist.emplace_back(tracklet->innerFPGAStub());
-    if (tracklet->getISeed() >= (int)N_TRKLSEED + 1)
-      trackstublist.emplace_back(tracklet->middleFPGAStub());
-    trackstublist.emplace_back(tracklet->outerFPGAStub());
+      // Get seed stubs first
+      trackstublist.emplace_back(tracklet->innerFPGAStub());
+      if (tracklet->getISeed() >= (int)N_TRKLSEED + 1)
+        trackstublist.emplace_back(tracklet->middleFPGAStub());
+      trackstublist.emplace_back(tracklet->outerFPGAStub());
 
-    // Now get ALL matches (can have multiple per layer)
-    for (const auto& i : fullmatch1_) {
-      for (unsigned int j = 0; j < i->nMatches(); j++) {
-        if (i->getTracklet(j)->TCID() == tracklet->TCID()) {
-          trackstublist.push_back(i->getMatch(j).second);
+      // Now get ALL matches (can have multiple per layer)
+      for (const auto& i : fullmatch1_) {
+        for (unsigned int j = 0; j < i->nMatches(); j++) {
+          if (i->getTracklet(j)->TCID() == tracklet->TCID()) {
+            trackstublist.push_back(i->getMatch(j).second);
+          }
         }
       }
-    }
 
-    for (const auto& i : fullmatch2_) {
-      for (unsigned int j = 0; j < i->nMatches(); j++) {
-        if (i->getTracklet(j)->TCID() == tracklet->TCID()) {
-          trackstublist.push_back(i->getMatch(j).second);
+      for (const auto& i : fullmatch2_) {
+        for (unsigned int j = 0; j < i->nMatches(); j++) {
+          if (i->getTracklet(j)->TCID() == tracklet->TCID()) {
+            trackstublist.push_back(i->getMatch(j).second);
+          }
         }
       }
-    }
 
-    for (const auto& i : fullmatch3_) {
-      for (unsigned int j = 0; j < i->nMatches(); j++) {
-        if (i->getTracklet(j)->TCID() == tracklet->TCID()) {
-          trackstublist.push_back(i->getMatch(j).second);
+      for (const auto& i : fullmatch3_) {
+        for (unsigned int j = 0; j < i->nMatches(); j++) {
+          if (i->getTracklet(j)->TCID() == tracklet->TCID()) {
+            trackstublist.push_back(i->getMatch(j).second);
+          }
         }
       }
-    }
 
-    for (const auto& i : fullmatch4_) {
-      for (unsigned int j = 0; j < i->nMatches(); j++) {
-        if (i->getTracklet(j)->TCID() == tracklet->TCID()) {
-          trackstublist.push_back(i->getMatch(j).second);
+      for (const auto& i : fullmatch4_) {
+        for (unsigned int j = 0; j < i->nMatches(); j++) {
+          if (i->getTracklet(j)->TCID() == tracklet->TCID()) {
+            trackstublist.push_back(i->getMatch(j).second);
+          }
         }
       }
-    }
 
-    // For merge removal, loop through the resulting list of stubs to calculate their stubids
-    if (settings_.removalType() == "merge") {
-      for (const auto& it : trackstublist) {
-        int layer = it->layer().value() + 1;  // Assume layer (1-6) stub first
-        if (it->layer().value() < 0) {        // if disk stub, though...
-          layer = it->disk().value() + 10 * it->disk().value() / abs(it->disk().value());  //disk = +/- 11-15
+      // For merge removal, loop through the resulting list of stubs to calculate their stubids
+      if (settings_.removalType() == "merge") {
+        for (const auto& it : trackstublist) {
+          int layer = it->layer().value() + 1;  // Assume layer (1-6) stub first
+          if (it->layer().value() < 0) {        // if disk stub, though...
+            layer = it->disk().value() + 10 * it->disk().value() / abs(it->disk().value());  //disk = +/- 11-15
+          }
+          stubidslist.push_back(std::make_pair(layer, it->phiregionaddress()));
         }
-        stubidslist.push_back(std::make_pair(layer, it->phiregionaddress()));
+
+        // And that's all we need! The rest is just for track fit (done in PurgeDuplicate)
+
+      } else {
+        // Track fit only called here if not running duplicate removal
+        // before fit. (e.g. If skipping duplicate removal).
+        HybridFit hybridFitter(iSector_, settings_, globals_);
+        hybridFitter.Fit(tracklet, trackstublist);
       }
-
-      // And that's all we need! The rest is just for track fit (done in PurgeDuplicate)
-
-    } else {
-      // Track fit only called here if not running duplicate removal
-      // before fit. (e.g. If skipping duplicate removal).
-      HybridFit hybridFitter(iSector_, settings_, globals_);
-      hybridFitter.Fit(tracklet, trackstublist);
     }
   }
-}
 #endif
 
-void FitTrack::trackFitChisq(Tracklet* tracklet, std::vector<const Stub*>&, std::vector<std::pair<int, int>>&) {
-  if (globals_->trackDerTable() == nullptr) {
-    TrackDerTable* derTablePtr = new TrackDerTable(settings_);
+  void FitTrack::trackFitChisq(Tracklet* tracklet, std::vector<const Stub*>&, std::vector<std::pair<int, int>>&) {
+    if (globals_->trackDerTable() == nullptr) {
+      TrackDerTable* derTablePtr = new TrackDerTable(settings_);
 
-    derTablePtr->readPatternFile(settings_.fitPatternFile());
-    derTablePtr->fillTable();
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << "Number of entries in derivative table: " << derTablePtr->getEntries();
-    }
-    assert(derTablePtr->getEntries() != 0);
-
-    globals_->trackDerTable() = derTablePtr;
-  }
-
-  const TrackDerTable& derTable = *globals_->trackDerTable();
-
-  //First step is to build list of layers and disks.
-  int layers[N_LAYER];
-  double r[N_LAYER];
-  unsigned int nlayers = 0;  // layers with found stub-projections
-  int disks[N_DISK];
-  double z[N_DISK];
-  unsigned int ndisks = 0;  // disks with found stub-projections
-
-  // residuals for each stub
-  double phiresid[N_FITSTUB];
-  double zresid[N_FITSTUB];
-  double phiresidexact[N_FITSTUB];
-  double zresidexact[N_FITSTUB];
-  int iphiresid[N_FITSTUB];
-  int izresid[N_FITSTUB];
-  double alpha[N_FITSTUB];
-
-  for (unsigned int i = 0; i < N_FITSTUB; i++) {
-    iphiresid[i] = 0;
-    izresid[i] = 0;
-    alpha[i] = 0.0;
-
-    phiresid[i] = 0.0;
-    zresid[i] = 0.0;
-    phiresidexact[i] = 0.0;
-    zresidexact[i] = 0.0;
-  }
-
-  std::bitset<N_LAYER> lmatches;     //layer matches
-  std::bitset<N_DISK * 2> dmatches;  //disk matches (2 per disk to separate 2S from PS)
-
-  int mult = 1;
-
-  unsigned int layermask = 0;
-  unsigned int diskmask = 0;
-  unsigned int alphaindex = 0;
-  unsigned int power = 1;
-
-  double t = tracklet->t();
-  double rinv = tracklet->rinv();
-
-  if (tracklet->isBarrel()) {
-    for (unsigned int l = 1; l <= N_LAYER; l++) {
-      if (l == (unsigned int)tracklet->layer() || l == (unsigned int)tracklet->layer() + 1) {
-        lmatches.set(N_LAYER - l);
-        layermask |= (1 << (N_LAYER - l));
-        layers[nlayers++] = l;
-        continue;
+      derTablePtr->readPatternFile(settings_.fitPatternFile());
+      derTablePtr->fillTable();
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << "Number of entries in derivative table: " << derTablePtr->getEntries();
       }
-      if (tracklet->match(l - 1)) {
-        const Residual& resid = tracklet->resid(l - 1);
-        lmatches.set(N_LAYER - l);
-        layermask |= (1 << (N_LAYER - l));
-        phiresid[nlayers] = resid.phiresidapprox();
-        zresid[nlayers] = resid.rzresidapprox();
-        phiresidexact[nlayers] = resid.phiresid();
-        zresidexact[nlayers] = resid.rzresid();
-        iphiresid[nlayers] = resid.fpgaphiresid().value();
-        izresid[nlayers] = resid.fpgarzresid().value();
+      assert(derTablePtr->getEntries() != 0);
 
-        layers[nlayers++] = l;
-      }
+      globals_->trackDerTable() = derTablePtr;
     }
 
-    for (unsigned int d = 1; d <= N_DISK; d++) {
-      if (layermask & (1 << (d - 1)))
-        continue;
+    const TrackDerTable& derTable = *globals_->trackDerTable();
 
-      if (mult == 1 << (3 * settings_.alphaBitsTable()))
-        continue;
+    //First step is to build list of layers and disks.
+    int layers[N_LAYER];
+    double r[N_LAYER];
+    unsigned int nlayers = 0;  // layers with found stub-projections
+    int disks[N_DISK];
+    double z[N_DISK];
+    unsigned int ndisks = 0;  // disks with found stub-projections
 
-      if (ndisks + nlayers >= N_FITSTUB)
-        continue;
-      if (tracklet->match(N_LAYER + d - 1)) {
-        const Residual& resid = tracklet->resid(N_LAYER + d - 1);
-        double pitch = settings_.stripPitch(resid.stubptr()->l1tstub()->isPSmodule());
-        if (std::abs(resid.stubptr()->l1tstub()->alpha(pitch)) < 1e-20) {
-          dmatches.set(2 * d - 1);
-          diskmask |= (1 << (2 * (N_DISK - d) + 1));
-        } else {
-          int ialpha = resid.stubptr()->alpha().value();
-          int nalpha = resid.stubptr()->alpha().nbits();
-          nalpha = nalpha - settings_.alphaBitsTable();
-          ialpha = (1 << (settings_.alphaBitsTable() - 1)) + (ialpha >> nalpha);
+    // residuals for each stub
+    double phiresid[N_FITSTUB];
+    double zresid[N_FITSTUB];
+    double phiresidexact[N_FITSTUB];
+    double zresidexact[N_FITSTUB];
+    int iphiresid[N_FITSTUB];
+    int izresid[N_FITSTUB];
+    double alpha[N_FITSTUB];
 
-          alphaindex += ialpha * power;
-          power = power << settings_.alphaBitsTable();
-          dmatches.set(2 * (N_DISK - d));
-          diskmask |= (1 << (2 * (N_DISK - d)));
-          mult = mult << settings_.alphaBitsTable();
+    for (unsigned int i = 0; i < N_FITSTUB; i++) {
+      iphiresid[i] = 0;
+      izresid[i] = 0;
+      alpha[i] = 0.0;
+
+      phiresid[i] = 0.0;
+      zresid[i] = 0.0;
+      phiresidexact[i] = 0.0;
+      zresidexact[i] = 0.0;
+    }
+
+    std::bitset<N_LAYER> lmatches;     //layer matches
+    std::bitset<N_DISK * 2> dmatches;  //disk matches (2 per disk to separate 2S from PS)
+
+    int mult = 1;
+
+    unsigned int layermask = 0;
+    unsigned int diskmask = 0;
+    unsigned int alphaindex = 0;
+    unsigned int power = 1;
+
+    double t = tracklet->t();
+    double rinv = tracklet->rinv();
+
+    if (tracklet->isBarrel()) {
+      for (unsigned int l = 1; l <= N_LAYER; l++) {
+        if (l == (unsigned int)tracklet->layer() || l == (unsigned int)tracklet->layer() + 1) {
+          lmatches.set(N_LAYER - l);
+          layermask |= (1 << (N_LAYER - l));
+          layers[nlayers++] = l;
+          continue;
         }
-        alpha[ndisks] = resid.stubptr()->l1tstub()->alpha(pitch);
-        phiresid[nlayers + ndisks] = resid.phiresidapprox();
-        zresid[nlayers + ndisks] = resid.rzresidapprox();
-        phiresidexact[nlayers + ndisks] = resid.phiresid();
-        zresidexact[nlayers + ndisks] = resid.rzresid();
-        iphiresid[nlayers + ndisks] = resid.fpgaphiresid().value();
-        izresid[nlayers + ndisks] = resid.fpgarzresid().value();
+        if (tracklet->match(l - 1)) {
+          const Residual& resid = tracklet->resid(l - 1);
+          lmatches.set(N_LAYER - l);
+          layermask |= (1 << (N_LAYER - l));
+          phiresid[nlayers] = resid.phiresidapprox();
+          zresid[nlayers] = resid.rzresidapprox();
+          phiresidexact[nlayers] = resid.phiresid();
+          zresidexact[nlayers] = resid.rzresid();
+          iphiresid[nlayers] = resid.fpgaphiresid().value();
+          izresid[nlayers] = resid.fpgarzresid().value();
 
-        disks[ndisks++] = d;
-      }
-    }
-
-    if (settings_.writeMonitorData("HitPattern")) {
-      if (mult <= 1 << (3 * settings_.alphaBitsTable())) {
-        globals_->ofstream("hitpattern.txt")
-            << lmatches.to_string() << " " << dmatches.to_string() << " " << mult << endl;
-      }
-    }
-  }
-
-  if (tracklet->isDisk()) {
-    for (unsigned int l = 1; l <= 2; l++) {
-      if (tracklet->match(l - 1)) {
-        lmatches.set(N_LAYER - l);
-
-        layermask |= (1 << (N_LAYER - l));
-        const Residual& resid = tracklet->resid(l - 1);
-        phiresid[nlayers] = resid.phiresidapprox();
-        zresid[nlayers] = resid.rzresidapprox();
-        phiresidexact[nlayers] = resid.phiresid();
-        zresidexact[nlayers] = resid.rzresid();
-        iphiresid[nlayers] = resid.fpgaphiresid().value();
-        izresid[nlayers] = resid.fpgarzresid().value();
-
-        layers[nlayers++] = l;
-      }
-    }
-
-    for (int d1 = 1; d1 <= N_DISK; d1++) {
-      int d = d1;
-
-      // skip F/B5 if there's already a L2 match
-      if (d == 5 and layermask & (1 << 4))
-        continue;
-
-      if (tracklet->fpgat().value() < 0.0)
-        d = -d1;
-      if (d1 == abs(tracklet->disk()) || d1 == abs(tracklet->disk()) + 1) {
-        dmatches.set(2 * d1 - 1);
-        diskmask |= (1 << (2 * (N_DISK - d1) + 1));
-        alpha[ndisks] = 0.0;
-        disks[ndisks++] = d;
-        continue;
-      }
-
-      if (ndisks + nlayers >= N_FITSTUB)
-        continue;
-      if (tracklet->match(N_LAYER + abs(d) - 1)) {
-        const Residual& resid = tracklet->resid(N_LAYER + abs(d) - 1);
-        double pitch = settings_.stripPitch(resid.stubptr()->l1tstub()->isPSmodule());
-        if (std::abs(resid.stubptr()->l1tstub()->alpha(pitch)) < 1e-20) {
-          dmatches.set(2 * d1 - 1);
-          diskmask |= (1 << (2 * (N_DISK - d1) + 1));
-        } else {
-          int ialpha = resid.stubptr()->alpha().value();
-          int nalpha = resid.stubptr()->alpha().nbits();
-          nalpha = nalpha - settings_.alphaBitsTable();
-          ialpha = (1 << (settings_.alphaBitsTable() - 1)) + (ialpha >> nalpha);
-
-          alphaindex += ialpha * power;
-          power = power << settings_.alphaBitsTable();
-          dmatches.set(2 * (N_DISK - d1));
-          diskmask |= (1 << (2 * (N_DISK - d1)));
-          mult = mult << settings_.alphaBitsTable();
+          layers[nlayers++] = l;
         }
-
-        alpha[ndisks] = resid.stubptr()->l1tstub()->alpha(pitch);
-        assert(std::abs(resid.phiresidapprox()) < 0.2);
-        phiresid[nlayers + ndisks] = resid.phiresidapprox();
-        zresid[nlayers + ndisks] = resid.rzresidapprox();
-        assert(std::abs(resid.phiresid()) < 0.2);
-        phiresidexact[nlayers + ndisks] = resid.phiresid();
-        zresidexact[nlayers + ndisks] = resid.rzresid();
-        iphiresid[nlayers + ndisks] = resid.fpgaphiresid().value();
-        izresid[nlayers + ndisks] = resid.fpgarzresid().value();
-
-        disks[ndisks++] = d;
-      }
-    }
-  }
-
-  if (tracklet->isOverlap()) {
-    for (unsigned int l = 1; l <= 2; l++) {
-      if (l == (unsigned int)tracklet->layer()) {
-        lmatches.set(N_LAYER - l);
-        layermask |= (1 << (N_LAYER - l));
-        layers[nlayers++] = l;
-        continue;
-      }
-      if (tracklet->match(l - 1)) {
-        lmatches.set(N_LAYER - l);
-        layermask |= (1 << (N_LAYER - l));
-        const Residual& resid = tracklet->resid(l - 1);
-        assert(std::abs(resid.phiresidapprox()) < 0.2);
-        phiresid[nlayers] = resid.phiresidapprox();
-        zresid[nlayers] = resid.rzresidapprox();
-        assert(std::abs(resid.phiresid()) < 0.2);
-        phiresidexact[nlayers] = resid.phiresid();
-        zresidexact[nlayers] = resid.rzresid();
-        iphiresid[nlayers] = resid.fpgaphiresid().value();
-        izresid[nlayers] = resid.fpgarzresid().value();
-
-        layers[nlayers++] = l;
-      }
-    }
-
-    for (unsigned int d1 = 1; d1 <= N_DISK; d1++) {
-      if (mult == 1 << (3 * settings_.alphaBitsTable()))
-        continue;
-      int d = d1;
-      if (tracklet->fpgat().value() < 0.0)
-        d = -d1;
-      if (d == tracklet->disk()) {  //All seeds in PS modules
-        disks[ndisks] = tracklet->disk();
-        dmatches.set(2 * d1 - 1);
-        diskmask |= (1 << (2 * (N_DISK - d1) + 1));
-        ndisks++;
-        continue;
       }
 
-      if (ndisks + nlayers >= N_FITSTUB)
-        continue;
-      if (tracklet->match(N_LAYER + abs(d) - 1)) {
-        const Residual& resid = tracklet->resid(N_LAYER + abs(d) - 1);
-        double pitch = settings_.stripPitch(resid.stubptr()->l1tstub()->isPSmodule());
-        if (std::abs(resid.stubptr()->l1tstub()->alpha(pitch)) < 1e-20) {
-          dmatches.set(2 * (N_DISK - d1));
-          diskmask |= (1 << (2 * (N_DISK - d1) + 1));
-          FPGAWord tmp;
-          tmp.set(diskmask, 10);
-        } else {
-          int ialpha = resid.stubptr()->alpha().value();
-          int nalpha = resid.stubptr()->alpha().nbits();
-          nalpha = nalpha - settings_.alphaBitsTable();
-          ialpha = (1 << (settings_.alphaBitsTable() - 1)) + (ialpha >> nalpha);
-
-          alphaindex += ialpha * power;
-          power = power << settings_.alphaBitsTable();
-          dmatches.set(2 * (N_DISK - d1));
-          diskmask |= (1 << (2 * (N_DISK - d1)));
-          FPGAWord tmp;
-          tmp.set(diskmask, 10);
-          mult = mult << settings_.alphaBitsTable();
-        }
-
-        alpha[ndisks] = resid.stubptr()->l1tstub()->alpha(pitch);
-        assert(std::abs(resid.phiresidapprox()) < 0.2);
-        phiresid[nlayers + ndisks] = resid.phiresidapprox();
-        zresid[nlayers + ndisks] = resid.rzresidapprox();
-        assert(std::abs(resid.phiresid()) < 0.2);
-        phiresidexact[nlayers + ndisks] = resid.phiresid();
-        zresidexact[nlayers + ndisks] = resid.rzresid();
-        iphiresid[nlayers + ndisks] = resid.fpgaphiresid().value();
-        izresid[nlayers + ndisks] = resid.fpgarzresid().value();
-
-        disks[ndisks++] = d;
-      }
-    }
-  }
-
-  int rinvindex =
-      (1 << (settings_.nrinvBitsTable() - 1)) * rinv / settings_.rinvmax() + (1 << (settings_.nrinvBitsTable() - 1));
-  if (rinvindex < 0)
-    rinvindex = 0;
-  if (rinvindex >= (1 << settings_.nrinvBitsTable()))
-    rinvindex = (1 << settings_.nrinvBitsTable()) - 1;
-
-  const TrackDer* derivatives = derTable.getDerivatives(layermask, diskmask, alphaindex, rinvindex);
-
-  if (derivatives == nullptr) {
-    if (settings_.warnNoDer()) {
-      FPGAWord tmpl, tmpd;
-      tmpl.set(layermask, 6);
-      tmpd.set(diskmask, 10);
-      edm::LogVerbatim("Tracklet") << "No derivative for layermask, diskmask : " << layermask << " " << tmpl.str()
-                                   << " " << diskmask << " " << tmpd.str() << " eta = " << asinh(t);
-    }
-    return;
-  }
-
-  double ttabi = TrackDerTable::tpar(settings_, diskmask, layermask);
-  if (t < 0.0)
-    ttabi = -ttabi;
-  double ttab = ttabi;
-
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "Doing trackfit in  " << getName();
-  }
-
-  int sign = 1;
-  if (t < 0.0)
-    sign = -1;
-
-  double rstub[6];
-
-  double realrstub[3];
-  realrstub[0] = -1.0;
-  realrstub[1] = -1.0;
-  realrstub[2] = -1.0;
-
-  for (unsigned i = 0; i < nlayers; i++) {
-    r[i] = settings_.rmean(layers[i] - 1);
-    if (layers[i] == tracklet->layer()) {
-      if (tracklet->isOverlap()) {
-        realrstub[i] = tracklet->outerFPGAStub()->l1tstub()->r();
-      } else {
-        realrstub[i] = tracklet->innerFPGAStub()->l1tstub()->r();
-      }
-    }
-    if (layers[i] == tracklet->layer() + 1) {
-      realrstub[i] = tracklet->outerFPGAStub()->l1tstub()->r();
-    }
-    if (tracklet->match(layers[i] - 1) && layers[i] < 4) {
-      const Stub* stubptr = tracklet->resid(layers[i] - 1).stubptr();
-      realrstub[i] = stubptr->l1tstub()->r();
-      assert(std::abs(realrstub[i] - r[i]) < 5.0);
-    }
-    rstub[i] = r[i];
-  }
-  for (unsigned i = 0; i < ndisks; i++) {
-    z[i] = sign * settings_.zmean(abs(disks[i]) - 1);
-    rstub[i + nlayers] = z[i] / ttabi;
-  }
-
-  double D[N_FITPARAM][N_FITSTUB * 2];
-  double MinvDt[N_FITPARAM][N_FITSTUB * 2];
-  int iD[N_FITPARAM][N_FITSTUB * 2];
-  int iMinvDt[N_FITPARAM][N_FITSTUB * 2];
-  double sigma[N_FITSTUB * 2];
-  double kfactor[N_FITSTUB * 2];
-
-  unsigned int n = nlayers + ndisks;
-
-  if (settings_.exactderivatives()) {
-    TrackDerTable::calculateDerivatives(
-        settings_, nlayers, r, ndisks, z, alpha, t, rinv, D, iD, MinvDt, iMinvDt, sigma, kfactor);
-    ttabi = t;
-    ttab = t;
-  } else {
-    if (settings_.exactderivativesforfloating()) {
-      TrackDerTable::calculateDerivatives(
-          settings_, nlayers, r, ndisks, z, alpha, t, rinv, D, iD, MinvDt, iMinvDt, sigma, kfactor);
-
-      double MinvDtDummy[N_FITPARAM][N_FITSTUB * 2];
-      derivatives->fill(tracklet->fpgat().value(), MinvDtDummy, iMinvDt);
-      ttab = t;
-    } else {
-      derivatives->fill(tracklet->fpgat().value(), MinvDt, iMinvDt);
-    }
-  }
-
-  if (!settings_.exactderivatives()) {
-    for (unsigned int i = 0; i < nlayers; i++) {
-      if (r[i] > settings_.rPS2S())
-        continue;
-      for (unsigned int ii = 0; ii < nlayers; ii++) {
-        if (r[ii] > settings_.rPS2S())
+      for (unsigned int d = 1; d <= N_DISK; d++) {
+        if (layermask & (1 << (d - 1)))
           continue;
 
-        double tder = derivatives->tdzcorr(i, ii);
-        double zder = derivatives->z0dzcorr(i, ii);
+        if (mult == 1 << (3 * settings_.alphaBitsTable()))
+          continue;
 
-        double dr = realrstub[i] - r[i];
+        if (ndisks + nlayers >= N_FITSTUB)
+          continue;
+        if (tracklet->match(N_LAYER + d - 1)) {
+          const Residual& resid = tracklet->resid(N_LAYER + d - 1);
+          double pitch = settings_.stripPitch(resid.stubptr()->l1tstub()->isPSmodule());
+          if (std::abs(resid.stubptr()->l1tstub()->alpha(pitch)) < 1e-20) {
+            dmatches.set(2 * d - 1);
+            diskmask |= (1 << (2 * (N_DISK - d) + 1));
+          } else {
+            int ialpha = resid.stubptr()->alpha().value();
+            int nalpha = resid.stubptr()->alpha().nbits();
+            nalpha = nalpha - settings_.alphaBitsTable();
+            ialpha = (1 << (settings_.alphaBitsTable() - 1)) + (ialpha >> nalpha);
 
-        MinvDt[2][2 * ii + 1] += dr * tder;
-        MinvDt[3][2 * ii + 1] += dr * zder;
+            alphaindex += ialpha * power;
+            power = power << settings_.alphaBitsTable();
+            dmatches.set(2 * (N_DISK - d));
+            diskmask |= (1 << (2 * (N_DISK - d)));
+            mult = mult << settings_.alphaBitsTable();
+          }
+          alpha[ndisks] = resid.stubptr()->l1tstub()->alpha(pitch);
+          phiresid[nlayers + ndisks] = resid.phiresidapprox();
+          zresid[nlayers + ndisks] = resid.rzresidapprox();
+          phiresidexact[nlayers + ndisks] = resid.phiresid();
+          zresidexact[nlayers + ndisks] = resid.rzresid();
+          iphiresid[nlayers + ndisks] = resid.fpgaphiresid().value();
+          izresid[nlayers + ndisks] = resid.fpgarzresid().value();
 
-        int itder = derivatives->itdzcorr(i, ii);
-        int izder = derivatives->iz0dzcorr(i, ii);
+          disks[ndisks++] = d;
+        }
+      }
 
-        int idr = dr / settings_.kr();
-
-        iMinvDt[2][2 * ii + 1] += ((idr * itder) >> settings_.rcorrbits());
-        iMinvDt[3][2 * ii + 1] += ((idr * izder) >> settings_.rcorrbits());
+      if (settings_.writeMonitorData("HitPattern")) {
+        if (mult <= 1 << (3 * settings_.alphaBitsTable())) {
+          globals_->ofstream("hitpattern.txt")
+              << lmatches.to_string() << " " << dmatches.to_string() << " " << mult << endl;
+        }
       }
     }
-  }
 
-  double rinvseed = tracklet->rinvapprox();
-  double phi0seed = tracklet->phi0approx();
-  double tseed = tracklet->tapprox();
-  double z0seed = tracklet->z0approx();
+    if (tracklet->isDisk()) {
+      for (unsigned int l = 1; l <= 2; l++) {
+        if (tracklet->match(l - 1)) {
+          lmatches.set(N_LAYER - l);
 
-  double rinvseedexact = tracklet->rinv();
-  double phi0seedexact = tracklet->phi0();
-  double tseedexact = tracklet->t();
-  double z0seedexact = tracklet->z0();
+          layermask |= (1 << (N_LAYER - l));
+          const Residual& resid = tracklet->resid(l - 1);
+          phiresid[nlayers] = resid.phiresidapprox();
+          zresid[nlayers] = resid.rzresidapprox();
+          phiresidexact[nlayers] = resid.phiresid();
+          zresidexact[nlayers] = resid.rzresid();
+          iphiresid[nlayers] = resid.fpgaphiresid().value();
+          izresid[nlayers] = resid.fpgarzresid().value();
 
-  double chisqseed = 0.0;
-  double chisqseedexact = 0.0;
+          layers[nlayers++] = l;
+        }
+      }
 
-  double delta[2 * N_FITSTUB];
-  double deltaexact[2 * N_FITSTUB];
-  int idelta[2 * N_FITSTUB];
+      for (int d1 = 1; d1 <= N_DISK; d1++) {
+        int d = d1;
 
-  for (unsigned int i = 0; i < 2 * N_FITSTUB; i++) {
-    delta[i] = 0.0;
-    deltaexact[i] = 0.0;
-    idelta[i] = 0;
-  }
+        // skip F/B5 if there's already a L2 match
+        if (d == 5 and layermask & (1 << 4))
+          continue;
 
-  int j = 0;
+        if (tracklet->fpgat().value() < 0.0)
+          d = -d1;
+        if (d1 == abs(tracklet->disk()) || d1 == abs(tracklet->disk()) + 1) {
+          dmatches.set(2 * d1 - 1);
+          diskmask |= (1 << (2 * (N_DISK - d1) + 1));
+          alpha[ndisks] = 0.0;
+          disks[ndisks++] = d;
+          continue;
+        }
 
-  for (unsigned int i = 0; i < n; i++) {
-    if (i >= nlayers) {
-      iphiresid[i] *= (t / ttabi);
-      phiresid[i] *= (t / ttab);
-      phiresidexact[i] *= (t / ttab);
+        if (ndisks + nlayers >= N_FITSTUB)
+          continue;
+        if (tracklet->match(N_LAYER + abs(d) - 1)) {
+          const Residual& resid = tracklet->resid(N_LAYER + abs(d) - 1);
+          double pitch = settings_.stripPitch(resid.stubptr()->l1tstub()->isPSmodule());
+          if (std::abs(resid.stubptr()->l1tstub()->alpha(pitch)) < 1e-20) {
+            dmatches.set(2 * d1 - 1);
+            diskmask |= (1 << (2 * (N_DISK - d1) + 1));
+          } else {
+            int ialpha = resid.stubptr()->alpha().value();
+            int nalpha = resid.stubptr()->alpha().nbits();
+            nalpha = nalpha - settings_.alphaBitsTable();
+            ialpha = (1 << (settings_.alphaBitsTable() - 1)) + (ialpha >> nalpha);
+
+            alphaindex += ialpha * power;
+            power = power << settings_.alphaBitsTable();
+            dmatches.set(2 * (N_DISK - d1));
+            diskmask |= (1 << (2 * (N_DISK - d1)));
+            mult = mult << settings_.alphaBitsTable();
+          }
+
+          alpha[ndisks] = resid.stubptr()->l1tstub()->alpha(pitch);
+          assert(std::abs(resid.phiresidapprox()) < 0.2);
+          phiresid[nlayers + ndisks] = resid.phiresidapprox();
+          zresid[nlayers + ndisks] = resid.rzresidapprox();
+          assert(std::abs(resid.phiresid()) < 0.2);
+          phiresidexact[nlayers + ndisks] = resid.phiresid();
+          zresidexact[nlayers + ndisks] = resid.rzresid();
+          iphiresid[nlayers + ndisks] = resid.fpgaphiresid().value();
+          izresid[nlayers + ndisks] = resid.fpgarzresid().value();
+
+          disks[ndisks++] = d;
+        }
+      }
     }
 
-    idelta[j] = iphiresid[i];
-    delta[j] = phiresid[i];
-    if (std::abs(phiresid[i]) > 0.2) {
-      edm::LogWarning("Tracklet") << getName() << " WARNING too large phiresid: " << phiresid[i] << " "
-                                  << phiresidexact[i];
+    if (tracklet->isOverlap()) {
+      for (unsigned int l = 1; l <= 2; l++) {
+        if (l == (unsigned int)tracklet->layer()) {
+          lmatches.set(N_LAYER - l);
+          layermask |= (1 << (N_LAYER - l));
+          layers[nlayers++] = l;
+          continue;
+        }
+        if (tracklet->match(l - 1)) {
+          lmatches.set(N_LAYER - l);
+          layermask |= (1 << (N_LAYER - l));
+          const Residual& resid = tracklet->resid(l - 1);
+          assert(std::abs(resid.phiresidapprox()) < 0.2);
+          phiresid[nlayers] = resid.phiresidapprox();
+          zresid[nlayers] = resid.rzresidapprox();
+          assert(std::abs(resid.phiresid()) < 0.2);
+          phiresidexact[nlayers] = resid.phiresid();
+          zresidexact[nlayers] = resid.rzresid();
+          iphiresid[nlayers] = resid.fpgaphiresid().value();
+          izresid[nlayers] = resid.fpgarzresid().value();
+
+          layers[nlayers++] = l;
+        }
+      }
+
+      for (unsigned int d1 = 1; d1 <= N_DISK; d1++) {
+        if (mult == 1 << (3 * settings_.alphaBitsTable()))
+          continue;
+        int d = d1;
+        if (tracklet->fpgat().value() < 0.0)
+          d = -d1;
+        if (d == tracklet->disk()) {  //All seeds in PS modules
+          disks[ndisks] = tracklet->disk();
+          dmatches.set(2 * d1 - 1);
+          diskmask |= (1 << (2 * (N_DISK - d1) + 1));
+          ndisks++;
+          continue;
+        }
+
+        if (ndisks + nlayers >= N_FITSTUB)
+          continue;
+        if (tracklet->match(N_LAYER + abs(d) - 1)) {
+          const Residual& resid = tracklet->resid(N_LAYER + abs(d) - 1);
+          double pitch = settings_.stripPitch(resid.stubptr()->l1tstub()->isPSmodule());
+          if (std::abs(resid.stubptr()->l1tstub()->alpha(pitch)) < 1e-20) {
+            dmatches.set(2 * (N_DISK - d1));
+            diskmask |= (1 << (2 * (N_DISK - d1) + 1));
+            FPGAWord tmp;
+            tmp.set(diskmask, 10);
+          } else {
+            int ialpha = resid.stubptr()->alpha().value();
+            int nalpha = resid.stubptr()->alpha().nbits();
+            nalpha = nalpha - settings_.alphaBitsTable();
+            ialpha = (1 << (settings_.alphaBitsTable() - 1)) + (ialpha >> nalpha);
+
+            alphaindex += ialpha * power;
+            power = power << settings_.alphaBitsTable();
+            dmatches.set(2 * (N_DISK - d1));
+            diskmask |= (1 << (2 * (N_DISK - d1)));
+            FPGAWord tmp;
+            tmp.set(diskmask, 10);
+            mult = mult << settings_.alphaBitsTable();
+          }
+
+          alpha[ndisks] = resid.stubptr()->l1tstub()->alpha(pitch);
+          assert(std::abs(resid.phiresidapprox()) < 0.2);
+          phiresid[nlayers + ndisks] = resid.phiresidapprox();
+          zresid[nlayers + ndisks] = resid.rzresidapprox();
+          assert(std::abs(resid.phiresid()) < 0.2);
+          phiresidexact[nlayers + ndisks] = resid.phiresid();
+          zresidexact[nlayers + ndisks] = resid.rzresid();
+          iphiresid[nlayers + ndisks] = resid.fpgaphiresid().value();
+          izresid[nlayers + ndisks] = resid.fpgarzresid().value();
+
+          disks[ndisks++] = d;
+        }
+      }
     }
-    assert(std::abs(phiresid[i]) < 1.0);
-    assert(std::abs(phiresidexact[i]) < 1.0);
-    deltaexact[j++] = phiresidexact[i];
 
-    idelta[j] = izresid[i];
-    delta[j] = zresid[i];
-    deltaexact[j++] = zresidexact[i];
+    int rinvindex =
+        (1 << (settings_.nrinvBitsTable() - 1)) * rinv / settings_.rinvmax() + (1 << (settings_.nrinvBitsTable() - 1));
+    if (rinvindex < 0)
+      rinvindex = 0;
+    if (rinvindex >= (1 << settings_.nrinvBitsTable()))
+      rinvindex = (1 << settings_.nrinvBitsTable()) - 1;
 
-    chisqseed += (delta[j - 2] * delta[j - 2] + delta[j - 1] * delta[j - 1]);
-    chisqseedexact += (deltaexact[j - 2] * deltaexact[j - 2] + deltaexact[j - 1] * deltaexact[j - 1]);
-  }
-  assert(j <= 12);
+    const TrackDer* derivatives = derTable.getDerivatives(layermask, diskmask, alphaindex, rinvindex);
 
-  double drinv = 0.0;
-  double dphi0 = 0.0;
-  double dt = 0.0;
-  double dz0 = 0.0;
-
-  double drinvexact = 0.0;
-  double dphi0exact = 0.0;
-  double dtexact = 0.0;
-  double dz0exact = 0.0;
-
-  int idrinv = 0;
-  int idphi0 = 0;
-  int idt = 0;
-  int idz0 = 0;
-
-  double drinv_cov = 0.0;
-  double dphi0_cov = 0.0;
-  double dt_cov = 0.0;
-  double dz0_cov = 0.0;
-
-  double drinv_covexact = 0.0;
-  double dphi0_covexact = 0.0;
-  double dt_covexact = 0.0;
-  double dz0_covexact = 0.0;
-
-  for (unsigned int j = 0; j < 2 * n; j++) {
-    drinv -= MinvDt[0][j] * delta[j];
-    dphi0 -= MinvDt[1][j] * delta[j];
-    dt -= MinvDt[2][j] * delta[j];
-    dz0 -= MinvDt[3][j] * delta[j];
-
-    drinv_cov += D[0][j] * delta[j];
-    dphi0_cov += D[1][j] * delta[j];
-    dt_cov += D[2][j] * delta[j];
-    dz0_cov += D[3][j] * delta[j];
-
-    drinvexact -= MinvDt[0][j] * deltaexact[j];
-    dphi0exact -= MinvDt[1][j] * deltaexact[j];
-    dtexact -= MinvDt[2][j] * deltaexact[j];
-    dz0exact -= MinvDt[3][j] * deltaexact[j];
-
-    drinv_covexact += D[0][j] * deltaexact[j];
-    dphi0_covexact += D[1][j] * deltaexact[j];
-    dt_covexact += D[2][j] * deltaexact[j];
-    dz0_covexact += D[3][j] * deltaexact[j];
-
-    idrinv += ((iMinvDt[0][j] * idelta[j]));
-    idphi0 += ((iMinvDt[1][j] * idelta[j]));
-    idt += ((iMinvDt[2][j] * idelta[j]));
-    idz0 += ((iMinvDt[3][j] * idelta[j]));
-
-    if (false && j % 2 == 0) {
-      edm::LogVerbatim("Tracklet") << "DEBUG CHI2FIT " << j << " " << rinvseed << " + " << MinvDt[0][j] * delta[j]
-                                   << " " << MinvDt[0][j] << " " << delta[j] * rstub[j / 2] * 10000 << " \n"
-                                   << j << " " << tracklet->fpgarinv().value() * settings_.krinvpars() << " + "
-                                   << ((iMinvDt[0][j] * idelta[j])) * settings_.krinvpars() / 1024.0 << " "
-                                   << iMinvDt[0][j] * settings_.krinvpars() / settings_.kphi() / 1024.0 << " "
-                                   << idelta[j] * settings_.kphi() * rstub[j / 2] * 10000 << " " << idelta[j];
+    if (derivatives == nullptr) {
+      if (settings_.warnNoDer()) {
+        FPGAWord tmpl, tmpd;
+        tmpl.set(layermask, 6);
+        tmpd.set(diskmask, 10);
+        edm::LogVerbatim("Tracklet") << "No derivative for layermask, diskmask : " << layermask << " " << tmpl.str()
+                                     << " " << diskmask << " " << tmpd.str() << " eta = " << asinh(t);
+      }
+      return;
     }
-  }
 
-  double deltaChisqexact =
-      drinvexact * drinv_covexact + dphi0exact * dphi0_covexact + dtexact * dt_covexact + dz0exact * dz0_covexact;
+    double ttabi = TrackDerTable::tpar(settings_, diskmask, layermask);
+    if (t < 0.0)
+      ttabi = -ttabi;
+    double ttab = ttabi;
 
-  int irinvseed = tracklet->fpgarinv().value();
-  int iphi0seed = tracklet->fpgaphi0().value();
-
-  int itseed = tracklet->fpgat().value();
-  int iz0seed = tracklet->fpgaz0().value();
-
-  int irinvfit = irinvseed + ((idrinv + (1 << settings_.fitrinvbitshift())) >> settings_.fitrinvbitshift());
-
-  int iphi0fit = iphi0seed + (idphi0 >> settings_.fitphi0bitshift());
-  int itfit = itseed + (idt >> settings_.fittbitshift());
-
-  int iz0fit = iz0seed + (idz0 >> settings_.fitz0bitshift());
-
-  double rinvfit = rinvseed - drinv;
-  double phi0fit = phi0seed - dphi0;
-
-  double tfit = tseed - dt;
-  double z0fit = z0seed - dz0;
-
-  double rinvfitexact = rinvseedexact - drinvexact;
-  double phi0fitexact = phi0seedexact - dphi0exact;
-
-  double tfitexact = tseedexact - dtexact;
-  double z0fitexact = z0seedexact - dz0exact;
-
-  double chisqfitexact = chisqseedexact + deltaChisqexact;
-
-  ////////////// NEW CHISQ /////////////////////
-  bool NewChisqDebug = false;
-  double chisqfit = 0.0;
-  uint ichisqfit = 0;
-
-  double phifactor;
-  double rzfactor;
-  double iphifactor;
-  double irzfactor;
-  int k = 0;  // column index of D matrix
-
-  if (NewChisqDebug) {
-    edm::LogVerbatim("Tracklet") << "OG chisq: \n"
-                                 << "drinv/cov = " << drinv << "/" << drinv_cov << " \n"
-                                 << "dphi0/cov = " << drinv << "/" << dphi0_cov << " \n"
-                                 << "dt/cov = " << drinv << "/" << dt_cov << " \n"
-                                 << "dz0/cov = " << drinv << "/" << dz0_cov << "\n";
-    std::string myout = "D[0][k]= ";
-    for (unsigned int i = 0; i < 2 * n; i++) {
-      myout += std::to_string(D[0][i]);
-      myout += ", ";
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "Doing trackfit in  " << getName();
     }
-    edm::LogVerbatim("Tracklet") << myout;
-  }
 
-  for (unsigned int i = 0; i < n; i++) {  // loop over stubs
+    int sign = 1;
+    if (t < 0.0)
+      sign = -1;
 
-    phifactor = rstub[k / 2] * delta[k] / sigma[k] + D[0][k] * drinv + D[1][k] * dphi0 + D[2][k] * dt + D[3][k] * dz0;
-    iphifactor = kfactor[k] * rstub[k / 2] * idelta[k] * (1 << settings_.chisqphifactbits()) / sigma[k] -
-                 iD[0][k] * idrinv - iD[1][k] * idphi0 - iD[2][k] * idt - iD[3][k] * idz0;
+    double rstub[6];
+
+    double realrstub[3];
+    realrstub[0] = -1.0;
+    realrstub[1] = -1.0;
+    realrstub[2] = -1.0;
+
+    for (unsigned i = 0; i < nlayers; i++) {
+      r[i] = settings_.rmean(layers[i] - 1);
+      if (layers[i] == tracklet->layer()) {
+        if (tracklet->isOverlap()) {
+          realrstub[i] = tracklet->outerFPGAStub()->l1tstub()->r();
+        } else {
+          realrstub[i] = tracklet->innerFPGAStub()->l1tstub()->r();
+        }
+      }
+      if (layers[i] == tracklet->layer() + 1) {
+        realrstub[i] = tracklet->outerFPGAStub()->l1tstub()->r();
+      }
+      if (tracklet->match(layers[i] - 1) && layers[i] < 4) {
+        const Stub* stubptr = tracklet->resid(layers[i] - 1).stubptr();
+        realrstub[i] = stubptr->l1tstub()->r();
+        assert(std::abs(realrstub[i] - r[i]) < 5.0);
+      }
+      rstub[i] = r[i];
+    }
+    for (unsigned i = 0; i < ndisks; i++) {
+      z[i] = sign * settings_.zmean(abs(disks[i]) - 1);
+      rstub[i + nlayers] = z[i] / ttabi;
+    }
+
+    double D[N_FITPARAM][N_FITSTUB * 2];
+    double MinvDt[N_FITPARAM][N_FITSTUB * 2];
+    int iD[N_FITPARAM][N_FITSTUB * 2];
+    int iMinvDt[N_FITPARAM][N_FITSTUB * 2];
+    double sigma[N_FITSTUB * 2];
+    double kfactor[N_FITSTUB * 2];
+
+    unsigned int n = nlayers + ndisks;
+
+    if (settings_.exactderivatives()) {
+      TrackDerTable::calculateDerivatives(
+          settings_, nlayers, r, ndisks, z, alpha, t, rinv, D, iD, MinvDt, iMinvDt, sigma, kfactor);
+      ttabi = t;
+      ttab = t;
+    } else {
+      if (settings_.exactderivativesforfloating()) {
+        TrackDerTable::calculateDerivatives(
+            settings_, nlayers, r, ndisks, z, alpha, t, rinv, D, iD, MinvDt, iMinvDt, sigma, kfactor);
+
+        double MinvDtDummy[N_FITPARAM][N_FITSTUB * 2];
+        derivatives->fill(tracklet->fpgat().value(), MinvDtDummy, iMinvDt);
+        ttab = t;
+      } else {
+        derivatives->fill(tracklet->fpgat().value(), MinvDt, iMinvDt);
+      }
+    }
+
+    if (!settings_.exactderivatives()) {
+      for (unsigned int i = 0; i < nlayers; i++) {
+        if (r[i] > settings_.rPS2S())
+          continue;
+        for (unsigned int ii = 0; ii < nlayers; ii++) {
+          if (r[ii] > settings_.rPS2S())
+            continue;
+
+          double tder = derivatives->tdzcorr(i, ii);
+          double zder = derivatives->z0dzcorr(i, ii);
+
+          double dr = realrstub[i] - r[i];
+
+          MinvDt[2][2 * ii + 1] += dr * tder;
+          MinvDt[3][2 * ii + 1] += dr * zder;
+
+          int itder = derivatives->itdzcorr(i, ii);
+          int izder = derivatives->iz0dzcorr(i, ii);
+
+          int idr = dr / settings_.kr();
+
+          iMinvDt[2][2 * ii + 1] += ((idr * itder) >> settings_.rcorrbits());
+          iMinvDt[3][2 * ii + 1] += ((idr * izder) >> settings_.rcorrbits());
+        }
+      }
+    }
+
+    double rinvseed = tracklet->rinvapprox();
+    double phi0seed = tracklet->phi0approx();
+    double tseed = tracklet->tapprox();
+    double z0seed = tracklet->z0approx();
+
+    double rinvseedexact = tracklet->rinv();
+    double phi0seedexact = tracklet->phi0();
+    double tseedexact = tracklet->t();
+    double z0seedexact = tracklet->z0();
+
+    double chisqseed = 0.0;
+    double chisqseedexact = 0.0;
+
+    double delta[2 * N_FITSTUB];
+    double deltaexact[2 * N_FITSTUB];
+    int idelta[2 * N_FITSTUB];
+
+    for (unsigned int i = 0; i < 2 * N_FITSTUB; i++) {
+      delta[i] = 0.0;
+      deltaexact[i] = 0.0;
+      idelta[i] = 0;
+    }
+
+    int j = 0;
+
+    for (unsigned int i = 0; i < n; i++) {
+      if (i >= nlayers) {
+        iphiresid[i] *= (t / ttabi);
+        phiresid[i] *= (t / ttab);
+        phiresidexact[i] *= (t / ttab);
+      }
+
+      idelta[j] = iphiresid[i];
+      delta[j] = phiresid[i];
+      if (std::abs(phiresid[i]) > 0.2) {
+        edm::LogWarning("Tracklet") << getName() << " WARNING too large phiresid: " << phiresid[i] << " "
+                                    << phiresidexact[i];
+      }
+      assert(std::abs(phiresid[i]) < 1.0);
+      assert(std::abs(phiresidexact[i]) < 1.0);
+      deltaexact[j++] = phiresidexact[i];
+
+      idelta[j] = izresid[i];
+      delta[j] = zresid[i];
+      deltaexact[j++] = zresidexact[i];
+
+      chisqseed += (delta[j - 2] * delta[j - 2] + delta[j - 1] * delta[j - 1]);
+      chisqseedexact += (deltaexact[j - 2] * deltaexact[j - 2] + deltaexact[j - 1] * deltaexact[j - 1]);
+    }
+    assert(j <= 12);
+
+    double drinv = 0.0;
+    double dphi0 = 0.0;
+    double dt = 0.0;
+    double dz0 = 0.0;
+
+    double drinvexact = 0.0;
+    double dphi0exact = 0.0;
+    double dtexact = 0.0;
+    double dz0exact = 0.0;
+
+    int idrinv = 0;
+    int idphi0 = 0;
+    int idt = 0;
+    int idz0 = 0;
+
+    double drinv_cov = 0.0;
+    double dphi0_cov = 0.0;
+    double dt_cov = 0.0;
+    double dz0_cov = 0.0;
+
+    double drinv_covexact = 0.0;
+    double dphi0_covexact = 0.0;
+    double dt_covexact = 0.0;
+    double dz0_covexact = 0.0;
+
+    for (unsigned int j = 0; j < 2 * n; j++) {
+      drinv -= MinvDt[0][j] * delta[j];
+      dphi0 -= MinvDt[1][j] * delta[j];
+      dt -= MinvDt[2][j] * delta[j];
+      dz0 -= MinvDt[3][j] * delta[j];
+
+      drinv_cov += D[0][j] * delta[j];
+      dphi0_cov += D[1][j] * delta[j];
+      dt_cov += D[2][j] * delta[j];
+      dz0_cov += D[3][j] * delta[j];
+
+      drinvexact -= MinvDt[0][j] * deltaexact[j];
+      dphi0exact -= MinvDt[1][j] * deltaexact[j];
+      dtexact -= MinvDt[2][j] * deltaexact[j];
+      dz0exact -= MinvDt[3][j] * deltaexact[j];
+
+      drinv_covexact += D[0][j] * deltaexact[j];
+      dphi0_covexact += D[1][j] * deltaexact[j];
+      dt_covexact += D[2][j] * deltaexact[j];
+      dz0_covexact += D[3][j] * deltaexact[j];
+
+      idrinv += ((iMinvDt[0][j] * idelta[j]));
+      idphi0 += ((iMinvDt[1][j] * idelta[j]));
+      idt += ((iMinvDt[2][j] * idelta[j]));
+      idz0 += ((iMinvDt[3][j] * idelta[j]));
+
+      if (false && j % 2 == 0) {
+        edm::LogVerbatim("Tracklet") << "DEBUG CHI2FIT " << j << " " << rinvseed << " + " << MinvDt[0][j] * delta[j]
+                                     << " " << MinvDt[0][j] << " " << delta[j] * rstub[j / 2] * 10000 << " \n"
+                                     << j << " " << tracklet->fpgarinv().value() * settings_.krinvpars() << " + "
+                                     << ((iMinvDt[0][j] * idelta[j])) * settings_.krinvpars() / 1024.0 << " "
+                                     << iMinvDt[0][j] * settings_.krinvpars() / settings_.kphi() / 1024.0 << " "
+                                     << idelta[j] * settings_.kphi() * rstub[j / 2] * 10000 << " " << idelta[j];
+      }
+    }
+
+    double deltaChisqexact =
+        drinvexact * drinv_covexact + dphi0exact * dphi0_covexact + dtexact * dt_covexact + dz0exact * dz0_covexact;
+
+    int irinvseed = tracklet->fpgarinv().value();
+    int iphi0seed = tracklet->fpgaphi0().value();
+
+    int itseed = tracklet->fpgat().value();
+    int iz0seed = tracklet->fpgaz0().value();
+
+    int irinvfit = irinvseed + ((idrinv + (1 << settings_.fitrinvbitshift())) >> settings_.fitrinvbitshift());
+
+    int iphi0fit = iphi0seed + (idphi0 >> settings_.fitphi0bitshift());
+    int itfit = itseed + (idt >> settings_.fittbitshift());
+
+    int iz0fit = iz0seed + (idz0 >> settings_.fitz0bitshift());
+
+    double rinvfit = rinvseed - drinv;
+    double phi0fit = phi0seed - dphi0;
+
+    double tfit = tseed - dt;
+    double z0fit = z0seed - dz0;
+
+    double rinvfitexact = rinvseedexact - drinvexact;
+    double phi0fitexact = phi0seedexact - dphi0exact;
+
+    double tfitexact = tseedexact - dtexact;
+    double z0fitexact = z0seedexact - dz0exact;
+
+    double chisqfitexact = chisqseedexact + deltaChisqexact;
+
+    ////////////// NEW CHISQ /////////////////////
+    bool NewChisqDebug = false;
+    double chisqfit = 0.0;
+    uint ichisqfit = 0;
+
+    double phifactor;
+    double rzfactor;
+    double iphifactor;
+    double irzfactor;
+    int k = 0;  // column index of D matrix
 
     if (NewChisqDebug) {
-      edm::LogVerbatim("Tracklet") << "delta[k]/sigma = " << delta[k] / sigma[k] << "  delta[k] = " << delta[k] << "\n"
-                                   << "sum = " << phifactor - delta[k] / sigma[k] << "  drinvterm = " << D[0][k] * drinv
-                                   << "  dphi0term = " << D[1][k] * dphi0 << "  dtterm = " << D[2][k] * dt
-                                   << "  dz0term = " << D[3][k] * dz0 << "\n  phifactor = " << phifactor;
+      edm::LogVerbatim("Tracklet") << "OG chisq: \n"
+                                   << "drinv/cov = " << drinv << "/" << drinv_cov << " \n"
+                                   << "dphi0/cov = " << drinv << "/" << dphi0_cov << " \n"
+                                   << "dt/cov = " << drinv << "/" << dt_cov << " \n"
+                                   << "dz0/cov = " << drinv << "/" << dz0_cov << "\n";
+      std::string myout = "D[0][k]= ";
+      for (unsigned int i = 0; i < 2 * n; i++) {
+        myout += std::to_string(D[0][i]);
+        myout += ", ";
+      }
+      edm::LogVerbatim("Tracklet") << myout;
     }
 
-    chisqfit += phifactor * phifactor;
-    ichisqfit += iphifactor * iphifactor / (1 << (2 * settings_.chisqphifactbits() - 4));
+    for (unsigned int i = 0; i < n; i++) {  // loop over stubs
 
-    k++;
+      phifactor = rstub[k / 2] * delta[k] / sigma[k] + D[0][k] * drinv + D[1][k] * dphi0 + D[2][k] * dt + D[3][k] * dz0;
+      iphifactor = kfactor[k] * rstub[k / 2] * idelta[k] * (1 << settings_.chisqphifactbits()) / sigma[k] -
+                   iD[0][k] * idrinv - iD[1][k] * idphi0 - iD[2][k] * idt - iD[3][k] * idz0;
 
-    rzfactor = delta[k] / sigma[k] + D[0][k] * drinv + D[1][k] * dphi0 + D[2][k] * dt + D[3][k] * dz0;
-    irzfactor = kfactor[k] * idelta[k] * (1 << settings_.chisqzfactbits()) / sigma[k] - iD[0][k] * idrinv -
-                iD[1][k] * idphi0 - iD[2][k] * idt - iD[3][k] * idz0;
+      if (NewChisqDebug) {
+        edm::LogVerbatim("Tracklet") << "delta[k]/sigma = " << delta[k] / sigma[k] << "  delta[k] = " << delta[k]
+                                     << "\n"
+                                     << "sum = " << phifactor - delta[k] / sigma[k]
+                                     << "  drinvterm = " << D[0][k] * drinv << "  dphi0term = " << D[1][k] * dphi0
+                                     << "  dtterm = " << D[2][k] * dt << "  dz0term = " << D[3][k] * dz0
+                                     << "\n  phifactor = " << phifactor;
+      }
 
-    if (NewChisqDebug) {
-      edm::LogVerbatim("Tracklet") << "delta[k]/sigma = " << delta[k] / sigma[k] << "  delta[k] = " << delta[k] << "\n"
-                                   << "sum = " << rzfactor - delta[k] / sigma[k] << "  drinvterm = " << D[0][k] * drinv
-                                   << "  dphi0term = " << D[1][k] * dphi0 << "  dtterm = " << D[2][k] * dt
-                                   << "  dz0term = " << D[3][k] * dz0 << "\n  rzfactor = " << rzfactor;
+      chisqfit += phifactor * phifactor;
+      ichisqfit += iphifactor * iphifactor / (1 << (2 * settings_.chisqphifactbits() - 4));
+
+      k++;
+
+      rzfactor = delta[k] / sigma[k] + D[0][k] * drinv + D[1][k] * dphi0 + D[2][k] * dt + D[3][k] * dz0;
+      irzfactor = kfactor[k] * idelta[k] * (1 << settings_.chisqzfactbits()) / sigma[k] - iD[0][k] * idrinv -
+                  iD[1][k] * idphi0 - iD[2][k] * idt - iD[3][k] * idz0;
+
+      if (NewChisqDebug) {
+        edm::LogVerbatim("Tracklet") << "delta[k]/sigma = " << delta[k] / sigma[k] << "  delta[k] = " << delta[k]
+                                     << "\n"
+                                     << "sum = " << rzfactor - delta[k] / sigma[k]
+                                     << "  drinvterm = " << D[0][k] * drinv << "  dphi0term = " << D[1][k] * dphi0
+                                     << "  dtterm = " << D[2][k] * dt << "  dz0term = " << D[3][k] * dz0
+                                     << "\n  rzfactor = " << rzfactor;
+      }
+
+      chisqfit += rzfactor * rzfactor;
+      ichisqfit += irzfactor * irzfactor / (1 << (2 * settings_.chisqzfactbits() - 4));
+
+      k++;
     }
 
-    chisqfit += rzfactor * rzfactor;
-    ichisqfit += irzfactor * irzfactor / (1 << (2 * settings_.chisqzfactbits() - 4));
-
-    k++;
-  }
-
-  if (settings_.writeMonitorData("ChiSq")) {
-    globals_->ofstream("chisq.txt") << asinh(itfit * settings_.ktpars()) << " " << chisqfit << " " << ichisqfit / 16.0
-                                    << endl;
-  }
-
-  // Chisquare per DOF capped out at 11 bits, so 15 is an educated guess
-  if (ichisqfit >= (1 << 15)) {
-    if (NewChisqDebug) {
-      edm::LogVerbatim("Tracklet") << "CHISQUARE (" << ichisqfit << ") LARGER THAN 11 BITS!";
+    if (settings_.writeMonitorData("ChiSq")) {
+      globals_->ofstream("chisq.txt") << asinh(itfit * settings_.ktpars()) << " " << chisqfit << " " << ichisqfit / 16.0
+                                      << endl;
     }
-    ichisqfit = (1 << 15) - 1;
+
+    // Chisquare per DOF capped out at 11 bits, so 15 is an educated guess
+    if (ichisqfit >= (1 << 15)) {
+      if (NewChisqDebug) {
+        edm::LogVerbatim("Tracklet") << "CHISQUARE (" << ichisqfit << ") LARGER THAN 11 BITS!";
+      }
+      ichisqfit = (1 << 15) - 1;
+    }
+
+    // Eliminate lower bits to fit in 8 bits
+    ichisqfit = ichisqfit >> 7;
+    // Probably redundant... enforce 8 bit cap
+    if (ichisqfit >= (1 << 8))
+      ichisqfit = (1 << 8) - 1;
+
+    double phicrit = phi0fit - asin(0.5 * settings_.rcrit() * rinvfit);
+    bool keep = (phicrit > settings_.phicritmin()) && (phicrit < settings_.phicritmax());
+
+    if (!keep) {
+      return;
+    }
+
+    // NOTE: setFitPars in Tracklet.h now accepts chi2 r-phi and chi2 r-z values. This class only has access
+    // to the composite chi2. When setting fit parameters on a tracklet, this places all of the chi2 into the
+    // r-phi fit, and sets the r-z fit value to zero.
+    //
+    // This is also true for the call to setFitPars in trackFitFake.
+    tracklet->setFitPars(rinvfit,
+                         phi0fit,
+                         0.0,
+                         tfit,
+                         z0fit,
+                         chisqfit,
+                         0.0,
+                         rinvfitexact,
+                         phi0fitexact,
+                         0.0,
+                         tfitexact,
+                         z0fitexact,
+                         chisqfitexact,
+                         0.0,
+                         irinvfit,
+                         iphi0fit,
+                         0,
+                         itfit,
+                         iz0fit,
+                         ichisqfit,
+                         0,
+                         0);
   }
 
-  // Eliminate lower bits to fit in 8 bits
-  ichisqfit = ichisqfit >> 7;
-  // Probably redundant... enforce 8 bit cap
-  if (ichisqfit >= (1 << 8))
-    ichisqfit = (1 << 8) - 1;
-
-  double phicrit = phi0fit - asin(0.5 * settings_.rcrit() * rinvfit);
-  bool keep = (phicrit > settings_.phicritmin()) && (phicrit < settings_.phicritmax());
-
-  if (!keep) {
+  void FitTrack::trackFitFake(Tracklet* tracklet, std::vector<const Stub*>&, std::vector<std::pair<int, int>>&) {
+    tracklet->setFitPars(tracklet->rinvapprox(),
+                         tracklet->phi0approx(),
+                         tracklet->d0approx(),
+                         tracklet->tapprox(),
+                         tracklet->z0approx(),
+                         0.0,
+                         0.0,
+                         tracklet->rinv(),
+                         tracklet->phi0(),
+                         tracklet->d0(),
+                         tracklet->t(),
+                         tracklet->z0(),
+                         0.0,
+                         0.0,
+                         tracklet->fpgarinv().value(),
+                         tracklet->fpgaphi0().value(),
+                         tracklet->fpgad0().value(),
+                         tracklet->fpgat().value(),
+                         tracklet->fpgaz0().value(),
+                         0,
+                         0,
+                         0);
     return;
   }
 
-  // NOTE: setFitPars in Tracklet.h now accepts chi2 r-phi and chi2 r-z values. This class only has access
-  // to the composite chi2. When setting fit parameters on a tracklet, this places all of the chi2 into the
-  // r-phi fit, and sets the r-z fit value to zero.
-  //
-  // This is also true for the call to setFitPars in trackFitFake.
-  tracklet->setFitPars(rinvfit,
-                       phi0fit,
-                       0.0,
-                       tfit,
-                       z0fit,
-                       chisqfit,
-                       0.0,
-                       rinvfitexact,
-                       phi0fitexact,
-                       0.0,
-                       tfitexact,
-                       z0fitexact,
-                       chisqfitexact,
-                       0.0,
-                       irinvfit,
-                       iphi0fit,
-                       0,
-                       itfit,
-                       iz0fit,
-                       ichisqfit,
-                       0,
-                       0);
-}
+  std::vector<Tracklet*> FitTrack::orderedMatches(vector<FullMatchMemory*>& fullmatch) {
+    std::vector<Tracklet*> tmp;
 
-void FitTrack::trackFitFake(Tracklet* tracklet, std::vector<const Stub*>&, std::vector<std::pair<int, int>>&) {
-  tracklet->setFitPars(tracklet->rinvapprox(),
-                       tracklet->phi0approx(),
-                       tracklet->d0approx(),
-                       tracklet->tapprox(),
-                       tracklet->z0approx(),
-                       0.0,
-                       0.0,
-                       tracklet->rinv(),
-                       tracklet->phi0(),
-                       tracklet->d0(),
-                       tracklet->t(),
-                       tracklet->z0(),
-                       0.0,
-                       0.0,
-                       tracklet->fpgarinv().value(),
-                       tracklet->fpgaphi0().value(),
-                       tracklet->fpgad0().value(),
-                       tracklet->fpgat().value(),
-                       tracklet->fpgaz0().value(),
-                       0,
-                       0,
-                       0);
-  return;
-}
+    std::vector<unsigned int> indexArray;
+    for (auto& imatch : fullmatch) {
+      //check that we have correct order
+      if (imatch->nMatches() > 1) {
+        for (unsigned int j = 0; j < imatch->nMatches() - 1; j++) {
+          assert(imatch->getTracklet(j)->TCID() <= imatch->getTracklet(j + 1)->TCID());
+        }
+      }
 
-std::vector<Tracklet*> FitTrack::orderedMatches(vector<FullMatchMemory*>& fullmatch) {
-  std::vector<Tracklet*> tmp;
+      if (settings_.debugTracklet() && imatch->nMatches() != 0) {
+        edm::LogVerbatim("Tracklet") << "orderedMatches: " << imatch->getName() << " " << imatch->nMatches();
+      }
 
-  std::vector<unsigned int> indexArray;
-  for (auto& imatch : fullmatch) {
-    //check that we have correct order
-    if (imatch->nMatches() > 1) {
-      for (unsigned int j = 0; j < imatch->nMatches() - 1; j++) {
-        assert(imatch->getTracklet(j)->TCID() <= imatch->getTracklet(j + 1)->TCID());
+      indexArray.push_back(0);
+    }
+
+    int bestIndex = -1;
+    do {
+      int bestTCID = -1;
+      bestIndex = -1;
+      for (unsigned int i = 0; i < fullmatch.size(); i++) {
+        if (indexArray[i] >= fullmatch[i]->nMatches()) {
+          //skip as we were at the end
+          continue;
+        }
+        int TCID = fullmatch[i]->getTracklet(indexArray[i])->TCID();
+        if (TCID < bestTCID || bestTCID < 0) {
+          bestTCID = TCID;
+          bestIndex = i;
+        }
+      }
+      if (bestIndex != -1) {
+        tmp.push_back(fullmatch[bestIndex]->getTracklet(indexArray[bestIndex]));
+        indexArray[bestIndex]++;
+      }
+    } while (bestIndex != -1);
+
+    for (unsigned int i = 0; i < tmp.size(); i++) {
+      if (i > 0) {
+        //This allows for equal TCIDs. This means that we can e.g. have a track seeded in L1L2 that projects to both L3 and D4.
+        //The algorithm will pick up the first hit and drop the second.
+        if (tmp[i - 1]->TCID() > tmp[i]->TCID()) {
+          edm::LogVerbatim("Tracklet") << "Wrong TCID ordering in " << getName() << " : " << tmp[i - 1]->TCID() << " "
+                                       << tmp[i]->TCID();
+        }
       }
     }
 
-    if (settings_.debugTracklet() && imatch->nMatches() != 0) {
-      edm::LogVerbatim("Tracklet") << "orderedMatches: " << imatch->getName() << " " << imatch->nMatches();
-    }
-
-    indexArray.push_back(0);
+    return tmp;
   }
 
-  int bestIndex = -1;
-  do {
-    int bestTCID = -1;
-    bestIndex = -1;
-    for (unsigned int i = 0; i < fullmatch.size(); i++) {
-      if (indexArray[i] >= fullmatch[i]->nMatches()) {
-        //skip as we were at the end
-        continue;
+  // Adds the fitted track to the output memories to be used by pure Tracklet algo.
+  // (Also used by Hybrid algo with non-exact Old KF emulation)
+  // Also create output streams, that bypass these memories, (so can include gaps in time),
+  // to be used by Hybrid case with exact New KF emulation.
+
+  void FitTrack::execute(deque<string>& streamTrackRaw,
+                         vector<deque<StubStreamData>>& streamsStubRaw,
+                         unsigned int iSector) {
+    // merge
+    const std::vector<Tracklet*>& matches1 = orderedMatches(fullmatch1_);
+    const std::vector<Tracklet*>& matches2 = orderedMatches(fullmatch2_);
+    const std::vector<Tracklet*>& matches3 = orderedMatches(fullmatch3_);
+    const std::vector<Tracklet*>& matches4 = orderedMatches(fullmatch4_);
+
+    iSector_ = iSector;
+
+    if (settings_.debugTracklet() && (matches1.size() + matches2.size() + matches3.size() + matches4.size()) > 0) {
+      for (auto& imatch : fullmatch1_) {
+        edm::LogVerbatim("Tracklet") << imatch->getName() << " " << imatch->nMatches();
       }
-      int TCID = fullmatch[i]->getTracklet(indexArray[i])->TCID();
-      if (TCID < bestTCID || bestTCID < 0) {
-        bestTCID = TCID;
-        bestIndex = i;
-      }
+      edm::LogVerbatim("Tracklet") << getName() << " matches : " << matches1.size() << " " << matches2.size() << " "
+                                   << matches3.size() << " " << matches4.size();
     }
-    if (bestIndex != -1) {
-      tmp.push_back(fullmatch[bestIndex]->getTracklet(indexArray[bestIndex]));
-      indexArray[bestIndex]++;
+
+    unsigned int indexArray[4];
+    for (unsigned int i = 0; i < 4; i++) {
+      indexArray[i] = 0;
     }
-  } while (bestIndex != -1);
 
-  for (unsigned int i = 0; i < tmp.size(); i++) {
-    if (i > 0) {
-      //This allows for equal TCIDs. This means that we can e.g. have a track seeded in L1L2 that projects to both L3 and D4.
-      //The algorithm will pick up the first hit and drop the second.
-      if (tmp[i - 1]->TCID() > tmp[i]->TCID()) {
-        edm::LogVerbatim("Tracklet") << "Wrong TCID ordering in " << getName() << " : " << tmp[i - 1]->TCID() << " "
-                                     << tmp[i]->TCID();
-      }
-    }
-  }
+    unsigned int countAll = 0;
+    unsigned int countFit = 0;
 
-  return tmp;
-}
+    Tracklet* bestTracklet = nullptr;
+    do {
+      countAll++;
+      bestTracklet = nullptr;
 
-// Adds the fitted track to the output memories to be used by pure Tracklet algo.
-// (Also used by Hybrid algo with non-exact Old KF emulation)
-// Also create output streams, that bypass these memories, (so can include gaps in time),
-// to be used by Hybrid case with exact New KF emulation.
-
-void FitTrack::execute(deque<string>& streamTrackRaw,
-                       vector<deque<StubStreamData>>& streamsStubRaw,
-                       unsigned int iSector) {
-  // merge
-  const std::vector<Tracklet*>& matches1 = orderedMatches(fullmatch1_);
-  const std::vector<Tracklet*>& matches2 = orderedMatches(fullmatch2_);
-  const std::vector<Tracklet*>& matches3 = orderedMatches(fullmatch3_);
-  const std::vector<Tracklet*>& matches4 = orderedMatches(fullmatch4_);
-
-  iSector_ = iSector;
-
-  if (settings_.debugTracklet() && (matches1.size() + matches2.size() + matches3.size() + matches4.size()) > 0) {
-    for (auto& imatch : fullmatch1_) {
-      edm::LogVerbatim("Tracklet") << imatch->getName() << " " << imatch->nMatches();
-    }
-    edm::LogVerbatim("Tracklet") << getName() << " matches : " << matches1.size() << " " << matches2.size() << " "
-                                 << matches3.size() << " " << matches4.size();
-  }
-
-  unsigned int indexArray[4];
-  for (unsigned int i = 0; i < 4; i++) {
-    indexArray[i] = 0;
-  }
-
-  unsigned int countAll = 0;
-  unsigned int countFit = 0;
-
-  Tracklet* bestTracklet = nullptr;
-  do {
-    countAll++;
-    bestTracklet = nullptr;
-
-    if (indexArray[0] < matches1.size()) {
-      if (bestTracklet == nullptr) {
-        bestTracklet = matches1[indexArray[0]];
-      } else {
-        if (matches1[indexArray[0]]->TCID() < bestTracklet->TCID())
+      if (indexArray[0] < matches1.size()) {
+        if (bestTracklet == nullptr) {
           bestTracklet = matches1[indexArray[0]];
+        } else {
+          if (matches1[indexArray[0]]->TCID() < bestTracklet->TCID())
+            bestTracklet = matches1[indexArray[0]];
+        }
       }
-    }
 
-    if (indexArray[1] < matches2.size()) {
-      if (bestTracklet == nullptr) {
-        bestTracklet = matches2[indexArray[1]];
-      } else {
-        if (matches2[indexArray[1]]->TCID() < bestTracklet->TCID())
+      if (indexArray[1] < matches2.size()) {
+        if (bestTracklet == nullptr) {
           bestTracklet = matches2[indexArray[1]];
+        } else {
+          if (matches2[indexArray[1]]->TCID() < bestTracklet->TCID())
+            bestTracklet = matches2[indexArray[1]];
+        }
       }
-    }
 
-    if (indexArray[2] < matches3.size()) {
-      if (bestTracklet == nullptr) {
-        bestTracklet = matches3[indexArray[2]];
-      } else {
-        if (matches3[indexArray[2]]->TCID() < bestTracklet->TCID())
+      if (indexArray[2] < matches3.size()) {
+        if (bestTracklet == nullptr) {
           bestTracklet = matches3[indexArray[2]];
+        } else {
+          if (matches3[indexArray[2]]->TCID() < bestTracklet->TCID())
+            bestTracklet = matches3[indexArray[2]];
+        }
       }
-    }
 
-    if (indexArray[3] < matches4.size()) {
-      if (bestTracklet == nullptr) {
-        bestTracklet = matches4[indexArray[3]];
-      } else {
-        if (matches4[indexArray[3]]->TCID() < bestTracklet->TCID())
+      if (indexArray[3] < matches4.size()) {
+        if (bestTracklet == nullptr) {
           bestTracklet = matches4[indexArray[3]];
+        } else {
+          if (matches4[indexArray[3]]->TCID() < bestTracklet->TCID())
+            bestTracklet = matches4[indexArray[3]];
+        }
       }
-    }
 
-    if (bestTracklet == nullptr)
-      break;
+      if (bestTracklet == nullptr)
+        break;
 
-    //Counts total number of matched hits
-    int nMatches = 0;
+      //Counts total number of matched hits
+      int nMatches = 0;
 
-    //Counts unique hits in each layer
-    int nMatchesUniq = 0;
-    bool match = false;
+      //Counts unique hits in each layer
+      int nMatchesUniq = 0;
+      bool match = false;
 
-    while (indexArray[0] < matches1.size() && matches1[indexArray[0]] == bestTracklet) {
-      indexArray[0]++;
-      nMatches++;
-      match = true;
-    }
+      while (indexArray[0] < matches1.size() && matches1[indexArray[0]] == bestTracklet) {
+        indexArray[0]++;
+        nMatches++;
+        match = true;
+      }
 
-    if (match)
-      nMatchesUniq++;
-    match = false;
+      if (match)
+        nMatchesUniq++;
+      match = false;
 
-    while (indexArray[1] < matches2.size() && matches2[indexArray[1]] == bestTracklet) {
-      indexArray[1]++;
-      nMatches++;
-      match = true;
-    }
+      while (indexArray[1] < matches2.size() && matches2[indexArray[1]] == bestTracklet) {
+        indexArray[1]++;
+        nMatches++;
+        match = true;
+      }
 
-    if (match)
-      nMatchesUniq++;
-    match = false;
+      if (match)
+        nMatchesUniq++;
+      match = false;
 
-    while (indexArray[2] < matches3.size() && matches3[indexArray[2]] == bestTracklet) {
-      indexArray[2]++;
-      nMatches++;
-      match = true;
-    }
+      while (indexArray[2] < matches3.size() && matches3[indexArray[2]] == bestTracklet) {
+        indexArray[2]++;
+        nMatches++;
+        match = true;
+      }
 
-    if (match)
-      nMatchesUniq++;
-    match = false;
+      if (match)
+        nMatchesUniq++;
+      match = false;
 
-    while (indexArray[3] < matches4.size() && matches4[indexArray[3]] == bestTracklet) {
-      indexArray[3]++;
-      nMatches++;
-      match = true;
-    }
+      while (indexArray[3] < matches4.size() && matches4[indexArray[3]] == bestTracklet) {
+        indexArray[3]++;
+        nMatches++;
+        match = true;
+      }
 
-    if (match)
-      nMatchesUniq++;
+      if (match)
+        nMatchesUniq++;
 
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << getName() << " : nMatches = " << nMatches << " nMatchesUniq = " << nMatchesUniq
-                                   << " " << asinh(bestTracklet->t());
-    }
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << getName() << " : nMatches = " << nMatches << " nMatchesUniq = " << nMatchesUniq
+                                     << " " << asinh(bestTracklet->t());
+      }
 
-    std::vector<const Stub*> trackstublist;
-    std::vector<std::pair<int, int>> stubidslist;
-    // Track Builder cut of >= 4 layers with stubs.
-    if ((bestTracklet->getISeed() >= (int)N_SEED_PROMPT && nMatchesUniq >= 1) ||
-        nMatchesUniq >= 2) {  //For seeds index >=8 (triplet seeds), there are three stubs associated from start.
-      countFit++;
+      std::vector<const Stub*> trackstublist;
+      std::vector<std::pair<int, int>> stubidslist;
+      // Track Builder cut of >= 4 layers with stubs.
+      if ((bestTracklet->getISeed() >= (int)N_SEED_PROMPT && nMatchesUniq >= 1) ||
+          nMatchesUniq >= 2) {  //For seeds index >=8 (triplet seeds), there are three stubs associated from start.
+        countFit++;
 
 #ifdef USEHYBRID
-      if (settings_.fakefit()) {
-        trackFitFake(bestTracklet, trackstublist, stubidslist);
-      } else {
-        trackFitKF(bestTracklet, trackstublist, stubidslist);
-      }
+        if (settings_.fakefit()) {
+          trackFitFake(bestTracklet, trackstublist, stubidslist);
+        } else {
+          trackFitKF(bestTracklet, trackstublist, stubidslist);
+        }
 #else
-      if (settings_.fakefit()) {
-        trackFitFake(bestTracklet, trackstublist, stubidslist);
-      } else {
-        trackFitChisq(bestTracklet, trackstublist, stubidslist);
-      }
+        if (settings_.fakefit()) {
+          trackFitFake(bestTracklet, trackstublist, stubidslist);
+        } else {
+          trackFitChisq(bestTracklet, trackstublist, stubidslist);
+        }
 #endif
 
-      if (settings_.removalType() == "merge") {
-        trackfit_->addStubList(trackstublist);
-        trackfit_->addStubidsList(stubidslist);
-        bestTracklet->setTrackIndex(trackfit_->nTracks());
-        trackfit_->addTrack(bestTracklet);
-      } else if (bestTracklet->fit()) {
-        assert(trackfit_ != nullptr);
-        if (settings_.writeMonitorData("Seeds")) {
-          ofstream fout("seeds.txt", ofstream::app);
-          fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_"
-               << " " << bestTracklet->getISeed() << endl;
-          fout.close();
-        }
-        bestTracklet->setTrackIndex(trackfit_->nTracks());
-        trackfit_->addTrack(bestTracklet);
-      }
-    }
-
-    // store bit and clock accurate TB output
-    if (settings_.storeTrackBuilderOutput() && bestTracklet) {
-      // add gap if TrackBuilder rejected track (due to too few stub layers).
-      if (!bestTracklet->fit()) {
-        static const string invalid = "0";
-        streamTrackRaw.emplace_back(invalid);
-        for (auto& stream : streamsStubRaw)
-          stream.emplace_back(StubStreamData());
-        continue;
-      }
-      // convert Track word
-      const string rinv = bestTracklet->fpgarinv().str();
-      const string phi0 = bestTracklet->fpgaphi0().str();
-      const string z0 = bestTracklet->fpgaz0().str();
-      const string t = bestTracklet->fpgat().str();
-      const int seedType = bestTracklet->getISeed();
-      const string seed = TTBV(seedType, settings_.nbitsseed()).str();
-      const string valid("1");
-      streamTrackRaw.emplace_back(valid + seed + rinv + phi0 + z0 + t);
-
-      unsigned int ihit(0);
-      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-        if (bestTracklet->match(ilayer)) {
-          const Residual& resid = bestTracklet->resid(ilayer);
-          // create bit accurate 64 bit word
-          const string valid("1");
-          string r = resid.stubptr()->r().str();
-          const string& phi = resid.fpgaphiresid().str();
-          const string& rz = resid.fpgarzresid().str();
-          const L1TStub* stub = resid.stubptr()->l1tstub();
-          static constexpr int widthDisk2Sidentifier = 8;
-          bool disk2S = (stub->disk() != 0) && (stub->isPSmodule() == 0);
-          if (disk2S)
-            r = string(widthDisk2Sidentifier, '0') + r;
-          // store seed, L1TStub, and bit accurate 64 bit word in clock accurate output
-          streamsStubRaw[ihit++].emplace_back(seedType, *stub, valid + r + phi + rz);
+        if (settings_.removalType() == "merge") {
+          trackfit_->addStubList(trackstublist);
+          trackfit_->addStubidsList(stubidslist);
+          bestTracklet->setTrackIndex(trackfit_->nTracks());
+          trackfit_->addTrack(bestTracklet);
+        } else if (bestTracklet->fit()) {
+          assert(trackfit_ != nullptr);
+          if (settings_.writeMonitorData("Seeds")) {
+            ofstream fout("seeds.txt", ofstream::app);
+            fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_"
+                 << " " << bestTracklet->getISeed() << endl;
+            fout.close();
+          }
+          bestTracklet->setTrackIndex(trackfit_->nTracks());
+          trackfit_->addTrack(bestTracklet);
         }
       }
-      // fill all layers that have no stubs with gaps
-      while (ihit < streamsStubRaw.size()) {
-        streamsStubRaw[ihit++].emplace_back();
+
+      // store bit and clock accurate TB output
+      if (settings_.storeTrackBuilderOutput() && bestTracklet) {
+        // add gap if TrackBuilder rejected track (due to too few stub layers).
+        if (!bestTracklet->fit()) {
+          static const string invalid = "0";
+          streamTrackRaw.emplace_back(invalid);
+          for (auto& stream : streamsStubRaw)
+            stream.emplace_back(StubStreamData());
+          continue;
+        }
+        // convert Track word
+        const string rinv = bestTracklet->fpgarinv().str();
+        const string phi0 = bestTracklet->fpgaphi0().str();
+        const string z0 = bestTracklet->fpgaz0().str();
+        const string t = bestTracklet->fpgat().str();
+        const int seedType = bestTracklet->getISeed();
+        const string seed = TTBV(seedType, settings_.nbitsseed()).str();
+        const string valid("1");
+        streamTrackRaw.emplace_back(valid + seed + rinv + phi0 + z0 + t);
+
+        unsigned int ihit(0);
+        for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+          if (bestTracklet->match(ilayer)) {
+            const Residual& resid = bestTracklet->resid(ilayer);
+            // create bit accurate 64 bit word
+            const string valid("1");
+            string r = resid.stubptr()->r().str();
+            const string& phi = resid.fpgaphiresid().str();
+            const string& rz = resid.fpgarzresid().str();
+            const L1TStub* stub = resid.stubptr()->l1tstub();
+            static constexpr int widthDisk2Sidentifier = 8;
+            bool disk2S = (stub->disk() != 0) && (stub->isPSmodule() == 0);
+            if (disk2S)
+              r = string(widthDisk2Sidentifier, '0') + r;
+            // store seed, L1TStub, and bit accurate 64 bit word in clock accurate output
+            streamsStubRaw[ihit++].emplace_back(seedType, *stub, valid + r + phi + rz);
+          }
+        }
+        // fill all layers that have no stubs with gaps
+        while (ihit < streamsStubRaw.size()) {
+          streamsStubRaw[ihit++].emplace_back();
+        }
       }
+
+    } while (bestTracklet != nullptr && countAll < settings_.maxStep("TB"));
+
+    if (settings_.writeMonitorData("FT")) {
+      globals_->ofstream("fittrack.txt") << getName() << " " << countAll << " " << countFit << endl;
     }
-
-  } while (bestTracklet != nullptr && countAll < settings_.maxStep("TB"));
-
-  if (settings_.writeMonitorData("FT")) {
-    globals_->ofstream("fittrack.txt") << getName() << " " << countAll << " " << countFit << endl;
   }
-}
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
@@ -10,58 +10,59 @@ using namespace std;
 
 namespace trklet {
 
-FullMatchMemory::FullMatchMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
-  size_t pos = find_nth(name, 0, "_", 1);
-  assert(pos != string::npos);
-  initLayerDisk(pos + 1, layer_, disk_);
-}
+  FullMatchMemory::FullMatchMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
+    size_t pos = find_nth(name, 0, "_", 1);
+    assert(pos != string::npos);
+    initLayerDisk(pos + 1, layer_, disk_);
+  }
 
-void FullMatchMemory::addMatch(Tracklet* tracklet, const Stub* stub) {
-  if (!settings_.doKF() || !settings_.doMultipleMatches()) {
-    // When allowing only one stub per track per layer (or no KF implying same).
-    for (auto& match : matches_) {
-      if (match.first == tracklet) {  //Better match: replace existing one
-        match.second = stub;
-        return;
+  void FullMatchMemory::addMatch(Tracklet* tracklet, const Stub* stub) {
+    if (!settings_.doKF() || !settings_.doMultipleMatches()) {
+      // When allowing only one stub per track per layer (or no KF implying same).
+      for (auto& match : matches_) {
+        if (match.first == tracklet) {  //Better match: replace existing one
+          match.second = stub;
+          return;
+        }
       }
     }
-  }
-  std::pair<Tracklet*, const Stub*> tmp(tracklet, stub);
-  //Check that we have the right TCID order
-  if (!matches_.empty()) {
-    if ((!settings_.doKF() && matches_[matches_.size() - 1].first->TCID() >= tracklet->TCID()) ||
-        (settings_.doKF() && matches_[matches_.size() - 1].first->TCID() > tracklet->TCID())) {
-      edm::LogPrint("Tracklet") << "Wrong TCID ordering in " << getName() << " : "
-                                << matches_[matches_.size() - 1].first->TCID() << " " << tracklet->TCID() << " "
-                                << matches_[matches_.size() - 1].first->trackletIndex() << " "
-                                << tracklet->trackletIndex();
+    std::pair<Tracklet*, const Stub*> tmp(tracklet, stub);
+    //Check that we have the right TCID order
+    if (!matches_.empty()) {
+      if ((!settings_.doKF() && matches_[matches_.size() - 1].first->TCID() >= tracklet->TCID()) ||
+          (settings_.doKF() && matches_[matches_.size() - 1].first->TCID() > tracklet->TCID())) {
+        edm::LogPrint("Tracklet") << "Wrong TCID ordering in " << getName() << " : "
+                                  << matches_[matches_.size() - 1].first->TCID() << " " << tracklet->TCID() << " "
+                                  << matches_[matches_.size() - 1].first->trackletIndex() << " "
+                                  << tracklet->trackletIndex();
+      }
     }
+    matches_.push_back(tmp);
   }
-  matches_.push_back(tmp);
-}
 
-void FullMatchMemory::writeMC(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirM = settings_.memPath() + "Matches/";
+  void FullMatchMemory::writeMC(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirM = settings_.memPath() + "Matches/";
 
-  std::ostringstream oss;
-  oss << dirM << "FullMatches_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
+    std::ostringstream oss;
+    oss << dirM << "FullMatches_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
+    auto const& fname = oss.str();
 
-  openfile(out_, first, dirM, fname, __FILE__, __LINE__);
+    openfile(out_, first, dirM, fname, __FILE__, __LINE__);
 
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
 
-  for (unsigned int j = 0; j < matches_.size(); j++) {
-    string match = (layer_ > 0) ? matches_[j].first->fullmatchstr(layer_) : matches_[j].first->fullmatchdiskstr(disk_);
-    out_ << hexstr(j) << " " << match << " " << trklet::hexFormat(match) << endl;
+    for (unsigned int j = 0; j < matches_.size(); j++) {
+      string match =
+          (layer_ > 0) ? matches_[j].first->fullmatchstr(layer_) : matches_[j].first->fullmatchdiskstr(disk_);
+      out_ << hexstr(j) << " " << match << " " << trklet::hexFormat(match) << endl;
+    }
+    out_.close();
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
   }
-  out_.close();
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
@@ -7,7 +7,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 FullMatchMemory::FullMatchMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
   size_t pos = find_nth(name, 0, "_", 1);
@@ -61,4 +62,6 @@ void FullMatchMemory::writeMC(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/Globals.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Globals.cc
@@ -9,7 +9,8 @@
 #include "L1Trigger/TrackFindingTracklet/interface/HistBase.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 Globals::Globals(Settings const& settings) {
   imathGlobals* imathGlobs = new imathGlobals();
@@ -48,4 +49,6 @@ std::ofstream& Globals::ofstream(std::string fname) {
   std::ofstream* outptr = new std::ofstream(fname.c_str());
   ofstreams_[fname] = outptr;
   return *outptr;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/Globals.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Globals.cc
@@ -12,43 +12,43 @@ using namespace std;
 
 namespace trklet {
 
-Globals::Globals(Settings const& settings) {
-  imathGlobals* imathGlobs = new imathGlobals();
+  Globals::Globals(Settings const& settings) {
+    imathGlobals* imathGlobs = new imathGlobals();
 
-  //takes owernship of globals pointer
-  imathGlobals_.reset(imathGlobs);
+    //takes owernship of globals pointer
+    imathGlobals_.reset(imathGlobs);
 
-  // tracklet calculators
-  ITC_L1L2_ = make_unique<IMATH_TrackletCalculator>(settings, imathGlobs, 1, 2);
-  ITC_L2L3_ = make_unique<IMATH_TrackletCalculator>(settings, imathGlobs, 2, 3);
-  ITC_L3L4_ = make_unique<IMATH_TrackletCalculator>(settings, imathGlobs, 3, 4);
-  ITC_L5L6_ = make_unique<IMATH_TrackletCalculator>(settings, imathGlobs, 5, 6);
+    // tracklet calculators
+    ITC_L1L2_ = make_unique<IMATH_TrackletCalculator>(settings, imathGlobs, 1, 2);
+    ITC_L2L3_ = make_unique<IMATH_TrackletCalculator>(settings, imathGlobs, 2, 3);
+    ITC_L3L4_ = make_unique<IMATH_TrackletCalculator>(settings, imathGlobs, 3, 4);
+    ITC_L5L6_ = make_unique<IMATH_TrackletCalculator>(settings, imathGlobs, 5, 6);
 
-  ITC_F1F2_ = make_unique<IMATH_TrackletCalculatorDisk>(settings, imathGlobs, 1, 2);
-  ITC_F3F4_ = make_unique<IMATH_TrackletCalculatorDisk>(settings, imathGlobs, 3, 4);
-  ITC_B1B2_ = make_unique<IMATH_TrackletCalculatorDisk>(settings, imathGlobs, -1, -2);
-  ITC_B3B4_ = make_unique<IMATH_TrackletCalculatorDisk>(settings, imathGlobs, -3, -4);
+    ITC_F1F2_ = make_unique<IMATH_TrackletCalculatorDisk>(settings, imathGlobs, 1, 2);
+    ITC_F3F4_ = make_unique<IMATH_TrackletCalculatorDisk>(settings, imathGlobs, 3, 4);
+    ITC_B1B2_ = make_unique<IMATH_TrackletCalculatorDisk>(settings, imathGlobs, -1, -2);
+    ITC_B3B4_ = make_unique<IMATH_TrackletCalculatorDisk>(settings, imathGlobs, -3, -4);
 
-  ITC_L1F1_ = make_unique<IMATH_TrackletCalculatorOverlap>(settings, imathGlobs, 1, 1);
-  ITC_L2F1_ = make_unique<IMATH_TrackletCalculatorOverlap>(settings, imathGlobs, 2, 1);
-  ITC_L1B1_ = make_unique<IMATH_TrackletCalculatorOverlap>(settings, imathGlobs, 1, -1);
-  ITC_L2B1_ = make_unique<IMATH_TrackletCalculatorOverlap>(settings, imathGlobs, 2, -1);
-}
-
-Globals::~Globals() {
-  for (auto i : thePhiCorr_) {
-    delete i;
-    i = nullptr;
+    ITC_L1F1_ = make_unique<IMATH_TrackletCalculatorOverlap>(settings, imathGlobs, 1, 1);
+    ITC_L2F1_ = make_unique<IMATH_TrackletCalculatorOverlap>(settings, imathGlobs, 2, 1);
+    ITC_L1B1_ = make_unique<IMATH_TrackletCalculatorOverlap>(settings, imathGlobs, 1, -1);
+    ITC_L2B1_ = make_unique<IMATH_TrackletCalculatorOverlap>(settings, imathGlobs, 2, -1);
   }
-}
 
-std::ofstream& Globals::ofstream(std::string fname) {
-  if (ofstreams_.find(fname) != ofstreams_.end()) {
-    return *(ofstreams_[fname]);
+  Globals::~Globals() {
+    for (auto i : thePhiCorr_) {
+      delete i;
+      i = nullptr;
+    }
   }
-  std::ofstream* outptr = new std::ofstream(fname.c_str());
-  ofstreams_[fname] = outptr;
-  return *outptr;
-}
 
-}
+  std::ofstream& Globals::ofstream(std::string fname) {
+    if (ofstreams_.find(fname) != ofstreams_.end()) {
+      return *(ofstreams_[fname]);
+    }
+    std::ofstream* outptr = new std::ofstream(fname.c_str());
+    ofstreams_[fname] = outptr;
+    return *outptr;
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -11,257 +11,257 @@ using namespace std;
 
 namespace trklet {
 
-HybridFit::HybridFit(unsigned int iSector, Settings const& settings, Globals* globals) : settings_(settings) {
-  iSector_ = iSector;
-  globals_ = globals;
-}
-
-void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist) {
-  if (settings_.fakefit()) {
-    vector<const L1TStub*> l1stubsFromFitTrack;
-    for (unsigned int k = 0; k < trackstublist.size(); k++) {
-      const L1TStub* L1stub = trackstublist[k]->l1tstub();
-      l1stubsFromFitTrack.push_back(L1stub);
-    }
-    tracklet->setFitPars(tracklet->rinvapprox(),
-                         tracklet->phi0approx(),
-                         tracklet->d0approx(),
-                         tracklet->tapprox(),
-                         tracklet->z0approx(),
-                         0.,
-                         0.,
-                         tracklet->rinv(),
-                         tracklet->phi0(),
-                         tracklet->d0(),
-                         tracklet->t(),
-                         tracklet->z0(),
-                         0.,
-                         0.,
-                         tracklet->fpgarinv().value(),
-                         tracklet->fpgaphi0().value(),
-                         tracklet->fpgad0().value(),
-                         tracklet->fpgat().value(),
-                         tracklet->fpgaz0().value(),
-                         0,
-                         0,
-                         0,
-                         l1stubsFromFitTrack);
-    return;
+  HybridFit::HybridFit(unsigned int iSector, Settings const& settings, Globals* globals) : settings_(settings) {
+    iSector_ = iSector;
+    globals_ = globals;
   }
 
-  std::vector<tmtt::Stub*> TMTTstubs;
-  std::map<unsigned int, const L1TStub*> L1StubIndices;
-  unsigned int L1stubID = 0;
-
-  if (globals_->tmttSettings() == nullptr) {
-    if (settings_.printDebugKF())
-      edm::LogVerbatim("L1track") << "Creating TMTT::Settings in HybridFit::Fit";
-    globals_->tmttSettings() = make_unique<tmtt::Settings>();
-    globals_->tmttSettings()->setMagneticField(settings_.bfield());
-  }
-
-  const tmtt::Settings& TMTTsettings = *globals_->tmttSettings();
-
-  int kf_phi_sec = iSector_;
-
-  for (unsigned int k = 0; k < trackstublist.size(); k++) {
-    const L1TStub* L1stubptr = trackstublist[k]->l1tstub();
-
-    double kfphi = L1stubptr->phi();
-    double kfr = L1stubptr->r();
-    double kfz = L1stubptr->z();
-    double kfbend = L1stubptr->bend();
-    bool psmodule = L1stubptr->isPSmodule();
-    unsigned int iphi = L1stubptr->iphi();
-    double alpha = L1stubptr->alpha(settings_.stripPitch(psmodule));
-    bool isTilted = L1stubptr->isTilted();
-
-    bool isBarrel = trackstublist[k]->layerdisk() < N_LAYER;
-    int kflayer;
-
-    if (isBarrel) {  // Barrel-specific
-      kflayer = L1stubptr->layer() + 1;
-      if (settings_.printDebugKF())
-        edm::LogVerbatim("L1track") << "Will create layer stub with : ";
-    } else {  // Disk-specific
-      kflayer = abs(L1stubptr->disk());
-      if (kfz > 0) {
-        kflayer += 10;
-      } else {
-        kflayer += 20;
+  void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist) {
+    if (settings_.fakefit()) {
+      vector<const L1TStub*> l1stubsFromFitTrack;
+      for (unsigned int k = 0; k < trackstublist.size(); k++) {
+        const L1TStub* L1stub = trackstublist[k]->l1tstub();
+        l1stubsFromFitTrack.push_back(L1stub);
       }
+      tracklet->setFitPars(tracklet->rinvapprox(),
+                           tracklet->phi0approx(),
+                           tracklet->d0approx(),
+                           tracklet->tapprox(),
+                           tracklet->z0approx(),
+                           0.,
+                           0.,
+                           tracklet->rinv(),
+                           tracklet->phi0(),
+                           tracklet->d0(),
+                           tracklet->t(),
+                           tracklet->z0(),
+                           0.,
+                           0.,
+                           tracklet->fpgarinv().value(),
+                           tracklet->fpgaphi0().value(),
+                           tracklet->fpgad0().value(),
+                           tracklet->fpgat().value(),
+                           tracklet->fpgaz0().value(),
+                           0,
+                           0,
+                           0,
+                           l1stubsFromFitTrack);
+      return;
+    }
+
+    std::vector<tmtt::Stub*> TMTTstubs;
+    std::map<unsigned int, const L1TStub*> L1StubIndices;
+    unsigned int L1stubID = 0;
+
+    if (globals_->tmttSettings() == nullptr) {
       if (settings_.printDebugKF())
-        edm::LogVerbatim("L1track") << "Will create disk stub with : ";
+        edm::LogVerbatim("L1track") << "Creating TMTT::Settings in HybridFit::Fit";
+      globals_->tmttSettings() = make_unique<tmtt::Settings>();
+      globals_->tmttSettings()->setMagneticField(settings_.bfield());
     }
 
-    float stripPitch = settings_.stripPitch(psmodule);
-    float stripLength = settings_.stripLength(psmodule);
-    unsigned int nStrips = settings_.nStrips(psmodule);
+    const tmtt::Settings& TMTTsettings = *globals_->tmttSettings();
+
+    int kf_phi_sec = iSector_;
+
+    for (unsigned int k = 0; k < trackstublist.size(); k++) {
+      const L1TStub* L1stubptr = trackstublist[k]->l1tstub();
+
+      double kfphi = L1stubptr->phi();
+      double kfr = L1stubptr->r();
+      double kfz = L1stubptr->z();
+      double kfbend = L1stubptr->bend();
+      bool psmodule = L1stubptr->isPSmodule();
+      unsigned int iphi = L1stubptr->iphi();
+      double alpha = L1stubptr->alpha(settings_.stripPitch(psmodule));
+      bool isTilted = L1stubptr->isTilted();
+
+      bool isBarrel = trackstublist[k]->layerdisk() < N_LAYER;
+      int kflayer;
+
+      if (isBarrel) {  // Barrel-specific
+        kflayer = L1stubptr->layer() + 1;
+        if (settings_.printDebugKF())
+          edm::LogVerbatim("L1track") << "Will create layer stub with : ";
+      } else {  // Disk-specific
+        kflayer = abs(L1stubptr->disk());
+        if (kfz > 0) {
+          kflayer += 10;
+        } else {
+          kflayer += 20;
+        }
+        if (settings_.printDebugKF())
+          edm::LogVerbatim("L1track") << "Will create disk stub with : ";
+      }
+
+      float stripPitch = settings_.stripPitch(psmodule);
+      float stripLength = settings_.stripLength(psmodule);
+      unsigned int nStrips = settings_.nStrips(psmodule);
+
+      if (settings_.printDebugKF()) {
+        edm::LogVerbatim("L1track") << kfphi << " " << kfr << " " << kfz << " " << kfbend << " " << kflayer << " "
+                                    << isBarrel << " " << psmodule << " " << isTilted << " \n"
+                                    << stripPitch << " " << stripLength << " " << nStrips;
+      }
+
+      unsigned int uniqueStubIndex = 1000 * L1stubID + L1stubptr->allStubIndex();
+      tmtt::Stub* TMTTstubptr = new tmtt::Stub(&TMTTsettings,
+                                               uniqueStubIndex,
+                                               kfphi,
+                                               kfr,
+                                               kfz,
+                                               kfbend,
+                                               iphi,
+                                               -alpha,
+                                               kflayer,
+                                               kf_phi_sec,
+                                               psmodule,
+                                               isBarrel,
+                                               isTilted,
+                                               stripPitch,
+                                               stripLength,
+                                               nStrips);
+      TMTTstubs.push_back(TMTTstubptr);
+      L1StubIndices[uniqueStubIndex] = L1stubptr;
+      L1stubID++;
+    }
 
     if (settings_.printDebugKF()) {
-      edm::LogVerbatim("L1track") << kfphi << " " << kfr << " " << kfz << " " << kfbend << " " << kflayer << " "
-                                  << isBarrel << " " << psmodule << " " << isTilted << " \n"
-                                  << stripPitch << " " << stripLength << " " << nStrips;
+      edm::LogVerbatim("L1track") << "Made TMTTstubs: trackstublist.size() = " << trackstublist.size();
     }
 
-    unsigned int uniqueStubIndex = 1000 * L1stubID + L1stubptr->allStubIndex();
-    tmtt::Stub* TMTTstubptr = new tmtt::Stub(&TMTTsettings,
-                                             uniqueStubIndex,
-                                             kfphi,
-                                             kfr,
-                                             kfz,
-                                             kfbend,
-                                             iphi,
-                                             -alpha,
-                                             kflayer,
-                                             kf_phi_sec,
-                                             psmodule,
-                                             isBarrel,
-                                             isTilted,
-                                             stripPitch,
-                                             stripLength,
-                                             nStrips);
-    TMTTstubs.push_back(TMTTstubptr);
-    L1StubIndices[uniqueStubIndex] = L1stubptr;
-    L1stubID++;
-  }
+    double kfrinv = tracklet->rinvapprox();
+    double kfphi0 = tracklet->phi0approx();
+    double kfz0 = tracklet->z0approx();
+    double kft = tracklet->tapprox();
+    double kfd0 = tracklet->d0approx();
 
-  if (settings_.printDebugKF()) {
-    edm::LogVerbatim("L1track") << "Made TMTTstubs: trackstublist.size() = " << trackstublist.size();
-  }
+    if (settings_.printDebugKF()) {
+      edm::LogVerbatim("L1track") << "tracklet phi0 = " << kfphi0 << "\n"
+                                  << "iSector = " << iSector_ << "\n"
+                                  << "dphisectorHG = " << settings_.dphisectorHG();
+    }
 
-  double kfrinv = tracklet->rinvapprox();
-  double kfphi0 = tracklet->phi0approx();
-  double kfz0 = tracklet->z0approx();
-  double kft = tracklet->tapprox();
-  double kfd0 = tracklet->d0approx();
+    // KF wants global phi0, not phi0 measured with respect to lower edge of sector (Tracklet convention).
+    kfphi0 = reco::reduceRange(kfphi0 + iSector_ * settings_.dphisector() - 0.5 * settings_.dphisectorHG());
 
-  if (settings_.printDebugKF()) {
-    edm::LogVerbatim("L1track") << "tracklet phi0 = " << kfphi0 << "\n"
-                                << "iSector = " << iSector_ << "\n"
-                                << "dphisectorHG = " << settings_.dphisectorHG();
-  }
+    std::pair<float, float> helixrphi(kfrinv / (0.01 * settings_.c() * settings_.bfield()), kfphi0);
+    std::pair<float, float> helixrz(kfz0, kft);
 
-  // KF wants global phi0, not phi0 measured with respect to lower edge of sector (Tracklet convention).
-  kfphi0 = reco::reduceRange(kfphi0 + iSector_ * settings_.dphisector() - 0.5 * settings_.dphisectorHG());
+    // KF HLS uses HT mbin (which is binned q/Pt) to allow for scattering. So estimate it from tracklet.
+    double chargeOverPt = helixrphi.first;
+    int mBin = std::floor(TMTTsettings.houghNbinsPt() / 2) +
+               std::floor((TMTTsettings.houghNbinsPt() / 2) * chargeOverPt / (1. / TMTTsettings.houghMinPt()));
+    mBin = max(min(mBin, int(TMTTsettings.houghNbinsPt() - 1)), 0);  // protect precision issues.
+    std::pair<unsigned int, unsigned int> celllocation(mBin, 1);
 
-  std::pair<float, float> helixrphi(kfrinv / (0.01 * settings_.c() * settings_.bfield()), kfphi0);
-  std::pair<float, float> helixrz(kfz0, kft);
+    // Get range in z of tracks covered by this sector at chosen radius from beam-line
+    const vector<double> etaRegions = TMTTsettings.etaRegions();
+    const float chosenRofZ = TMTTsettings.chosenRofZ();
 
-  // KF HLS uses HT mbin (which is binned q/Pt) to allow for scattering. So estimate it from tracklet.
-  double chargeOverPt = helixrphi.first;
-  int mBin = std::floor(TMTTsettings.houghNbinsPt() / 2) +
-             std::floor((TMTTsettings.houghNbinsPt() / 2) * chargeOverPt / (1. / TMTTsettings.houghMinPt()));
-  mBin = max(min(mBin, int(TMTTsettings.houghNbinsPt() - 1)), 0);  // protect precision issues.
-  std::pair<unsigned int, unsigned int> celllocation(mBin, 1);
+    float kfzRef = kfz0 + chosenRofZ * kft;
 
-  // Get range in z of tracks covered by this sector at chosen radius from beam-line
-  const vector<double> etaRegions = TMTTsettings.etaRegions();
-  const float chosenRofZ = TMTTsettings.chosenRofZ();
+    unsigned int kf_eta_reg = 0;
+    for (unsigned int iEtaSec = 1; iEtaSec < etaRegions.size() - 1; iEtaSec++) {  // Doesn't apply eta < 2.4 cut.
+      const float etaMax = etaRegions[iEtaSec];
+      const float zRefMax = chosenRofZ / tan(2. * atan(exp(-etaMax)));
+      if (kfzRef > zRefMax)
+        kf_eta_reg = iEtaSec;
+    }
 
-  float kfzRef = kfz0 + chosenRofZ * kft;
+    tmtt::L1track3D l1track3d(
+        &TMTTsettings, TMTTstubs, celllocation, helixrphi, helixrz, kfd0, kf_phi_sec, kf_eta_reg, 1, false);
+    unsigned int seedType = tracklet->getISeed();
+    unsigned int numPS = tracklet->PSseed();  // Function PSseed() is out of date!
+    l1track3d.setSeedLayerType(seedType);
+    l1track3d.setSeedPS(numPS);
 
-  unsigned int kf_eta_reg = 0;
-  for (unsigned int iEtaSec = 1; iEtaSec < etaRegions.size() - 1; iEtaSec++) {  // Doesn't apply eta < 2.4 cut.
-    const float etaMax = etaRegions[iEtaSec];
-    const float zRefMax = chosenRofZ / tan(2. * atan(exp(-etaMax)));
-    if (kfzRef > zRefMax)
-      kf_eta_reg = iEtaSec;
-  }
+    if (globals_->tmttKFParamsComb() == nullptr) {
+      if (settings_.printDebugKF())
+        edm::LogVerbatim("L1track") << "Will make KFParamsComb for " << settings_.nHelixPar() << " param fit";
+      globals_->tmttKFParamsComb() = make_unique<tmtt::KFParamsComb>(&TMTTsettings, settings_.nHelixPar(), "KFfitter");
+    }
 
-  tmtt::L1track3D l1track3d(
-      &TMTTsettings, TMTTstubs, celllocation, helixrphi, helixrz, kfd0, kf_phi_sec, kf_eta_reg, 1, false);
-  unsigned int seedType = tracklet->getISeed();
-  unsigned int numPS = tracklet->PSseed();  // Function PSseed() is out of date!
-  l1track3d.setSeedLayerType(seedType);
-  l1track3d.setSeedPS(numPS);
+    tmtt::KFParamsComb& fitterKF = *globals_->tmttKFParamsComb();
 
-  if (globals_->tmttKFParamsComb() == nullptr) {
-    if (settings_.printDebugKF())
-      edm::LogVerbatim("L1track") << "Will make KFParamsComb for " << settings_.nHelixPar() << " param fit";
-    globals_->tmttKFParamsComb() = make_unique<tmtt::KFParamsComb>(&TMTTsettings, settings_.nHelixPar(), "KFfitter");
-  }
+    // Call Kalman fit
+    tmtt::L1fittedTrack fittedTrk = fitterKF.fit(l1track3d);
 
-  tmtt::KFParamsComb& fitterKF = *globals_->tmttKFParamsComb();
+    if (fittedTrk.accepted()) {
+      tmtt::KFTrackletTrack trk = fittedTrk.returnKFTrackletTrack();
 
-  // Call Kalman fit
-  tmtt::L1fittedTrack fittedTrk = fitterKF.fit(l1track3d);
+      if (settings_.printDebugKF())
+        edm::LogVerbatim("L1track") << "Done with Kalman fit. Pars: pt = " << trk.pt()
+                                    << ", 1/2R = " << settings_.bfield() * 3 * trk.qOverPt() / 2000
+                                    << ", phi0 = " << trk.phi0() << ", eta = " << trk.eta() << ", z0 = " << trk.z0()
+                                    << ", chi2 = " << trk.chi2() << ", accepted = " << trk.accepted();
 
-  if (fittedTrk.accepted()) {
-    tmtt::KFTrackletTrack trk = fittedTrk.returnKFTrackletTrack();
+      double d0, chi2rphi, phi0, qoverpt = -999;
+      if (trk.done_bcon()) {
+        d0 = trk.d0_bcon();
+        chi2rphi = trk.chi2rphi_bcon();
+        phi0 = trk.phi0_bcon();
+        qoverpt = trk.qOverPt_bcon();
+      } else {
+        d0 = trk.d0();
+        chi2rphi = trk.chi2rphi();
+        phi0 = trk.phi0();
+        qoverpt = trk.qOverPt();
+      }
 
-    if (settings_.printDebugKF())
-      edm::LogVerbatim("L1track") << "Done with Kalman fit. Pars: pt = " << trk.pt()
-                                  << ", 1/2R = " << settings_.bfield() * 3 * trk.qOverPt() / 2000
-                                  << ", phi0 = " << trk.phi0() << ", eta = " << trk.eta() << ", z0 = " << trk.z0()
-                                  << ", chi2 = " << trk.chi2() << ", accepted = " << trk.accepted();
+      // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
+      double phi0fit = reco::reduceRange(phi0 - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
+      double rinvfit = 0.01 * settings_.c() * settings_.bfield() * qoverpt;
 
-    double d0, chi2rphi, phi0, qoverpt = -999;
-    if (trk.done_bcon()) {
-      d0 = trk.d0_bcon();
-      chi2rphi = trk.chi2rphi_bcon();
-      phi0 = trk.phi0_bcon();
-      qoverpt = trk.qOverPt_bcon();
+      int irinvfit = floor(rinvfit / settings_.krinvpars());
+      int iphi0fit = floor(phi0fit / settings_.kphi0pars());
+      int itanlfit = floor(trk.tanLambda() / settings_.ktpars());
+      int iz0fit = floor(trk.z0() / settings_.kz0pars());
+      int id0fit = floor(d0 / settings_.kd0pars());
+      int ichi2rphifit = chi2rphi / 16;
+      int ichi2rzfit = trk.chi2rz() / 16;
+
+      const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
+      vector<const L1TStub*> l1stubsFromFit;
+      for (const tmtt::Stub* s : stubsFromFit) {
+        unsigned int IDf = s->index();
+        const L1TStub* l1s = L1StubIndices.at(IDf);
+        l1stubsFromFit.push_back(l1s);
+      }
+
+      tracklet->setFitPars(rinvfit,
+                           phi0fit,
+                           d0,
+                           trk.tanLambda(),
+                           trk.z0(),
+                           chi2rphi,
+                           trk.chi2rz(),
+                           rinvfit,
+                           phi0fit,
+                           d0,
+                           trk.tanLambda(),
+                           trk.z0(),
+                           chi2rphi,
+                           trk.chi2rz(),
+                           irinvfit,
+                           iphi0fit,
+                           id0fit,
+                           itanlfit,
+                           iz0fit,
+                           ichi2rphifit,
+                           ichi2rzfit,
+                           trk.hitPattern(),
+                           l1stubsFromFit);
     } else {
-      d0 = trk.d0();
-      chi2rphi = trk.chi2rphi();
-      phi0 = trk.phi0();
-      qoverpt = trk.qOverPt();
+      if (settings_.printDebugKF()) {
+        edm::LogVerbatim("L1track") << "FitTrack:KF rejected track";
+      }
     }
 
-    // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
-    double phi0fit = reco::reduceRange(phi0 - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
-    double rinvfit = 0.01 * settings_.c() * settings_.bfield() * qoverpt;
-
-    int irinvfit = floor(rinvfit / settings_.krinvpars());
-    int iphi0fit = floor(phi0fit / settings_.kphi0pars());
-    int itanlfit = floor(trk.tanLambda() / settings_.ktpars());
-    int iz0fit = floor(trk.z0() / settings_.kz0pars());
-    int id0fit = floor(d0 / settings_.kd0pars());
-    int ichi2rphifit = chi2rphi / 16;
-    int ichi2rzfit = trk.chi2rz() / 16;
-
-    const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
-    vector<const L1TStub*> l1stubsFromFit;
-    for (const tmtt::Stub* s : stubsFromFit) {
-      unsigned int IDf = s->index();
-      const L1TStub* l1s = L1StubIndices.at(IDf);
-      l1stubsFromFit.push_back(l1s);
-    }
-
-    tracklet->setFitPars(rinvfit,
-                         phi0fit,
-                         d0,
-                         trk.tanLambda(),
-                         trk.z0(),
-                         chi2rphi,
-                         trk.chi2rz(),
-                         rinvfit,
-                         phi0fit,
-                         d0,
-                         trk.tanLambda(),
-                         trk.z0(),
-                         chi2rphi,
-                         trk.chi2rz(),
-                         irinvfit,
-                         iphi0fit,
-                         id0fit,
-                         itanlfit,
-                         iz0fit,
-                         ichi2rphifit,
-                         ichi2rzfit,
-                         trk.hitPattern(),
-                         l1stubsFromFit);
-  } else {
-    if (settings_.printDebugKF()) {
-      edm::LogVerbatim("L1track") << "FitTrack:KF rejected track";
+    for (const tmtt::Stub* s : TMTTstubs) {
+      delete s;
     }
   }
 
-  for (const tmtt::Stub* s : TMTTstubs) {
-    delete s;
-  }
-}
-
-}
+}  // namespace trklet
 #endif

--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -8,7 +8,8 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 HybridFit::HybridFit(unsigned int iSector, Settings const& settings, Globals* globals) : settings_(settings) {
   iSector_ = iSector;
@@ -260,5 +261,7 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
   for (const tmtt::Stub* s : TMTTstubs) {
     delete s;
   }
+}
+
 }
 #endif

--- a/L1Trigger/TrackFindingTracklet/src/InputLinkMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/InputLinkMemory.cc
@@ -13,22 +13,23 @@ using namespace std;
 
 namespace trklet {
 
-InputLinkMemory::InputLinkMemory(string name, Settings const& settings, double, double) : MemoryBase(name, settings) {}
+  InputLinkMemory::InputLinkMemory(string name, Settings const& settings, double, double)
+      : MemoryBase(name, settings) {}
 
-void InputLinkMemory::addStub(Stub* stub) { stubs_.push_back(stub); }
+  void InputLinkMemory::addStub(Stub* stub) { stubs_.push_back(stub); }
 
-void InputLinkMemory::writeStubs(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirIS = settings_.memPath() + "InputStubs/";
-  openFile(first, dirIS, "InputStubs_");
+  void InputLinkMemory::writeStubs(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirIS = settings_.memPath() + "InputStubs/";
+    openFile(first, dirIS, "InputStubs_");
 
-  for (unsigned int j = 0; j < stubs_.size(); j++) {
-    string stub = stubs_[j]->str();
-    out_ << hexstr(j) << " " << stub << " " << trklet::hexFormat(stub) << endl;
+    for (unsigned int j = 0; j < stubs_.size(); j++) {
+      string stub = stubs_[j]->str();
+      out_ << hexstr(j) << " " << stub << " " << trklet::hexFormat(stub) << endl;
+    }
+    out_.close();
   }
-  out_.close();
-}
 
-void InputLinkMemory::clean() { stubs_.clear(); }
+  void InputLinkMemory::clean() { stubs_.clear(); }
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/InputLinkMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/InputLinkMemory.cc
@@ -9,8 +9,9 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-using namespace trklet;
 using namespace std;
+
+namespace trklet {
 
 InputLinkMemory::InputLinkMemory(string name, Settings const& settings, double, double) : MemoryBase(name, settings) {}
 
@@ -29,3 +30,5 @@ void InputLinkMemory::writeStubs(bool first, unsigned int iSector) {
 }
 
 void InputLinkMemory::clean() { stubs_.clear(); }
+
+}

--- a/L1Trigger/TrackFindingTracklet/src/InputRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/InputRouter.cc
@@ -10,7 +10,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 InputRouter::InputRouter(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global) {}
@@ -77,4 +78,6 @@ void InputRouter::execute() {
     if (!(settings_.reduced()))
       assert(iadd == 1);
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/InputRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/InputRouter.cc
@@ -13,71 +13,71 @@ using namespace std;
 
 namespace trklet {
 
-InputRouter::InputRouter(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global) {}
+  InputRouter::InputRouter(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global) {}
 
-void InputRouter::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-
-  if (output == "stubout") {
-    InputLinkMemory* tmp = dynamic_cast<InputLinkMemory*>(memory);
-    assert(tmp != nullptr);
-    unsigned int layerdisk = tmp->getName()[4] - '1';
-    if (tmp->getName()[3] == 'D') {
-      layerdisk += N_LAYER;
-    }
-    assert(layerdisk < N_LAYER + N_DISK);
-    unsigned int phireg = tmp->getName()[8] - 'A';
-    std::pair<unsigned int, unsigned int> layerphireg(layerdisk, phireg);
-    irstubs_.emplace_back(layerphireg, tmp);
-    return;
-  }
-
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
-}
-
-void InputRouter::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input == "stubin") {
-    dtcstubs_ = dynamic_cast<DTCLinkMemory*>(memory);
-    assert(dtcstubs_ != nullptr);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
-}
-
-void InputRouter::execute() {
-  for (unsigned int i = 0; i < settings_.maxStep("IR"); i++) {
-    if (i >= dtcstubs_->nStubs()) {
-      break;
+  void InputRouter::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
     }
 
-    Stub* stub = dtcstubs_->getStub(i);
-
-    unsigned int layerdisk = stub->l1tstub()->layerdisk();
-
-    FPGAWord iphi = stub->phicorr();
-    unsigned int iphipos = iphi.value() >> (iphi.nbits() - settings_.nbitsallstubs(layerdisk));
-
-    std::pair<unsigned int, unsigned int> layerphireg(layerdisk, iphipos);
-
-    //Fill inner allstubs memories - in HLS this is the same write to multiple memories
-    int iadd = 0;
-    for (auto& irstubmem : irstubs_) {
-      if (layerphireg == irstubmem.first) {
-        irstubmem.second->addStub(stub);
-        iadd++;
+    if (output == "stubout") {
+      InputLinkMemory* tmp = dynamic_cast<InputLinkMemory*>(memory);
+      assert(tmp != nullptr);
+      unsigned int layerdisk = tmp->getName()[4] - '1';
+      if (tmp->getName()[3] == 'D') {
+        layerdisk += N_LAYER;
       }
+      assert(layerdisk < N_LAYER + N_DISK);
+      unsigned int phireg = tmp->getName()[8] - 'A';
+      std::pair<unsigned int, unsigned int> layerphireg(layerdisk, phireg);
+      irstubs_.emplace_back(layerphireg, tmp);
+      return;
     }
-    if (!(settings_.reduced()))
-      assert(iadd == 1);
-  }
-}
 
-}
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
+  }
+
+  void InputRouter::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input == "stubin") {
+      dtcstubs_ = dynamic_cast<DTCLinkMemory*>(memory);
+      assert(dtcstubs_ != nullptr);
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
+  }
+
+  void InputRouter::execute() {
+    for (unsigned int i = 0; i < settings_.maxStep("IR"); i++) {
+      if (i >= dtcstubs_->nStubs()) {
+        break;
+      }
+
+      Stub* stub = dtcstubs_->getStub(i);
+
+      unsigned int layerdisk = stub->l1tstub()->layerdisk();
+
+      FPGAWord iphi = stub->phicorr();
+      unsigned int iphipos = iphi.value() >> (iphi.nbits() - settings_.nbitsallstubs(layerdisk));
+
+      std::pair<unsigned int, unsigned int> layerphireg(layerdisk, iphipos);
+
+      //Fill inner allstubs memories - in HLS this is the same write to multiple memories
+      int iadd = 0;
+      for (auto& irstubmem : irstubs_) {
+        if (layerphireg == irstubmem.first) {
+          irstubmem.second->addStub(stub);
+          iadd++;
+        }
+      }
+      if (!(settings_.reduced()))
+        assert(iadd == 1);
+    }
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/L1SimTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/L1SimTrack.cc
@@ -5,36 +5,36 @@ using namespace std;
 
 namespace trklet {
 
-L1SimTrack::L1SimTrack() {
-  eventid_ = -1;
-  trackid_ = -1;
-}
-
-L1SimTrack::L1SimTrack(
-    int eventid, int trackid, int type, double pt, double eta, double phi, double vx, double vy, double vz) {
-  eventid_ = eventid;
-  trackid_ = trackid;
-  type_ = type;
-  pt_ = pt;
-  eta_ = eta;
-  phi_ = phi;
-  vx_ = vx;
-  vy_ = vy;
-  vz_ = vz;
-}
-
-void L1SimTrack::write(ofstream& out) {
-  if (pt_ > -2.0) {
-    out << "SimTrack: " << eventid_ << "\t" << trackid_ << "\t" << type_ << "\t" << pt_ << "\t" << eta_ << "\t" << phi_
-        << "\t" << vx_ << "\t" << vy_ << "\t" << vz_ << "\t" << endl;
+  L1SimTrack::L1SimTrack() {
+    eventid_ = -1;
+    trackid_ = -1;
   }
-}
 
-void L1SimTrack::write(ostream& out) {
-  if (pt_ > -2) {
-    out << "SimTrack: " << eventid_ << "\t" << trackid_ << "\t" << type_ << "\t" << pt_ << "\t" << eta_ << "\t" << phi_
-        << "\t" << vx_ << "\t" << vy_ << "\t" << vz_ << "\t" << endl;
+  L1SimTrack::L1SimTrack(
+      int eventid, int trackid, int type, double pt, double eta, double phi, double vx, double vy, double vz) {
+    eventid_ = eventid;
+    trackid_ = trackid;
+    type_ = type;
+    pt_ = pt;
+    eta_ = eta;
+    phi_ = phi;
+    vx_ = vx;
+    vy_ = vy;
+    vz_ = vz;
   }
-}
 
-}
+  void L1SimTrack::write(ofstream& out) {
+    if (pt_ > -2.0) {
+      out << "SimTrack: " << eventid_ << "\t" << trackid_ << "\t" << type_ << "\t" << pt_ << "\t" << eta_ << "\t"
+          << phi_ << "\t" << vx_ << "\t" << vy_ << "\t" << vz_ << "\t" << endl;
+    }
+  }
+
+  void L1SimTrack::write(ostream& out) {
+    if (pt_ > -2) {
+      out << "SimTrack: " << eventid_ << "\t" << trackid_ << "\t" << type_ << "\t" << pt_ << "\t" << eta_ << "\t"
+          << phi_ << "\t" << vx_ << "\t" << vy_ << "\t" << vz_ << "\t" << endl;
+    }
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/L1SimTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/L1SimTrack.cc
@@ -2,7 +2,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 L1SimTrack::L1SimTrack() {
   eventid_ = -1;
@@ -34,4 +35,6 @@ void L1SimTrack::write(ostream& out) {
     out << "SimTrack: " << eventid_ << "\t" << trackid_ << "\t" << type_ << "\t" << pt_ << "\t" << eta_ << "\t" << phi_
         << "\t" << vx_ << "\t" << vy_ << "\t" << vz_ << "\t" << endl;
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/L1TStub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/L1TStub.cc
@@ -1,7 +1,8 @@
 #include "L1Trigger/TrackFindingTracklet/interface/L1TStub.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 L1TStub::L1TStub() {}
 
@@ -127,4 +128,6 @@ bool L1TStub::tpmatch2(int tp) const {
   }
 
   return match1 && match2;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/L1TStub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/L1TStub.cc
@@ -4,130 +4,130 @@ using namespace std;
 
 namespace trklet {
 
-L1TStub::L1TStub() {}
+  L1TStub::L1TStub() {}
 
-L1TStub::L1TStub(std::string DTClink,
-                 int region,
-                 int layerdisk,
-                 std::string stubword,
-                 int isPSmodule,
-                 int isFlipped,
-                 bool tiltedBarrel,
-                 unsigned int tiltedRingId,
-                 unsigned int endcapRingId,
-                 unsigned int detId,
-                 double x,
-                 double y,
-                 double z,
-                 double bend,
-                 double strip,
-                 std::vector<int> tps) {
-  DTClink_ = DTClink;
-  layerdisk_ = layerdisk;
-  region_ = region;
-  stubword_ = stubword;
-  eventid_ = -1;
-  tps_ = tps;
-  iphi_ = -1;
-  iz_ = -1;
-  layer_ = layerdisk;
-  if (layerdisk >= N_LAYER) {
-    layer_ = 1000 + layerdisk - N_LAYER + 1;
-    if (z < 0.0)
-      layer_ += 1000;
-  }
-
-  strip_ = strip;
-  x_ = x;
-  y_ = y;
-  z_ = z;
-  sigmax_ = -1.0;
-  sigmaz_ = -1.0;
-  pt_ = -1.0;
-  bend_ = bend;
-  isPSmodule_ = isPSmodule;
-  isFlipped_ = isFlipped;
-  tiltedBarrel_ = tiltedBarrel;
-  tiltedRingId_ = tiltedRingId;
-  endcapRingId_ = endcapRingId;
-  detId_ = detId;
-
-  allstubindex_ = 999;
-  uniqueindex_ = 99999;
-}
-
-void L1TStub::write(ofstream& out) {
-  out << "Stub: " << DTClink_ << "\t" << region_ << "\t" << layerdisk_ << "\t" << stubword_ << "\t" << isPSmodule_
-      << "\t" << isFlipped_ << "\t" << x_ << "\t" << y_ << "\t" << z_ << "\t" << bend_ << "\t" << strip_ << "\t"
-      << "\t" << tps_.size() << " \t";
-  for (int itp : tps_) {
-    out << itp << " \t";
-  }
-  out << endl;
-}
-
-bool L1TStub::operator==(const L1TStub& other) const {
-  return (other.iphi() == iphi_ && other.iz() == iz_ && other.layer() == layer_ && other.detId() == detId_);
-}
-
-void L1TStub::lorentzcor(double shift) {
-  double r = this->r();
-  double phi = this->phi() - shift / r;
-  this->x_ = r * cos(phi);
-  this->y_ = r * sin(phi);
-}
-
-double L1TStub::alpha(double pitch) const {
-  if (isPSmodule())
-    return 0.0;
-  int flip = 1;
-  if (isFlipped())
-    flip = -1;
-  if (z_ > 0.0) {
-    return ((int)strip_ - 509.5) * pitch * flip / r2();
-  }
-  return -((int)strip_ - 509.5) * pitch * flip / r2();
-}
-
-double L1TStub::alphanorm() const {
-  if (isPSmodule())
-    return 0.0;
-  int flip = 1;
-  if (isFlipped())
-    flip = -1;
-  if (z_ > 0.0) {
-    return ((int)strip_ - 509.5) * flip / 510.0;
-  }
-  return -((int)strip_ - 509.5) * flip / 510.0;
-}
-
-void L1TStub::setXY(double x, double y) {
-  x_ = x;
-  y_ = y;
-}
-
-bool L1TStub::tpmatch(int tp) const {
-  for (int itp : tps_) {
-    if (tp == std::abs(itp))
-      return true;
-  }
-
-  return false;
-}
-
-bool L1TStub::tpmatch2(int tp) const {
-  bool match1 = false;
-  bool match2 = false;
-  for (int itp : tps_) {
-    if (tp == itp) {
-      match1 = true;
+  L1TStub::L1TStub(std::string DTClink,
+                   int region,
+                   int layerdisk,
+                   std::string stubword,
+                   int isPSmodule,
+                   int isFlipped,
+                   bool tiltedBarrel,
+                   unsigned int tiltedRingId,
+                   unsigned int endcapRingId,
+                   unsigned int detId,
+                   double x,
+                   double y,
+                   double z,
+                   double bend,
+                   double strip,
+                   std::vector<int> tps) {
+    DTClink_ = DTClink;
+    layerdisk_ = layerdisk;
+    region_ = region;
+    stubword_ = stubword;
+    eventid_ = -1;
+    tps_ = tps;
+    iphi_ = -1;
+    iz_ = -1;
+    layer_ = layerdisk;
+    if (layerdisk >= N_LAYER) {
+      layer_ = 1000 + layerdisk - N_LAYER + 1;
+      if (z < 0.0)
+        layer_ += 1000;
     }
-    if (tp == -itp) {
-      match2 = true;
-    }
+
+    strip_ = strip;
+    x_ = x;
+    y_ = y;
+    z_ = z;
+    sigmax_ = -1.0;
+    sigmaz_ = -1.0;
+    pt_ = -1.0;
+    bend_ = bend;
+    isPSmodule_ = isPSmodule;
+    isFlipped_ = isFlipped;
+    tiltedBarrel_ = tiltedBarrel;
+    tiltedRingId_ = tiltedRingId;
+    endcapRingId_ = endcapRingId;
+    detId_ = detId;
+
+    allstubindex_ = 999;
+    uniqueindex_ = 99999;
   }
 
-  return match1 && match2;
-}
+  void L1TStub::write(ofstream& out) {
+    out << "Stub: " << DTClink_ << "\t" << region_ << "\t" << layerdisk_ << "\t" << stubword_ << "\t" << isPSmodule_
+        << "\t" << isFlipped_ << "\t" << x_ << "\t" << y_ << "\t" << z_ << "\t" << bend_ << "\t" << strip_ << "\t"
+        << "\t" << tps_.size() << " \t";
+    for (int itp : tps_) {
+      out << itp << " \t";
+    }
+    out << endl;
+  }
 
-}
+  bool L1TStub::operator==(const L1TStub& other) const {
+    return (other.iphi() == iphi_ && other.iz() == iz_ && other.layer() == layer_ && other.detId() == detId_);
+  }
+
+  void L1TStub::lorentzcor(double shift) {
+    double r = this->r();
+    double phi = this->phi() - shift / r;
+    this->x_ = r * cos(phi);
+    this->y_ = r * sin(phi);
+  }
+
+  double L1TStub::alpha(double pitch) const {
+    if (isPSmodule())
+      return 0.0;
+    int flip = 1;
+    if (isFlipped())
+      flip = -1;
+    if (z_ > 0.0) {
+      return ((int)strip_ - 509.5) * pitch * flip / r2();
+    }
+    return -((int)strip_ - 509.5) * pitch * flip / r2();
+  }
+
+  double L1TStub::alphanorm() const {
+    if (isPSmodule())
+      return 0.0;
+    int flip = 1;
+    if (isFlipped())
+      flip = -1;
+    if (z_ > 0.0) {
+      return ((int)strip_ - 509.5) * flip / 510.0;
+    }
+    return -((int)strip_ - 509.5) * flip / 510.0;
+  }
+
+  void L1TStub::setXY(double x, double y) {
+    x_ = x;
+    y_ = y;
+  }
+
+  bool L1TStub::tpmatch(int tp) const {
+    for (int itp : tps_) {
+      if (tp == std::abs(itp))
+        return true;
+    }
+
+    return false;
+  }
+
+  bool L1TStub::tpmatch2(int tp) const {
+    bool match1 = false;
+    bool match2 = false;
+    for (int itp : tps_) {
+      if (tp == itp) {
+        match1 = true;
+      }
+      if (tp == -itp) {
+        match2 = true;
+      }
+    }
+
+    return match1 && match2;
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -30,561 +30,562 @@ using namespace std;
 
 namespace trklet {
 
-MatchCalculator::MatchCalculator(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global),
-      phimatchcuttable_(settings),
-      zmatchcuttable_(settings),
-      rphicutPStable_(settings),
-      rphicut2Stable_(settings),
-      rcutPStable_(settings),
-      rcut2Stable_(settings),
-      alphainner_(settings),
-      alphaouter_(settings),
-      rSSinner_(settings),
-      rSSouter_(settings) {
-  phiregion_ = name[8] - 'A';
-  layerdisk_ = initLayerDisk(3);
+  MatchCalculator::MatchCalculator(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global),
+        phimatchcuttable_(settings),
+        zmatchcuttable_(settings),
+        rphicutPStable_(settings),
+        rphicut2Stable_(settings),
+        rcutPStable_(settings),
+        rcut2Stable_(settings),
+        alphainner_(settings),
+        alphaouter_(settings),
+        rSSinner_(settings),
+        rSSouter_(settings) {
+    phiregion_ = name[8] - 'A';
+    layerdisk_ = initLayerDisk(3);
 
-  fullMatches_.resize(12, nullptr);
+    fullMatches_.resize(12, nullptr);
 
-  //TODO - need to sort out constants here
-  icorrshift_ = 7;
+    //TODO - need to sort out constants here
+    icorrshift_ = 7;
 
-  if (layerdisk_ < N_PSLAYER) {
-    icorzshift_ = -1 - settings_.PS_zderL_shift();
-  } else {
-    icorzshift_ = -1 - settings_.SS_zderL_shift();
-  }
-  phi0shift_ = 3;
-  fact_ = 1;
-  if (layerdisk_ >= N_PSLAYER && layerdisk_ < N_LAYER) {
-    fact_ = (1 << (settings_.nzbitsstub(0) - settings_.nzbitsstub(5)));
-    icorrshift_ -= (10 - settings_.nrbitsstub(layerdisk_));
-    icorzshift_ += (settings_.nzbitsstub(0) - settings_.nzbitsstub(5) + settings_.nrbitsstub(layerdisk_) -
-                    settings_.nrbitsstub(0));
-    phi0shift_ = 0;
-  }
-
-  unsigned int region = getName()[8] - 'A';
-  assert(region < settings_.nallstubs(layerdisk_));
-
-  if (layerdisk_ < N_LAYER) {
-    phimatchcuttable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::barrelphi, region);
-    zmatchcuttable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::barrelz, region);
-  } else {
-    rphicutPStable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::diskPSphi, region);
-    rphicut2Stable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::disk2Sphi, region);
-    rcutPStable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::diskPSr, region);
-    rcut2Stable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::disk2Sr, region);
-    alphainner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphainner, region);
-    alphaouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphaouter, region);
-    rSSinner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSinner, region);
-    rSSouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSouter, region);
-  }
-
-  for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
-    ialphafactinner_[i] = (1 << settings_.alphashift()) * settings_.krprojshiftdisk() * settings_.half2SmoduleWidth() /
-                          (1 << (settings_.nbitsalpha() - 1)) / (settings_.rDSSinner(i) * settings_.rDSSinner(i)) /
-                          settings_.kphi();
-    ialphafactouter_[i] = (1 << settings_.alphashift()) * settings_.krprojshiftdisk() * settings_.half2SmoduleWidth() /
-                          (1 << (settings_.nbitsalpha() - 1)) / (settings_.rDSSouter(i) * settings_.rDSSouter(i)) /
-                          settings_.kphi();
-  }
-}
-
-void MatchCalculator::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-  if (output.substr(0, 8) == "matchout") {
-    auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
-    assert(tmp != nullptr);
-    unsigned int iSeed = getISeed(memory->getName());
-    fullMatches_[iSeed] = tmp;
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find output " << output;
-}
-
-void MatchCalculator::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input == "allstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    allstubs_ = tmp;
-    return;
-  }
-  if (input == "allprojin") {
-    auto* tmp = dynamic_cast<AllProjectionsMemory*>(memory);
-    assert(tmp != nullptr);
-    allprojs_ = tmp;
-    return;
-  }
-  if (input.substr(0, 5) == "match" && input.substr(input.size() - 2, 2) == "in") {
-    auto* tmp = dynamic_cast<CandidateMatchMemory*>(memory);
-    assert(tmp != nullptr);
-    matches_.push_back(tmp);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input " << input;
-}
-
-void MatchCalculator::execute(unsigned int iSector, double phioffset) {
-  unsigned int countall = 0;
-  unsigned int countsel = 0;
-
-  //bool print = getName() == "MC_L4PHIC" && iSector == 3;
-
-  Tracklet* oldTracklet = nullptr;
-
-  // Get all tracklet/stub pairs
-  std::vector<std::pair<std::pair<Tracklet*, int>, const Stub*> > mergedMatches = mergeMatches(matches_);
-
-  // Number of clock cycles the pipeline in HLS takes to process the projection merging to
-  // produce the first projection
-  unsigned int mergedepth = 3;
-
-  unsigned int maxProc = std::min(settings_.maxStep("MC") - mergedepth, (unsigned int)mergedMatches.size());
-
-  // Pick some initial large values
-  int best_ideltaphi_barrel = 0xFFFF;
-  int best_ideltaz_barrel = 0xFFFF;
-  int best_ideltaphi_disk = 0xFFFF;
-  int best_ideltar_disk = 0xFFFF;
-  unsigned int curr_projid = -1;
-  unsigned int next_projid = -1;
-
-  for (unsigned int j = 0; j < maxProc; j++) {
-    if (settings_.debugTracklet() && j == 0) {
-      edm::LogVerbatim("Tracklet") << getName() << " has " << mergedMatches.size() << " candidate matches";
+    if (layerdisk_ < N_PSLAYER) {
+      icorzshift_ = -1 - settings_.PS_zderL_shift();
+    } else {
+      icorzshift_ = -1 - settings_.SS_zderL_shift();
+    }
+    phi0shift_ = 3;
+    fact_ = 1;
+    if (layerdisk_ >= N_PSLAYER && layerdisk_ < N_LAYER) {
+      fact_ = (1 << (settings_.nzbitsstub(0) - settings_.nzbitsstub(5)));
+      icorrshift_ -= (10 - settings_.nrbitsstub(layerdisk_));
+      icorzshift_ += (settings_.nzbitsstub(0) - settings_.nzbitsstub(5) + settings_.nrbitsstub(layerdisk_) -
+                      settings_.nrbitsstub(0));
+      phi0shift_ = 0;
     }
 
-    countall++;
-
-    const Stub* fpgastub = mergedMatches[j].second;
-    Tracklet* tracklet = mergedMatches[j].first.first;
-    const L1TStub* stub = fpgastub->l1tstub();
-
-    //check that the matches are ordered correctly
-    //allow equal here since we can have more than one candidate match per tracklet projection
-    if (oldTracklet != nullptr) {
-      assert(oldTracklet->TCID() <= tracklet->TCID());
-    }
-    oldTracklet = tracklet;
+    unsigned int region = getName()[8] - 'A';
+    assert(region < settings_.nallstubs(layerdisk_));
 
     if (layerdisk_ < N_LAYER) {
-      //Integer calculation
+      phimatchcuttable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::barrelphi, region);
+      zmatchcuttable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::barrelz, region);
+    } else {
+      rphicutPStable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::diskPSphi, region);
+      rphicut2Stable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::disk2Sphi, region);
+      rcutPStable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::diskPSr, region);
+      rcut2Stable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::disk2Sr, region);
+      alphainner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphainner, region);
+      alphaouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphaouter, region);
+      rSSinner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSinner, region);
+      rSSouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSouter, region);
+    }
 
-      const Projection& proj = tracklet->proj(layerdisk_);
+    for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
+      ialphafactinner_[i] = (1 << settings_.alphashift()) * settings_.krprojshiftdisk() *
+                            settings_.half2SmoduleWidth() / (1 << (settings_.nbitsalpha() - 1)) /
+                            (settings_.rDSSinner(i) * settings_.rDSSinner(i)) / settings_.kphi();
+      ialphafactouter_[i] = (1 << settings_.alphashift()) * settings_.krprojshiftdisk() *
+                            settings_.half2SmoduleWidth() / (1 << (settings_.nbitsalpha() - 1)) /
+                            (settings_.rDSSouter(i) * settings_.rDSSouter(i)) / settings_.kphi();
+    }
+  }
 
-      int ir = fpgastub->r().value();
-      int iphi = proj.fpgaphiproj().value();
-      int icorr = (ir * proj.fpgaphiprojder().value()) >> icorrshift_;
-      iphi += icorr;
+  void MatchCalculator::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
+    if (output.substr(0, 8) == "matchout") {
+      auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
+      assert(tmp != nullptr);
+      unsigned int iSeed = getISeed(memory->getName());
+      fullMatches_[iSeed] = tmp;
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find output " << output;
+  }
 
-      int iz = proj.fpgarzproj().value();
-      int izcor = (ir * proj.fpgarzprojder().value() + (1 << (icorzshift_ - 1))) >> icorzshift_;
-      iz += izcor;
+  void MatchCalculator::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input == "allstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      allstubs_ = tmp;
+      return;
+    }
+    if (input == "allprojin") {
+      auto* tmp = dynamic_cast<AllProjectionsMemory*>(memory);
+      assert(tmp != nullptr);
+      allprojs_ = tmp;
+      return;
+    }
+    if (input.substr(0, 5) == "match" && input.substr(input.size() - 2, 2) == "in") {
+      auto* tmp = dynamic_cast<CandidateMatchMemory*>(memory);
+      assert(tmp != nullptr);
+      matches_.push_back(tmp);
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input " << input;
+  }
 
-      int ideltaz = fpgastub->z().value() - iz;
-      int ideltaphi = (fpgastub->phi().value() << phi0shift_) - (iphi << (settings_.phi0bitshift() - 1 + phi0shift_));
+  void MatchCalculator::execute(unsigned int iSector, double phioffset) {
+    unsigned int countall = 0;
+    unsigned int countsel = 0;
 
-      //Floating point calculations
+    //bool print = getName() == "MC_L4PHIC" && iSector == 3;
 
-      double phi = stub->phi() - phioffset;
-      double r = stub->r();
-      double z = stub->z();
+    Tracklet* oldTracklet = nullptr;
 
-      if (settings_.useapprox()) {
-        double dphi = reco::reduceRange(phi - fpgastub->phiapprox(0.0, 0.0));
-        assert(std::abs(dphi) < 0.001);
-        phi = fpgastub->phiapprox(0.0, 0.0);
-        z = fpgastub->zapprox();
-        r = fpgastub->rapprox();
+    // Get all tracklet/stub pairs
+    std::vector<std::pair<std::pair<Tracklet*, int>, const Stub*> > mergedMatches = mergeMatches(matches_);
+
+    // Number of clock cycles the pipeline in HLS takes to process the projection merging to
+    // produce the first projection
+    unsigned int mergedepth = 3;
+
+    unsigned int maxProc = std::min(settings_.maxStep("MC") - mergedepth, (unsigned int)mergedMatches.size());
+
+    // Pick some initial large values
+    int best_ideltaphi_barrel = 0xFFFF;
+    int best_ideltaz_barrel = 0xFFFF;
+    int best_ideltaphi_disk = 0xFFFF;
+    int best_ideltar_disk = 0xFFFF;
+    unsigned int curr_projid = -1;
+    unsigned int next_projid = -1;
+
+    for (unsigned int j = 0; j < maxProc; j++) {
+      if (settings_.debugTracklet() && j == 0) {
+        edm::LogVerbatim("Tracklet") << getName() << " has " << mergedMatches.size() << " candidate matches";
       }
 
-      if (phi < 0)
-        phi += 2 * M_PI;
+      countall++;
 
-      double dr = r - settings_.rmean(layerdisk_);
-      assert(std::abs(dr) < settings_.drmax());
+      const Stub* fpgastub = mergedMatches[j].second;
+      Tracklet* tracklet = mergedMatches[j].first.first;
+      const L1TStub* stub = fpgastub->l1tstub();
 
-      double dphi = reco::reduceRange(phi - (proj.phiproj() + dr * proj.phiprojder()));
-
-      double dz = z - (proj.rzproj() + dr * proj.rzprojder());
-
-      double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dr * proj.phiprojderapprox()));
-
-      double dzapprox = z - (proj.rzprojapprox() + dr * proj.rzprojderapprox());
-
-      int seedindex = tracklet->getISeed();
-      unsigned int projindex = mergedMatches[j].first.second;  // Allproj index
-      curr_projid = next_projid;
-      next_projid = projindex;
-
-      // Do we have a new tracklet?
-      bool newtracklet = (j == 0 || projindex != curr_projid);
-      if (j == 0)
-        best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
-      // If so, replace the "best" values with the cut tables
-      if (newtracklet) {
-        best_ideltaphi_barrel = (int)phimatchcuttable_.lookup(seedindex);
-        best_ideltaz_barrel = (int)zmatchcuttable_.lookup(seedindex);
+      //check that the matches are ordered correctly
+      //allow equal here since we can have more than one candidate match per tracklet projection
+      if (oldTracklet != nullptr) {
+        assert(oldTracklet->TCID() <= tracklet->TCID());
       }
+      oldTracklet = tracklet;
 
-      assert(phimatchcuttable_.lookup(seedindex) > 0);
-      assert(zmatchcuttable_.lookup(seedindex) > 0);
+      if (layerdisk_ < N_LAYER) {
+        //Integer calculation
 
-      if (settings_.bookHistos()) {
-        bool truthmatch = tracklet->stubtruthmatch(stub);
+        const Projection& proj = tracklet->proj(layerdisk_);
 
-        HistBase* hists = globals_->histograms();
-        hists->FillLayerResidual(layerdisk_ + 1,
-                                 seedindex,
-                                 dphiapprox * settings_.rmean(layerdisk_),
-                                 ideltaphi * settings_.kphi1() * settings_.rmean(layerdisk_),
-                                 ideltaz * fact_ * settings_.kz(),
-                                 dz,
-                                 truthmatch);
-      }
+        int ir = fpgastub->r().value();
+        int iphi = proj.fpgaphiproj().value();
+        int icorr = (ir * proj.fpgaphiprojder().value()) >> icorrshift_;
+        iphi += icorr;
 
-      //This would catch significant consistency problems in the configuration - helps to debug if there are problems.
-      if (std::abs(dphi) > 0.5 * settings_.dphisectorHG() || std::abs(dphiapprox) > 0.5 * settings_.dphisectorHG()) {
-        throw cms::Exception("LogicError")
-            << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox << endl;
-      }
+        int iz = proj.fpgarzproj().value();
+        int izcor = (ir * proj.fpgarzprojder().value() + (1 << (icorzshift_ - 1))) >> icorzshift_;
+        iz += izcor;
 
-      if (settings_.writeMonitorData("Residuals")) {
-        double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
+        int ideltaz = fpgastub->z().value() - iz;
+        int ideltaphi = (fpgastub->phi().value() << phi0shift_) - (iphi << (settings_.phi0bitshift() - 1 + phi0shift_));
 
-        globals_->ofstream("layerresiduals.txt")
-            << layerdisk_ + 1 << " " << seedindex << " " << pt << " "
-            << ideltaphi * settings_.kphi1() * settings_.rmean(layerdisk_) << " "
-            << dphiapprox * settings_.rmean(layerdisk_) << " "
-            << phimatchcuttable_.lookup(seedindex) * settings_.kphi1() * settings_.rmean(layerdisk_) << "   "
-            << ideltaz * fact_ * settings_.kz() << " " << dz << " "
-            << zmatchcuttable_.lookup(seedindex) * settings_.kz() << endl;
-      }
+        //Floating point calculations
 
-      // integer match
-      bool imatch = (std::abs(ideltaphi) <= best_ideltaphi_barrel) && (ideltaz * fact_ < best_ideltaz_barrel) &&
-                    (ideltaz * fact_ >= -best_ideltaz_barrel);
-      // Update the "best" values
-      if (imatch) {
-        best_ideltaphi_barrel = std::abs(ideltaphi);
-        best_ideltaz_barrel = std::abs(ideltaz * fact_);
-      }
+        double phi = stub->phi() - phioffset;
+        double r = stub->r();
+        double z = stub->z();
 
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << getName() << " imatch = " << imatch << " ideltaphi cut " << ideltaphi << " "
-                                     << phimatchcuttable_.lookup(seedindex) << " ideltaz*fact cut " << ideltaz * fact_
-                                     << " " << zmatchcuttable_.lookup(seedindex);
-      }
-
-      if (imatch) {
-        countsel++;
-
-        tracklet->addMatch(layerdisk_,
-                           ideltaphi,
-                           ideltaz,
-                           dphi,
-                           dz,
-                           dphiapprox,
-                           dzapprox,
-                           (phiregion_ << 7) + fpgastub->stubindex().value(),
-                           mergedMatches[j].second);
-
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << "Accepted full match in layer " << getName() << " " << tracklet;
+        if (settings_.useapprox()) {
+          double dphi = reco::reduceRange(phi - fpgastub->phiapprox(0.0, 0.0));
+          assert(std::abs(dphi) < 0.001);
+          phi = fpgastub->phiapprox(0.0, 0.0);
+          z = fpgastub->zapprox();
+          r = fpgastub->rapprox();
         }
 
-        fullMatches_[seedindex]->addMatch(tracklet, mergedMatches[j].second);
-      }
-    } else {  //disk matches
-      //check that stubs and projections in same half of detector
-      assert(stub->z() * tracklet->t() > 0.0);
+        if (phi < 0)
+          phi += 2 * M_PI;
 
-      int sign = (tracklet->t() > 0.0) ? 1 : -1;
-      int disk = sign * (layerdisk_ - (N_LAYER - 1));
-      assert(disk != 0);
+        double dr = r - settings_.rmean(layerdisk_);
+        assert(std::abs(dr) < settings_.drmax());
 
-      //Perform integer calculations here
+        double dphi = reco::reduceRange(phi - (proj.phiproj() + dr * proj.phiprojder()));
 
-      const Projection& proj = tracklet->proj(layerdisk_);
+        double dz = z - (proj.rzproj() + dr * proj.rzprojder());
 
-      int iz = fpgastub->z().value();
-      int iphi = proj.fpgaphiproj().value();
+        double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dr * proj.phiprojderapprox()));
 
-      //TODO - need to express in terms of constants
-      int shifttmp = 6;
-      int iphicorr = (iz * proj.fpgaphiprojder().value()) >> shifttmp;
+        double dzapprox = z - (proj.rzprojapprox() + dr * proj.rzprojderapprox());
 
-      iphi += iphicorr;
+        int seedindex = tracklet->getISeed();
+        unsigned int projindex = mergedMatches[j].first.second;  // Allproj index
+        curr_projid = next_projid;
+        next_projid = projindex;
 
-      int ir = proj.fpgarzproj().value();
-
-      //TODO - need to express in terms of constants
-      int shifttmp2 = 7;
-      int ircorr = (iz * proj.fpgarzprojder().value()) >> shifttmp2;
-
-      ir += ircorr;
-
-      int ideltaphi = fpgastub->phi().value() * settings_.kphi() / settings_.kphi() - iphi;
-
-      int irstub = fpgastub->r().value();
-      int ialphafact = 0;
-      if (!stub->isPSmodule()) {
-        assert(irstub < (int)N_DSS_MOD * 2);
-        if (abs(disk) <= 2) {
-          ialphafact = ialphafactinner_[irstub];
-          irstub = settings_.rDSSinner(irstub) / settings_.kr();
-        } else {
-          ialphafact = ialphafactouter_[irstub];
-          irstub = settings_.rDSSouter(irstub) / settings_.kr();
+        // Do we have a new tracklet?
+        bool newtracklet = (j == 0 || projindex != curr_projid);
+        if (j == 0)
+          best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
+        // If so, replace the "best" values with the cut tables
+        if (newtracklet) {
+          best_ideltaphi_barrel = (int)phimatchcuttable_.lookup(seedindex);
+          best_ideltaz_barrel = (int)zmatchcuttable_.lookup(seedindex);
         }
-      }
 
-      //TODO stub and projection r should not use different # bits...
-      int ideltar = (irstub >> 1) - ir;
+        assert(phimatchcuttable_.lookup(seedindex) > 0);
+        assert(zmatchcuttable_.lookup(seedindex) > 0);
 
-      if (!stub->isPSmodule()) {
-        int ialpha = fpgastub->alpha().value();
-        int iphialphacor = ((ideltar * ialpha * ialphafact) >> settings_.alphashift());
-        ideltaphi += iphialphacor;
-      }
+        if (settings_.bookHistos()) {
+          bool truthmatch = tracklet->stubtruthmatch(stub);
 
-      //Perform floating point calculations here
+          HistBase* hists = globals_->histograms();
+          hists->FillLayerResidual(layerdisk_ + 1,
+                                   seedindex,
+                                   dphiapprox * settings_.rmean(layerdisk_),
+                                   ideltaphi * settings_.kphi1() * settings_.rmean(layerdisk_),
+                                   ideltaz * fact_ * settings_.kz(),
+                                   dz,
+                                   truthmatch);
+        }
 
-      double phi = stub->phi() - phioffset;
-      double z = stub->z();
-      double r = stub->r();
+        //This would catch significant consistency problems in the configuration - helps to debug if there are problems.
+        if (std::abs(dphi) > 0.5 * settings_.dphisectorHG() || std::abs(dphiapprox) > 0.5 * settings_.dphisectorHG()) {
+          throw cms::Exception("LogicError")
+              << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox << endl;
+        }
 
-      if (settings_.useapprox()) {
-        double dphi = reco::reduceRange(phi - fpgastub->phiapprox(0.0, 0.0));
-        assert(std::abs(dphi) < 0.001);
-        phi = fpgastub->phiapprox(0.0, 0.0);
-        z = fpgastub->zapprox();
-        r = fpgastub->rapprox();
-      }
-
-      if (phi < 0)
-        phi += 2 * M_PI;
-
-      double dz = z - sign * settings_.zmean(layerdisk_ - N_LAYER);
-
-      if (std::abs(dz) > settings_.dzmax()) {
-        throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " " << name_ << " " << tracklet->getISeed()
-                                           << "\n stub " << stub->z() << " disk " << disk << " " << dz;
-      }
-
-      double phiproj = proj.phiproj() + dz * proj.phiprojder();
-
-      double rproj = proj.rzproj() + dz * proj.rzprojder();
-
-      double deltar = r - rproj;
-
-      double dr = stub->r() - rproj;
-
-      double dphi = reco::reduceRange(phi - phiproj);
-
-      double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dz * proj.phiprojderapprox()));
-
-      double drapprox = stub->r() - (proj.rzprojapprox() + dz * proj.rzprojderapprox());
-
-      double drphi = dphi * stub->r();
-      double drphiapprox = dphiapprox * stub->r();
-
-      if (!stub->isPSmodule()) {
-        double alphanorm = stub->alphanorm();
-        dphi += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r2();
-        dphiapprox += drapprox * alphanorm * settings_.half2SmoduleWidth() / stub->r2();
-
-        drphi += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r();
-        drphiapprox += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r();
-      }
-
-      int seedindex = tracklet->getISeed();
-
-      int idrphicut = rphicutPStable_.lookup(seedindex);
-      int idrcut = rcutPStable_.lookup(seedindex);
-      if (!stub->isPSmodule()) {
-        idrphicut = rphicut2Stable_.lookup(seedindex);
-        idrcut = rcut2Stable_.lookup(seedindex);
-      }
-
-      unsigned int projindex = mergedMatches[j].first.second;  // Allproj index
-      curr_projid = next_projid;
-      next_projid = projindex;
-      // Do we have a new tracklet?
-      bool newtracklet = (j == 0 || projindex != curr_projid);
-      if (j == 0)
-        best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
-      // If so, replace the "best" values with the cut tables
-      if (newtracklet) {
-        best_ideltaphi_disk = idrphicut;
-        best_ideltar_disk = idrcut;
-      }
-
-      // Update the cut vales (cut table if new tracklet, otherwise current best)
-      idrphicut = newtracklet ? idrphicut : best_ideltaphi_disk;
-      idrcut = newtracklet ? idrcut : best_ideltar_disk;
-
-      double drphicut = idrphicut * settings_.kphi() * settings_.kr();
-      double drcut = idrcut * settings_.krprojshiftdisk();
-
-      bool match, imatch;
-      if (std::abs(dphi) < third * settings_.dphisectorHG() &&
-          std::abs(dphiapprox) < third * settings_.dphisectorHG()) {  //1/3 of sector size to catch errors
         if (settings_.writeMonitorData("Residuals")) {
           double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
 
-          globals_->ofstream("diskresiduals.txt")
-              << disk << " " << stub->isPSmodule() << " " << tracklet->layer() << " " << abs(tracklet->disk()) << " "
-              << pt << " " << ideltaphi * settings_.kphi() * stub->r() << " " << drphiapprox << " " << drphicut << " "
-              << ideltar * settings_.krprojshiftdisk() << " " << deltar << " " << drcut << " " << endl;
+          globals_->ofstream("layerresiduals.txt")
+              << layerdisk_ + 1 << " " << seedindex << " " << pt << " "
+              << ideltaphi * settings_.kphi1() * settings_.rmean(layerdisk_) << " "
+              << dphiapprox * settings_.rmean(layerdisk_) << " "
+              << phimatchcuttable_.lookup(seedindex) * settings_.kphi1() * settings_.rmean(layerdisk_) << "   "
+              << ideltaz * fact_ * settings_.kz() << " " << dz << " "
+              << zmatchcuttable_.lookup(seedindex) * settings_.kz() << endl;
         }
-
-        // floating point match
-        match = (std::abs(drphi) < drphicut) && (std::abs(deltar) < drcut);
 
         // integer match
-        imatch = (std::abs(ideltaphi) * irstub < best_ideltaphi_disk) && (std::abs(ideltar) < best_ideltar_disk);
+        bool imatch = (std::abs(ideltaphi) <= best_ideltaphi_barrel) && (ideltaz * fact_ < best_ideltaz_barrel) &&
+                      (ideltaz * fact_ >= -best_ideltaz_barrel);
         // Update the "best" values
         if (imatch) {
-          best_ideltaphi_disk = std::abs(ideltaphi) * irstub;
-          best_ideltar_disk = std::abs(ideltar);
+          best_ideltaphi_barrel = std::abs(ideltaphi);
+          best_ideltaz_barrel = std::abs(ideltaz * fact_);
         }
-      } else {
-        edm::LogProblem("Tracklet") << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox
-                                    << "dphi " << dphi << " Seed / ISeed " << tracklet->getISeed() << endl;
-        match = false;
-        imatch = false;
-      }
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "imatch match disk: " << imatch << " " << match << " " << std::abs(ideltaphi)
-                                     << " " << drphicut / (settings_.kphi() * stub->r()) << " " << std::abs(ideltar)
-                                     << " " << drcut / settings_.krprojshiftdisk() << " r = " << stub->r();
-      }
-
-      if (imatch) {
-        countsel++;
 
         if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << "MatchCalculator found match in disk " << getName();
+          edm::LogVerbatim("Tracklet") << getName() << " imatch = " << imatch << " ideltaphi cut " << ideltaphi << " "
+                                       << phimatchcuttable_.lookup(seedindex) << " ideltaz*fact cut " << ideltaz * fact_
+                                       << " " << zmatchcuttable_.lookup(seedindex);
         }
 
-        tracklet->addMatch(layerdisk_,
-                           ideltaphi,
-                           ideltar,
-                           drphi / stub->r(),
-                           dr,
-                           drphiapprox / stub->r(),
-                           drapprox,
-                           (phiregion_ << 7) + fpgastub->stubindex().value(),
-                           fpgastub);
+        if (imatch) {
+          countsel++;
 
+          tracklet->addMatch(layerdisk_,
+                             ideltaphi,
+                             ideltaz,
+                             dphi,
+                             dz,
+                             dphiapprox,
+                             dzapprox,
+                             (phiregion_ << 7) + fpgastub->stubindex().value(),
+                             mergedMatches[j].second);
+
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << "Accepted full match in layer " << getName() << " " << tracklet;
+          }
+
+          fullMatches_[seedindex]->addMatch(tracklet, mergedMatches[j].second);
+        }
+      } else {  //disk matches
+        //check that stubs and projections in same half of detector
+        assert(stub->z() * tracklet->t() > 0.0);
+
+        int sign = (tracklet->t() > 0.0) ? 1 : -1;
+        int disk = sign * (layerdisk_ - (N_LAYER - 1));
+        assert(disk != 0);
+
+        //Perform integer calculations here
+
+        const Projection& proj = tracklet->proj(layerdisk_);
+
+        int iz = fpgastub->z().value();
+        int iphi = proj.fpgaphiproj().value();
+
+        //TODO - need to express in terms of constants
+        int shifttmp = 6;
+        int iphicorr = (iz * proj.fpgaphiprojder().value()) >> shifttmp;
+
+        iphi += iphicorr;
+
+        int ir = proj.fpgarzproj().value();
+
+        //TODO - need to express in terms of constants
+        int shifttmp2 = 7;
+        int ircorr = (iz * proj.fpgarzprojder().value()) >> shifttmp2;
+
+        ir += ircorr;
+
+        int ideltaphi = fpgastub->phi().value() * settings_.kphi() / settings_.kphi() - iphi;
+
+        int irstub = fpgastub->r().value();
+        int ialphafact = 0;
+        if (!stub->isPSmodule()) {
+          assert(irstub < (int)N_DSS_MOD * 2);
+          if (abs(disk) <= 2) {
+            ialphafact = ialphafactinner_[irstub];
+            irstub = settings_.rDSSinner(irstub) / settings_.kr();
+          } else {
+            ialphafact = ialphafactouter_[irstub];
+            irstub = settings_.rDSSouter(irstub) / settings_.kr();
+          }
+        }
+
+        //TODO stub and projection r should not use different # bits...
+        int ideltar = (irstub >> 1) - ir;
+
+        if (!stub->isPSmodule()) {
+          int ialpha = fpgastub->alpha().value();
+          int iphialphacor = ((ideltar * ialpha * ialphafact) >> settings_.alphashift());
+          ideltaphi += iphialphacor;
+        }
+
+        //Perform floating point calculations here
+
+        double phi = stub->phi() - phioffset;
+        double z = stub->z();
+        double r = stub->r();
+
+        if (settings_.useapprox()) {
+          double dphi = reco::reduceRange(phi - fpgastub->phiapprox(0.0, 0.0));
+          assert(std::abs(dphi) < 0.001);
+          phi = fpgastub->phiapprox(0.0, 0.0);
+          z = fpgastub->zapprox();
+          r = fpgastub->rapprox();
+        }
+
+        if (phi < 0)
+          phi += 2 * M_PI;
+
+        double dz = z - sign * settings_.zmean(layerdisk_ - N_LAYER);
+
+        if (std::abs(dz) > settings_.dzmax()) {
+          throw cms::Exception("LogicError")
+              << __FILE__ << " " << __LINE__ << " " << name_ << " " << tracklet->getISeed() << "\n stub " << stub->z()
+              << " disk " << disk << " " << dz;
+        }
+
+        double phiproj = proj.phiproj() + dz * proj.phiprojder();
+
+        double rproj = proj.rzproj() + dz * proj.rzprojder();
+
+        double deltar = r - rproj;
+
+        double dr = stub->r() - rproj;
+
+        double dphi = reco::reduceRange(phi - phiproj);
+
+        double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dz * proj.phiprojderapprox()));
+
+        double drapprox = stub->r() - (proj.rzprojapprox() + dz * proj.rzprojderapprox());
+
+        double drphi = dphi * stub->r();
+        double drphiapprox = dphiapprox * stub->r();
+
+        if (!stub->isPSmodule()) {
+          double alphanorm = stub->alphanorm();
+          dphi += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r2();
+          dphiapprox += drapprox * alphanorm * settings_.half2SmoduleWidth() / stub->r2();
+
+          drphi += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r();
+          drphiapprox += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r();
+        }
+
+        int seedindex = tracklet->getISeed();
+
+        int idrphicut = rphicutPStable_.lookup(seedindex);
+        int idrcut = rcutPStable_.lookup(seedindex);
+        if (!stub->isPSmodule()) {
+          idrphicut = rphicut2Stable_.lookup(seedindex);
+          idrcut = rcut2Stable_.lookup(seedindex);
+        }
+
+        unsigned int projindex = mergedMatches[j].first.second;  // Allproj index
+        curr_projid = next_projid;
+        next_projid = projindex;
+        // Do we have a new tracklet?
+        bool newtracklet = (j == 0 || projindex != curr_projid);
+        if (j == 0)
+          best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
+        // If so, replace the "best" values with the cut tables
+        if (newtracklet) {
+          best_ideltaphi_disk = idrphicut;
+          best_ideltar_disk = idrcut;
+        }
+
+        // Update the cut vales (cut table if new tracklet, otherwise current best)
+        idrphicut = newtracklet ? idrphicut : best_ideltaphi_disk;
+        idrcut = newtracklet ? idrcut : best_ideltar_disk;
+
+        double drphicut = idrphicut * settings_.kphi() * settings_.kr();
+        double drcut = idrcut * settings_.krprojshiftdisk();
+
+        bool match, imatch;
+        if (std::abs(dphi) < third * settings_.dphisectorHG() &&
+            std::abs(dphiapprox) < third * settings_.dphisectorHG()) {  //1/3 of sector size to catch errors
+          if (settings_.writeMonitorData("Residuals")) {
+            double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
+
+            globals_->ofstream("diskresiduals.txt")
+                << disk << " " << stub->isPSmodule() << " " << tracklet->layer() << " " << abs(tracklet->disk()) << " "
+                << pt << " " << ideltaphi * settings_.kphi() * stub->r() << " " << drphiapprox << " " << drphicut << " "
+                << ideltar * settings_.krprojshiftdisk() << " " << deltar << " " << drcut << " " << endl;
+          }
+
+          // floating point match
+          match = (std::abs(drphi) < drphicut) && (std::abs(deltar) < drcut);
+
+          // integer match
+          imatch = (std::abs(ideltaphi) * irstub < best_ideltaphi_disk) && (std::abs(ideltar) < best_ideltar_disk);
+          // Update the "best" values
+          if (imatch) {
+            best_ideltaphi_disk = std::abs(ideltaphi) * irstub;
+            best_ideltar_disk = std::abs(ideltar);
+          }
+        } else {
+          edm::LogProblem("Tracklet") << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox
+                                      << "dphi " << dphi << " Seed / ISeed " << tracklet->getISeed() << endl;
+          match = false;
+          imatch = false;
+        }
         if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << "Accepted full match in disk " << getName() << " " << tracklet;
+          edm::LogVerbatim("Tracklet") << "imatch match disk: " << imatch << " " << match << " " << std::abs(ideltaphi)
+                                       << " " << drphicut / (settings_.kphi() * stub->r()) << " " << std::abs(ideltar)
+                                       << " " << drcut / settings_.krprojshiftdisk() << " r = " << stub->r();
         }
 
-        fullMatches_[seedindex]->addMatch(tracklet, mergedMatches[j].second);
+        if (imatch) {
+          countsel++;
+
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << "MatchCalculator found match in disk " << getName();
+          }
+
+          tracklet->addMatch(layerdisk_,
+                             ideltaphi,
+                             ideltar,
+                             drphi / stub->r(),
+                             dr,
+                             drphiapprox / stub->r(),
+                             drapprox,
+                             (phiregion_ << 7) + fpgastub->stubindex().value(),
+                             fpgastub);
+
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << "Accepted full match in disk " << getName() << " " << tracklet;
+          }
+
+          fullMatches_[seedindex]->addMatch(tracklet, mergedMatches[j].second);
+        }
       }
+      if (countall >= settings_.maxStep("MC"))
+        break;
     }
-    if (countall >= settings_.maxStep("MC"))
-      break;
+
+    if (settings_.writeMonitorData("MC")) {
+      globals_->ofstream("matchcalculator.txt") << getName() << " " << countall << " " << countsel << endl;
+    }
   }
 
-  if (settings_.writeMonitorData("MC")) {
-    globals_->ofstream("matchcalculator.txt") << getName() << " " << countall << " " << countsel << endl;
-  }
-}
+  // Combines all tracklet/stub pairs into a vector
+  std::vector<std::pair<std::pair<Tracklet*, int>, const Stub*> > MatchCalculator::mergeMatches(
+      vector<CandidateMatchMemory*>& candmatch) {
+    std::vector<std::pair<std::pair<Tracklet*, int>, const Stub*> > tmp;
 
-// Combines all tracklet/stub pairs into a vector
-std::vector<std::pair<std::pair<Tracklet*, int>, const Stub*> > MatchCalculator::mergeMatches(
-    vector<CandidateMatchMemory*>& candmatch) {
-  std::vector<std::pair<std::pair<Tracklet*, int>, const Stub*> > tmp;
-
-  std::vector<unsigned int> indexArray;
-  indexArray.reserve(candmatch.size());
-  for (unsigned int i = 0; i < candmatch.size(); i++) {
-    indexArray.push_back(0);
-  }
-
-  int bestIndex = -1;
-  do {
-    int bestSector = 100;
-    int bestTCID = -1;
-    bestIndex = -1;
+    std::vector<unsigned int> indexArray;
+    indexArray.reserve(candmatch.size());
     for (unsigned int i = 0; i < candmatch.size(); i++) {
-      if (indexArray[i] >= candmatch[i]->nMatches()) {
-        // skip as we were at the end
-        continue;
-      }
-      int TCID = candmatch[i]->getMatch(indexArray[i]).first.first->TCID();
-      int dSector = 0;
-      if (dSector > 2)
-        dSector -= N_SECTOR;
-      if (dSector < -2)
-        dSector += N_SECTOR;
-      assert(abs(dSector) < 2);
-      if (dSector == -1)
-        dSector = 2;
-      if (dSector < bestSector) {
-        bestSector = dSector;
-        bestTCID = TCID;
-        bestIndex = i;
-      }
-      if (dSector == bestSector) {
-        if (TCID < bestTCID || bestTCID < 0) {
+      indexArray.push_back(0);
+    }
+
+    int bestIndex = -1;
+    do {
+      int bestSector = 100;
+      int bestTCID = -1;
+      bestIndex = -1;
+      for (unsigned int i = 0; i < candmatch.size(); i++) {
+        if (indexArray[i] >= candmatch[i]->nMatches()) {
+          // skip as we were at the end
+          continue;
+        }
+        int TCID = candmatch[i]->getMatch(indexArray[i]).first.first->TCID();
+        int dSector = 0;
+        if (dSector > 2)
+          dSector -= N_SECTOR;
+        if (dSector < -2)
+          dSector += N_SECTOR;
+        assert(abs(dSector) < 2);
+        if (dSector == -1)
+          dSector = 2;
+        if (dSector < bestSector) {
+          bestSector = dSector;
           bestTCID = TCID;
           bestIndex = i;
         }
+        if (dSector == bestSector) {
+          if (TCID < bestTCID || bestTCID < 0) {
+            bestTCID = TCID;
+            bestIndex = i;
+          }
+        }
       }
-    }
-    if (bestIndex != -1) {
-      tmp.push_back(candmatch[bestIndex]->getMatch(indexArray[bestIndex]));
-      indexArray[bestIndex]++;
-    }
-  } while (bestIndex != -1);
-
-  if (layerdisk_ < N_LAYER) {
-    int lastTCID = -1;
-    bool error = false;
-
-    //Allow equal TCIDs since we can have multiple candidate matches
-    for (unsigned int i = 1; i < tmp.size(); i++) {
-      if (lastTCID > tmp[i].first.first->TCID()) {
-        edm::LogProblem("Tracklet") << "Wrong TCID ordering for projections in " << getName() << " last " << lastTCID
-                                    << " " << tmp[i].first.first->TCID();
-        error = true;
-      } else {
-        lastTCID = tmp[i].first.first->TCID();
+      if (bestIndex != -1) {
+        tmp.push_back(candmatch[bestIndex]->getMatch(indexArray[bestIndex]));
+        indexArray[bestIndex]++;
       }
-    }
+    } while (bestIndex != -1);
 
-    if (error) {
+    if (layerdisk_ < N_LAYER) {
+      int lastTCID = -1;
+      bool error = false;
+
+      //Allow equal TCIDs since we can have multiple candidate matches
       for (unsigned int i = 1; i < tmp.size(); i++) {
-        edm::LogProblem("Tracklet") << "Wrong order for in " << getName() << " " << i << " " << tmp[i].first.first
-                                    << " " << tmp[i].first.first->TCID();
+        if (lastTCID > tmp[i].first.first->TCID()) {
+          edm::LogProblem("Tracklet") << "Wrong TCID ordering for projections in " << getName() << " last " << lastTCID
+                                      << " " << tmp[i].first.first->TCID();
+          error = true;
+        } else {
+          lastTCID = tmp[i].first.first->TCID();
+        }
+      }
+
+      if (error) {
+        for (unsigned int i = 1; i < tmp.size(); i++) {
+          edm::LogProblem("Tracklet") << "Wrong order for in " << getName() << " " << i << " " << tmp[i].first.first
+                                      << " " << tmp[i].first.first->TCID();
+        }
       }
     }
-  }
 
-  for (unsigned int i = 0; i < tmp.size(); i++) {
-    if (i > 0) {
-      //This allows for equal TCIDs. This means that we can e.g. have a track seeded
-      //in L1L2 that projects to both L3 and D4. The algorithm will pick up the first hit and
-      //drop the second
+    for (unsigned int i = 0; i < tmp.size(); i++) {
+      if (i > 0) {
+        //This allows for equal TCIDs. This means that we can e.g. have a track seeded
+        //in L1L2 that projects to both L3 and D4. The algorithm will pick up the first hit and
+        //drop the second
 
-      assert(tmp[i - 1].first.first->TCID() <= tmp[i].first.first->TCID());
+        assert(tmp[i - 1].first.first->TCID() <= tmp[i].first.first->TCID());
+      }
     }
+
+    return tmp;
   }
 
-  return tmp;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchCalculator.cc
@@ -27,7 +27,8 @@
 #include <algorithm>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 MatchCalculator::MatchCalculator(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global),
@@ -584,4 +585,6 @@ std::vector<std::pair<std::pair<Tracklet*, int>, const Stub*> > MatchCalculator:
   }
 
   return tmp;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngine.cc
@@ -16,290 +16,291 @@ using namespace std;
 
 namespace trklet {
 
-MatchEngine::MatchEngine(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global), luttable_(settings) {
-  layerdisk_ = initLayerDisk(3);
+  MatchEngine::MatchEngine(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global), luttable_(settings) {
+    layerdisk_ = initLayerDisk(3);
 
-  barrel_ = layerdisk_ < N_LAYER;
+    barrel_ = layerdisk_ < N_LAYER;
 
-  luttable_.initBendMatch(layerdisk_);
+    luttable_.initBendMatch(layerdisk_);
 
-  nrinv_ = NRINVBITS;
-}
-
-void MatchEngine::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
+    nrinv_ = NRINVBITS;
   }
-  if (output == "matchout") {
-    auto* tmp = dynamic_cast<CandidateMatchMemory*>(memory);
-    assert(tmp != nullptr);
-    candmatches_ = tmp;
-    return;
+
+  void MatchEngine::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
+    if (output == "matchout") {
+      auto* tmp = dynamic_cast<CandidateMatchMemory*>(memory);
+      assert(tmp != nullptr);
+      candmatches_ = tmp;
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find output: " << output;
   }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find output: " << output;
-}
 
-void MatchEngine::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
+  void MatchEngine::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input == "vmstubin") {
+      auto* tmp = dynamic_cast<VMStubsMEMemory*>(memory);
+      assert(tmp != nullptr);
+      vmstubs_ = tmp;
+      return;
+    }
+    if (input == "vmprojin") {
+      auto* tmp = dynamic_cast<VMProjectionsMemory*>(memory);
+      assert(tmp != nullptr);
+      vmprojs_ = tmp;
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input: " << input;
   }
-  if (input == "vmstubin") {
-    auto* tmp = dynamic_cast<VMStubsMEMemory*>(memory);
-    assert(tmp != nullptr);
-    vmstubs_ = tmp;
-    return;
-  }
-  if (input == "vmprojin") {
-    auto* tmp = dynamic_cast<VMProjectionsMemory*>(memory);
-    assert(tmp != nullptr);
-    vmprojs_ = tmp;
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input: " << input;
-}
 
-void MatchEngine::execute(unsigned int iSector) {
-  unsigned int countall = 0;
-  unsigned int countpass = 0;
+  void MatchEngine::execute(unsigned int iSector) {
+    unsigned int countall = 0;
+    unsigned int countpass = 0;
 
-  //bool print = (iSector == 3 && getName() == "ME_L3PHIC20");
-  bool print = false;
+    //bool print = (iSector == 3 && getName() == "ME_L3PHIC20");
+    bool print = false;
 
-  constexpr unsigned int kNBitsBuffer = 3;
+    constexpr unsigned int kNBitsBuffer = 3;
 
-  int writeindex = 0;
-  int readindex = 0;
-  std::pair<int, int> projbuffer[1 << kNBitsBuffer];  //iproj zbin
+    int writeindex = 0;
+    int readindex = 0;
+    std::pair<int, int> projbuffer[1 << kNBitsBuffer];  //iproj zbin
 
-  //The next projection to read, the number of projections and flag if we have more projections to read
-  int iproj = 0;
-  int nproj = vmprojs_->nTracklets();
-  bool moreproj = iproj < nproj;
+    //The next projection to read, the number of projections and flag if we have more projections to read
+    int iproj = 0;
+    int nproj = vmprojs_->nTracklets();
+    bool moreproj = iproj < nproj;
 
-  //Projection that is read from the buffer and compared to stubs
-  int rzbin = 0;
-  int projfinerz = 0;
-  int projfinerzadj = 0;
-  unsigned int projfinephi = 0;
+    //Projection that is read from the buffer and compared to stubs
+    int rzbin = 0;
+    int projfinerz = 0;
+    int projfinerzadj = 0;
+    unsigned int projfinephi = 0;
 
-  int projindex = 0;
-  int projrinv = 0;
-  bool isPSseed = false;
+    int projindex = 0;
+    int projrinv = 0;
+    bool isPSseed = false;
 
-  //Number of stubs for current zbin and the stub being processed on this clock
-  int nstubs = 0;
-  int istub = 0;
+    //Number of stubs for current zbin and the stub being processed on this clock
+    int nstubs = 0;
+    int istub = 0;
 
-  //Main processing loops starts here
-  for (unsigned int istep = 0; istep < settings_.maxStep("ME"); istep++) {
-    countall++;
+    //Main processing loops starts here
+    for (unsigned int istep = 0; istep < settings_.maxStep("ME"); istep++) {
+      countall++;
 
-    int writeindexplus = (writeindex + 1) % (1 << kNBitsBuffer);
-    int writeindexplusplus = (writeindex + 2) % (1 << kNBitsBuffer);
+      int writeindexplus = (writeindex + 1) % (1 << kNBitsBuffer);
+      int writeindexplusplus = (writeindex + 2) % (1 << kNBitsBuffer);
 
-    //Determine if buffer is full - or near full as a projection
-    //can point to two z bins we might fill two slots in the buffer
-    bool bufferfull = (writeindexplus == readindex) || (writeindexplusplus == readindex);
+      //Determine if buffer is full - or near full as a projection
+      //can point to two z bins we might fill two slots in the buffer
+      bool bufferfull = (writeindexplus == readindex) || (writeindexplusplus == readindex);
 
-    //Determin if buffer is empty
-    bool buffernotempty = (writeindex != readindex);
+      //Determin if buffer is empty
+      bool buffernotempty = (writeindex != readindex);
 
-    //If we have more projections and the buffer is not full we read
-    //next projection and put in buffer if there are stubs in the
-    //memory the projection points to
+      //If we have more projections and the buffer is not full we read
+      //next projection and put in buffer if there are stubs in the
+      //memory the projection points to
 
-    if ((!moreproj) && (!buffernotempty))
-      break;
+      if ((!moreproj) && (!buffernotempty))
+        break;
 
-    if (moreproj && (!bufferfull)) {
-      Tracklet* proj = vmprojs_->getTracklet(iproj);
+      if (moreproj && (!bufferfull)) {
+        Tracklet* proj = vmprojs_->getTracklet(iproj);
 
-      int iprojtmp = iproj;
+        int iprojtmp = iproj;
 
-      iproj++;
-      moreproj = iproj < nproj;
+        iproj++;
+        moreproj = iproj < nproj;
 
-      unsigned int rzfirst = proj->proj(layerdisk_).fpgarzbin1projvm().value();
-      unsigned int rzlast = rzfirst;
+        unsigned int rzfirst = proj->proj(layerdisk_).fpgarzbin1projvm().value();
+        unsigned int rzlast = rzfirst;
 
-      bool second = proj->proj(layerdisk_).fpgarzbin2projvm().value();
+        bool second = proj->proj(layerdisk_).fpgarzbin2projvm().value();
 
-      if (second)
-        rzlast += 1;
+        if (second)
+          rzlast += 1;
 
-      //Check if there are stubs in the memory
-      int nstubfirst = vmstubs_->nStubsBin(rzfirst);
-      int nstublast = vmstubs_->nStubsBin(rzlast);
-      bool savefirst = nstubfirst != 0;
-      bool savelast = second && (nstublast != 0);
+        //Check if there are stubs in the memory
+        int nstubfirst = vmstubs_->nStubsBin(rzfirst);
+        int nstublast = vmstubs_->nStubsBin(rzlast);
+        bool savefirst = nstubfirst != 0;
+        bool savelast = second && (nstublast != 0);
 
-      int writeindextmp = writeindex;
-      int writeindextmpplus = (writeindex + 1) % (1 << kNBitsBuffer);
+        int writeindextmp = writeindex;
+        int writeindextmpplus = (writeindex + 1) % (1 << kNBitsBuffer);
 
-      if (savefirst && savelast) {
-        writeindex = writeindexplusplus;
-      } else if (savefirst || savelast) {
-        writeindex = writeindexplus;
-      }
+        if (savefirst && savelast) {
+          writeindex = writeindexplusplus;
+        } else if (savefirst || savelast) {
+          writeindex = writeindexplus;
+        }
 
-      if (savefirst) {  //TODO for HLS (make code logic simpler)
-        std::pair<int, int> tmp(iprojtmp, rzfirst);
-        projbuffer[writeindextmp] = tmp;
-      }
-      if (savelast) {
-        std::pair<int, int> tmp(iprojtmp, rzlast + 100);  //TODO for HLS (fix flagging that this is second bin)
-        if (savefirst) {
-          projbuffer[writeindextmpplus] = tmp;
-        } else {
+        if (savefirst) {  //TODO for HLS (make code logic simpler)
+          std::pair<int, int> tmp(iprojtmp, rzfirst);
           projbuffer[writeindextmp] = tmp;
         }
-      }
-    }
-
-    //If the buffer is not empty we have a projection that we need to process.
-
-    if (buffernotempty) {
-      int istubtmp = istub;
-
-      //New projection
-      if (istub == 0) {
-        projindex = projbuffer[readindex].first;
-        rzbin = projbuffer[readindex].second;
-        bool second = false;
-        if (rzbin >= 100) {
-          rzbin -= 100;
-          second = true;
-        }
-
-        Tracklet* proj = vmprojs_->getTracklet(projindex);
-
-        FPGAWord fpgafinephi = proj->proj(layerdisk_).fpgafinephivm();
-
-        projfinephi = fpgafinephi.value();
-
-        nstubs = vmstubs_->nStubsBin(rzbin);
-
-        projfinerz = proj->proj(layerdisk_).fpgafinerzvm().value();
-
-        projrinv = barrel_ ? ((1 << (nrinv_ - 1)) + ((-2 * proj->proj(layerdisk_).fpgaphiprojder().value()) >>
-                                                     (proj->proj(layerdisk_).fpgaphiprojder().nbits() - (nrinv_ - 1))))
-                           : proj->proj(layerdisk_).getBendIndex().value();
-        assert(projrinv >= 0);
-        if (settings_.extended() && projrinv == (1 << nrinv_)) {
-          if (settings_.debugTracklet()) {
-            edm::LogVerbatim("Tracklet") << "Extended tracking, projrinv:" << projrinv;
+        if (savelast) {
+          std::pair<int, int> tmp(iprojtmp, rzlast + 100);  //TODO for HLS (fix flagging that this is second bin)
+          if (savefirst) {
+            projbuffer[writeindextmpplus] = tmp;
+          } else {
+            projbuffer[writeindextmp] = tmp;
           }
-          projrinv = (1 << nrinv_) - 1;
-        }
-        assert(projrinv < (1 << nrinv_));
-
-        isPSseed = proj->PSseed();
-
-        //Calculate fine z position
-        if (second) {
-          projfinerzadj = projfinerz - (1 << NFINERZBITS);
-        } else {
-          projfinerzadj = projfinerz;
-        }
-        if (nstubs == 1) {
-          istub = 0;
-          readindex = (readindex + 1) % (1 << kNBitsBuffer);
-        } else {
-          istub++;
-        }
-      } else {
-        //Check if last stub, if so, go to next buffer entry
-        if (istub + 1 >= nstubs) {
-          istub = 0;
-          readindex = (readindex + 1) % (1 << kNBitsBuffer);
-        } else {
-          istub++;
         }
       }
 
-      //Read vmstub memory and extract data fields
-      const VMStubME& vmstub = vmstubs_->getVMStubMEBin(rzbin, istubtmp);
+      //If the buffer is not empty we have a projection that we need to process.
 
-      int stubfinerz = vmstub.finerz().value();
+      if (buffernotempty) {
+        int istubtmp = istub;
 
-      bool isPSmodule;
+        //New projection
+        if (istub == 0) {
+          projindex = projbuffer[readindex].first;
+          rzbin = projbuffer[readindex].second;
+          bool second = false;
+          if (rzbin >= 100) {
+            rzbin -= 100;
+            second = true;
+          }
 
-      if (barrel_) {
-        isPSmodule = layerdisk_ < N_PSLAYER;
-      } else {
-        if (layerdisk_ < N_LAYER + 2) {
-          isPSmodule = ((rzbin & 7) < 3) || ((rzbin & 7) == 3 && stubfinerz <= 3);
-        } else {
-          isPSmodule = ((rzbin & 7) < 3) || ((rzbin & 7) == 3 && stubfinerz <= 2);
-        }
-      }
-
-      assert(isPSmodule == vmstub.isPSmodule());
-
-      int nbits = isPSmodule ? N_BENDBITS_PS : N_BENDBITS_2S;
-
-      int deltaphi = projfinephi - vmstub.finephi().value();
-
-      constexpr int mindeltaphicut = 3;
-      constexpr int maxdeltaphicut = 5;
-      bool passphi = (std::abs(deltaphi) < mindeltaphicut) || (std::abs(deltaphi) > maxdeltaphicut);
-
-      unsigned int index = (projrinv << nbits) + vmstub.bend().value();
-      if (!barrel_ && isPSmodule) {
-        index += (1 << (nrinv_ + N_BENDBITS_2S));
-      }
-
-      //Check if stub z position consistent
-      int idrz = stubfinerz - projfinerzadj;
-      bool passz;
-
-      if (barrel_) {
-        if (isPSseed) {
-          constexpr int drzcut = 1;
-          passz = std::abs(idrz) <= drzcut;
-        } else {
-          constexpr int drzcut = 5;
-          passz = std::abs(idrz) <= drzcut;
-        }
-      } else {
-        if (isPSmodule) {
-          constexpr int drzcut = 1;
-          passz = std::abs(idrz) <= drzcut;
-        } else {
-          constexpr int drzcut = 3;
-          passz = std::abs(idrz) <= drzcut;
-        }
-      }
-
-      if (print) {
-        edm::LogVerbatim("Tracklet") << "istep index : " << istep << " " << index << " " << vmstub.bend().value()
-                                     << " rzbin istubtmp : " << rzbin << " " << istubtmp << " dz " << stubfinerz << " "
-                                     << projfinerzadj << "  dphi: " << deltaphi;
-      }
-
-      //Check if stub bend and proj rinv consistent
-      if (passz && passphi) {
-        if (luttable_.lookup(index)) {
           Tracklet* proj = vmprojs_->getTracklet(projindex);
-          std::pair<Tracklet*, int> tmp(proj, vmprojs_->getAllProjIndex(projindex));
-          if (settings_.writeMonitorData("Seeds")) {
-            ofstream fout("seeds.txt", ofstream::app);
-            fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << proj->getISeed() << endl;
-            fout.close();
+
+          FPGAWord fpgafinephi = proj->proj(layerdisk_).fpgafinephivm();
+
+          projfinephi = fpgafinephi.value();
+
+          nstubs = vmstubs_->nStubsBin(rzbin);
+
+          projfinerz = proj->proj(layerdisk_).fpgafinerzvm().value();
+
+          projrinv = barrel_
+                         ? ((1 << (nrinv_ - 1)) + ((-2 * proj->proj(layerdisk_).fpgaphiprojder().value()) >>
+                                                   (proj->proj(layerdisk_).fpgaphiprojder().nbits() - (nrinv_ - 1))))
+                         : proj->proj(layerdisk_).getBendIndex().value();
+          assert(projrinv >= 0);
+          if (settings_.extended() && projrinv == (1 << nrinv_)) {
+            if (settings_.debugTracklet()) {
+              edm::LogVerbatim("Tracklet") << "Extended tracking, projrinv:" << projrinv;
+            }
+            projrinv = (1 << nrinv_) - 1;
           }
-          candmatches_->addMatch(tmp, vmstub.stub());
-          countpass++;
+          assert(projrinv < (1 << nrinv_));
+
+          isPSseed = proj->PSseed();
+
+          //Calculate fine z position
+          if (second) {
+            projfinerzadj = projfinerz - (1 << NFINERZBITS);
+          } else {
+            projfinerzadj = projfinerz;
+          }
+          if (nstubs == 1) {
+            istub = 0;
+            readindex = (readindex + 1) % (1 << kNBitsBuffer);
+          } else {
+            istub++;
+          }
+        } else {
+          //Check if last stub, if so, go to next buffer entry
+          if (istub + 1 >= nstubs) {
+            istub = 0;
+            readindex = (readindex + 1) % (1 << kNBitsBuffer);
+          } else {
+            istub++;
+          }
+        }
+
+        //Read vmstub memory and extract data fields
+        const VMStubME& vmstub = vmstubs_->getVMStubMEBin(rzbin, istubtmp);
+
+        int stubfinerz = vmstub.finerz().value();
+
+        bool isPSmodule;
+
+        if (barrel_) {
+          isPSmodule = layerdisk_ < N_PSLAYER;
+        } else {
+          if (layerdisk_ < N_LAYER + 2) {
+            isPSmodule = ((rzbin & 7) < 3) || ((rzbin & 7) == 3 && stubfinerz <= 3);
+          } else {
+            isPSmodule = ((rzbin & 7) < 3) || ((rzbin & 7) == 3 && stubfinerz <= 2);
+          }
+        }
+
+        assert(isPSmodule == vmstub.isPSmodule());
+
+        int nbits = isPSmodule ? N_BENDBITS_PS : N_BENDBITS_2S;
+
+        int deltaphi = projfinephi - vmstub.finephi().value();
+
+        constexpr int mindeltaphicut = 3;
+        constexpr int maxdeltaphicut = 5;
+        bool passphi = (std::abs(deltaphi) < mindeltaphicut) || (std::abs(deltaphi) > maxdeltaphicut);
+
+        unsigned int index = (projrinv << nbits) + vmstub.bend().value();
+        if (!barrel_ && isPSmodule) {
+          index += (1 << (nrinv_ + N_BENDBITS_2S));
+        }
+
+        //Check if stub z position consistent
+        int idrz = stubfinerz - projfinerzadj;
+        bool passz;
+
+        if (barrel_) {
+          if (isPSseed) {
+            constexpr int drzcut = 1;
+            passz = std::abs(idrz) <= drzcut;
+          } else {
+            constexpr int drzcut = 5;
+            passz = std::abs(idrz) <= drzcut;
+          }
+        } else {
+          if (isPSmodule) {
+            constexpr int drzcut = 1;
+            passz = std::abs(idrz) <= drzcut;
+          } else {
+            constexpr int drzcut = 3;
+            passz = std::abs(idrz) <= drzcut;
+          }
+        }
+
+        if (print) {
+          edm::LogVerbatim("Tracklet") << "istep index : " << istep << " " << index << " " << vmstub.bend().value()
+                                       << " rzbin istubtmp : " << rzbin << " " << istubtmp << " dz " << stubfinerz
+                                       << " " << projfinerzadj << "  dphi: " << deltaphi;
+        }
+
+        //Check if stub bend and proj rinv consistent
+        if (passz && passphi) {
+          if (luttable_.lookup(index)) {
+            Tracklet* proj = vmprojs_->getTracklet(projindex);
+            std::pair<Tracklet*, int> tmp(proj, vmprojs_->getAllProjIndex(projindex));
+            if (settings_.writeMonitorData("Seeds")) {
+              ofstream fout("seeds.txt", ofstream::app);
+              fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << proj->getISeed() << endl;
+              fout.close();
+            }
+            candmatches_->addMatch(tmp, vmstub.stub());
+            countpass++;
+          }
         }
       }
     }
+
+    if (settings_.writeMonitorData("ME")) {
+      globals_->ofstream("matchengine.txt") << getName() << " " << countall << " " << countpass << endl;
+    }
   }
 
-  if (settings_.writeMonitorData("ME")) {
-    globals_->ofstream("matchengine.txt") << getName() << " " << countall << " " << countpass << endl;
-  }
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngine.cc
@@ -13,7 +13,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 MatchEngine::MatchEngine(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global), luttable_(settings) {
@@ -299,4 +300,6 @@ void MatchEngine::execute(unsigned int iSector) {
   if (settings_.writeMonitorData("ME")) {
     globals_->ofstream("matchengine.txt") << getName() << " " << countall << " " << countpass << endl;
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -3,7 +3,8 @@
 #include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 MatchEngineUnit::MatchEngineUnit(const Settings& settings,
                                  bool barrel,
@@ -203,4 +204,6 @@ int MatchEngineUnit::TCID() const {
   }
 
   return proj_->TCID();
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -26,148 +26,148 @@ using namespace std;
 
 namespace trklet {
 
-MatchProcessor::MatchProcessor(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global),
-      phimatchcuttable_(settings),
-      zmatchcuttable_(settings),
-      rphicutPStable_(settings),
-      rphicut2Stable_(settings),
-      rcutPStable_(settings),
-      rcut2Stable_(settings),
-      alphainner_(settings),
-      alphaouter_(settings),
-      rSSinner_(settings),
-      rSSouter_(settings),
-      diskRadius_(settings),
-      fullmatches_(12),
-      rinvbendlut_(settings),
-      luttable_(settings),
-      inputProjBuffer_(3) {
-  phiregion_ = name[8] - 'A';
+  MatchProcessor::MatchProcessor(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global),
+        phimatchcuttable_(settings),
+        zmatchcuttable_(settings),
+        rphicutPStable_(settings),
+        rphicut2Stable_(settings),
+        rcutPStable_(settings),
+        rcut2Stable_(settings),
+        alphainner_(settings),
+        alphaouter_(settings),
+        rSSinner_(settings),
+        rSSouter_(settings),
+        diskRadius_(settings),
+        fullmatches_(12),
+        rinvbendlut_(settings),
+        luttable_(settings),
+        inputProjBuffer_(3) {
+    phiregion_ = name[8] - 'A';
 
-  layerdisk_ = initLayerDisk(3);
+    layerdisk_ = initLayerDisk(3);
 
-  barrel_ = layerdisk_ < N_LAYER;
+    barrel_ = layerdisk_ < N_LAYER;
 
-  phishift_ = settings_.nphibitsstub(N_LAYER - 1) - settings_.nphibitsstub(layerdisk_);
-  dzshift_ = settings_.nzbitsstub(0) - settings_.nzbitsstub(layerdisk_);
+    phishift_ = settings_.nphibitsstub(N_LAYER - 1) - settings_.nphibitsstub(layerdisk_);
+    dzshift_ = settings_.nzbitsstub(0) - settings_.nzbitsstub(layerdisk_);
 
-  if (barrel_) {
-    icorrshift_ = ilog2(settings_.kphi(layerdisk_) / (settings_.krbarrel() * settings_.kphider()));
-    icorzshift_ = ilog2(settings_.kz(layerdisk_) / (settings_.krbarrel() * settings_.kzder()));
-  } else {
-    icorrshift_ = ilog2(settings_.kphi(layerdisk_) / (settings_.kz() * settings_.kphiderdisk()));
-    icorzshift_ = ilog2(settings_.krprojshiftdisk() / (settings_.kz() * settings_.krder()));
+    if (barrel_) {
+      icorrshift_ = ilog2(settings_.kphi(layerdisk_) / (settings_.krbarrel() * settings_.kphider()));
+      icorzshift_ = ilog2(settings_.kz(layerdisk_) / (settings_.krbarrel() * settings_.kzder()));
+    } else {
+      icorrshift_ = ilog2(settings_.kphi(layerdisk_) / (settings_.kz() * settings_.kphiderdisk()));
+      icorzshift_ = ilog2(settings_.krprojshiftdisk() / (settings_.kz() * settings_.krder()));
+    }
+
+    luttable_.initBendMatch(layerdisk_);
+
+    nrbits_ = 5;
+    nphiderbits_ = 6;
+
+    nrprojbits_ = 8;
+
+    if (!barrel_) {
+      rinvbendlut_.initProjectionBend(
+          global->ITC_L1L2()->der_phiD_final.K(), layerdisk_ - N_LAYER, nrbits_, nphiderbits_);
+    }
+
+    nrinv_ = NRINVBITS;
+
+    unsigned int region = getName()[8] - 'A';
+    assert(region < settings_.nallstubs(layerdisk_));
+
+    if (barrel_) {
+      phimatchcuttable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::barrelphi, region);
+      zmatchcuttable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::barrelz, region);
+    } else {
+      rphicutPStable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::diskPSphi, region);
+      rphicut2Stable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::disk2Sphi, region);
+      rcutPStable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::diskPSr, region);
+      rcut2Stable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::disk2Sr, region);
+      alphainner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphainner, region);
+      alphaouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphaouter, region);
+      rSSinner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSinner, region);
+      rSSouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSouter, region);
+      diskRadius_.initProjectionDiskRadius(nrprojbits_);
+    }
+
+    for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
+      ialphafactinner_[i] = (1 << settings_.alphashift()) * settings_.krprojshiftdisk() *
+                            settings_.half2SmoduleWidth() / (1 << (settings_.nbitsalpha() - 1)) /
+                            (settings_.rDSSinner(i) * settings_.rDSSinner(i)) / settings_.kphi();
+      ialphafactouter_[i] = (1 << settings_.alphashift()) * settings_.krprojshiftdisk() *
+                            settings_.half2SmoduleWidth() / (1 << (settings_.nbitsalpha() - 1)) /
+                            (settings_.rDSSouter(i) * settings_.rDSSouter(i)) / settings_.kphi();
+    }
+
+    nvm_ = settings_.nvmme(layerdisk_) * settings_.nallstubs(layerdisk_);
+    nvmbins_ = settings_.nvmme(layerdisk_);
+    nvmbits_ = settings_.nbitsvmme(layerdisk_) + settings_.nbitsallstubs(layerdisk_);
+
+    nMatchEngines_ = 4;
+    for (unsigned int iME = 0; iME < nMatchEngines_; iME++) {
+      MatchEngineUnit tmpME(settings_, barrel_, layerdisk_, luttable_);
+      tmpME.setimeu(iME);
+      matchengines_.push_back(tmpME);
+    }
+
+    // Pick some initial large values
+    best_ideltaphi_barrel = 0xFFFF;
+    best_ideltaz_barrel = 0xFFFF;
+    best_ideltaphi_disk = 0xFFFF;
+    best_ideltar_disk = 0xFFFF;
+    curr_tracklet = nullptr;
+    next_tracklet = nullptr;
   }
 
-  luttable_.initBendMatch(layerdisk_);
-
-  nrbits_ = 5;
-  nphiderbits_ = 6;
-
-  nrprojbits_ = 8;
-
-  if (!barrel_) {
-    rinvbendlut_.initProjectionBend(
-        global->ITC_L1L2()->der_phiD_final.K(), layerdisk_ - N_LAYER, nrbits_, nphiderbits_);
+  void MatchProcessor::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
+    if (output.find("matchout") != std::string::npos) {
+      auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
+      assert(tmp != nullptr);
+      unsigned int iSeed = getISeed(tmp->getName());
+      assert(iSeed < fullmatches_.size());
+      assert(fullmatches_[iSeed] == nullptr);
+      fullmatches_[iSeed] = tmp;
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find output: " << output;
   }
 
-  nrinv_ = NRINVBITS;
-
-  unsigned int region = getName()[8] - 'A';
-  assert(region < settings_.nallstubs(layerdisk_));
-
-  if (barrel_) {
-    phimatchcuttable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::barrelphi, region);
-    zmatchcuttable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::barrelz, region);
-  } else {
-    rphicutPStable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::diskPSphi, region);
-    rphicut2Stable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::disk2Sphi, region);
-    rcutPStable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::diskPSr, region);
-    rcut2Stable_.initmatchcut(layerdisk_, TrackletLUT::MatchType::disk2Sr, region);
-    alphainner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphainner, region);
-    alphaouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::alphaouter, region);
-    rSSinner_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSinner, region);
-    rSSouter_.initmatchcut(layerdisk_, TrackletLUT::MatchType::rSSouter, region);
-    diskRadius_.initProjectionDiskRadius(nrprojbits_);
+  void MatchProcessor::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input == "allstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      allstubs_ = tmp;
+      return;
+    }
+    if (input == "vmstubin") {
+      auto* tmp = dynamic_cast<VMStubsMEMemory*>(memory);
+      assert(tmp != nullptr);
+      vmstubs_.push_back(tmp);  //to allow more than one stub in?  vmstubs_=tmp;
+      return;
+    }
+    if (input == "projin") {
+      auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
+      assert(tmp != nullptr);
+      inputprojs_.push_back(tmp);
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input: " << input;
   }
 
-  for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
-    ialphafactinner_[i] = (1 << settings_.alphashift()) * settings_.krprojshiftdisk() * settings_.half2SmoduleWidth() /
-                          (1 << (settings_.nbitsalpha() - 1)) / (settings_.rDSSinner(i) * settings_.rDSSinner(i)) /
-                          settings_.kphi();
-    ialphafactouter_[i] = (1 << settings_.alphashift()) * settings_.krprojshiftdisk() * settings_.half2SmoduleWidth() /
-                          (1 << (settings_.nbitsalpha() - 1)) / (settings_.rDSSouter(i) * settings_.rDSSouter(i)) /
-                          settings_.kphi();
-  }
+  void MatchProcessor::execute(unsigned int iSector, double phimin) {
+    assert(vmstubs_.size() == 1);
 
-  nvm_ = settings_.nvmme(layerdisk_) * settings_.nallstubs(layerdisk_);
-  nvmbins_ = settings_.nvmme(layerdisk_);
-  nvmbits_ = settings_.nbitsvmme(layerdisk_) + settings_.nbitsallstubs(layerdisk_);
-
-  nMatchEngines_ = 4;
-  for (unsigned int iME = 0; iME < nMatchEngines_; iME++) {
-    MatchEngineUnit tmpME(settings_, barrel_, layerdisk_, luttable_);
-    tmpME.setimeu(iME);
-    matchengines_.push_back(tmpME);
-  }
-
-  // Pick some initial large values
-  best_ideltaphi_barrel = 0xFFFF;
-  best_ideltaz_barrel = 0xFFFF;
-  best_ideltaphi_disk = 0xFFFF;
-  best_ideltar_disk = 0xFFFF;
-  curr_tracklet = nullptr;
-  next_tracklet = nullptr;
-}
-
-void MatchProcessor::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-  if (output.find("matchout") != std::string::npos) {
-    auto* tmp = dynamic_cast<FullMatchMemory*>(memory);
-    assert(tmp != nullptr);
-    unsigned int iSeed = getISeed(tmp->getName());
-    assert(iSeed < fullmatches_.size());
-    assert(fullmatches_[iSeed] == nullptr);
-    fullmatches_[iSeed] = tmp;
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find output: " << output;
-}
-
-void MatchProcessor::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input == "allstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    allstubs_ = tmp;
-    return;
-  }
-  if (input == "vmstubin") {
-    auto* tmp = dynamic_cast<VMStubsMEMemory*>(memory);
-    assert(tmp != nullptr);
-    vmstubs_.push_back(tmp);  //to allow more than one stub in?  vmstubs_=tmp;
-    return;
-  }
-  if (input == "projin") {
-    auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
-    assert(tmp != nullptr);
-    inputprojs_.push_back(tmp);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input: " << input;
-}
-
-void MatchProcessor::execute(unsigned int iSector, double phimin) {
-  assert(vmstubs_.size() == 1);
-
-  /*
+    /*
     The code is organized in three 'steps' corresponding to the PR, ME, and MC functions. The output from
     the PR step is buffered in a 'circular' buffer, and similarly the ME output is put in a circular buffer.     
     The implementation is done in steps, emulating what can be done in firmware. On each step we do:
@@ -182,43 +182,43 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
     
   */
 
-  bool print = getName() == "MP_L3PHIC" && iSector == 3;
-  print = false;
+    bool print = getName() == "MP_L3PHIC" && iSector == 3;
+    print = false;
 
-  phimin_ = phimin;
+    phimin_ = phimin;
 
-  Tracklet* oldTracklet = nullptr;
+    Tracklet* oldTracklet = nullptr;
 
-  unsigned int countme = 0;
-  unsigned int countall = 0;
-  unsigned int countsel = 0;
-  unsigned int countinputproj = 0;
+    unsigned int countme = 0;
+    unsigned int countall = 0;
+    unsigned int countsel = 0;
+    unsigned int countinputproj = 0;
 
-  unsigned int iprojmem = 0;
-  while (iprojmem < inputprojs_.size() && inputprojs_[iprojmem]->nTracklets() == 0) {
-    iprojmem++;
-  }
+    unsigned int iprojmem = 0;
+    while (iprojmem < inputprojs_.size() && inputprojs_[iprojmem]->nTracklets() == 0) {
+      iprojmem++;
+    }
 
-  unsigned int iproj = 0;
+    unsigned int iproj = 0;
 
-  inputProjBuffer_.reset();
+    inputProjBuffer_.reset();
 
-  for (const auto& inputproj : inputprojs_) {
-    countinputproj += inputproj->nTracklets();
-  }
+    for (const auto& inputproj : inputprojs_) {
+      countinputproj += inputproj->nTracklets();
+    }
 
-  for (auto& matchengine : matchengines_) {
-    matchengine.reset();
-  }
+    for (auto& matchengine : matchengines_) {
+      matchengine.reset();
+    }
 
-  ProjectionTemp tmpProj_, tmpProj__;
-  bool good_ = false;
-  bool good__ = false;
+    ProjectionTemp tmpProj_, tmpProj__;
+    bool good_ = false;
+    bool good__ = false;
 
-  for (unsigned int istep = 0; istep < settings_.maxStep("MP"); istep++) {
-    // This print statement is useful for detailed comparison with the HLS code
-    // It prints out detailed status information for each clock step
-    /* 
+    for (unsigned int istep = 0; istep < settings_.maxStep("MP"); istep++) {
+      // This print statement is useful for detailed comparison with the HLS code
+      // It prints out detailed status information for each clock step
+      /* 
     if (print) {
       cout << "istep = "<<istep<<" projBuff: "<<inputProjBuffer_.rptr()<<" "<<inputProjBuffer_.wptr()<<" "<<projBuffNearFull;
       unsigned int iMEU = 0;
@@ -232,597 +232,597 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
     }
     */
 
-    //First do some caching of state at the start of the clock
+      //First do some caching of state at the start of the clock
 
-    bool projdone = false;
+      bool projdone = false;
 
-    bool projBuffNearFull = inputProjBuffer_.nearfull();
+      bool projBuffNearFull = inputProjBuffer_.nearfull();
 
-    for (unsigned int iME = 0; iME < nMatchEngines_; iME++) {
-      matchengines_[iME].setAlmostFull();
-    }
-
-    //Step 3
-    //Check if we have candidate match to process
-
-    unsigned int iMEbest = 0;
-    int bestTCID = matchengines_[0].TCID();
-    bool meactive = matchengines_[0].active();
-    for (unsigned int iME = 1; iME < nMatchEngines_; iME++) {
-      meactive = meactive || matchengines_[iME].active();
-      int tcid = matchengines_[iME].TCID();
-      if (tcid < bestTCID) {
-        bestTCID = tcid;
-        iMEbest = iME;
-      }
-    }
-
-    // check if the matche engine processing the smallest tcid has match
-
-    if (!matchengines_[iMEbest].empty()) {
-      std::pair<Tracklet*, const Stub*> candmatch = matchengines_[iMEbest].read();
-
-      const Stub* fpgastub = candmatch.second;
-      Tracklet* tracklet = candmatch.first;
-
-      //Consistency check
-      if (oldTracklet != nullptr) {
-        //allow equal here since we can have more than one cadidate match per tracklet projection
-        //cout << "old new : "<<oldTracklet->TCID()<<" "<<tracklet->TCID()<<" "<<iMEbest<<endl;
-        assert(oldTracklet->TCID() <= tracklet->TCID());
-      }
-      oldTracklet = tracklet;
-
-      bool match = matchCalculator(tracklet, fpgastub, print, istep);
-
-      if (settings_.debugTracklet() && match) {
-        edm::LogVerbatim("Tracklet") << getName() << " have match";
+      for (unsigned int iME = 0; iME < nMatchEngines_; iME++) {
+        matchengines_[iME].setAlmostFull();
       }
 
-      countall++;
-      if (match)
-        countsel++;
-    }
+      //Step 3
+      //Check if we have candidate match to process
 
-    //Step 2
-    //Check if we have ME that can process projection
-
-    bool addedProjection = false;
-    for (unsigned int iME = 0; iME < nMatchEngines_; iME++) {
-      if (!matchengines_[iME].idle())
-        countme++;
-      //if match engine empty and we have queued projections add to match engine
-      if ((!addedProjection) && matchengines_[iME].idle() && (!inputProjBuffer_.empty())) {
-        ProjectionTemp tmpProj = inputProjBuffer_.read();
-        VMStubsMEMemory* stubmem = vmstubs_[0];
-
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << getName() << " adding projection to match engine";
+      unsigned int iMEbest = 0;
+      int bestTCID = matchengines_[0].TCID();
+      bool meactive = matchengines_[0].active();
+      for (unsigned int iME = 1; iME < nMatchEngines_; iME++) {
+        meactive = meactive || matchengines_[iME].active();
+        int tcid = matchengines_[iME].TCID();
+        if (tcid < bestTCID) {
+          bestTCID = tcid;
+          iMEbest = iME;
         }
-
-        int nbins = (1 << N_RZBITS);
-        if (layerdisk_ >= N_LAYER) {
-          nbins *= 2;  //twice as many bins in disks (since there are two disks)
-        }
-
-        matchengines_[iME].init(stubmem,
-                                nbins,
-                                tmpProj.slot(),
-                                tmpProj.iphi(),
-                                tmpProj.shift(),
-                                tmpProj.projrinv(),
-                                tmpProj.projfinerz(),
-                                tmpProj.projfinephi(),
-                                tmpProj.use(0, 0),
-                                tmpProj.use(0, 1),
-                                tmpProj.use(1, 0),
-                                tmpProj.use(1, 1),
-                                tmpProj.isPSseed(),
-                                tmpProj.proj());
-        meactive = true;
-        addedProjection = true;
-      } else {
-        matchengines_[iME].step();
       }
-      matchengines_[iME].processPipeline();
-    }
 
-    //Step 1
-    //First step here checks if we have more input projections to put into
-    //the input puffer for projections
+      // check if the matche engine processing the smallest tcid has match
 
-    if (good__) {
-      inputProjBuffer_.store(tmpProj__);
-    }
+      if (!matchengines_[iMEbest].empty()) {
+        std::pair<Tracklet*, const Stub*> candmatch = matchengines_[iMEbest].read();
 
-    good__ = good_;
-    tmpProj__ = tmpProj_;
+        const Stub* fpgastub = candmatch.second;
+        Tracklet* tracklet = candmatch.first;
 
-    good_ = false;
+        //Consistency check
+        if (oldTracklet != nullptr) {
+          //allow equal here since we can have more than one cadidate match per tracklet projection
+          //cout << "old new : "<<oldTracklet->TCID()<<" "<<tracklet->TCID()<<" "<<iMEbest<<endl;
+          assert(oldTracklet->TCID() <= tracklet->TCID());
+        }
+        oldTracklet = tracklet;
 
-    if (iprojmem < inputprojs_.size()) {
-      TrackletProjectionsMemory* projMem = inputprojs_[iprojmem];
-      if (!projBuffNearFull) {
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << getName() << " have projection in memory : " << projMem->getName();
+        bool match = matchCalculator(tracklet, fpgastub, print, istep);
+
+        if (settings_.debugTracklet() && match) {
+          edm::LogVerbatim("Tracklet") << getName() << " have match";
         }
 
-        Tracklet* proj = projMem->getTracklet(iproj);
+        countall++;
+        if (match)
+          countsel++;
+      }
 
-        FPGAWord fpgaphi = proj->proj(layerdisk_).fpgaphiproj();
+      //Step 2
+      //Check if we have ME that can process projection
 
-        unsigned int iphi = (fpgaphi.value() >> (fpgaphi.nbits() - nvmbits_)) & (nvmbins_ - 1);
+      bool addedProjection = false;
+      for (unsigned int iME = 0; iME < nMatchEngines_; iME++) {
+        if (!matchengines_[iME].idle())
+          countme++;
+        //if match engine empty and we have queued projections add to match engine
+        if ((!addedProjection) && matchengines_[iME].idle() && (!inputProjBuffer_.empty())) {
+          ProjectionTemp tmpProj = inputProjBuffer_.read();
+          VMStubsMEMemory* stubmem = vmstubs_[0];
 
-        int nextrabits = 2;
-        int overlapbits = nvmbits_ + nextrabits;
-
-        unsigned int extrabits = fpgaphi.bits(fpgaphi.nbits() - overlapbits - nextrabits, nextrabits);
-
-        unsigned int ivmPlus = iphi;
-
-        int shift = 0;
-
-        if (extrabits == ((1U << nextrabits) - 1) && iphi != ((1U << settings_.nbitsvmme(layerdisk_)) - 1)) {
-          shift = 1;
-          ivmPlus++;
-        }
-        unsigned int ivmMinus = iphi;
-        if (extrabits == 0 && iphi != 0) {
-          shift = -1;
-          ivmMinus--;
-        }
-
-        int projrinv = -1;
-        if (barrel_) {
-          FPGAWord phider = proj->proj(layerdisk_).fpgaphiprojder();
-          projrinv = (1 << (nrinv_ - 1)) - 1 - (phider.value() >> (phider.nbits() - nrinv_));
-        } else {
-          //The next lines looks up the predicted bend based on:
-          // 1 - r projections
-          // 2 - phi derivative
-          // 3 - the sign - i.e. if track is forward or backward
-
-          int rindex =
-              (proj->proj(layerdisk_).fpgarzproj().value() >> (proj->proj(layerdisk_).fpgarzproj().nbits() - nrbits_)) &
-              ((1 << nrbits_) - 1);
-
-          int phiprojder = proj->proj(layerdisk_).fpgaphiprojder().value();
-
-          int phiderindex = (phiprojder >> (proj->proj(layerdisk_).fpgaphiprojder().nbits() - nphiderbits_)) &
-                            ((1 << nphiderbits_) - 1);
-
-          int signindex = proj->proj(layerdisk_).fpgarzprojder().value() < 0;
-
-          int bendindex = (signindex << (nphiderbits_ + nrbits_)) + (rindex << (nphiderbits_)) + phiderindex;
-
-          projrinv = rinvbendlut_.lookup(bendindex);
-
-          proj->proj(layerdisk_).setBendIndex(projrinv);
-        }
-        assert(projrinv >= 0);
-
-        unsigned int projfinephi =
-            (fpgaphi.value() >> (fpgaphi.nbits() - (nvmbits_ + NFINEPHIBITS))) & ((1 << NFINEPHIBITS) - 1);
-
-        unsigned int slot;
-        bool second;
-        int projfinerz;
-
-        if (barrel_) {
-          slot = proj->proj(layerdisk_).fpgarzbin1projvm().value();
-          second = proj->proj(layerdisk_).fpgarzbin2projvm().value();
-          projfinerz = proj->proj(layerdisk_).fpgafinerzvm().value();
-        } else {
-          //The -1 here is due to not using the full range of bits. Should be fixed.
-          unsigned int ir = proj->proj(layerdisk_).fpgarzproj().value() >>
-                            (proj->proj(layerdisk_).fpgarzproj().nbits() - nrprojbits_ - 1);
-          unsigned int word = diskRadius_.lookup(ir);
-
-          slot = (word >> 1) & ((1 << N_RZBITS) - 1);
-          if (proj->proj(layerdisk_).fpgarzprojder().value() < 0) {
-            slot += (1 << N_RZBITS);
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << getName() << " adding projection to match engine";
           }
-          second = word & 1;
-          projfinerz = word >> 4;
+
+          int nbins = (1 << N_RZBITS);
+          if (layerdisk_ >= N_LAYER) {
+            nbins *= 2;  //twice as many bins in disks (since there are two disks)
+          }
+
+          matchengines_[iME].init(stubmem,
+                                  nbins,
+                                  tmpProj.slot(),
+                                  tmpProj.iphi(),
+                                  tmpProj.shift(),
+                                  tmpProj.projrinv(),
+                                  tmpProj.projfinerz(),
+                                  tmpProj.projfinephi(),
+                                  tmpProj.use(0, 0),
+                                  tmpProj.use(0, 1),
+                                  tmpProj.use(1, 0),
+                                  tmpProj.use(1, 1),
+                                  tmpProj.isPSseed(),
+                                  tmpProj.proj());
+          meactive = true;
+          addedProjection = true;
+        } else {
+          matchengines_[iME].step();
+        }
+        matchengines_[iME].processPipeline();
+      }
+
+      //Step 1
+      //First step here checks if we have more input projections to put into
+      //the input puffer for projections
+
+      if (good__) {
+        inputProjBuffer_.store(tmpProj__);
+      }
+
+      good__ = good_;
+      tmpProj__ = tmpProj_;
+
+      good_ = false;
+
+      if (iprojmem < inputprojs_.size()) {
+        TrackletProjectionsMemory* projMem = inputprojs_[iprojmem];
+        if (!projBuffNearFull) {
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << getName() << " have projection in memory : " << projMem->getName();
+          }
+
+          Tracklet* proj = projMem->getTracklet(iproj);
+
+          FPGAWord fpgaphi = proj->proj(layerdisk_).fpgaphiproj();
+
+          unsigned int iphi = (fpgaphi.value() >> (fpgaphi.nbits() - nvmbits_)) & (nvmbins_ - 1);
+
+          int nextrabits = 2;
+          int overlapbits = nvmbits_ + nextrabits;
+
+          unsigned int extrabits = fpgaphi.bits(fpgaphi.nbits() - overlapbits - nextrabits, nextrabits);
+
+          unsigned int ivmPlus = iphi;
+
+          int shift = 0;
+
+          if (extrabits == ((1U << nextrabits) - 1) && iphi != ((1U << settings_.nbitsvmme(layerdisk_)) - 1)) {
+            shift = 1;
+            ivmPlus++;
+          }
+          unsigned int ivmMinus = iphi;
+          if (extrabits == 0 && iphi != 0) {
+            shift = -1;
+            ivmMinus--;
+          }
+
+          int projrinv = -1;
+          if (barrel_) {
+            FPGAWord phider = proj->proj(layerdisk_).fpgaphiprojder();
+            projrinv = (1 << (nrinv_ - 1)) - 1 - (phider.value() >> (phider.nbits() - nrinv_));
+          } else {
+            //The next lines looks up the predicted bend based on:
+            // 1 - r projections
+            // 2 - phi derivative
+            // 3 - the sign - i.e. if track is forward or backward
+
+            int rindex = (proj->proj(layerdisk_).fpgarzproj().value() >>
+                          (proj->proj(layerdisk_).fpgarzproj().nbits() - nrbits_)) &
+                         ((1 << nrbits_) - 1);
+
+            int phiprojder = proj->proj(layerdisk_).fpgaphiprojder().value();
+
+            int phiderindex = (phiprojder >> (proj->proj(layerdisk_).fpgaphiprojder().nbits() - nphiderbits_)) &
+                              ((1 << nphiderbits_) - 1);
+
+            int signindex = proj->proj(layerdisk_).fpgarzprojder().value() < 0;
+
+            int bendindex = (signindex << (nphiderbits_ + nrbits_)) + (rindex << (nphiderbits_)) + phiderindex;
+
+            projrinv = rinvbendlut_.lookup(bendindex);
+
+            proj->proj(layerdisk_).setBendIndex(projrinv);
+          }
+          assert(projrinv >= 0);
+
+          unsigned int projfinephi =
+              (fpgaphi.value() >> (fpgaphi.nbits() - (nvmbits_ + NFINEPHIBITS))) & ((1 << NFINEPHIBITS) - 1);
+
+          unsigned int slot;
+          bool second;
+          int projfinerz;
+
+          if (barrel_) {
+            slot = proj->proj(layerdisk_).fpgarzbin1projvm().value();
+            second = proj->proj(layerdisk_).fpgarzbin2projvm().value();
+            projfinerz = proj->proj(layerdisk_).fpgafinerzvm().value();
+          } else {
+            //The -1 here is due to not using the full range of bits. Should be fixed.
+            unsigned int ir = proj->proj(layerdisk_).fpgarzproj().value() >>
+                              (proj->proj(layerdisk_).fpgarzproj().nbits() - nrprojbits_ - 1);
+            unsigned int word = diskRadius_.lookup(ir);
+
+            slot = (word >> 1) & ((1 << N_RZBITS) - 1);
+            if (proj->proj(layerdisk_).fpgarzprojder().value() < 0) {
+              slot += (1 << N_RZBITS);
+            }
+            second = word & 1;
+            projfinerz = word >> 4;
+          }
+
+          bool isPSseed = proj->PSseed();
+
+          int nbins = (1 << N_RZBITS);
+          if (layerdisk_ >= N_LAYER) {
+            nbins *= 2;  //twice as many bins in disks (since there are two disks)
+          }
+
+          VMStubsMEMemory* stubmem = vmstubs_[0];
+          bool usefirstMinus = stubmem->nStubsBin(ivmMinus * nbins + slot) != 0;
+          bool usesecondMinus = (second && (stubmem->nStubsBin(ivmMinus * nbins + slot + 1) != 0));
+          bool usefirstPlus = ivmPlus != ivmMinus && stubmem->nStubsBin(ivmPlus * nbins + slot) != 0;
+          bool usesecondPlus = ivmPlus != ivmMinus && (second && (stubmem->nStubsBin(ivmPlus * nbins + slot + 1) != 0));
+
+          good_ = usefirstPlus || usesecondPlus || usefirstMinus || usesecondMinus;
+
+          if (good_) {
+            ProjectionTemp tmpProj(proj,
+                                   slot,
+                                   projrinv,
+                                   projfinerz,
+                                   projfinephi,
+                                   ivmMinus,
+                                   shift,
+                                   usefirstMinus,
+                                   usefirstPlus,
+                                   usesecondMinus,
+                                   usesecondPlus,
+                                   isPSseed);
+            tmpProj_ = tmpProj;
+          }
+
+          iproj++;
+          if (iproj == projMem->nTracklets()) {
+            iproj = 0;
+            do {
+              iprojmem++;
+            } while (iprojmem < inputprojs_.size() && inputprojs_[iprojmem]->nTracklets() == 0);
+          }
+
+        } else {
+          projdone = true && !good_ && !good__;
+        }
+      }
+
+      //
+      //  Check if done
+      //
+      //
+      //
+
+      if ((projdone && !meactive && inputProjBuffer_.rptr() == inputProjBuffer_.wptr()) ||
+          (istep == settings_.maxStep("MP") - 1)) {
+        if (settings_.writeMonitorData("MP")) {
+          globals_->ofstream("matchprocessor.txt") << getName() << " " << istep << " " << countall << " " << countsel
+                                                   << " " << countme << " " << countinputproj << endl;
+        }
+        break;
+      }
+    }
+
+    if (settings_.writeMonitorData("MC")) {
+      globals_->ofstream("matchcalculator.txt") << getName() << " " << countall << " " << countsel << endl;
+    }
+  }
+
+  bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, bool, unsigned int istep) {
+    const L1TStub* stub = fpgastub->l1tstub();
+
+    if (layerdisk_ < N_LAYER) {
+      const Projection& proj = tracklet->proj(layerdisk_);
+      int ir = fpgastub->r().value();
+      int iphi = proj.fpgaphiproj().value();
+      int icorr = (ir * proj.fpgaphiprojder().value()) >> icorrshift_;
+      iphi += icorr;
+
+      int iz = proj.fpgarzproj().value();
+      int izcor = (ir * proj.fpgarzprojder().value() + (1 << (icorzshift_ - 1))) >> icorzshift_;
+      iz += izcor;
+
+      int ideltaz = fpgastub->z().value() - iz;
+      int ideltaphi = (fpgastub->phi().value() - iphi) << phishift_;
+
+      //Floating point calculations
+
+      double phi = stub->phi();
+      double r = stub->r();
+      double z = stub->z();
+
+      if (settings_.useapprox()) {
+        double dphi = reco::reduceRange(phi - fpgastub->phiapprox(phimin_, 0.0));
+        assert(std::abs(dphi) < 0.001);
+        phi = fpgastub->phiapprox(phimin_, 0.0);
+        z = fpgastub->zapprox();
+        r = fpgastub->rapprox();
+      }
+
+      if (phi < 0)
+        phi += 2 * M_PI;
+      phi -= phimin_;
+
+      double dr = r - settings_.rmean(layerdisk_);
+      assert(std::abs(dr) < settings_.drmax());
+
+      double dphi = reco::reduceRange(phi - (proj.phiproj() + dr * proj.phiprojder()));
+
+      double dz = z - (proj.rzproj() + dr * proj.rzprojder());
+
+      double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dr * proj.phiprojderapprox()));
+
+      double dzapprox = z - (proj.rzprojapprox() + dr * proj.rzprojderapprox());
+
+      int seedindex = tracklet->getISeed();
+      curr_tracklet = next_tracklet;
+      next_tracklet = tracklet;
+
+      // Do we have a new tracklet?
+      bool newtracklet = (istep == 0 || tracklet != curr_tracklet);
+      if (istep == 0)
+        best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
+      // If so, replace the "best" values with the cut tables
+      if (newtracklet) {
+        best_ideltaphi_barrel = (int)phimatchcuttable_.lookup(seedindex);
+        best_ideltaz_barrel = (int)zmatchcuttable_.lookup(seedindex);
+      }
+
+      assert(phimatchcuttable_.lookup(seedindex) > 0);
+      assert(zmatchcuttable_.lookup(seedindex) > 0);
+
+      if (settings_.bookHistos()) {
+        bool truthmatch = tracklet->stubtruthmatch(stub);
+
+        HistBase* hists = globals_->histograms();
+        hists->FillLayerResidual(layerdisk_ + 1,
+                                 seedindex,
+                                 dphiapprox * settings_.rmean(layerdisk_),
+                                 ideltaphi * settings_.kphi1() * settings_.rmean(layerdisk_),
+                                 (ideltaz << dzshift_) * settings_.kz(),
+                                 dz,
+                                 truthmatch);
+      }
+
+      if (settings_.writeMonitorData("Residuals")) {
+        double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
+
+        globals_->ofstream("layerresiduals.txt")
+            << layerdisk_ + 1 << " " << seedindex << " " << pt << " "
+            << ideltaphi * settings_.kphi1() * settings_.rmean(layerdisk_) << " "
+            << dphiapprox * settings_.rmean(layerdisk_) << " "
+            << phimatchcuttable_.lookup(seedindex) * settings_.kphi1() * settings_.rmean(layerdisk_) << "   "
+            << (ideltaz << dzshift_) * settings_.kz() << " " << dz << " "
+            << zmatchcuttable_.lookup(seedindex) * settings_.kz() << endl;
+      }
+
+      bool imatch = (std::abs(ideltaphi) <= best_ideltaphi_barrel && (ideltaz << dzshift_ < best_ideltaz_barrel) &&
+                     (ideltaz << dzshift_ >= -best_ideltaz_barrel));
+      // Update the "best" values
+      if (imatch) {
+        best_ideltaphi_barrel = std::abs(ideltaphi);
+        best_ideltaz_barrel = std::abs(ideltaz);
+      }
+
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << getName() << " imatch = " << imatch << " ideltaphi cut " << ideltaphi << " "
+                                     << phimatchcuttable_.lookup(seedindex) << " ideltaz<<dzshift cut "
+                                     << (ideltaz << dzshift_) << " " << zmatchcuttable_.lookup(seedindex);
+      }
+
+      //This would catch significant consistency problems in the configuration - helps to debug if there are problems.
+      if (std::abs(dphi) > 0.5 * settings_.dphisectorHG() || std::abs(dphiapprox) > 0.5 * settings_.dphisectorHG()) {
+        throw cms::Exception("LogicError")
+            << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox << endl;
+      }
+
+      bool keep = true;
+      if (!settings_.doKF() || !settings_.doMultipleMatches()) {
+        // Case of allowing only one stub per track per layer (or no KF which implies the same).
+        if (imatch && tracklet->match(layerdisk_)) {
+          // Veto match if is not the best one for this tracklet (in given layer)
+          auto res = tracklet->resid(layerdisk_);
+          keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
+          imatch = keep;
+        }
+      }
+
+      if (imatch) {
+        tracklet->addMatch(layerdisk_,
+                           ideltaphi,
+                           ideltaz,
+                           dphi,
+                           dz,
+                           dphiapprox,
+                           dzapprox,
+                           (phiregion_ << N_BITSMEMADDRESS) + fpgastub->stubindex().value(),
+                           fpgastub);
+
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << "Accepted full match in layer " << getName() << " " << tracklet;
         }
 
-        bool isPSseed = proj->PSseed();
+        int iSeed = tracklet->getISeed();
+        assert(fullmatches_[iSeed] != nullptr);
+        fullmatches_[iSeed]->addMatch(tracklet, fpgastub);
 
-        int nbins = (1 << N_RZBITS);
-        if (layerdisk_ >= N_LAYER) {
-          nbins *= 2;  //twice as many bins in disks (since there are two disks)
-        }
-
-        VMStubsMEMemory* stubmem = vmstubs_[0];
-        bool usefirstMinus = stubmem->nStubsBin(ivmMinus * nbins + slot) != 0;
-        bool usesecondMinus = (second && (stubmem->nStubsBin(ivmMinus * nbins + slot + 1) != 0));
-        bool usefirstPlus = ivmPlus != ivmMinus && stubmem->nStubsBin(ivmPlus * nbins + slot) != 0;
-        bool usesecondPlus = ivmPlus != ivmMinus && (second && (stubmem->nStubsBin(ivmPlus * nbins + slot + 1) != 0));
-
-        good_ = usefirstPlus || usesecondPlus || usefirstMinus || usesecondMinus;
-
-        if (good_) {
-          ProjectionTemp tmpProj(proj,
-                                 slot,
-                                 projrinv,
-                                 projfinerz,
-                                 projfinephi,
-                                 ivmMinus,
-                                 shift,
-                                 usefirstMinus,
-                                 usefirstPlus,
-                                 usesecondMinus,
-                                 usesecondPlus,
-                                 isPSseed);
-          tmpProj_ = tmpProj;
-        }
-
-        iproj++;
-        if (iproj == projMem->nTracklets()) {
-          iproj = 0;
-          do {
-            iprojmem++;
-          } while (iprojmem < inputprojs_.size() && inputprojs_[iprojmem]->nTracklets() == 0);
-        }
-
+        return true;
       } else {
-        projdone = true && !good_ && !good__;
+        return false;
       }
-    }
+    } else {  //disk matches
 
-    //
-    //  Check if done
-    //
-    //
-    //
+      //check that stubs and projections in same half of detector
+      assert(stub->z() * tracklet->t() > 0.0);
 
-    if ((projdone && !meactive && inputProjBuffer_.rptr() == inputProjBuffer_.wptr()) ||
-        (istep == settings_.maxStep("MP") - 1)) {
-      if (settings_.writeMonitorData("MP")) {
-        globals_->ofstream("matchprocessor.txt") << getName() << " " << istep << " " << countall << " " << countsel
-                                                 << " " << countme << " " << countinputproj << endl;
+      int sign = (tracklet->t() > 0.0) ? 1 : -1;
+      int disk = sign * (layerdisk_ - N_LAYER + 1);
+      assert(disk != 0);
+
+      //Perform integer calculations here
+
+      int iz = fpgastub->z().value();
+
+      const Projection& proj = tracklet->proj(layerdisk_);
+
+      int iphi = proj.fpgaphiproj().value();
+      int iphicorr = (iz * proj.fpgaphiprojder().value()) >> icorrshift_;
+
+      iphi += iphicorr;
+
+      int ir = proj.fpgarzproj().value();
+      int ircorr = (iz * proj.fpgarzprojder().value()) >> icorzshift_;
+      ir += ircorr;
+
+      int ideltaphi = fpgastub->phi().value() - iphi;
+
+      int irstub = fpgastub->r().value();
+      int ialphafact = 0;
+      if (!stub->isPSmodule()) {
+        assert(irstub < (int)N_DSS_MOD * 2);
+        if (layerdisk_ - N_LAYER <= 1) {
+          ialphafact = ialphafactinner_[irstub];
+          irstub = settings_.rDSSinner(irstub) / settings_.kr();
+        } else {
+          ialphafact = ialphafactouter_[irstub];
+          irstub = settings_.rDSSouter(irstub) / settings_.kr();
+        }
       }
-      break;
-    }
-  }
 
-  if (settings_.writeMonitorData("MC")) {
-    globals_->ofstream("matchcalculator.txt") << getName() << " " << countall << " " << countsel << endl;
-  }
-}
+      int ideltar = (irstub * settings_.kr()) / settings_.krprojshiftdisk() - ir;
 
-bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, bool, unsigned int istep) {
-  const L1TStub* stub = fpgastub->l1tstub();
-
-  if (layerdisk_ < N_LAYER) {
-    const Projection& proj = tracklet->proj(layerdisk_);
-    int ir = fpgastub->r().value();
-    int iphi = proj.fpgaphiproj().value();
-    int icorr = (ir * proj.fpgaphiprojder().value()) >> icorrshift_;
-    iphi += icorr;
-
-    int iz = proj.fpgarzproj().value();
-    int izcor = (ir * proj.fpgarzprojder().value() + (1 << (icorzshift_ - 1))) >> icorzshift_;
-    iz += izcor;
-
-    int ideltaz = fpgastub->z().value() - iz;
-    int ideltaphi = (fpgastub->phi().value() - iphi) << phishift_;
-
-    //Floating point calculations
-
-    double phi = stub->phi();
-    double r = stub->r();
-    double z = stub->z();
-
-    if (settings_.useapprox()) {
-      double dphi = reco::reduceRange(phi - fpgastub->phiapprox(phimin_, 0.0));
-      assert(std::abs(dphi) < 0.001);
-      phi = fpgastub->phiapprox(phimin_, 0.0);
-      z = fpgastub->zapprox();
-      r = fpgastub->rapprox();
-    }
-
-    if (phi < 0)
-      phi += 2 * M_PI;
-    phi -= phimin_;
-
-    double dr = r - settings_.rmean(layerdisk_);
-    assert(std::abs(dr) < settings_.drmax());
-
-    double dphi = reco::reduceRange(phi - (proj.phiproj() + dr * proj.phiprojder()));
-
-    double dz = z - (proj.rzproj() + dr * proj.rzprojder());
-
-    double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dr * proj.phiprojderapprox()));
-
-    double dzapprox = z - (proj.rzprojapprox() + dr * proj.rzprojderapprox());
-
-    int seedindex = tracklet->getISeed();
-    curr_tracklet = next_tracklet;
-    next_tracklet = tracklet;
-
-    // Do we have a new tracklet?
-    bool newtracklet = (istep == 0 || tracklet != curr_tracklet);
-    if (istep == 0)
-      best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
-    // If so, replace the "best" values with the cut tables
-    if (newtracklet) {
-      best_ideltaphi_barrel = (int)phimatchcuttable_.lookup(seedindex);
-      best_ideltaz_barrel = (int)zmatchcuttable_.lookup(seedindex);
-    }
-
-    assert(phimatchcuttable_.lookup(seedindex) > 0);
-    assert(zmatchcuttable_.lookup(seedindex) > 0);
-
-    if (settings_.bookHistos()) {
-      bool truthmatch = tracklet->stubtruthmatch(stub);
-
-      HistBase* hists = globals_->histograms();
-      hists->FillLayerResidual(layerdisk_ + 1,
-                               seedindex,
-                               dphiapprox * settings_.rmean(layerdisk_),
-                               ideltaphi * settings_.kphi1() * settings_.rmean(layerdisk_),
-                               (ideltaz << dzshift_) * settings_.kz(),
-                               dz,
-                               truthmatch);
-    }
-
-    if (settings_.writeMonitorData("Residuals")) {
-      double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
-
-      globals_->ofstream("layerresiduals.txt")
-          << layerdisk_ + 1 << " " << seedindex << " " << pt << " "
-          << ideltaphi * settings_.kphi1() * settings_.rmean(layerdisk_) << " "
-          << dphiapprox * settings_.rmean(layerdisk_) << " "
-          << phimatchcuttable_.lookup(seedindex) * settings_.kphi1() * settings_.rmean(layerdisk_) << "   "
-          << (ideltaz << dzshift_) * settings_.kz() << " " << dz << " "
-          << zmatchcuttable_.lookup(seedindex) * settings_.kz() << endl;
-    }
-
-    bool imatch = (std::abs(ideltaphi) <= best_ideltaphi_barrel && (ideltaz << dzshift_ < best_ideltaz_barrel) &&
-                   (ideltaz << dzshift_ >= -best_ideltaz_barrel));
-    // Update the "best" values
-    if (imatch) {
-      best_ideltaphi_barrel = std::abs(ideltaphi);
-      best_ideltaz_barrel = std::abs(ideltaz);
-    }
-
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << getName() << " imatch = " << imatch << " ideltaphi cut " << ideltaphi << " "
-                                   << phimatchcuttable_.lookup(seedindex) << " ideltaz<<dzshift cut "
-                                   << (ideltaz << dzshift_) << " " << zmatchcuttable_.lookup(seedindex);
-    }
-
-    //This would catch significant consistency problems in the configuration - helps to debug if there are problems.
-    if (std::abs(dphi) > 0.5 * settings_.dphisectorHG() || std::abs(dphiapprox) > 0.5 * settings_.dphisectorHG()) {
-      throw cms::Exception("LogicError") << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox
-                                         << endl;
-    }
-
-    bool keep = true;
-    if (!settings_.doKF() || !settings_.doMultipleMatches()) {
-      // Case of allowing only one stub per track per layer (or no KF which implies the same).
-      if (imatch && tracklet->match(layerdisk_)) {
-        // Veto match if is not the best one for this tracklet (in given layer)
-        auto res = tracklet->resid(layerdisk_);
-        keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
-        imatch = keep;
+      if (!stub->isPSmodule()) {
+        int ialpha = fpgastub->alpha().value();
+        int iphialphacor = ((ideltar * ialpha * ialphafact) >> settings_.alphashift());
+        ideltaphi += iphialphacor;
       }
-    }
 
-    if (imatch) {
-      tracklet->addMatch(layerdisk_,
-                         ideltaphi,
-                         ideltaz,
-                         dphi,
-                         dz,
-                         dphiapprox,
-                         dzapprox,
-                         (phiregion_ << N_BITSMEMADDRESS) + fpgastub->stubindex().value(),
-                         fpgastub);
+      //Perform floating point calculations here
+
+      double phi = stub->phi();
+      double z = stub->z();
+      double r = stub->r();
+
+      if (settings_.useapprox()) {
+        double dphi = reco::reduceRange(phi - fpgastub->phiapprox(phimin_, 0.0));
+        assert(std::abs(dphi) < 0.001);
+        phi = fpgastub->phiapprox(phimin_, 0.0);
+        z = fpgastub->zapprox();
+        r = fpgastub->rapprox();
+      }
+
+      if (phi < 0)
+        phi += 2 * M_PI;
+      phi -= phimin_;
+
+      double dz = z - sign * settings_.zmean(layerdisk_ - N_LAYER);
+
+      if (std::abs(dz) > settings_.dzmax()) {
+        edm::LogProblem("Tracklet") << __FILE__ << ":" << __LINE__ << " " << name_ << " " << tracklet->getISeed();
+        edm::LogProblem("Tracklet") << "stub " << stub->z() << " disk " << disk << " " << dz;
+        assert(std::abs(dz) < settings_.dzmax());
+      }
+
+      double phiproj = proj.phiproj() + dz * proj.phiprojder();
+      double rproj = proj.rzproj() + dz * proj.rzprojder();
+      double deltar = r - rproj;
+
+      double dr = stub->r() - rproj;
+      double drapprox = stub->r() - (proj.rzprojapprox() + dz * proj.rzprojderapprox());
+
+      double dphi = reco::reduceRange(phi - phiproj);
+
+      double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dz * proj.phiprojderapprox()));
+
+      double drphi = dphi * stub->r();
+      double drphiapprox = dphiapprox * stub->r();
+
+      if (!stub->isPSmodule()) {
+        double alphanorm = stub->alphanorm();
+        dphi += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r2();
+        ;
+        dphiapprox += drapprox * alphanorm * settings_.half2SmoduleWidth() / stub->r2();
+
+        drphi += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r();
+        drphiapprox += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r();
+      }
+
+      int seedindex = tracklet->getISeed();
+
+      int idrphicut = rphicutPStable_.lookup(seedindex);
+      int idrcut = rcutPStable_.lookup(seedindex);
+      if (!stub->isPSmodule()) {
+        idrphicut = rphicut2Stable_.lookup(seedindex);
+        idrcut = rcut2Stable_.lookup(seedindex);
+      }
+
+      curr_tracklet = next_tracklet;
+      next_tracklet = tracklet;
+      // Do we have a new tracklet?
+      bool newtracklet = (istep == 0 || tracklet != curr_tracklet);
+      if (istep == 0)
+        best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
+      // If so, replace the "best" values with the cut tables
+      if (newtracklet) {
+        best_ideltaphi_disk = idrphicut;
+        best_ideltar_disk = idrcut;
+      }
+
+      double drphicut = idrphicut * settings_.kphi() * settings_.kr();
+      double drcut = idrcut * settings_.krprojshiftdisk();
+
+      if (settings_.writeMonitorData("Residuals")) {
+        double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
+
+        globals_->ofstream("diskresiduals.txt")
+            << layerdisk_ - N_LAYER + 1 << " " << stub->isPSmodule() << " " << tracklet->layer() << " "
+            << abs(tracklet->disk()) << " " << pt << " " << ideltaphi * settings_.kphi() * stub->r() << " "
+            << drphiapprox << " " << drphicut << " " << ideltar * settings_.krprojshiftdisk() << " " << deltar << " "
+            << drcut << " " << endl;
+      }
+
+      bool match = (std::abs(drphi) < drphicut) && (std::abs(deltar) < drcut);
+      bool imatch = (std::abs(ideltaphi * irstub) < best_ideltaphi_disk) && (std::abs(ideltar) < best_ideltar_disk);
+      // Update the "best" values
+      if (imatch) {
+        best_ideltaphi_disk = std::abs(ideltaphi) * irstub;
+        best_ideltar_disk = std::abs(ideltar);
+      }
 
       if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "Accepted full match in layer " << getName() << " " << tracklet;
+        edm::LogVerbatim("Tracklet") << "imatch match disk: " << imatch << " " << match << " " << std::abs(ideltaphi)
+                                     << " " << drphicut / (settings_.kphi() * stub->r()) << " " << std::abs(ideltar)
+                                     << " " << drcut / settings_.krprojshiftdisk() << " r = " << stub->r();
       }
 
-      int iSeed = tracklet->getISeed();
-      assert(fullmatches_[iSeed] != nullptr);
-      fullmatches_[iSeed]->addMatch(tracklet, fpgastub);
+      bool keep = true;
+      if (!settings_.doKF() || !settings_.doMultipleMatches()) {
+        // Case of allowing only one stub per track per layer (or no KF which implies the same).
+        if (imatch && tracklet->match(layerdisk_)) {
+          // Veto match if is not the best one for this tracklet (in given layer)
+          auto res = tracklet->resid(layerdisk_);
+          keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
+          imatch = keep;
+        }
+      }
 
-      return true;
-    } else {
-      return false;
-    }
-  } else {  //disk matches
+      if (imatch) {
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << "MatchCalculator found match in disk " << getName();
+        }
 
-    //check that stubs and projections in same half of detector
-    assert(stub->z() * tracklet->t() > 0.0);
+        if (std::abs(dphi) >= third * settings_.dphisectorHG()) {
+          edm::LogPrint("Tracklet") << "dphi " << dphi << " ISeed " << tracklet->getISeed();
+        }
+        assert(std::abs(dphi) < third * settings_.dphisectorHG());
+        assert(std::abs(dphiapprox) < third * settings_.dphisectorHG());
 
-    int sign = (tracklet->t() > 0.0) ? 1 : -1;
-    int disk = sign * (layerdisk_ - N_LAYER + 1);
-    assert(disk != 0);
+        tracklet->addMatch(layerdisk_,
+                           ideltaphi,
+                           ideltar,
+                           drphi / stub->r(),
+                           dr,
+                           drphiapprox / stub->r(),
+                           drapprox,
+                           (phiregion_ << N_BITSMEMADDRESS) + fpgastub->stubindex().value(),
+                           fpgastub);
 
-    //Perform integer calculations here
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << "Accepted full match in disk " << getName() << " " << tracklet;
+        }
 
-    int iz = fpgastub->z().value();
+        int iSeed = tracklet->getISeed();
+        assert(fullmatches_[iSeed] != nullptr);
+        fullmatches_[iSeed]->addMatch(tracklet, fpgastub);
 
-    const Projection& proj = tracklet->proj(layerdisk_);
-
-    int iphi = proj.fpgaphiproj().value();
-    int iphicorr = (iz * proj.fpgaphiprojder().value()) >> icorrshift_;
-
-    iphi += iphicorr;
-
-    int ir = proj.fpgarzproj().value();
-    int ircorr = (iz * proj.fpgarzprojder().value()) >> icorzshift_;
-    ir += ircorr;
-
-    int ideltaphi = fpgastub->phi().value() - iphi;
-
-    int irstub = fpgastub->r().value();
-    int ialphafact = 0;
-    if (!stub->isPSmodule()) {
-      assert(irstub < (int)N_DSS_MOD * 2);
-      if (layerdisk_ - N_LAYER <= 1) {
-        ialphafact = ialphafactinner_[irstub];
-        irstub = settings_.rDSSinner(irstub) / settings_.kr();
+        return true;
       } else {
-        ialphafact = ialphafactouter_[irstub];
-        irstub = settings_.rDSSouter(irstub) / settings_.kr();
+        return false;
       }
-    }
-
-    int ideltar = (irstub * settings_.kr()) / settings_.krprojshiftdisk() - ir;
-
-    if (!stub->isPSmodule()) {
-      int ialpha = fpgastub->alpha().value();
-      int iphialphacor = ((ideltar * ialpha * ialphafact) >> settings_.alphashift());
-      ideltaphi += iphialphacor;
-    }
-
-    //Perform floating point calculations here
-
-    double phi = stub->phi();
-    double z = stub->z();
-    double r = stub->r();
-
-    if (settings_.useapprox()) {
-      double dphi = reco::reduceRange(phi - fpgastub->phiapprox(phimin_, 0.0));
-      assert(std::abs(dphi) < 0.001);
-      phi = fpgastub->phiapprox(phimin_, 0.0);
-      z = fpgastub->zapprox();
-      r = fpgastub->rapprox();
-    }
-
-    if (phi < 0)
-      phi += 2 * M_PI;
-    phi -= phimin_;
-
-    double dz = z - sign * settings_.zmean(layerdisk_ - N_LAYER);
-
-    if (std::abs(dz) > settings_.dzmax()) {
-      edm::LogProblem("Tracklet") << __FILE__ << ":" << __LINE__ << " " << name_ << " " << tracklet->getISeed();
-      edm::LogProblem("Tracklet") << "stub " << stub->z() << " disk " << disk << " " << dz;
-      assert(std::abs(dz) < settings_.dzmax());
-    }
-
-    double phiproj = proj.phiproj() + dz * proj.phiprojder();
-    double rproj = proj.rzproj() + dz * proj.rzprojder();
-    double deltar = r - rproj;
-
-    double dr = stub->r() - rproj;
-    double drapprox = stub->r() - (proj.rzprojapprox() + dz * proj.rzprojderapprox());
-
-    double dphi = reco::reduceRange(phi - phiproj);
-
-    double dphiapprox = reco::reduceRange(phi - (proj.phiprojapprox() + dz * proj.phiprojderapprox()));
-
-    double drphi = dphi * stub->r();
-    double drphiapprox = dphiapprox * stub->r();
-
-    if (!stub->isPSmodule()) {
-      double alphanorm = stub->alphanorm();
-      dphi += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r2();
-      ;
-      dphiapprox += drapprox * alphanorm * settings_.half2SmoduleWidth() / stub->r2();
-
-      drphi += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r();
-      drphiapprox += dr * alphanorm * settings_.half2SmoduleWidth() / stub->r();
-    }
-
-    int seedindex = tracklet->getISeed();
-
-    int idrphicut = rphicutPStable_.lookup(seedindex);
-    int idrcut = rcutPStable_.lookup(seedindex);
-    if (!stub->isPSmodule()) {
-      idrphicut = rphicut2Stable_.lookup(seedindex);
-      idrcut = rcut2Stable_.lookup(seedindex);
-    }
-
-    curr_tracklet = next_tracklet;
-    next_tracklet = tracklet;
-    // Do we have a new tracklet?
-    bool newtracklet = (istep == 0 || tracklet != curr_tracklet);
-    if (istep == 0)
-      best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
-    // If so, replace the "best" values with the cut tables
-    if (newtracklet) {
-      best_ideltaphi_disk = idrphicut;
-      best_ideltar_disk = idrcut;
-    }
-
-    double drphicut = idrphicut * settings_.kphi() * settings_.kr();
-    double drcut = idrcut * settings_.krprojshiftdisk();
-
-    if (settings_.writeMonitorData("Residuals")) {
-      double pt = 0.01 * settings_.c() * settings_.bfield() / std::abs(tracklet->rinv());
-
-      globals_->ofstream("diskresiduals.txt")
-          << layerdisk_ - N_LAYER + 1 << " " << stub->isPSmodule() << " " << tracklet->layer() << " "
-          << abs(tracklet->disk()) << " " << pt << " " << ideltaphi * settings_.kphi() * stub->r() << " " << drphiapprox
-          << " " << drphicut << " " << ideltar * settings_.krprojshiftdisk() << " " << deltar << " " << drcut << " "
-          << endl;
-    }
-
-    bool match = (std::abs(drphi) < drphicut) && (std::abs(deltar) < drcut);
-    bool imatch = (std::abs(ideltaphi * irstub) < best_ideltaphi_disk) && (std::abs(ideltar) < best_ideltar_disk);
-    // Update the "best" values
-    if (imatch) {
-      best_ideltaphi_disk = std::abs(ideltaphi) * irstub;
-      best_ideltar_disk = std::abs(ideltar);
-    }
-
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << "imatch match disk: " << imatch << " " << match << " " << std::abs(ideltaphi)
-                                   << " " << drphicut / (settings_.kphi() * stub->r()) << " " << std::abs(ideltar)
-                                   << " " << drcut / settings_.krprojshiftdisk() << " r = " << stub->r();
-    }
-
-    bool keep = true;
-    if (!settings_.doKF() || !settings_.doMultipleMatches()) {
-      // Case of allowing only one stub per track per layer (or no KF which implies the same).
-      if (imatch && tracklet->match(layerdisk_)) {
-        // Veto match if is not the best one for this tracklet (in given layer)
-        auto res = tracklet->resid(layerdisk_);
-        keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
-        imatch = keep;
-      }
-    }
-
-    if (imatch) {
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "MatchCalculator found match in disk " << getName();
-      }
-
-      if (std::abs(dphi) >= third * settings_.dphisectorHG()) {
-        edm::LogPrint("Tracklet") << "dphi " << dphi << " ISeed " << tracklet->getISeed();
-      }
-      assert(std::abs(dphi) < third * settings_.dphisectorHG());
-      assert(std::abs(dphiapprox) < third * settings_.dphisectorHG());
-
-      tracklet->addMatch(layerdisk_,
-                         ideltaphi,
-                         ideltar,
-                         drphi / stub->r(),
-                         dr,
-                         drphiapprox / stub->r(),
-                         drapprox,
-                         (phiregion_ << N_BITSMEMADDRESS) + fpgastub->stubindex().value(),
-                         fpgastub);
-
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "Accepted full match in disk " << getName() << " " << tracklet;
-      }
-
-      int iSeed = tracklet->getISeed();
-      assert(fullmatches_[iSeed] != nullptr);
-      fullmatches_[iSeed]->addMatch(tracklet, fpgastub);
-
-      return true;
-    } else {
-      return false;
     }
   }
-}
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -23,7 +23,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 MatchProcessor::MatchProcessor(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global),
@@ -822,4 +823,6 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
       return false;
     }
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
@@ -8,8 +8,9 @@
 #include <filesystem>
 #include <sstream>
 
-using namespace trklet;
 using namespace std;
+
+namespace trklet {
 
 MemoryBase::MemoryBase(string name, Settings const& settings) : name_(name), settings_(settings) {
   iSector_ = 0;
@@ -112,4 +113,6 @@ std::string MemoryBase::hexstr(unsigned int index) {
   std::ostringstream oss;
   oss << "0x" << std::setfill('0') << std::setw(2) << hex << index << dec;
   return oss.str();
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
@@ -12,107 +12,107 @@ using namespace std;
 
 namespace trklet {
 
-MemoryBase::MemoryBase(string name, Settings const& settings) : name_(name), settings_(settings) {
-  iSector_ = 0;
-  bx_ = 0;
-  event_ = 0;
-}
-
-void MemoryBase::initLayerDisk(unsigned int pos, int& layer, int& disk) {
-  string subname = name_.substr(pos, 2);
-  layer = 0;
-  disk = 0;
-
-  if (subname.substr(0, 1) == "L")
-    layer = stoi(subname.substr(1, 1));
-  else if (subname.substr(0, 1) == "D")
-    disk = stoi(subname.substr(1, 1));
-  else
-    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " name = " << name_ << " subname = " << subname
-                                      << " " << layer << " " << disk;
-}
-
-unsigned int MemoryBase::initLayerDisk(unsigned int pos) {
-  int layer, disk;
-  initLayerDisk(pos, layer, disk);
-
-  if (disk > 0)
-    return N_DISK + disk;
-  return layer - 1;
-}
-
-void MemoryBase::initSpecialSeeding(unsigned int pos, bool& overlap, bool& extra, bool& extended) {
-  overlap = false;
-  extra = false;
-  extended = false;
-
-  char subname = name_[pos];
-
-  static const std::set<char> overlapset = {
-      'X', 'Y', 'W', 'Q', 'R', 'S', 'T', 'Z', 'x', 'y', 'w', 'q', 'r', 's', 't', 'z'};
-  overlap = overlapset.find(subname) != overlapset.end();
-
-  static const std::set<char> extraset = {'I', 'J', 'K', 'L'};
-  extra = extraset.find(subname) != extraset.end();
-
-  static const std::set<char> extendedset = {
-      'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'x', 'y', 'z', 'w', 'q', 'r', 's', 't'};
-  extended = extendedset.find(subname) != extendedset.end();
-}
-
-void MemoryBase::findAndReplaceAll(std::string& data, std::string toSearch, std::string replaceStr) {
-  // Get the first occurrence
-  size_t pos = data.find(toSearch);
-
-  // Repeat till end is reached
-  while (pos != std::string::npos) {
-    // Replace this occurrence of Sub String
-    data.replace(pos, toSearch.size(), replaceStr);
-    // Get the next occurrence from the current position
-    pos = data.find(toSearch, pos + replaceStr.size());
-  }
-}
-
-void MemoryBase::openFile(bool first, std::string dirName, std::string filebase) {
-  std::string fname = filebase + getName();
-
-  findAndReplaceAll(fname, "PHIa", "PHIaa");
-  findAndReplaceAll(fname, "PHIb", "PHIbb");
-  findAndReplaceAll(fname, "PHIc", "PHIcc");
-  findAndReplaceAll(fname, "PHId", "PHIdd");
-
-  findAndReplaceAll(fname, "PHIx", "PHIxx");
-  findAndReplaceAll(fname, "PHIy", "PHIyy");
-  findAndReplaceAll(fname, "PHIz", "PHIzz");
-  findAndReplaceAll(fname, "PHIw", "PHIww");
-
-  fname += "_";
-  if (iSector_ + 1 < 10)
-    fname += "0";
-  fname += std::to_string(iSector_ + 1);
-  fname += ".dat";
-
-  openfile(out_, first, dirName, dirName + fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
-
-  bx_++;
-  event_++;
-  if (bx_ > 7)
+  MemoryBase::MemoryBase(string name, Settings const& settings) : name_(name), settings_(settings) {
+    iSector_ = 0;
     bx_ = 0;
-}
+    event_ = 0;
+  }
 
-size_t MemoryBase::find_nth(const string& haystack, size_t pos, const string& needle, size_t nth) {
-  size_t found_pos = haystack.find(needle, pos);
-  if (0 == nth || string::npos == found_pos)
-    return found_pos;
-  return find_nth(haystack, found_pos + 1, needle, nth - 1);
-}
+  void MemoryBase::initLayerDisk(unsigned int pos, int& layer, int& disk) {
+    string subname = name_.substr(pos, 2);
+    layer = 0;
+    disk = 0;
 
-std::string MemoryBase::hexstr(unsigned int index) {
-  std::ostringstream oss;
-  oss << "0x" << std::setfill('0') << std::setw(2) << hex << index << dec;
-  return oss.str();
-}
+    if (subname.substr(0, 1) == "L")
+      layer = stoi(subname.substr(1, 1));
+    else if (subname.substr(0, 1) == "D")
+      disk = stoi(subname.substr(1, 1));
+    else
+      throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " name = " << name_
+                                        << " subname = " << subname << " " << layer << " " << disk;
+  }
 
-}
+  unsigned int MemoryBase::initLayerDisk(unsigned int pos) {
+    int layer, disk;
+    initLayerDisk(pos, layer, disk);
+
+    if (disk > 0)
+      return N_DISK + disk;
+    return layer - 1;
+  }
+
+  void MemoryBase::initSpecialSeeding(unsigned int pos, bool& overlap, bool& extra, bool& extended) {
+    overlap = false;
+    extra = false;
+    extended = false;
+
+    char subname = name_[pos];
+
+    static const std::set<char> overlapset = {
+        'X', 'Y', 'W', 'Q', 'R', 'S', 'T', 'Z', 'x', 'y', 'w', 'q', 'r', 's', 't', 'z'};
+    overlap = overlapset.find(subname) != overlapset.end();
+
+    static const std::set<char> extraset = {'I', 'J', 'K', 'L'};
+    extra = extraset.find(subname) != extraset.end();
+
+    static const std::set<char> extendedset = {
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'x', 'y', 'z', 'w', 'q', 'r', 's', 't'};
+    extended = extendedset.find(subname) != extendedset.end();
+  }
+
+  void MemoryBase::findAndReplaceAll(std::string& data, std::string toSearch, std::string replaceStr) {
+    // Get the first occurrence
+    size_t pos = data.find(toSearch);
+
+    // Repeat till end is reached
+    while (pos != std::string::npos) {
+      // Replace this occurrence of Sub String
+      data.replace(pos, toSearch.size(), replaceStr);
+      // Get the next occurrence from the current position
+      pos = data.find(toSearch, pos + replaceStr.size());
+    }
+  }
+
+  void MemoryBase::openFile(bool first, std::string dirName, std::string filebase) {
+    std::string fname = filebase + getName();
+
+    findAndReplaceAll(fname, "PHIa", "PHIaa");
+    findAndReplaceAll(fname, "PHIb", "PHIbb");
+    findAndReplaceAll(fname, "PHIc", "PHIcc");
+    findAndReplaceAll(fname, "PHId", "PHIdd");
+
+    findAndReplaceAll(fname, "PHIx", "PHIxx");
+    findAndReplaceAll(fname, "PHIy", "PHIyy");
+    findAndReplaceAll(fname, "PHIz", "PHIzz");
+    findAndReplaceAll(fname, "PHIw", "PHIww");
+
+    fname += "_";
+    if (iSector_ + 1 < 10)
+      fname += "0";
+    fname += std::to_string(iSector_ + 1);
+    fname += ".dat";
+
+    openfile(out_, first, dirName, dirName + fname, __FILE__, __LINE__);
+
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
+  }
+
+  size_t MemoryBase::find_nth(const string& haystack, size_t pos, const string& needle, size_t nth) {
+    size_t found_pos = haystack.find(needle, pos);
+    if (0 == nth || string::npos == found_pos)
+      return found_pos;
+    return find_nth(haystack, found_pos + 1, needle, nth - 1);
+  }
+
+  std::string MemoryBase::hexstr(unsigned int index) {
+    std::ostringstream oss;
+    oss << "0x" << std::setfill('0') << std::setw(2) << hex << index << dec;
+    return oss.str();
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/ProcessBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProcessBase.cc
@@ -8,8 +8,9 @@
 
 #include <unordered_map>
 
-using namespace trklet;
 using namespace std;
+
+namespace trklet {
 
 ProcessBase::ProcessBase(string name, Settings const& settings, Globals* global)
     : name_(name), settings_(settings), globals_(global) {}
@@ -133,4 +134,6 @@ unsigned int ProcessBase::getISeed(const std::string& name) {
   throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " " << getName() << " name name1 name2 " << name
                                      << " - " << name1 << " - " << name2;
   return 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/ProcessBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProcessBase.cc
@@ -12,128 +12,128 @@ using namespace std;
 
 namespace trklet {
 
-ProcessBase::ProcessBase(string name, Settings const& settings, Globals* global)
-    : name_(name), settings_(settings), globals_(global) {}
+  ProcessBase::ProcessBase(string name, Settings const& settings, Globals* global)
+      : name_(name), settings_(settings), globals_(global) {}
 
-unsigned int ProcessBase::nbits(unsigned int power) {
-  if (power == 2)
-    return 1;
-  if (power == 4)
-    return 2;
-  if (power == 8)
-    return 3;
-  if (power == 16)
-    return 4;
-  if (power == 32)
-    return 5;
+  unsigned int ProcessBase::nbits(unsigned int power) {
+    if (power == 2)
+      return 1;
+    if (power == 4)
+      return 2;
+    if (power == 8)
+      return 3;
+    if (power == 16)
+      return 4;
+    if (power == 32)
+      return 5;
 
-  throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << "nbits: power = " << power;
-  return 0;
-}
+    throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << "nbits: power = " << power;
+    return 0;
+  }
 
-void ProcessBase::initLayerDisk(unsigned int pos, int& layer, int& disk) {
-  string subname = name_.substr(pos, 2);
-  layer = 0;
-  disk = 0;
-  if (subname.substr(0, 1) == "L")
-    layer = stoi(subname.substr(1, 1));
-  else if (subname.substr(0, 1) == "D")
-    disk = stoi(subname.substr(1, 1));
-  else
-    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " " << name_ << " subname = " << subname << " "
-                                      << layer << " " << disk;
-}
+  void ProcessBase::initLayerDisk(unsigned int pos, int& layer, int& disk) {
+    string subname = name_.substr(pos, 2);
+    layer = 0;
+    disk = 0;
+    if (subname.substr(0, 1) == "L")
+      layer = stoi(subname.substr(1, 1));
+    else if (subname.substr(0, 1) == "D")
+      disk = stoi(subname.substr(1, 1));
+    else
+      throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " " << name_ << " subname = " << subname
+                                        << " " << layer << " " << disk;
+  }
 
-void ProcessBase::initLayerDisk(unsigned int pos, int& layer, int& disk, int& layerdisk) {
-  initLayerDisk(pos, layer, disk);
+  void ProcessBase::initLayerDisk(unsigned int pos, int& layer, int& disk, int& layerdisk) {
+    initLayerDisk(pos, layer, disk);
 
-  layerdisk = layer - 1;
-  if (disk > 0)
-    layerdisk = N_LAYER + disk - 1;
-}
+    layerdisk = layer - 1;
+    if (disk > 0)
+      layerdisk = N_LAYER + disk - 1;
+  }
 
-unsigned int ProcessBase::initLayerDisk(unsigned int pos) {
-  int layer, disk;
-  initLayerDisk(pos, layer, disk);
+  unsigned int ProcessBase::initLayerDisk(unsigned int pos) {
+    int layer, disk;
+    initLayerDisk(pos, layer, disk);
 
-  if (disk > 0)
-    return N_LAYER + disk - 1;
-  return layer - 1;
-}
+    if (disk > 0)
+      return N_LAYER + disk - 1;
+    return layer - 1;
+  }
 
-void ProcessBase::initLayerDisksandISeed(unsigned int& layerdisk1, unsigned int& layerdisk2, unsigned int& iSeed) {
-  layerdisk1 = 99;
-  layerdisk2 = 99;
+  void ProcessBase::initLayerDisksandISeed(unsigned int& layerdisk1, unsigned int& layerdisk2, unsigned int& iSeed) {
+    layerdisk1 = 99;
+    layerdisk2 = 99;
 
-  if (name_.substr(0, 3) == "TE_") {
-    if (name_[3] == 'L') {
-      layerdisk1 = name_[4] - '1';
-    } else if (name_[3] == 'D') {
-      layerdisk1 = N_LAYER + name_[4] - '1';
+    if (name_.substr(0, 3) == "TE_") {
+      if (name_[3] == 'L') {
+        layerdisk1 = name_[4] - '1';
+      } else if (name_[3] == 'D') {
+        layerdisk1 = N_LAYER + name_[4] - '1';
+      }
+      if (name_[11] == 'L') {
+        layerdisk2 = name_[12] - '1';
+      } else if (name_[11] == 'D') {
+        layerdisk2 = N_LAYER + name_[12] - '1';
+      } else if (name_[12] == 'L') {
+        layerdisk2 = name_[13] - '1';
+      } else if (name_[12] == 'D') {
+        layerdisk2 = N_LAYER + name_[13] - '1';
+      }
     }
-    if (name_[11] == 'L') {
-      layerdisk2 = name_[12] - '1';
-    } else if (name_[11] == 'D') {
-      layerdisk2 = N_LAYER + name_[12] - '1';
-    } else if (name_[12] == 'L') {
-      layerdisk2 = name_[13] - '1';
-    } else if (name_[12] == 'D') {
-      layerdisk2 = N_LAYER + name_[13] - '1';
+
+    if ((name_.substr(0, 3) == "TC_") || (name_.substr(0, 3) == "TP_")) {
+      if (name_[3] == 'L') {
+        layerdisk1 = name_[4] - '1';
+      } else if (name_[3] == 'D') {
+        layerdisk1 = N_LAYER + name_[4] - '1';
+      }
+      if (name_[5] == 'L') {
+        layerdisk2 = name_[6] - '1';
+      } else if (name_[5] == 'D') {
+        layerdisk2 = N_LAYER + name_[6] - '1';
+      }
+    }
+
+    if (layerdisk1 == LayerDisk::L1 && layerdisk2 == LayerDisk::L2)
+      iSeed = Seed::L1L2;
+    else if (layerdisk1 == LayerDisk::L2 && layerdisk2 == LayerDisk::L3)
+      iSeed = Seed::L2L3;
+    else if (layerdisk1 == LayerDisk::L3 && layerdisk2 == LayerDisk::L4)
+      iSeed = Seed::L3L4;
+    else if (layerdisk1 == LayerDisk::L5 && layerdisk2 == LayerDisk::L6)
+      iSeed = Seed::L5L6;
+    else if (layerdisk1 == LayerDisk::D1 && layerdisk2 == LayerDisk::D2)
+      iSeed = Seed::D1D2;
+    else if (layerdisk1 == LayerDisk::D3 && layerdisk2 == LayerDisk::D4)
+      iSeed = Seed::D3D4;
+    else if (layerdisk1 == LayerDisk::L1 && layerdisk2 == LayerDisk::D1)
+      iSeed = Seed::L1D1;
+    else if (layerdisk1 == LayerDisk::L2 && layerdisk2 == LayerDisk::D1)
+      iSeed = Seed::L2D1;
+    else {
+      throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " layerdisk1 " << layerdisk1
+                                         << " layerdisk2 " << layerdisk2;
     }
   }
 
-  if ((name_.substr(0, 3) == "TC_") || (name_.substr(0, 3) == "TP_")) {
-    if (name_[3] == 'L') {
-      layerdisk1 = name_[4] - '1';
-    } else if (name_[3] == 'D') {
-      layerdisk1 = N_LAYER + name_[4] - '1';
-    }
-    if (name_[5] == 'L') {
-      layerdisk2 = name_[6] - '1';
-    } else if (name_[5] == 'D') {
-      layerdisk2 = N_LAYER + name_[6] - '1';
-    }
+  unsigned int ProcessBase::getISeed(const std::string& name) {
+    std::size_t pos = name.find('_');
+    std::string name1 = name.substr(pos + 1);
+    pos = name1.find('_');
+    std::string name2 = name1.substr(0, pos);
+
+    unordered_map<string, unsigned int> seedmap = {
+        {"L1L2", 0},   {"L2L3", 1},   {"L3L4", 2},   {"L5L6", 3},   {"D1D2", 4},    {"D3D4", 5},   {"L1D1", 6},
+        {"L2D1", 7},   {"L1L2XX", 0}, {"L2L3XX", 1}, {"L3L4XX", 2}, {"L5L6XX", 3},  {"D1D2XX", 4}, {"D3D4XX", 5},
+        {"L1D1XX", 6}, {"L2D1XX", 7}, {"L3L4L2", 8}, {"L5L6L4", 9}, {"L2L3D1", 10}, {"D1D2L2", 11}};
+    auto found = seedmap.find(name2);
+    if (found != seedmap.end())
+      return found->second;
+
+    throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " " << getName() << " name name1 name2 "
+                                       << name << " - " << name1 << " - " << name2;
+    return 0;
   }
 
-  if (layerdisk1 == LayerDisk::L1 && layerdisk2 == LayerDisk::L2)
-    iSeed = Seed::L1L2;
-  else if (layerdisk1 == LayerDisk::L2 && layerdisk2 == LayerDisk::L3)
-    iSeed = Seed::L2L3;
-  else if (layerdisk1 == LayerDisk::L3 && layerdisk2 == LayerDisk::L4)
-    iSeed = Seed::L3L4;
-  else if (layerdisk1 == LayerDisk::L5 && layerdisk2 == LayerDisk::L6)
-    iSeed = Seed::L5L6;
-  else if (layerdisk1 == LayerDisk::D1 && layerdisk2 == LayerDisk::D2)
-    iSeed = Seed::D1D2;
-  else if (layerdisk1 == LayerDisk::D3 && layerdisk2 == LayerDisk::D4)
-    iSeed = Seed::D3D4;
-  else if (layerdisk1 == LayerDisk::L1 && layerdisk2 == LayerDisk::D1)
-    iSeed = Seed::L1D1;
-  else if (layerdisk1 == LayerDisk::L2 && layerdisk2 == LayerDisk::D1)
-    iSeed = Seed::L2D1;
-  else {
-    throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " layerdisk1 " << layerdisk1 << " layerdisk2 "
-                                       << layerdisk2;
-  }
-}
-
-unsigned int ProcessBase::getISeed(const std::string& name) {
-  std::size_t pos = name.find('_');
-  std::string name1 = name.substr(pos + 1);
-  pos = name1.find('_');
-  std::string name2 = name1.substr(0, pos);
-
-  unordered_map<string, unsigned int> seedmap = {
-      {"L1L2", 0},   {"L2L3", 1},   {"L3L4", 2},   {"L5L6", 3},   {"D1D2", 4},    {"D3D4", 5},   {"L1D1", 6},
-      {"L2D1", 7},   {"L1L2XX", 0}, {"L2L3XX", 1}, {"L3L4XX", 2}, {"L5L6XX", 3},  {"D1D2XX", 4}, {"D3D4XX", 5},
-      {"L1D1XX", 6}, {"L2D1XX", 7}, {"L3L4L2", 8}, {"L5L6L4", 9}, {"L2L3D1", 10}, {"D1D2L2", 11}};
-  auto found = seedmap.find(name2);
-  if (found != seedmap.end())
-    return found->second;
-
-  throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " " << getName() << " name name1 name2 " << name
-                                     << " - " << name1 << " - " << name2;
-  return 0;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/Projection.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Projection.cc
@@ -6,7 +6,8 @@
 #include <algorithm>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 void Projection::init(Settings const& settings,
                       unsigned int layerdisk,
@@ -129,4 +130,6 @@ void Projection::init(Settings const& settings,
   rzprojapprox_ = rzprojapprox;
   phiprojderapprox_ = phiprojderapprox;
   rzprojderapprox_ = rzprojderapprox;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/Projection.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Projection.cc
@@ -9,127 +9,127 @@ using namespace std;
 
 namespace trklet {
 
-void Projection::init(Settings const& settings,
-                      unsigned int layerdisk,
-                      int iphiproj,
-                      int irzproj,
-                      int iphider,
-                      int irzder,
-                      double phiproj,
-                      double rzproj,
-                      double phiprojder,
-                      double rzprojder,
-                      double phiprojapprox,
-                      double rzprojapprox,
-                      double phiprojderapprox,
-                      double rzprojderapprox,
-                      bool isPSseed) {
-  assert(layerdisk < N_LAYER + N_DISK);
+  void Projection::init(Settings const& settings,
+                        unsigned int layerdisk,
+                        int iphiproj,
+                        int irzproj,
+                        int iphider,
+                        int irzder,
+                        double phiproj,
+                        double rzproj,
+                        double phiprojder,
+                        double rzprojder,
+                        double phiprojapprox,
+                        double rzprojapprox,
+                        double phiprojderapprox,
+                        double rzprojderapprox,
+                        bool isPSseed) {
+    assert(layerdisk < N_LAYER + N_DISK);
 
-  valid_ = true;
+    valid_ = true;
 
-  fpgaphiproj_.set(iphiproj, settings.nphibitsstub(layerdisk), true, __LINE__, __FILE__);
+    fpgaphiproj_.set(iphiproj, settings.nphibitsstub(layerdisk), true, __LINE__, __FILE__);
 
-  if (layerdisk < N_LAYER) {
-    fpgarzproj_.set(irzproj, settings.nzbitsstub(layerdisk), false, __LINE__, __FILE__);
-  } else {
-    fpgarzproj_.set(irzproj, settings.nrbitsstub(layerdisk), false, __LINE__, __FILE__);
-  }
-
-  if (layerdisk < N_LAYER) {
-    if (layerdisk < N_PSLAYER) {
-      fpgaphiprojder_.set(iphider, settings.nbitsphiprojderL123(), false, __LINE__, __FILE__);
-      fpgarzprojder_.set(irzder, settings.nbitszprojderL123(), false, __LINE__, __FILE__);
+    if (layerdisk < N_LAYER) {
+      fpgarzproj_.set(irzproj, settings.nzbitsstub(layerdisk), false, __LINE__, __FILE__);
     } else {
-      fpgaphiprojder_.set(iphider, settings.nbitsphiprojderL456(), false, __LINE__, __FILE__);
-      fpgarzprojder_.set(irzder, settings.nbitszprojderL456(), false, __LINE__, __FILE__);
+      fpgarzproj_.set(irzproj, settings.nrbitsstub(layerdisk), false, __LINE__, __FILE__);
     }
-  } else {
-    fpgaphiprojder_.set(iphider, settings.nbitsphiprojderL123(), false, __LINE__, __FILE__);
-    fpgarzprojder_.set(irzder, settings.nrbitsprojderdisk(), false, __LINE__, __FILE__);
+
+    if (layerdisk < N_LAYER) {
+      if (layerdisk < N_PSLAYER) {
+        fpgaphiprojder_.set(iphider, settings.nbitsphiprojderL123(), false, __LINE__, __FILE__);
+        fpgarzprojder_.set(irzder, settings.nbitszprojderL123(), false, __LINE__, __FILE__);
+      } else {
+        fpgaphiprojder_.set(iphider, settings.nbitsphiprojderL456(), false, __LINE__, __FILE__);
+        fpgarzprojder_.set(irzder, settings.nbitszprojderL456(), false, __LINE__, __FILE__);
+      }
+    } else {
+      fpgaphiprojder_.set(iphider, settings.nbitsphiprojderL123(), false, __LINE__, __FILE__);
+      fpgarzprojder_.set(irzder, settings.nrbitsprojderdisk(), false, __LINE__, __FILE__);
+    }
+
+    if (layerdisk < N_LAYER) {
+      ////Separate the vm projections into zbins
+      ////This determines the central bin:
+      ////int zbin=4+(zproj.value()>>(zproj.nbits()-3));
+      ////But we need some range (particularly for L5L6 seed projecting to L1-L3):
+      int offset = isPSseed ? 1 : 4;
+
+      int ztemp = fpgarzproj_.value() >> (fpgarzproj_.nbits() - settings.MEBinsBits() - NFINERZBITS);
+      unsigned int zbin1 = (1 << (settings.MEBinsBits() - 1)) + ((ztemp - offset) >> NFINERZBITS);
+      unsigned int zbin2 = (1 << (settings.MEBinsBits() - 1)) + ((ztemp + offset) >> NFINERZBITS);
+
+      if (zbin1 >= settings.MEBins()) {
+        zbin1 = 0;  //note that zbin1 is unsigned
+      }
+      if (zbin2 >= settings.MEBins()) {
+        zbin2 = settings.MEBins() - 1;
+      }
+
+      assert(zbin1 <= zbin2);
+      assert(zbin2 - zbin1 <= 1);
+
+      fpgarzbin1projvm_.set(zbin1, settings.MEBinsBits(), true, __LINE__, __FILE__);  // first z bin
+
+      int nextbin = zbin1 != zbin2;
+      fpgarzbin2projvm_.set(nextbin, 1, true, __LINE__, __FILE__);  // need to check adjacent z bin?
+
+      //fine vm z bits. Use 4 bits for fine position. starting at zbin 1
+      int finez = ((1 << (settings.MEBinsBits() + NFINERZBITS - 1)) + ztemp) - (zbin1 << NFINERZBITS);
+
+      fpgafinerzvm_.set(finez, NFINERZBITS + 1, true, __LINE__, __FILE__);  // fine z postions starting at zbin1
+
+    } else {
+      //TODO the -3 and +3 should be evaluated and efficiency for matching hits checked.
+      //This code should be migrated in the ProjectionRouter
+      double roffset = 3.0;
+      int rbin1 = 8.0 * (irzproj * settings.krprojshiftdisk() - roffset - settings.rmindiskvm()) /
+                  (settings.rmaxdisk() - settings.rmindiskvm());
+      int rbin2 = 8.0 * (irzproj * settings.krprojshiftdisk() + roffset - settings.rmindiskvm()) /
+                  (settings.rmaxdisk() - settings.rmindiskvm());
+
+      if (rbin1 < 0) {
+        rbin1 = 0;
+      }
+      rbin2 = clamp(rbin2, 0, 7);
+
+      assert(rbin1 <= rbin2);
+      assert(rbin2 - rbin1 <= 1);
+
+      int finer = 64 *
+                  ((irzproj * settings.krprojshiftdisk() - settings.rmindiskvm()) -
+                   rbin1 * (settings.rmaxdisk() - settings.rmindiskvm()) / 8.0) /
+                  (settings.rmaxdisk() - settings.rmindiskvm());
+
+      finer = clamp(finer, 0, 15);
+
+      int diff = rbin1 != rbin2;
+      if (irzder < 0)
+        rbin1 += 8;
+
+      fpgarzbin1projvm_.set(rbin1, 4, true, __LINE__, __FILE__);  // first r bin
+      fpgarzbin2projvm_.set(diff, 1, true, __LINE__, __FILE__);   // need to check adjacent r bin
+
+      fpgafinerzvm_.set(finer, 4, true, __LINE__, __FILE__);  // fine r postions starting at rbin1
+    }
+
+    //fine phi bits
+    int projfinephi =
+        (fpgaphiproj_.value() >>
+         (fpgaphiproj_.nbits() - (settings.nbitsallstubs(layerdisk) + settings.nbitsvmme(layerdisk) + NFINEPHIBITS))) &
+        ((1 << NFINEPHIBITS) - 1);
+    fpgafinephivm_.set(projfinephi, NFINEPHIBITS, true, __LINE__, __FILE__);  // fine phi postions
+
+    phiproj_ = phiproj;
+    rzproj_ = rzproj;
+    phiprojder_ = phiprojder;
+    rzprojder_ = rzprojder;
+
+    phiprojapprox_ = phiprojapprox;
+    rzprojapprox_ = rzprojapprox;
+    phiprojderapprox_ = phiprojderapprox;
+    rzprojderapprox_ = rzprojderapprox;
   }
 
-  if (layerdisk < N_LAYER) {
-    ////Separate the vm projections into zbins
-    ////This determines the central bin:
-    ////int zbin=4+(zproj.value()>>(zproj.nbits()-3));
-    ////But we need some range (particularly for L5L6 seed projecting to L1-L3):
-    int offset = isPSseed ? 1 : 4;
-
-    int ztemp = fpgarzproj_.value() >> (fpgarzproj_.nbits() - settings.MEBinsBits() - NFINERZBITS);
-    unsigned int zbin1 = (1 << (settings.MEBinsBits() - 1)) + ((ztemp - offset) >> NFINERZBITS);
-    unsigned int zbin2 = (1 << (settings.MEBinsBits() - 1)) + ((ztemp + offset) >> NFINERZBITS);
-
-    if (zbin1 >= settings.MEBins()) {
-      zbin1 = 0;  //note that zbin1 is unsigned
-    }
-    if (zbin2 >= settings.MEBins()) {
-      zbin2 = settings.MEBins() - 1;
-    }
-
-    assert(zbin1 <= zbin2);
-    assert(zbin2 - zbin1 <= 1);
-
-    fpgarzbin1projvm_.set(zbin1, settings.MEBinsBits(), true, __LINE__, __FILE__);  // first z bin
-
-    int nextbin = zbin1 != zbin2;
-    fpgarzbin2projvm_.set(nextbin, 1, true, __LINE__, __FILE__);  // need to check adjacent z bin?
-
-    //fine vm z bits. Use 4 bits for fine position. starting at zbin 1
-    int finez = ((1 << (settings.MEBinsBits() + NFINERZBITS - 1)) + ztemp) - (zbin1 << NFINERZBITS);
-
-    fpgafinerzvm_.set(finez, NFINERZBITS + 1, true, __LINE__, __FILE__);  // fine z postions starting at zbin1
-
-  } else {
-    //TODO the -3 and +3 should be evaluated and efficiency for matching hits checked.
-    //This code should be migrated in the ProjectionRouter
-    double roffset = 3.0;
-    int rbin1 = 8.0 * (irzproj * settings.krprojshiftdisk() - roffset - settings.rmindiskvm()) /
-                (settings.rmaxdisk() - settings.rmindiskvm());
-    int rbin2 = 8.0 * (irzproj * settings.krprojshiftdisk() + roffset - settings.rmindiskvm()) /
-                (settings.rmaxdisk() - settings.rmindiskvm());
-
-    if (rbin1 < 0) {
-      rbin1 = 0;
-    }
-    rbin2 = clamp(rbin2, 0, 7);
-
-    assert(rbin1 <= rbin2);
-    assert(rbin2 - rbin1 <= 1);
-
-    int finer = 64 *
-                ((irzproj * settings.krprojshiftdisk() - settings.rmindiskvm()) -
-                 rbin1 * (settings.rmaxdisk() - settings.rmindiskvm()) / 8.0) /
-                (settings.rmaxdisk() - settings.rmindiskvm());
-
-    finer = clamp(finer, 0, 15);
-
-    int diff = rbin1 != rbin2;
-    if (irzder < 0)
-      rbin1 += 8;
-
-    fpgarzbin1projvm_.set(rbin1, 4, true, __LINE__, __FILE__);  // first r bin
-    fpgarzbin2projvm_.set(diff, 1, true, __LINE__, __FILE__);   // need to check adjacent r bin
-
-    fpgafinerzvm_.set(finer, 4, true, __LINE__, __FILE__);  // fine r postions starting at rbin1
-  }
-
-  //fine phi bits
-  int projfinephi =
-      (fpgaphiproj_.value() >>
-       (fpgaphiproj_.nbits() - (settings.nbitsallstubs(layerdisk) + settings.nbitsvmme(layerdisk) + NFINEPHIBITS))) &
-      ((1 << NFINEPHIBITS) - 1);
-  fpgafinephivm_.set(projfinephi, NFINEPHIBITS, true, __LINE__, __FILE__);  // fine phi postions
-
-  phiproj_ = phiproj;
-  rzproj_ = rzproj;
-  phiprojder_ = phiprojder;
-  rzprojder_ = rzprojder;
-
-  phiprojapprox_ = phiprojapprox;
-  rzprojapprox_ = rzprojapprox;
-  phiprojderapprox_ = phiprojderapprox;
-  rzprojderapprox_ = rzprojderapprox;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/ProjectionRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProjectionRouter.cc
@@ -12,144 +12,144 @@ using namespace std;
 
 namespace trklet {
 
-ProjectionRouter::ProjectionRouter(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global), rinvbendlut_(settings) {
-  layerdisk_ = initLayerDisk(3);
+  ProjectionRouter::ProjectionRouter(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global), rinvbendlut_(settings) {
+    layerdisk_ = initLayerDisk(3);
 
-  vmprojs_.resize(settings_.nvmme(layerdisk_), nullptr);
+    vmprojs_.resize(settings_.nvmme(layerdisk_), nullptr);
 
-  nrbits_ = 5;
-  nphiderbits_ = 6;
+    nrbits_ = 5;
+    nphiderbits_ = 6;
 
-  if (layerdisk_ >= N_LAYER) {
-    rinvbendlut_.initProjectionBend(
-        global->ITC_L1L2()->der_phiD_final.K(), layerdisk_ - N_LAYER, nrbits_, nphiderbits_);
-  }
-}
-
-void ProjectionRouter::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-  if (output == "allprojout") {
-    auto* tmp = dynamic_cast<AllProjectionsMemory*>(memory);
-    assert(tmp != nullptr);
-    allproj_ = tmp;
-    return;
+    if (layerdisk_ >= N_LAYER) {
+      rinvbendlut_.initProjectionBend(
+          global->ITC_L1L2()->der_phiD_final.K(), layerdisk_ - N_LAYER, nrbits_, nphiderbits_);
+    }
   }
 
-  unsigned int nproj = settings_.nallstubs(layerdisk_);
-  unsigned int nprojvm = settings_.nvmme(layerdisk_);
+  void ProjectionRouter::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
+    if (output == "allprojout") {
+      auto* tmp = dynamic_cast<AllProjectionsMemory*>(memory);
+      assert(tmp != nullptr);
+      allproj_ = tmp;
+      return;
+    }
 
-  for (unsigned int iproj = 0; iproj < nproj; iproj++) {
-    for (unsigned int iprojvm = 0; iprojvm < nprojvm; iprojvm++) {
-      std::string name = "vmprojoutPHI";
-      name += char(iproj + 'A');
-      name += std::to_string(iproj * nprojvm + iprojvm + 1);
-      if (output == name) {
-        auto* tmp = dynamic_cast<VMProjectionsMemory*>(memory);
-        assert(tmp != nullptr);
-        vmprojs_[iprojvm] = tmp;
-        return;
+    unsigned int nproj = settings_.nallstubs(layerdisk_);
+    unsigned int nprojvm = settings_.nvmme(layerdisk_);
+
+    for (unsigned int iproj = 0; iproj < nproj; iproj++) {
+      for (unsigned int iprojvm = 0; iprojvm < nprojvm; iprojvm++) {
+        std::string name = "vmprojoutPHI";
+        name += char(iproj + 'A');
+        name += std::to_string(iproj * nprojvm + iprojvm + 1);
+        if (output == name) {
+          auto* tmp = dynamic_cast<VMProjectionsMemory*>(memory);
+          assert(tmp != nullptr);
+          vmprojs_[iprojvm] = tmp;
+          return;
+        }
+      }
+    }
+
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find output: " << output;
+  }
+
+  void ProjectionRouter::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input.substr(0, 4) == "proj" && input.substr(input.size() - 2, 2) == "in") {
+      auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
+      assert(tmp != nullptr);
+      inputproj_.push_back(tmp);
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input: " << input;
+  }
+
+  void ProjectionRouter::execute() {
+    unsigned int allprojcount = 0;
+
+    //These are just here to test that the order is correct. Does not affect the actual execution
+
+    int lastTCID = -1;
+
+    for (auto& iproj : inputproj_) {
+      for (unsigned int i = 0; i < iproj->nTracklets(); i++) {
+        if (allprojcount >= settings_.maxStep("PR"))
+          continue;
+
+        Tracklet* tracklet = iproj->getTracklet(i);
+
+        FPGAWord fpgaphi;
+
+        if (layerdisk_ < N_LAYER) {
+          fpgaphi = tracklet->proj(layerdisk_).fpgaphiproj();
+        } else {
+          Projection& proj = tracklet->proj(layerdisk_);
+          fpgaphi = proj.fpgaphiproj();
+
+          //The next lines looks up the predicted bend based on:
+          // 1 - r projections
+          // 2 - phi derivative
+          // 3 - the sign - i.e. if track is forward or backward
+
+          int rindex = (proj.fpgarzproj().value() >> (proj.fpgarzproj().nbits() - nrbits_)) & ((1 << nrbits_) - 1);
+
+          int phiderindex = (proj.fpgaphiprojder().value() >> (proj.fpgaphiprojder().nbits() - nphiderbits_)) &
+                            ((1 << nphiderbits_) - 1);
+
+          int signindex = (proj.fpgarzprojder().value() < 0);
+
+          int bendindex = (signindex << (nphiderbits_ + nrbits_)) + (rindex << (nphiderbits_)) + phiderindex;
+
+          int ibendproj = rinvbendlut_.lookup(bendindex);
+
+          proj.setBendIndex(ibendproj);
+        }
+
+        unsigned int iphivm =
+            fpgaphi.bits(fpgaphi.nbits() - settings_.nbitsallstubs(layerdisk_) - settings_.nbitsvmme(layerdisk_),
+                         settings_.nbitsvmme(layerdisk_));
+
+        //This block of code just checks that the configuration is consistent
+        if (lastTCID >= tracklet->TCID()) {
+          edm::LogPrint("Tracklet") << "Wrong TCID ordering for projections in " << getName();
+        } else {
+          lastTCID = tracklet->TCID();
+        }
+
+        allproj_->addTracklet(tracklet);
+
+        vmprojs_[iphivm]->addTracklet(tracklet, allprojcount);
+
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << getName() << " projection to " << vmprojs_[iphivm]->getName() << " iphivm "
+                                       << iphivm;
+        }
+
+        allprojcount++;
+      }
+    }
+
+    if (settings_.writeMonitorData("AP")) {
+      globals_->ofstream("allprojections.txt") << getName() << " " << allproj_->nTracklets() << endl;
+    }
+
+    if (settings_.writeMonitorData("VMP")) {
+      ofstream& out = globals_->ofstream("chisq.txt");
+      for (unsigned int i = 0; i < 8; i++) {
+        if (vmprojs_[i] != nullptr) {
+          out << vmprojs_[i]->getName() << " " << vmprojs_[i]->nTracklets() << endl;
+        }
       }
     }
   }
 
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find output: " << output;
-}
-
-void ProjectionRouter::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input.substr(0, 4) == "proj" && input.substr(input.size() - 2, 2) == "in") {
-    auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
-    assert(tmp != nullptr);
-    inputproj_.push_back(tmp);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input: " << input;
-}
-
-void ProjectionRouter::execute() {
-  unsigned int allprojcount = 0;
-
-  //These are just here to test that the order is correct. Does not affect the actual execution
-
-  int lastTCID = -1;
-
-  for (auto& iproj : inputproj_) {
-    for (unsigned int i = 0; i < iproj->nTracklets(); i++) {
-      if (allprojcount >= settings_.maxStep("PR"))
-        continue;
-
-      Tracklet* tracklet = iproj->getTracklet(i);
-
-      FPGAWord fpgaphi;
-
-      if (layerdisk_ < N_LAYER) {
-        fpgaphi = tracklet->proj(layerdisk_).fpgaphiproj();
-      } else {
-        Projection& proj = tracklet->proj(layerdisk_);
-        fpgaphi = proj.fpgaphiproj();
-
-        //The next lines looks up the predicted bend based on:
-        // 1 - r projections
-        // 2 - phi derivative
-        // 3 - the sign - i.e. if track is forward or backward
-
-        int rindex = (proj.fpgarzproj().value() >> (proj.fpgarzproj().nbits() - nrbits_)) & ((1 << nrbits_) - 1);
-
-        int phiderindex = (proj.fpgaphiprojder().value() >> (proj.fpgaphiprojder().nbits() - nphiderbits_)) &
-                          ((1 << nphiderbits_) - 1);
-
-        int signindex = (proj.fpgarzprojder().value() < 0);
-
-        int bendindex = (signindex << (nphiderbits_ + nrbits_)) + (rindex << (nphiderbits_)) + phiderindex;
-
-        int ibendproj = rinvbendlut_.lookup(bendindex);
-
-        proj.setBendIndex(ibendproj);
-      }
-
-      unsigned int iphivm =
-          fpgaphi.bits(fpgaphi.nbits() - settings_.nbitsallstubs(layerdisk_) - settings_.nbitsvmme(layerdisk_),
-                       settings_.nbitsvmme(layerdisk_));
-
-      //This block of code just checks that the configuration is consistent
-      if (lastTCID >= tracklet->TCID()) {
-        edm::LogPrint("Tracklet") << "Wrong TCID ordering for projections in " << getName();
-      } else {
-        lastTCID = tracklet->TCID();
-      }
-
-      allproj_->addTracklet(tracklet);
-
-      vmprojs_[iphivm]->addTracklet(tracklet, allprojcount);
-
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << getName() << " projection to " << vmprojs_[iphivm]->getName() << " iphivm "
-                                     << iphivm;
-      }
-
-      allprojcount++;
-    }
-  }
-
-  if (settings_.writeMonitorData("AP")) {
-    globals_->ofstream("allprojections.txt") << getName() << " " << allproj_->nTracklets() << endl;
-  }
-
-  if (settings_.writeMonitorData("VMP")) {
-    ofstream& out = globals_->ofstream("chisq.txt");
-    for (unsigned int i = 0; i < 8; i++) {
-      if (vmprojs_[i] != nullptr) {
-        out << vmprojs_[i]->getName() << " " << vmprojs_[i]->nTracklets() << endl;
-      }
-    }
-  }
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/ProjectionRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProjectionRouter.cc
@@ -9,7 +9,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 ProjectionRouter::ProjectionRouter(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global), rinvbendlut_(settings) {
@@ -149,4 +150,6 @@ void ProjectionRouter::execute() {
       }
     }
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/ProjectionTemp.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProjectionTemp.cc
@@ -4,45 +4,45 @@ using namespace std;
 
 namespace trklet {
 
-ProjectionTemp::ProjectionTemp(Tracklet* proj,
-                               unsigned int slot,
-                               unsigned int projrinv,
-                               int projfinerz,
-                               unsigned int projfinephi,
-                               unsigned int iphi,
-                               int shift,
-                               bool usefirstMinus,
-                               bool usefirstPlus,
-                               bool usesecondMinus,
-                               bool usesecondPlus,
-                               bool isPSseed) {
-  proj_ = proj;
-  slot_ = slot;
-  projrinv_ = projrinv;
-  projfinerz_ = projfinerz;
-  projfinephi_ = projfinephi;
-  iphi_ = iphi;
-  shift_ = shift;
-  use_[0][0] = usefirstMinus;
-  use_[0][1] = usefirstPlus;
-  use_[1][0] = usesecondMinus;
-  use_[1][1] = usesecondPlus;
-  isPSseed_ = isPSseed;
-}
+  ProjectionTemp::ProjectionTemp(Tracklet* proj,
+                                 unsigned int slot,
+                                 unsigned int projrinv,
+                                 int projfinerz,
+                                 unsigned int projfinephi,
+                                 unsigned int iphi,
+                                 int shift,
+                                 bool usefirstMinus,
+                                 bool usefirstPlus,
+                                 bool usesecondMinus,
+                                 bool usesecondPlus,
+                                 bool isPSseed) {
+    proj_ = proj;
+    slot_ = slot;
+    projrinv_ = projrinv;
+    projfinerz_ = projfinerz;
+    projfinephi_ = projfinephi;
+    iphi_ = iphi;
+    shift_ = shift;
+    use_[0][0] = usefirstMinus;
+    use_[0][1] = usefirstPlus;
+    use_[1][0] = usesecondMinus;
+    use_[1][1] = usesecondPlus;
+    isPSseed_ = isPSseed;
+  }
 
-ProjectionTemp::ProjectionTemp() {
-  proj_ = nullptr;
-  slot_ = 0;
-  projrinv_ = 0;
-  projfinerz_ = 0;
-  projfinephi_ = 0;
-  iphi_ = 0;
-  shift_ = 0;
-  use_[0][0] = false;
-  use_[0][1] = false;
-  use_[1][0] = false;
-  use_[1][1] = false;
-  isPSseed_ = false;
-}
+  ProjectionTemp::ProjectionTemp() {
+    proj_ = nullptr;
+    slot_ = 0;
+    projrinv_ = 0;
+    projfinerz_ = 0;
+    projfinephi_ = 0;
+    iphi_ = 0;
+    shift_ = 0;
+    use_[0][0] = false;
+    use_[0][1] = false;
+    use_[1][0] = false;
+    use_[1][1] = false;
+    isPSseed_ = false;
+  }
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/ProjectionTemp.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProjectionTemp.cc
@@ -1,7 +1,8 @@
 #include "L1Trigger/TrackFindingTracklet/interface/ProjectionTemp.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 ProjectionTemp::ProjectionTemp(Tracklet* proj,
                                unsigned int slot,
@@ -42,4 +43,6 @@ ProjectionTemp::ProjectionTemp() {
   use_[1][0] = false;
   use_[1][1] = false;
   isPSseed_ = false;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -23,766 +23,766 @@ using namespace std;
 
 namespace trklet {
 
-PurgeDuplicate::PurgeDuplicate(std::string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global) {}
+  PurgeDuplicate::PurgeDuplicate(std::string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global) {}
 
-void PurgeDuplicate::addOutput(MemoryBase* memory, std::string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-  unordered_set<string> outputs = {"trackout",
-                                   "trackout1",
-                                   "trackout2",
-                                   "trackout3",
-                                   "trackout4",
-                                   "trackout5",
-                                   "trackout6",
-                                   "trackout7",
-                                   "trackout8",
-                                   "trackout9",
-                                   "trackout10",
-                                   "trackout11"};
-  if (outputs.find(output) != outputs.end()) {
-    auto* tmp = dynamic_cast<CleanTrackMemory*>(memory);
-    assert(tmp != nullptr);
-    outputtracklets_.push_back(tmp);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find output: " << output;
-}
-
-void PurgeDuplicate::addInput(MemoryBase* memory, std::string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  unordered_set<string> inputs = {"trackin",
-                                  "trackin1",
-                                  "trackin2",
-                                  "trackin3",
-                                  "trackin4",
-                                  "trackin5",
-                                  "trackin6",
-                                  "trackin7",
-                                  "trackin8",
-                                  "trackin9",
-                                  "trackin10",
-                                  "trackin11",
-                                  "trackin12"};
-  if (inputs.find(input) != inputs.end()) {
-    auto* tmp = dynamic_cast<TrackFitMemory*>(memory);
-    assert(tmp != nullptr);
-    inputtrackfits_.push_back(tmp);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input: " << input;
-}
-
-void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSector) {
-  inputtracklets_.clear();
-  inputtracks_.clear();
-
-  inputstubidslists_.clear();
-  inputstublists_.clear();
-  mergedstubidslists_.clear();
-
-  if (settings_.removalType() != "merge") {
-    for (auto& inputtrackfit : inputtrackfits_) {
-      if (inputtrackfit->nTracks() == 0)
-        continue;
-      for (unsigned int j = 0; j < inputtrackfit->nTracks(); j++) {
-        Track* aTrack = inputtrackfit->getTrack(j)->getTrack();
-        aTrack->setSector(iSector);
-        inputtracks_.push_back(aTrack);
-      }
+  void PurgeDuplicate::addOutput(MemoryBase* memory, std::string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
     }
-    if (inputtracks_.empty())
+    unordered_set<string> outputs = {"trackout",
+                                     "trackout1",
+                                     "trackout2",
+                                     "trackout3",
+                                     "trackout4",
+                                     "trackout5",
+                                     "trackout6",
+                                     "trackout7",
+                                     "trackout8",
+                                     "trackout9",
+                                     "trackout10",
+                                     "trackout11"};
+    if (outputs.find(output) != outputs.end()) {
+      auto* tmp = dynamic_cast<CleanTrackMemory*>(memory);
+      assert(tmp != nullptr);
+      outputtracklets_.push_back(tmp);
       return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find output: " << output;
   }
 
-  unsigned int numTrk = inputtracks_.size();
+  void PurgeDuplicate::addInput(MemoryBase* memory, std::string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    unordered_set<string> inputs = {"trackin",
+                                    "trackin1",
+                                    "trackin2",
+                                    "trackin3",
+                                    "trackin4",
+                                    "trackin5",
+                                    "trackin6",
+                                    "trackin7",
+                                    "trackin8",
+                                    "trackin9",
+                                    "trackin10",
+                                    "trackin11",
+                                    "trackin12"};
+    if (inputs.find(input) != inputs.end()) {
+      auto* tmp = dynamic_cast<TrackFitMemory*>(memory);
+      assert(tmp != nullptr);
+      inputtrackfits_.push_back(tmp);
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input: " << input;
+  }
 
-  ////////////////////
-  // Hybrid Removal //
-  ////////////////////
+  void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSector) {
+    inputtracklets_.clear();
+    inputtracks_.clear();
+
+    inputstubidslists_.clear();
+    inputstublists_.clear();
+    mergedstubidslists_.clear();
+
+    if (settings_.removalType() != "merge") {
+      for (auto& inputtrackfit : inputtrackfits_) {
+        if (inputtrackfit->nTracks() == 0)
+          continue;
+        for (unsigned int j = 0; j < inputtrackfit->nTracks(); j++) {
+          Track* aTrack = inputtrackfit->getTrack(j)->getTrack();
+          aTrack->setSector(iSector);
+          inputtracks_.push_back(aTrack);
+        }
+      }
+      if (inputtracks_.empty())
+        return;
+    }
+
+    unsigned int numTrk = inputtracks_.size();
+
+    ////////////////////
+    // Hybrid Removal //
+    ////////////////////
 #ifdef USEHYBRID
 
-  if (settings_.removalType() == "merge") {
-    // Track seed & duplicate flag
-    std::vector<std::pair<int, bool>> trackInfo;
-    // Flag for tracks in multiple bins that get merged but are not in the correct variable bin
-    std::vector<bool> trackBinInfo;
-    // Vector to store the relative rank of the track candidate for merging, based on seed type
-    std::vector<int> seedRank;
+    if (settings_.removalType() == "merge") {
+      // Track seed & duplicate flag
+      std::vector<std::pair<int, bool>> trackInfo;
+      // Flag for tracks in multiple bins that get merged but are not in the correct variable bin
+      std::vector<bool> trackBinInfo;
+      // Vector to store the relative rank of the track candidate for merging, based on seed type
+      std::vector<int> seedRank;
 
-    // Stubs on every track
-    std::vector<std::vector<const Stub*>> inputstublistsall;
-    // (layer, unique stub index within layer) of each stub on every track
-    std::vector<std::vector<std::pair<int, int>>> mergedstubidslistsall;
-    std::vector<std::vector<std::pair<int, int>>> inputstubidslistsall;
-    std::vector<Tracklet*> inputtrackletsall;
+      // Stubs on every track
+      std::vector<std::vector<const Stub*>> inputstublistsall;
+      // (layer, unique stub index within layer) of each stub on every track
+      std::vector<std::vector<std::pair<int, int>>> mergedstubidslistsall;
+      std::vector<std::vector<std::pair<int, int>>> inputstubidslistsall;
+      std::vector<Tracklet*> inputtrackletsall;
 
-    std::vector<unsigned int> prefTracks;  // Stores all the tracks that are sent to the KF from each bin
-    std::vector<int> prefTrackFit;  // Stores the track seed that corresponds to the associated track in prefTracks
+      std::vector<unsigned int> prefTracks;  // Stores all the tracks that are sent to the KF from each bin
+      std::vector<int> prefTrackFit;  // Stores the track seed that corresponds to the associated track in prefTracks
 
-    for (unsigned int bin = 0; bin < settings_.varRInvBins().size() - 1; bin++) {
-      // Get vectors from TrackFit and save them
-      // inputtracklets: Tracklet objects from the FitTrack (not actually fit yet)
-      // inputstublists: L1Stubs for that track
-      // inputstubidslists: Stub stubIDs for that 3rack
-      // mergedstubidslists: the same as inputstubidslists, but will be used during duplicate removal
-      for (unsigned int i = 0; i < inputtrackfits_.size(); i++) {
-        if (inputtrackfits_[i]->nStublists() == 0)
-          continue;
-        if (inputtrackfits_[i]->nStublists() != inputtrackfits_[i]->nTracks())
-          throw "Number of stublists and tracks don't match up!";
-        for (unsigned int j = 0; j < inputtrackfits_[i]->nStublists(); j++) {
-          if (isTrackInBin(findOverlapRInvBins(inputtrackfits_[i]->getTrack(j)), bin)) {
-            if (inputtracklets_.size() >= settings_.maxStep("DR"))
+      for (unsigned int bin = 0; bin < settings_.varRInvBins().size() - 1; bin++) {
+        // Get vectors from TrackFit and save them
+        // inputtracklets: Tracklet objects from the FitTrack (not actually fit yet)
+        // inputstublists: L1Stubs for that track
+        // inputstubidslists: Stub stubIDs for that 3rack
+        // mergedstubidslists: the same as inputstubidslists, but will be used during duplicate removal
+        for (unsigned int i = 0; i < inputtrackfits_.size(); i++) {
+          if (inputtrackfits_[i]->nStublists() == 0)
+            continue;
+          if (inputtrackfits_[i]->nStublists() != inputtrackfits_[i]->nTracks())
+            throw "Number of stublists and tracks don't match up!";
+          for (unsigned int j = 0; j < inputtrackfits_[i]->nStublists(); j++) {
+            if (isTrackInBin(findOverlapRInvBins(inputtrackfits_[i]->getTrack(j)), bin)) {
+              if (inputtracklets_.size() >= settings_.maxStep("DR"))
+                continue;
+              Tracklet* aTrack = inputtrackfits_[i]->getTrack(j);
+              inputtracklets_.push_back(inputtrackfits_[i]->getTrack(j));
+              std::vector<const Stub*> stublist = inputtrackfits_[i]->getStublist(j);
+              inputstublists_.push_back(stublist);
+              std::vector<std::pair<int, int>> stubidslist = inputtrackfits_[i]->getStubidslist(j);
+              inputstubidslists_.push_back(stubidslist);
+              mergedstubidslists_.push_back(stubidslist);
+
+              // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7
+              // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
+              // Best Rank:           L1L2 > L3L4 > D3D4 > D1D2 > L2L3 > L2D1 > L5L6 > L1D1
+              // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
+              unsigned int curSeed = aTrack->seedIndex();
+              std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
+              if (settings_.extended())
+                seedRank.push_back(9);
+              else
+                seedRank.push_back(ranks[curSeed]);
+
+              if (stublist.size() != stubidslist.size())
+                throw "Number of stubs and stubids don't match up!";
+
+              trackInfo.emplace_back(i, false);
+              trackBinInfo.emplace_back(false);
+            } else
               continue;
-            Tracklet* aTrack = inputtrackfits_[i]->getTrack(j);
-            inputtracklets_.push_back(inputtrackfits_[i]->getTrack(j));
-            std::vector<const Stub*> stublist = inputtrackfits_[i]->getStublist(j);
-            inputstublists_.push_back(stublist);
-            std::vector<std::pair<int, int>> stubidslist = inputtrackfits_[i]->getStubidslist(j);
-            inputstubidslists_.push_back(stubidslist);
-            mergedstubidslists_.push_back(stubidslist);
-
-            // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7
-            // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
-            // Best Rank:           L1L2 > L3L4 > D3D4 > D1D2 > L2L3 > L2D1 > L5L6 > L1D1
-            // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
-            unsigned int curSeed = aTrack->seedIndex();
-            std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
-            if (settings_.extended())
-              seedRank.push_back(9);
-            else
-              seedRank.push_back(ranks[curSeed]);
-
-            if (stublist.size() != stubidslist.size())
-              throw "Number of stubs and stubids don't match up!";
-
-            trackInfo.emplace_back(i, false);
-            trackBinInfo.emplace_back(false);
-          } else
-            continue;
+          }
         }
-      }
 
-      if (inputtracklets_.empty())
-        continue;
-      unsigned int numStublists = inputstublists_.size();
+        if (inputtracklets_.empty())
+          continue;
+        unsigned int numStublists = inputstublists_.size();
 
-      if (settings_.inventStubs()) {
+        if (settings_.inventStubs()) {
+          for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
+            inputstublists_[itrk] = getInventedSeedingStub(iSector, inputtracklets_[itrk], inputstublists_[itrk]);
+          }
+        }
+
+        // Initialize all-false 2D array of tracks being duplicates to other tracks
+        bool dupMap[numStublists][numStublists];  // Ends up symmetric
         for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-          inputstublists_[itrk] = getInventedSeedingStub(iSector, inputtracklets_[itrk], inputstublists_[itrk]);
+          for (unsigned int jtrk = 0; jtrk < numStublists; jtrk++) {
+            dupMap[itrk][jtrk] = false;
+          }
         }
-      }
 
-      // Initialize all-false 2D array of tracks being duplicates to other tracks
-      bool dupMap[numStublists][numStublists];  // Ends up symmetric
-      for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-        for (unsigned int jtrk = 0; jtrk < numStublists; jtrk++) {
-          dupMap[itrk][jtrk] = false;
+        // Used to check if a track is in two bins, is not a duplicate in either bin, so is sent out twice
+        bool noMerge[numStublists];
+        for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
+          noMerge[itrk] = false;
         }
-      }
 
-      // Used to check if a track is in two bins, is not a duplicate in either bin, so is sent out twice
-      bool noMerge[numStublists];
-      for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-        noMerge[itrk] = false;
-      }
+        // Find duplicates; Fill dupMap by looping over all pairs of "tracks"
+        // numStublists-1 since last track has no other to compare to
+        for (unsigned int itrk = 0; itrk < numStublists - 1; itrk++) {
+          for (unsigned int jtrk = itrk + 1; jtrk < numStublists; jtrk++) {
+            if (itrk >= settings_.numTracksComparedPerBin())
+              continue;
+            // Get primary track stubids = (layer, unique stub index within layer)
+            const std::vector<std::pair<int, int>>& stubsTrk1 = inputstubidslists_[itrk];
 
-      // Find duplicates; Fill dupMap by looping over all pairs of "tracks"
-      // numStublists-1 since last track has no other to compare to
-      for (unsigned int itrk = 0; itrk < numStublists - 1; itrk++) {
-        for (unsigned int jtrk = itrk + 1; jtrk < numStublists; jtrk++) {
-          if (itrk >= settings_.numTracksComparedPerBin())
-            continue;
-          // Get primary track stubids = (layer, unique stub index within layer)
-          const std::vector<std::pair<int, int>>& stubsTrk1 = inputstubidslists_[itrk];
+            // Get and count secondary track stubids
+            const std::vector<std::pair<int, int>>& stubsTrk2 = inputstubidslists_[jtrk];
 
-          // Get and count secondary track stubids
-          const std::vector<std::pair<int, int>>& stubsTrk2 = inputstubidslists_[jtrk];
-
-          // Count number of layers that share stubs, and the number of UR that each track hits
-          unsigned int nShareLay = 0;
-          unsigned int nLayStubTrk1 = 0;
-          unsigned int nLayStubTrk2 = 0;
-          if (settings_.mergeComparison() == "CompareAll") {
-            bool layerArr[16];
-            for (auto& i : layerArr) {
-              i = false;
-            };
-            for (const auto& st1 : stubsTrk1) {
-              for (const auto& st2 : stubsTrk2) {
-                if (st1.first == st2.first && st1.second == st2.second) {  // tracks share stub
-                  // Converts layer/disk encoded in st1->first to an index in the layer array
-                  int i = st1.first;  // layer/disk
-                  bool barrel = (i > 0 && i < 10);
-                  bool endcapA = (i > 10);
-                  bool endcapB = (i < 0);
-                  int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
-                  if (!layerArr[lay]) {
-                    nShareLay++;
-                    layerArr[lay] = true;
+            // Count number of layers that share stubs, and the number of UR that each track hits
+            unsigned int nShareLay = 0;
+            unsigned int nLayStubTrk1 = 0;
+            unsigned int nLayStubTrk2 = 0;
+            if (settings_.mergeComparison() == "CompareAll") {
+              bool layerArr[16];
+              for (auto& i : layerArr) {
+                i = false;
+              };
+              for (const auto& st1 : stubsTrk1) {
+                for (const auto& st2 : stubsTrk2) {
+                  if (st1.first == st2.first && st1.second == st2.second) {  // tracks share stub
+                    // Converts layer/disk encoded in st1->first to an index in the layer array
+                    int i = st1.first;  // layer/disk
+                    bool barrel = (i > 0 && i < 10);
+                    bool endcapA = (i > 10);
+                    bool endcapB = (i < 0);
+                    int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
+                    if (!layerArr[lay]) {
+                      nShareLay++;
+                      layerArr[lay] = true;
+                    }
                   }
                 }
               }
-            }
-          } else if (settings_.mergeComparison() == "CompareBest") {
-            std::vector<const Stub*> fullStubslistsTrk1 = inputstublists_[itrk];
-            std::vector<const Stub*> fullStubslistsTrk2 = inputstublists_[jtrk];
+            } else if (settings_.mergeComparison() == "CompareBest") {
+              std::vector<const Stub*> fullStubslistsTrk1 = inputstublists_[itrk];
+              std::vector<const Stub*> fullStubslistsTrk2 = inputstublists_[jtrk];
 
-            // Arrays to store the index of the best stub in each layer
-            int layStubidsTrk1[16];
-            int layStubidsTrk2[16];
-            for (int i = 0; i < 16; i++) {
-              layStubidsTrk1[i] = -1;
-              layStubidsTrk2[i] = -1;
-            }
-            // For each stub on the first track, find the stub with the best residual and store its index in the layStubidsTrk1 array
-            for (unsigned int stcount = 0; stcount < stubsTrk1.size(); stcount++) {
-              int i = stubsTrk1[stcount].first;  // layer/disk
-              bool barrel = (i > 0 && i < 10);
-              bool endcapA = (i > 10);
-              bool endcapB = (i < 0);
-              int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
-              double nres = getPhiRes(inputtracklets_[itrk], fullStubslistsTrk1[stcount]);
-              double ores = 0;
-              if (layStubidsTrk1[lay] != -1)
-                ores = getPhiRes(inputtracklets_[itrk], fullStubslistsTrk1[layStubidsTrk1[lay]]);
-              if (layStubidsTrk1[lay] == -1 || nres < ores) {
-                layStubidsTrk1[lay] = stcount;
+              // Arrays to store the index of the best stub in each layer
+              int layStubidsTrk1[16];
+              int layStubidsTrk2[16];
+              for (int i = 0; i < 16; i++) {
+                layStubidsTrk1[i] = -1;
+                layStubidsTrk2[i] = -1;
               }
-            }
-            // For each stub on the second track, find the stub with the best residual and store its index in the layStubidsTrk1 array
-            for (unsigned int stcount = 0; stcount < stubsTrk2.size(); stcount++) {
-              int i = stubsTrk2[stcount].first;  // layer/disk
-              bool barrel = (i > 0 && i < 10);
-              bool endcapA = (i > 10);
-              bool endcapB = (i < 0);
-              int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
-              double nres = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[stcount]);
-              double ores = 0;
-              if (layStubidsTrk2[lay] != -1)
-                ores = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[layStubidsTrk2[lay]]);
-              if (layStubidsTrk2[lay] == -1 || nres < ores) {
-                layStubidsTrk2[lay] = stcount;
-              }
-            }
-            // For all 16 layers (6 layers and 10 disks), count the number of layers who's best stub on both tracks are the same
-            for (int i = 0; i < 16; i++) {
-              int t1i = layStubidsTrk1[i];
-              int t2i = layStubidsTrk2[i];
-              if (t1i != -1 && t2i != -1 && stubsTrk1[t1i].first == stubsTrk2[t2i].first &&
-                  stubsTrk1[t1i].second == stubsTrk2[t2i].second)
-                nShareLay++;
-            }
-            // Calculate the number of layers hit by each track, so that this number can be used in calculating the number of independent
-            // stubs on a track (not enabled/used by default)
-            for (int i = 0; i < 16; i++) {
-              if (layStubidsTrk1[i] != -1)
-                nLayStubTrk1++;
-              if (layStubidsTrk2[i] != -1)
-                nLayStubTrk2++;
-            }
-          }
-
-          // Fill duplicate map
-          if (nShareLay >= settings_.minIndStubs()) {  // For number of shared stub merge condition
-            dupMap[itrk][jtrk] = true;
-            dupMap[jtrk][itrk] = true;
-          }
-        }
-      }
-
-      // Check to see if the track is a duplicate
-      for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-        for (unsigned int jtrk = 0; jtrk < numStublists; jtrk++) {
-          if (dupMap[itrk][jtrk]) {
-            noMerge[itrk] = true;
-          }
-        }
-      }
-
-      // If the track isn't a duplicate, and if it's in more than one bin, and it is not in the proper varrinvbin, then mark it so it won't be sent to output
-      for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-        if (noMerge[itrk] == false) {
-          if ((findOverlapRInvBins(inputtracklets_[itrk]).size() > 1) &&
-              (findVarRInvBin(inputtracklets_[itrk]) != bin)) {
-            trackInfo[itrk].second = true;
-          }
-        }
-      }
-      // Merge duplicate tracks
-      for (unsigned int itrk = 0; itrk < numStublists - 1; itrk++) {
-        for (unsigned int jtrk = itrk + 1; jtrk < numStublists; jtrk++) {
-          // Merge a track with its first duplicate found.
-          if (dupMap[itrk][jtrk]) {
-            // Set preferred track based on seed rank
-            int preftrk;
-            int rejetrk;
-            if (seedRank[itrk] < seedRank[jtrk]) {
-              preftrk = itrk;
-              rejetrk = jtrk;
-            } else {
-              preftrk = jtrk;
-              rejetrk = itrk;
-            }
-
-            // If the preffered track is in more than one bin, but not in the proper varrinvbin, then mark as true
-            if ((findOverlapRInvBins(inputtracklets_[preftrk]).size() > 1) &&
-                (findVarRInvBin(inputtracklets_[preftrk]) != bin)) {
-              trackBinInfo[preftrk] = true;
-              trackBinInfo[rejetrk] = true;
-            } else {
-              // Get a merged stub list
-              std::vector<const Stub*> newStubList;
-              std::vector<const Stub*> stubsTrk1 = inputstublists_[preftrk];
-              std::vector<const Stub*> stubsTrk2 = inputstublists_[rejetrk];
-              std::vector<unsigned int> stubsTrk1indices;
-              std::vector<unsigned int> stubsTrk2indices;
-              for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
-                stubsTrk1indices.push_back(stubsTrk1[stub1it]->l1tstub()->uniqueIndex());
-              }
-              for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
-                stubsTrk2indices.push_back(stubsTrk2[stub2it]->l1tstub()->uniqueIndex());
-              }
-              newStubList = stubsTrk1;
-              for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
-                if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) ==
-                    stubsTrk1indices.end()) {
-                  newStubList.push_back(stubsTrk2[stub2it]);
+              // For each stub on the first track, find the stub with the best residual and store its index in the layStubidsTrk1 array
+              for (unsigned int stcount = 0; stcount < stubsTrk1.size(); stcount++) {
+                int i = stubsTrk1[stcount].first;  // layer/disk
+                bool barrel = (i > 0 && i < 10);
+                bool endcapA = (i > 10);
+                bool endcapB = (i < 0);
+                int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
+                double nres = getPhiRes(inputtracklets_[itrk], fullStubslistsTrk1[stcount]);
+                double ores = 0;
+                if (layStubidsTrk1[lay] != -1)
+                  ores = getPhiRes(inputtracklets_[itrk], fullStubslistsTrk1[layStubidsTrk1[lay]]);
+                if (layStubidsTrk1[lay] == -1 || nres < ores) {
+                  layStubidsTrk1[lay] = stcount;
                 }
               }
-              //   Overwrite stublist of preferred track with merged list
-              inputstublists_[preftrk] = newStubList;
-
-              std::vector<std::pair<int, int>> newStubidsList;
-              std::vector<std::pair<int, int>> stubidsTrk1 = mergedstubidslists_[preftrk];
-              std::vector<std::pair<int, int>> stubidsTrk2 = mergedstubidslists_[rejetrk];
-              newStubidsList = stubidsTrk1;
-
-              for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
-                if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) ==
-                    stubsTrk1indices.end()) {
-                  newStubidsList.push_back(stubidsTrk2[stub2it]);
+              // For each stub on the second track, find the stub with the best residual and store its index in the layStubidsTrk1 array
+              for (unsigned int stcount = 0; stcount < stubsTrk2.size(); stcount++) {
+                int i = stubsTrk2[stcount].first;  // layer/disk
+                bool barrel = (i > 0 && i < 10);
+                bool endcapA = (i > 10);
+                bool endcapB = (i < 0);
+                int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
+                double nres = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[stcount]);
+                double ores = 0;
+                if (layStubidsTrk2[lay] != -1)
+                  ores = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[layStubidsTrk2[lay]]);
+                if (layStubidsTrk2[lay] == -1 || nres < ores) {
+                  layStubidsTrk2[lay] = stcount;
                 }
               }
-              // Overwrite stubidslist of preferred track with merged list
-              mergedstubidslists_[preftrk] = newStubidsList;
+              // For all 16 layers (6 layers and 10 disks), count the number of layers who's best stub on both tracks are the same
+              for (int i = 0; i < 16; i++) {
+                int t1i = layStubidsTrk1[i];
+                int t2i = layStubidsTrk2[i];
+                if (t1i != -1 && t2i != -1 && stubsTrk1[t1i].first == stubsTrk2[t2i].first &&
+                    stubsTrk1[t1i].second == stubsTrk2[t2i].second)
+                  nShareLay++;
+              }
+              // Calculate the number of layers hit by each track, so that this number can be used in calculating the number of independent
+              // stubs on a track (not enabled/used by default)
+              for (int i = 0; i < 16; i++) {
+                if (layStubidsTrk1[i] != -1)
+                  nLayStubTrk1++;
+                if (layStubidsTrk2[i] != -1)
+                  nLayStubTrk2++;
+              }
+            }
 
-              // Mark that rejected track has been merged into another track
-              trackInfo[rejetrk].second = true;
+            // Fill duplicate map
+            if (nShareLay >= settings_.minIndStubs()) {  // For number of shared stub merge condition
+              dupMap[itrk][jtrk] = true;
+              dupMap[jtrk][itrk] = true;
             }
           }
         }
+
+        // Check to see if the track is a duplicate
+        for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
+          for (unsigned int jtrk = 0; jtrk < numStublists; jtrk++) {
+            if (dupMap[itrk][jtrk]) {
+              noMerge[itrk] = true;
+            }
+          }
+        }
+
+        // If the track isn't a duplicate, and if it's in more than one bin, and it is not in the proper varrinvbin, then mark it so it won't be sent to output
+        for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
+          if (noMerge[itrk] == false) {
+            if ((findOverlapRInvBins(inputtracklets_[itrk]).size() > 1) &&
+                (findVarRInvBin(inputtracklets_[itrk]) != bin)) {
+              trackInfo[itrk].second = true;
+            }
+          }
+        }
+        // Merge duplicate tracks
+        for (unsigned int itrk = 0; itrk < numStublists - 1; itrk++) {
+          for (unsigned int jtrk = itrk + 1; jtrk < numStublists; jtrk++) {
+            // Merge a track with its first duplicate found.
+            if (dupMap[itrk][jtrk]) {
+              // Set preferred track based on seed rank
+              int preftrk;
+              int rejetrk;
+              if (seedRank[itrk] < seedRank[jtrk]) {
+                preftrk = itrk;
+                rejetrk = jtrk;
+              } else {
+                preftrk = jtrk;
+                rejetrk = itrk;
+              }
+
+              // If the preffered track is in more than one bin, but not in the proper varrinvbin, then mark as true
+              if ((findOverlapRInvBins(inputtracklets_[preftrk]).size() > 1) &&
+                  (findVarRInvBin(inputtracklets_[preftrk]) != bin)) {
+                trackBinInfo[preftrk] = true;
+                trackBinInfo[rejetrk] = true;
+              } else {
+                // Get a merged stub list
+                std::vector<const Stub*> newStubList;
+                std::vector<const Stub*> stubsTrk1 = inputstublists_[preftrk];
+                std::vector<const Stub*> stubsTrk2 = inputstublists_[rejetrk];
+                std::vector<unsigned int> stubsTrk1indices;
+                std::vector<unsigned int> stubsTrk2indices;
+                for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
+                  stubsTrk1indices.push_back(stubsTrk1[stub1it]->l1tstub()->uniqueIndex());
+                }
+                for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
+                  stubsTrk2indices.push_back(stubsTrk2[stub2it]->l1tstub()->uniqueIndex());
+                }
+                newStubList = stubsTrk1;
+                for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
+                  if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) ==
+                      stubsTrk1indices.end()) {
+                    newStubList.push_back(stubsTrk2[stub2it]);
+                  }
+                }
+                //   Overwrite stublist of preferred track with merged list
+                inputstublists_[preftrk] = newStubList;
+
+                std::vector<std::pair<int, int>> newStubidsList;
+                std::vector<std::pair<int, int>> stubidsTrk1 = mergedstubidslists_[preftrk];
+                std::vector<std::pair<int, int>> stubidsTrk2 = mergedstubidslists_[rejetrk];
+                newStubidsList = stubidsTrk1;
+
+                for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
+                  if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) ==
+                      stubsTrk1indices.end()) {
+                    newStubidsList.push_back(stubidsTrk2[stub2it]);
+                  }
+                }
+                // Overwrite stubidslist of preferred track with merged list
+                mergedstubidslists_[preftrk] = newStubidsList;
+
+                // Mark that rejected track has been merged into another track
+                trackInfo[rejetrk].second = true;
+              }
+            }
+          }
+        }
+
+        for (unsigned int ktrk = 0; ktrk < numStublists; ktrk++) {
+          if ((trackInfo[ktrk].second != true) && (trackBinInfo[ktrk] != true)) {
+            prefTracks.push_back(ktrk);
+            prefTrackFit.push_back(trackInfo[ktrk].first);
+            inputtrackletsall.push_back(inputtracklets_[ktrk]);
+            inputstublistsall.push_back(inputstublists_[ktrk]);
+            inputstubidslistsall.push_back(inputstubidslists_[ktrk]);
+            mergedstubidslistsall.push_back(mergedstubidslists_[ktrk]);
+          }
+        }
+
+        // Need to clear all the vectors which will be used in the next bin
+        seedRank.clear();
+        trackInfo.clear();
+        trackBinInfo.clear();
+        inputtracklets_.clear();
+        inputstublists_.clear();
+        inputstubidslists_.clear();
+        mergedstubidslists_.clear();
       }
 
-      for (unsigned int ktrk = 0; ktrk < numStublists; ktrk++) {
-        if ((trackInfo[ktrk].second != true) && (trackBinInfo[ktrk] != true)) {
-          prefTracks.push_back(ktrk);
-          prefTrackFit.push_back(trackInfo[ktrk].first);
-          inputtrackletsall.push_back(inputtracklets_[ktrk]);
-          inputstublistsall.push_back(inputstublists_[ktrk]);
-          inputstubidslistsall.push_back(inputstubidslists_[ktrk]);
-          mergedstubidslistsall.push_back(mergedstubidslists_[ktrk]);
+      // Make the final track objects, fit with KF, and send to output
+      for (unsigned int itrk = 0; itrk < prefTracks.size(); itrk++) {
+        Tracklet* tracklet = inputtrackletsall[itrk];
+        std::vector<const Stub*> trackstublist = inputstublistsall[itrk];
+
+        // Run KF track fit
+        HybridFit hybridFitter(iSector, settings_, globals_);
+        hybridFitter.Fit(tracklet, trackstublist);
+
+        // If the track was accepted (and thus fit), add to output
+        if (tracklet->fit()) {
+          // Add fitted Track to output (later converted to TTTrack)
+          Track* outtrack = tracklet->getTrack();
+          outtrack->setSector(iSector);
+          // Also store fitted track as more detailed Tracklet object.
+          outputtracklets_[prefTrackFit[itrk]]->addTrack(tracklet);
+
+          // Add all tracks to standalone root file output
+          outtrack->setStubIDpremerge(inputstubidslistsall[itrk]);
+          outtrack->setStubIDprefit(mergedstubidslistsall[itrk]);
+          outputtracks_.push_back(*outtrack);
         }
       }
-
-      // Need to clear all the vectors which will be used in the next bin
-      seedRank.clear();
-      trackInfo.clear();
-      trackBinInfo.clear();
-      inputtracklets_.clear();
-      inputstublists_.clear();
-      inputstubidslists_.clear();
-      mergedstubidslists_.clear();
     }
-
-    // Make the final track objects, fit with KF, and send to output
-    for (unsigned int itrk = 0; itrk < prefTracks.size(); itrk++) {
-      Tracklet* tracklet = inputtrackletsall[itrk];
-      std::vector<const Stub*> trackstublist = inputstublistsall[itrk];
-
-      // Run KF track fit
-      HybridFit hybridFitter(iSector, settings_, globals_);
-      hybridFitter.Fit(tracklet, trackstublist);
-
-      // If the track was accepted (and thus fit), add to output
-      if (tracklet->fit()) {
-        // Add fitted Track to output (later converted to TTTrack)
-        Track* outtrack = tracklet->getTrack();
-        outtrack->setSector(iSector);
-        // Also store fitted track as more detailed Tracklet object.
-        outputtracklets_[prefTrackFit[itrk]]->addTrack(tracklet);
-
-        // Add all tracks to standalone root file output
-        outtrack->setStubIDpremerge(inputstubidslistsall[itrk]);
-        outtrack->setStubIDprefit(mergedstubidslistsall[itrk]);
-        outputtracks_.push_back(*outtrack);
-      }
-    }
-  }
 
 #endif
 
-  //////////////////
-  // Grid removal //
-  //////////////////
-  if (settings_.removalType() == "grid") {
-    // Sort tracks by ichisq/DoF so that removal will keep the lower ichisq/DoF track
-    std::sort(inputtracks_.begin(), inputtracks_.end(), [](const Track* lhs, const Track* rhs) {
-      return lhs->ichisq() / lhs->stubID().size() < rhs->ichisq() / rhs->stubID().size();
-    });
-    bool grid[35][40] = {{false}};
+    //////////////////
+    // Grid removal //
+    //////////////////
+    if (settings_.removalType() == "grid") {
+      // Sort tracks by ichisq/DoF so that removal will keep the lower ichisq/DoF track
+      std::sort(inputtracks_.begin(), inputtracks_.end(), [](const Track* lhs, const Track* rhs) {
+        return lhs->ichisq() / lhs->stubID().size() < rhs->ichisq() / rhs->stubID().size();
+      });
+      bool grid[35][40] = {{false}};
 
-    for (unsigned int itrk = 0; itrk < numTrk; itrk++) {
-      if (inputtracks_[itrk]->duplicate())
-        edm::LogPrint("Tracklet") << "WARNING: Track already tagged as duplicate!!";
+      for (unsigned int itrk = 0; itrk < numTrk; itrk++) {
+        if (inputtracks_[itrk]->duplicate())
+          edm::LogPrint("Tracklet") << "WARNING: Track already tagged as duplicate!!";
 
-      double phiBin = (inputtracks_[itrk]->phi0(settings_) - 2 * M_PI / 27 * iSector) / (2 * M_PI / 9 / 50) + 9;
-      phiBin = std::max(phiBin, 0.);
-      phiBin = std::min(phiBin, 34.);
+        double phiBin = (inputtracks_[itrk]->phi0(settings_) - 2 * M_PI / 27 * iSector) / (2 * M_PI / 9 / 50) + 9;
+        phiBin = std::max(phiBin, 0.);
+        phiBin = std::min(phiBin, 34.);
 
-      double ptBin = 1 / inputtracks_[itrk]->pt(settings_) * 40 + 20;
-      ptBin = std::max(ptBin, 0.);
-      ptBin = std::min(ptBin, 39.);
+        double ptBin = 1 / inputtracks_[itrk]->pt(settings_) * 40 + 20;
+        ptBin = std::max(ptBin, 0.);
+        ptBin = std::min(ptBin, 39.);
 
-      if (grid[(int)phiBin][(int)ptBin])
-        inputtracks_[itrk]->setDuplicate(true);
-      grid[(int)phiBin][(int)ptBin] = true;
+        if (grid[(int)phiBin][(int)ptBin])
+          inputtracks_[itrk]->setDuplicate(true);
+        grid[(int)phiBin][(int)ptBin] = true;
 
-      double phiTest = inputtracks_[itrk]->phi0(settings_) - 2 * M_PI / 27 * iSector;
-      if (phiTest < -2 * M_PI / 27)
-        edm::LogVerbatim("Tracklet") << "track phi too small!";
-      if (phiTest > 2 * 2 * M_PI / 27)
-        edm::LogVerbatim("Tracklet") << "track phi too big!";
-    }
-  }  // end grid removal
+        double phiTest = inputtracks_[itrk]->phi0(settings_) - 2 * M_PI / 27 * iSector;
+        if (phiTest < -2 * M_PI / 27)
+          edm::LogVerbatim("Tracklet") << "track phi too small!";
+        if (phiTest > 2 * 2 * M_PI / 27)
+          edm::LogVerbatim("Tracklet") << "track phi too big!";
+      }
+    }  // end grid removal
 
-  //////////////////////////
-  // ichi + nstub removal //
-  //////////////////////////
-  if (settings_.removalType() == "ichi" || settings_.removalType() == "nstub") {
-    for (unsigned int itrk = 0; itrk < numTrk - 1; itrk++) {  // numTrk-1 since last track has no other to compare to
+    //////////////////////////
+    // ichi + nstub removal //
+    //////////////////////////
+    if (settings_.removalType() == "ichi" || settings_.removalType() == "nstub") {
+      for (unsigned int itrk = 0; itrk < numTrk - 1; itrk++) {  // numTrk-1 since last track has no other to compare to
 
-      // If primary track is a duplicate, it cannot veto any...move on
-      if (inputtracks_[itrk]->duplicate() == 1)
-        continue;
-
-      unsigned int nStubP = 0;
-      vector<unsigned int> nStubS(numTrk);
-      vector<unsigned int> nShare(numTrk);
-      // Get and count primary stubs
-      std::map<int, int> stubsTrk1 = inputtracks_[itrk]->stubID();
-      nStubP = stubsTrk1.size();
-
-      for (unsigned int jtrk = itrk + 1; jtrk < numTrk; jtrk++) {
-        // Skip duplicate tracks
-        if (inputtracks_[jtrk]->duplicate() == 1)
+        // If primary track is a duplicate, it cannot veto any...move on
+        if (inputtracks_[itrk]->duplicate() == 1)
           continue;
 
-        // Get and count secondary stubs
-        std::map<int, int> stubsTrk2 = inputtracks_[jtrk]->stubID();
-        nStubS[jtrk] = stubsTrk2.size();
+        unsigned int nStubP = 0;
+        vector<unsigned int> nStubS(numTrk);
+        vector<unsigned int> nShare(numTrk);
+        // Get and count primary stubs
+        std::map<int, int> stubsTrk1 = inputtracks_[itrk]->stubID();
+        nStubP = stubsTrk1.size();
 
-        // Count shared stubs
-        for (auto& st : stubsTrk1) {
-          if (stubsTrk2.find(st.first) != stubsTrk2.end()) {
-            if (st.second == stubsTrk2[st.first])
-              nShare[jtrk]++;
+        for (unsigned int jtrk = itrk + 1; jtrk < numTrk; jtrk++) {
+          // Skip duplicate tracks
+          if (inputtracks_[jtrk]->duplicate() == 1)
+            continue;
+
+          // Get and count secondary stubs
+          std::map<int, int> stubsTrk2 = inputtracks_[jtrk]->stubID();
+          nStubS[jtrk] = stubsTrk2.size();
+
+          // Count shared stubs
+          for (auto& st : stubsTrk1) {
+            if (stubsTrk2.find(st.first) != stubsTrk2.end()) {
+              if (st.second == stubsTrk2[st.first])
+                nShare[jtrk]++;
+            }
           }
         }
-      }
 
-      // Tag duplicates
-      for (unsigned int jtrk = itrk + 1; jtrk < numTrk; jtrk++) {
-        // Skip duplicate tracks
-        if (inputtracks_[jtrk]->duplicate() == 1)
-          continue;
+        // Tag duplicates
+        for (unsigned int jtrk = itrk + 1; jtrk < numTrk; jtrk++) {
+          // Skip duplicate tracks
+          if (inputtracks_[jtrk]->duplicate() == 1)
+            continue;
 
-        // Chi2 duplicate removal
-        if (settings_.removalType() == "ichi") {
-          if ((nStubP - nShare[jtrk] < settings_.minIndStubs()) ||
-              (nStubS[jtrk] - nShare[jtrk] < settings_.minIndStubs())) {
-            if ((int)inputtracks_[itrk]->ichisq() / (2 * inputtracks_[itrk]->stubID().size() - 4) >
-                (int)inputtracks_[jtrk]->ichisq() / (2 * inputtracks_[itrk]->stubID().size() - 4)) {
+          // Chi2 duplicate removal
+          if (settings_.removalType() == "ichi") {
+            if ((nStubP - nShare[jtrk] < settings_.minIndStubs()) ||
+                (nStubS[jtrk] - nShare[jtrk] < settings_.minIndStubs())) {
+              if ((int)inputtracks_[itrk]->ichisq() / (2 * inputtracks_[itrk]->stubID().size() - 4) >
+                  (int)inputtracks_[jtrk]->ichisq() / (2 * inputtracks_[itrk]->stubID().size() - 4)) {
+                inputtracks_[itrk]->setDuplicate(true);
+              } else if ((int)inputtracks_[itrk]->ichisq() / (2 * inputtracks_[itrk]->stubID().size() - 4) <=
+                         (int)inputtracks_[jtrk]->ichisq() / (2 * inputtracks_[itrk]->stubID().size() - 4)) {
+                inputtracks_[jtrk]->setDuplicate(true);
+              } else {
+                edm::LogVerbatim("Tracklet") << "Error: Didn't tag either track in duplicate pair.";
+              }
+            }
+          }  // end ichi removal
+
+          // nStub duplicate removal
+          if (settings_.removalType() == "nstub") {
+            if ((nStubP - nShare[jtrk] < settings_.minIndStubs()) && (nStubP < nStubS[jtrk])) {
               inputtracks_[itrk]->setDuplicate(true);
-            } else if ((int)inputtracks_[itrk]->ichisq() / (2 * inputtracks_[itrk]->stubID().size() - 4) <=
-                       (int)inputtracks_[jtrk]->ichisq() / (2 * inputtracks_[itrk]->stubID().size() - 4)) {
+            } else if ((nStubS[jtrk] - nShare[jtrk] < settings_.minIndStubs()) && (nStubS[jtrk] <= nStubP)) {
               inputtracks_[jtrk]->setDuplicate(true);
             } else {
               edm::LogVerbatim("Tracklet") << "Error: Didn't tag either track in duplicate pair.";
             }
+          }  // end nstub removal
+
+        }  // end tag duplicates
+
+      }  // end loop over primary track
+
+    }  // end ichi + nstub removal
+
+    //Add tracks to output
+    if (settings_.removalType() != "merge") {
+      for (unsigned int i = 0; i < inputtrackfits_.size(); i++) {
+        for (unsigned int j = 0; j < inputtrackfits_[i]->nTracks(); j++) {
+          if (inputtrackfits_[i]->getTrack(j)->getTrack()->duplicate() == 0) {
+            if (settings_.writeMonitorData("Seeds")) {
+              ofstream fout("seeds.txt", ofstream::app);
+              fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector << " "
+                   << inputtrackfits_[i]->getTrack(j)->getISeed() << endl;
+              fout.close();
+            }
+            outputtracklets_[i]->addTrack(inputtrackfits_[i]->getTrack(j));
           }
-        }  // end ichi removal
-
-        // nStub duplicate removal
-        if (settings_.removalType() == "nstub") {
-          if ((nStubP - nShare[jtrk] < settings_.minIndStubs()) && (nStubP < nStubS[jtrk])) {
-            inputtracks_[itrk]->setDuplicate(true);
-          } else if ((nStubS[jtrk] - nShare[jtrk] < settings_.minIndStubs()) && (nStubS[jtrk] <= nStubP)) {
-            inputtracks_[jtrk]->setDuplicate(true);
-          } else {
-            edm::LogVerbatim("Tracklet") << "Error: Didn't tag either track in duplicate pair.";
-          }
-        }  // end nstub removal
-
-      }  // end tag duplicates
-
-    }  // end loop over primary track
-
-  }  // end ichi + nstub removal
-
-  //Add tracks to output
-  if (settings_.removalType() != "merge") {
-    for (unsigned int i = 0; i < inputtrackfits_.size(); i++) {
-      for (unsigned int j = 0; j < inputtrackfits_[i]->nTracks(); j++) {
-        if (inputtrackfits_[i]->getTrack(j)->getTrack()->duplicate() == 0) {
-          if (settings_.writeMonitorData("Seeds")) {
-            ofstream fout("seeds.txt", ofstream::app);
-            fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector << " "
-                 << inputtrackfits_[i]->getTrack(j)->getISeed() << endl;
-            fout.close();
-          }
-          outputtracklets_[i]->addTrack(inputtrackfits_[i]->getTrack(j));
+          //For root file:
+          outputtracks_.push_back(*inputtrackfits_[i]->getTrack(j)->getTrack());
         }
-        //For root file:
-        outputtracks_.push_back(*inputtrackfits_[i]->getTrack(j)->getTrack());
       }
     }
   }
-}
 
-double PurgeDuplicate::getPhiRes(Tracklet* curTracklet, const Stub* curStub) const {
-  double phiproj;
-  double stubphi;
-  double phires;
-  // Get phi position of stub
-  stubphi = curStub->l1tstub()->phi();
-  // Get layer that the stub is in (Layer 1->6, Disk 1->5)
-  int Layer = curStub->layerdisk() + 1;
-  if (Layer > N_LAYER) {
-    Layer = 0;
-  }
-  int Disk = curStub->layerdisk() - (N_LAYER - 1);
-  if (Disk < 0) {
-    Disk = 0;
-  }
-  // Get phi projection of tracklet
-  int seedindex = curTracklet->seedIndex();
-  // If this stub is a seed stub, set projection=phi, so that res=0
-  if (isSeedingStub(seedindex, Layer, Disk)) {
-    phiproj = stubphi;
-    // Otherwise, get projection of tracklet
-  } else {
-    phiproj = curTracklet->proj(curStub->layerdisk()).phiproj();
-  }
-  // Calculate residual
-  phires = std::abs(stubphi - phiproj);
-  return phires;
-}
-
-bool PurgeDuplicate::isSeedingStub(int seedindex, int Layer, int Disk) const {
-  if ((seedindex == 0 && (Layer == 1 || Layer == 2)) || (seedindex == 1 && (Layer == 2 || Layer == 3)) ||
-      (seedindex == 2 && (Layer == 3 || Layer == 4)) || (seedindex == 3 && (Layer == 5 || Layer == 6)) ||
-      (seedindex == 4 && (abs(Disk) == 1 || abs(Disk) == 2)) ||
-      (seedindex == 5 && (abs(Disk) == 3 || abs(Disk) == 4)) || (seedindex == 6 && (Layer == 1 || abs(Disk) == 1)) ||
-      (seedindex == 7 && (Layer == 2 || abs(Disk) == 1)) ||
-      (seedindex == 8 && (Layer == 2 || Layer == 3 || Layer == 4)) ||
-      (seedindex == 9 && (Layer == 4 || Layer == 5 || Layer == 6)) ||
-      (seedindex == 10 && (Layer == 2 || Layer == 3 || abs(Disk) == 1)) ||
-      (seedindex == 11 && (Layer == 2 || abs(Disk) == 1 || abs(Disk) == 2)))
-    return true;
-
-  return false;
-}
-
-std::pair<int, int> PurgeDuplicate::findLayerDisk(const Stub* st) const {
-  std::pair<int, int> layer_disk;
-  layer_disk.first = st->layerdisk() + 1;
-  if (layer_disk.first > N_LAYER) {
-    layer_disk.first = 0;
-  }
-  layer_disk.second = st->layerdisk() - (N_LAYER - 1);
-  if (layer_disk.second < 0) {
-    layer_disk.second = 0;
-  }
-  return layer_disk;
-}
-
-std::string PurgeDuplicate::l1tinfo(const L1TStub* l1stub, std::string str = "") const {
-  std::string thestr = Form("\t %s stub info:  r/z/phi:\t%f\t%f\t%f\t%d\t%f\t%d",
-                            str.c_str(),
-                            l1stub->r(),
-                            l1stub->z(),
-                            l1stub->phi(),
-                            l1stub->iphi(),
-                            l1stub->bend(),
-                            l1stub->layerdisk());
-  return thestr;
-}
-
-std::vector<double> PurgeDuplicate::getInventedCoords(unsigned int iSector,
-                                                      const Stub* st,
-                                                      const Tracklet* tracklet) const {
-  int stubLayer = (findLayerDisk(st)).first;
-  int stubDisk = (findLayerDisk(st)).second;
-
-  double stub_phi = -99;
-  double stub_z = -99;
-  double stub_r = -99;
-
-  double tracklet_rinv = tracklet->rinv();
-
-  if (st->isBarrel()) {
-    stub_r = settings_.rmean(stubLayer - 1);
-    stub_phi = tracklet->phi0() - std::asin(stub_r * tracklet_rinv / 2);
-    stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-    stub_phi = reco::reduceRange(stub_phi);
-    stub_z = tracklet->z0() + 2 * tracklet->t() * 1 / tracklet_rinv * std::asin(stub_r * tracklet_rinv / 2);
-  } else {
-    stub_z = settings_.zmean(stubDisk - 1) * tracklet->disk() / abs(tracklet->disk());
-    stub_phi = tracklet->phi0() - (stub_z - tracklet->z0()) * tracklet_rinv / 2 / tracklet->t();
-    stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-    stub_phi = reco::reduceRange(stub_phi);
-    stub_r = 2 / tracklet_rinv * std::sin((stub_z - tracklet->z0()) * tracklet_rinv / 2 / tracklet->t());
-  }
-
-  std::vector invented_coords{stub_r, stub_z, stub_phi};
-  return invented_coords;
-}
-
-std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSector,
-                                                              const Stub* st,
-                                                              const Tracklet* tracklet) const {
-  int stubLayer = (findLayerDisk(st)).first;
-  int stubDisk = (findLayerDisk(st)).second;
-
-  double stub_phi = -99;
-  double stub_z = -99;
-  double stub_r = -99;
-
-  double rho = 1 / tracklet->rinv();
-  double rho_minus_d0 = rho + tracklet->d0();  // should be -, but otherwise does not work
-
-  // exact helix
-  if (st->isBarrel()) {
-    stub_r = settings_.rmean(stubLayer - 1);
-
-    double sin_val = (stub_r * stub_r + rho_minus_d0 * rho_minus_d0 - rho * rho) / (2 * stub_r * rho_minus_d0);
-    stub_phi = tracklet->phi0() - std::asin(sin_val);
-    stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-    stub_phi = reco::reduceRange(stub_phi);
-
-    double beta = std::acos((rho * rho + rho_minus_d0 * rho_minus_d0 - stub_r * stub_r) / (2 * rho * rho_minus_d0));
-    stub_z = tracklet->z0() + tracklet->t() * std::abs(rho * beta);
-  } else {
-    stub_z = settings_.zmean(stubDisk - 1) * tracklet->disk() / abs(tracklet->disk());
-
-    double beta = (stub_z - tracklet->z0()) / (tracklet->t() * std::abs(rho));  // maybe rho should be abs value
-    double r_square = -2 * rho * rho_minus_d0 * std::cos(beta) + rho * rho + rho_minus_d0 * rho_minus_d0;
-    stub_r = sqrt(r_square);
-
-    double sin_val = (stub_r * stub_r + rho_minus_d0 * rho_minus_d0 - rho * rho) / (2 * stub_r * rho_minus_d0);
-    stub_phi = tracklet->phi0() - std::asin(sin_val);
-    stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
-    stub_phi = reco::reduceRange(stub_phi);
-  }
-
-  // TMP: for displaced tracking, exclude one of the 3 seeding stubs
-  // to be discussed
-  int seed = tracklet->seedIndex();
-  if ((seed == 8 && stubLayer == 4) || (seed == 9 && stubLayer == 5) || (seed == 10 && stubLayer == 3) ||
-      (seed == 11 && abs(stubDisk) == 1)) {
-    stub_phi = st->l1tstub()->phi();
-    stub_z = st->l1tstub()->z();
-    stub_r = st->l1tstub()->r();
-  }
-
-  std::vector invented_coords{stub_r, stub_z, stub_phi};
-  return invented_coords;
-}
-
-std::vector<const Stub*> PurgeDuplicate::getInventedSeedingStub(
-    unsigned int iSector, const Tracklet* tracklet, const std::vector<const Stub*>& originalStubsList) const {
-  std::vector<const Stub*> newStubList;
-
-  for (unsigned int stubit = 0; stubit < originalStubsList.size(); stubit++) {
-    const Stub* thisStub = originalStubsList[stubit];
-
-    if (isSeedingStub(tracklet->seedIndex(), (findLayerDisk(thisStub)).first, (findLayerDisk(thisStub)).second)) {
-      // get a vector containing r, z, phi
-      std::vector<double> inv_r_z_phi;
-      if (!settings_.extended())
-        inv_r_z_phi = getInventedCoords(iSector, thisStub, tracklet);
-      else {
-        inv_r_z_phi = getInventedCoordsExtended(iSector, thisStub, tracklet);
-      }
-      double stub_x_invent = inv_r_z_phi[0] * std::cos(inv_r_z_phi[2]);
-      double stub_y_invent = inv_r_z_phi[0] * std::sin(inv_r_z_phi[2]);
-      double stub_z_invent = inv_r_z_phi[1];
-
-      Stub* invent_stub_ptr = new Stub(*thisStub);
-      const L1TStub* l1stub = thisStub->l1tstub();
-      L1TStub invent_l1stub = *l1stub;
-      invent_l1stub.setCoords(stub_x_invent, stub_y_invent, stub_z_invent);
-
-      invent_stub_ptr->setl1tstub(new L1TStub(invent_l1stub));
-      invent_stub_ptr->l1tstub()->setAllStubIndex(l1stub->allStubIndex());
-      invent_stub_ptr->l1tstub()->setUniqueIndex(l1stub->uniqueIndex());
-
-      newStubList.push_back(invent_stub_ptr);
-
+  double PurgeDuplicate::getPhiRes(Tracklet* curTracklet, const Stub* curStub) const {
+    double phiproj;
+    double stubphi;
+    double phires;
+    // Get phi position of stub
+    stubphi = curStub->l1tstub()->phi();
+    // Get layer that the stub is in (Layer 1->6, Disk 1->5)
+    int Layer = curStub->layerdisk() + 1;
+    if (Layer > N_LAYER) {
+      Layer = 0;
+    }
+    int Disk = curStub->layerdisk() - (N_LAYER - 1);
+    if (Disk < 0) {
+      Disk = 0;
+    }
+    // Get phi projection of tracklet
+    int seedindex = curTracklet->seedIndex();
+    // If this stub is a seed stub, set projection=phi, so that res=0
+    if (isSeedingStub(seedindex, Layer, Disk)) {
+      phiproj = stubphi;
+      // Otherwise, get projection of tracklet
     } else {
-      newStubList.push_back(thisStub);
+      phiproj = curTracklet->proj(curStub->layerdisk()).phiproj();
     }
+    // Calculate residual
+    phires = std::abs(stubphi - phiproj);
+    return phires;
   }
-  return newStubList;
-}
 
-// Tells us the variable bin to which a track would belong
-unsigned int PurgeDuplicate::findVarRInvBin(const Tracklet* trk) const {
-  std::vector<double> rInvBins = settings_.varRInvBins();
+  bool PurgeDuplicate::isSeedingStub(int seedindex, int Layer, int Disk) const {
+    if ((seedindex == 0 && (Layer == 1 || Layer == 2)) || (seedindex == 1 && (Layer == 2 || Layer == 3)) ||
+        (seedindex == 2 && (Layer == 3 || Layer == 4)) || (seedindex == 3 && (Layer == 5 || Layer == 6)) ||
+        (seedindex == 4 && (abs(Disk) == 1 || abs(Disk) == 2)) ||
+        (seedindex == 5 && (abs(Disk) == 3 || abs(Disk) == 4)) || (seedindex == 6 && (Layer == 1 || abs(Disk) == 1)) ||
+        (seedindex == 7 && (Layer == 2 || abs(Disk) == 1)) ||
+        (seedindex == 8 && (Layer == 2 || Layer == 3 || Layer == 4)) ||
+        (seedindex == 9 && (Layer == 4 || Layer == 5 || Layer == 6)) ||
+        (seedindex == 10 && (Layer == 2 || Layer == 3 || abs(Disk) == 1)) ||
+        (seedindex == 11 && (Layer == 2 || abs(Disk) == 1 || abs(Disk) == 2)))
+      return true;
 
-  //Get rinverse of track
-  double rInv = trk->rinv();
+    return false;
+  }
 
-  //Check between what 2 values in rinvbins rinv is between
-  auto bins = std::upper_bound(rInvBins.begin(), rInvBins.end(), rInv);
-
-  //return integer for bin index
-  unsigned int rIndx = std::distance(rInvBins.begin(), bins);
-  if (rIndx == std::distance(rInvBins.end(), bins))
-    return rInvBins.size() - 2;
-  else if (bins == rInvBins.begin())
-    return std::distance(rInvBins.begin(), bins);
-  else
-    return rIndx - 1;
-}
-
-// Tells us the overlap bin(s) to which a track belongs
-std::vector<unsigned int> PurgeDuplicate::findOverlapRInvBins(const Tracklet* trk) const {
-  double rInv = trk->rinv();
-  const double overlapSize = settings_.overlapSize();
-  const std::vector<double>& varRInvBins = settings_.varRInvBins();
-  std::vector<unsigned int> chosenBins;
-  for (long unsigned int i = 0; i < varRInvBins.size() - 1; i++) {
-    if ((rInv < varRInvBins[i + 1] + overlapSize) && (rInv > varRInvBins[i] - overlapSize)) {
-      chosenBins.push_back(i);
+  std::pair<int, int> PurgeDuplicate::findLayerDisk(const Stub* st) const {
+    std::pair<int, int> layer_disk;
+    layer_disk.first = st->layerdisk() + 1;
+    if (layer_disk.first > N_LAYER) {
+      layer_disk.first = 0;
     }
+    layer_disk.second = st->layerdisk() - (N_LAYER - 1);
+    if (layer_disk.second < 0) {
+      layer_disk.second = 0;
+    }
+    return layer_disk;
   }
-  return chosenBins;
-}
 
-// Tells us if a track is in the current bin
-bool PurgeDuplicate::isTrackInBin(const std::vector<unsigned int>& vec, unsigned int num) const {
-  auto result = std::find(vec.begin(), vec.end(), num);
-  bool found = (result != vec.end());
-  return found;
-}
+  std::string PurgeDuplicate::l1tinfo(const L1TStub* l1stub, std::string str = "") const {
+    std::string thestr = Form("\t %s stub info:  r/z/phi:\t%f\t%f\t%f\t%d\t%f\t%d",
+                              str.c_str(),
+                              l1stub->r(),
+                              l1stub->z(),
+                              l1stub->phi(),
+                              l1stub->iphi(),
+                              l1stub->bend(),
+                              l1stub->layerdisk());
+    return thestr;
+  }
 
-}
+  std::vector<double> PurgeDuplicate::getInventedCoords(unsigned int iSector,
+                                                        const Stub* st,
+                                                        const Tracklet* tracklet) const {
+    int stubLayer = (findLayerDisk(st)).first;
+    int stubDisk = (findLayerDisk(st)).second;
+
+    double stub_phi = -99;
+    double stub_z = -99;
+    double stub_r = -99;
+
+    double tracklet_rinv = tracklet->rinv();
+
+    if (st->isBarrel()) {
+      stub_r = settings_.rmean(stubLayer - 1);
+      stub_phi = tracklet->phi0() - std::asin(stub_r * tracklet_rinv / 2);
+      stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+      stub_phi = reco::reduceRange(stub_phi);
+      stub_z = tracklet->z0() + 2 * tracklet->t() * 1 / tracklet_rinv * std::asin(stub_r * tracklet_rinv / 2);
+    } else {
+      stub_z = settings_.zmean(stubDisk - 1) * tracklet->disk() / abs(tracklet->disk());
+      stub_phi = tracklet->phi0() - (stub_z - tracklet->z0()) * tracklet_rinv / 2 / tracklet->t();
+      stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+      stub_phi = reco::reduceRange(stub_phi);
+      stub_r = 2 / tracklet_rinv * std::sin((stub_z - tracklet->z0()) * tracklet_rinv / 2 / tracklet->t());
+    }
+
+    std::vector invented_coords{stub_r, stub_z, stub_phi};
+    return invented_coords;
+  }
+
+  std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSector,
+                                                                const Stub* st,
+                                                                const Tracklet* tracklet) const {
+    int stubLayer = (findLayerDisk(st)).first;
+    int stubDisk = (findLayerDisk(st)).second;
+
+    double stub_phi = -99;
+    double stub_z = -99;
+    double stub_r = -99;
+
+    double rho = 1 / tracklet->rinv();
+    double rho_minus_d0 = rho + tracklet->d0();  // should be -, but otherwise does not work
+
+    // exact helix
+    if (st->isBarrel()) {
+      stub_r = settings_.rmean(stubLayer - 1);
+
+      double sin_val = (stub_r * stub_r + rho_minus_d0 * rho_minus_d0 - rho * rho) / (2 * stub_r * rho_minus_d0);
+      stub_phi = tracklet->phi0() - std::asin(sin_val);
+      stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+      stub_phi = reco::reduceRange(stub_phi);
+
+      double beta = std::acos((rho * rho + rho_minus_d0 * rho_minus_d0 - stub_r * stub_r) / (2 * rho * rho_minus_d0));
+      stub_z = tracklet->z0() + tracklet->t() * std::abs(rho * beta);
+    } else {
+      stub_z = settings_.zmean(stubDisk - 1) * tracklet->disk() / abs(tracklet->disk());
+
+      double beta = (stub_z - tracklet->z0()) / (tracklet->t() * std::abs(rho));  // maybe rho should be abs value
+      double r_square = -2 * rho * rho_minus_d0 * std::cos(beta) + rho * rho + rho_minus_d0 * rho_minus_d0;
+      stub_r = sqrt(r_square);
+
+      double sin_val = (stub_r * stub_r + rho_minus_d0 * rho_minus_d0 - rho * rho) / (2 * stub_r * rho_minus_d0);
+      stub_phi = tracklet->phi0() - std::asin(sin_val);
+      stub_phi = stub_phi + iSector * settings_.dphisector() - 0.5 * settings_.dphisectorHG();
+      stub_phi = reco::reduceRange(stub_phi);
+    }
+
+    // TMP: for displaced tracking, exclude one of the 3 seeding stubs
+    // to be discussed
+    int seed = tracklet->seedIndex();
+    if ((seed == 8 && stubLayer == 4) || (seed == 9 && stubLayer == 5) || (seed == 10 && stubLayer == 3) ||
+        (seed == 11 && abs(stubDisk) == 1)) {
+      stub_phi = st->l1tstub()->phi();
+      stub_z = st->l1tstub()->z();
+      stub_r = st->l1tstub()->r();
+    }
+
+    std::vector invented_coords{stub_r, stub_z, stub_phi};
+    return invented_coords;
+  }
+
+  std::vector<const Stub*> PurgeDuplicate::getInventedSeedingStub(
+      unsigned int iSector, const Tracklet* tracklet, const std::vector<const Stub*>& originalStubsList) const {
+    std::vector<const Stub*> newStubList;
+
+    for (unsigned int stubit = 0; stubit < originalStubsList.size(); stubit++) {
+      const Stub* thisStub = originalStubsList[stubit];
+
+      if (isSeedingStub(tracklet->seedIndex(), (findLayerDisk(thisStub)).first, (findLayerDisk(thisStub)).second)) {
+        // get a vector containing r, z, phi
+        std::vector<double> inv_r_z_phi;
+        if (!settings_.extended())
+          inv_r_z_phi = getInventedCoords(iSector, thisStub, tracklet);
+        else {
+          inv_r_z_phi = getInventedCoordsExtended(iSector, thisStub, tracklet);
+        }
+        double stub_x_invent = inv_r_z_phi[0] * std::cos(inv_r_z_phi[2]);
+        double stub_y_invent = inv_r_z_phi[0] * std::sin(inv_r_z_phi[2]);
+        double stub_z_invent = inv_r_z_phi[1];
+
+        Stub* invent_stub_ptr = new Stub(*thisStub);
+        const L1TStub* l1stub = thisStub->l1tstub();
+        L1TStub invent_l1stub = *l1stub;
+        invent_l1stub.setCoords(stub_x_invent, stub_y_invent, stub_z_invent);
+
+        invent_stub_ptr->setl1tstub(new L1TStub(invent_l1stub));
+        invent_stub_ptr->l1tstub()->setAllStubIndex(l1stub->allStubIndex());
+        invent_stub_ptr->l1tstub()->setUniqueIndex(l1stub->uniqueIndex());
+
+        newStubList.push_back(invent_stub_ptr);
+
+      } else {
+        newStubList.push_back(thisStub);
+      }
+    }
+    return newStubList;
+  }
+
+  // Tells us the variable bin to which a track would belong
+  unsigned int PurgeDuplicate::findVarRInvBin(const Tracklet* trk) const {
+    std::vector<double> rInvBins = settings_.varRInvBins();
+
+    //Get rinverse of track
+    double rInv = trk->rinv();
+
+    //Check between what 2 values in rinvbins rinv is between
+    auto bins = std::upper_bound(rInvBins.begin(), rInvBins.end(), rInv);
+
+    //return integer for bin index
+    unsigned int rIndx = std::distance(rInvBins.begin(), bins);
+    if (rIndx == std::distance(rInvBins.end(), bins))
+      return rInvBins.size() - 2;
+    else if (bins == rInvBins.begin())
+      return std::distance(rInvBins.begin(), bins);
+    else
+      return rIndx - 1;
+  }
+
+  // Tells us the overlap bin(s) to which a track belongs
+  std::vector<unsigned int> PurgeDuplicate::findOverlapRInvBins(const Tracklet* trk) const {
+    double rInv = trk->rinv();
+    const double overlapSize = settings_.overlapSize();
+    const std::vector<double>& varRInvBins = settings_.varRInvBins();
+    std::vector<unsigned int> chosenBins;
+    for (long unsigned int i = 0; i < varRInvBins.size() - 1; i++) {
+      if ((rInv < varRInvBins[i + 1] + overlapSize) && (rInv > varRInvBins[i] - overlapSize)) {
+        chosenBins.push_back(i);
+      }
+    }
+    return chosenBins;
+  }
+
+  // Tells us if a track is in the current bin
+  bool PurgeDuplicate::isTrackInBin(const std::vector<unsigned int>& vec, unsigned int num) const {
+    auto result = std::find(vec.begin(), vec.end(), num);
+    bool found = (result != vec.end());
+    return found;
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -20,7 +20,8 @@
 #include <algorithm>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 PurgeDuplicate::PurgeDuplicate(std::string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global) {}
@@ -782,4 +783,6 @@ bool PurgeDuplicate::isTrackInBin(const std::vector<unsigned int>& vec, unsigned
   auto result = std::find(vec.begin(), vec.end(), num);
   bool found = (result != vec.end());
   return found;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/Residual.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Residual.cc
@@ -5,43 +5,43 @@ using namespace std;
 
 namespace trklet {
 
-void Residual::init(Settings const& settings,
-                    unsigned int layerdisk,
-                    int iphiresid,
-                    int irzresid,
-                    int istubid,
-                    double phiresid,
-                    double rzresid,
-                    double phiresidapprox,
-                    double rzresidapprox,
-                    const Stub* stubptr) {
-  assert(layerdisk < N_LAYER + N_DISK);
+  void Residual::init(Settings const& settings,
+                      unsigned int layerdisk,
+                      int iphiresid,
+                      int irzresid,
+                      int istubid,
+                      double phiresid,
+                      double rzresid,
+                      double phiresidapprox,
+                      double rzresidapprox,
+                      const Stub* stubptr) {
+    assert(layerdisk < N_LAYER + N_DISK);
 
-  if (valid_ && (std::abs(iphiresid) > std::abs(fpgaphiresid_.value())))
-    return;
+    if (valid_ && (std::abs(iphiresid) > std::abs(fpgaphiresid_.value())))
+      return;
 
-  valid_ = true;
+    valid_ = true;
 
-  layerdisk_ = layerdisk;
+    layerdisk_ = layerdisk;
 
-  fpgaphiresid_.set(iphiresid, settings.phiresidbits(), false, __LINE__, __FILE__);
-  if (layerdisk < N_LAYER) {
-    fpgarzresid_.set(irzresid, settings.zresidbits(), false, __LINE__, __FILE__);
-  } else {
-    fpgarzresid_.set(irzresid, settings.rresidbits(), false, __LINE__, __FILE__);
+    fpgaphiresid_.set(iphiresid, settings.phiresidbits(), false, __LINE__, __FILE__);
+    if (layerdisk < N_LAYER) {
+      fpgarzresid_.set(irzresid, settings.zresidbits(), false, __LINE__, __FILE__);
+    } else {
+      fpgarzresid_.set(irzresid, settings.rresidbits(), false, __LINE__, __FILE__);
+    }
+
+    int nbitsid = 10;
+    fpgastubid_.set(istubid, nbitsid, true, __LINE__, __FILE__);
+    assert(!fpgaphiresid_.atExtreme());
+
+    phiresid_ = phiresid;
+    rzresid_ = rzresid;
+
+    phiresidapprox_ = phiresidapprox;
+    rzresidapprox_ = rzresidapprox;
+
+    stubptr_ = stubptr;
   }
 
-  int nbitsid = 10;
-  fpgastubid_.set(istubid, nbitsid, true, __LINE__, __FILE__);
-  assert(!fpgaphiresid_.atExtreme());
-
-  phiresid_ = phiresid;
-  rzresid_ = rzresid;
-
-  phiresidapprox_ = phiresidapprox;
-  rzresidapprox_ = rzresidapprox;
-
-  stubptr_ = stubptr;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/Residual.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Residual.cc
@@ -2,7 +2,8 @@
 #include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 void Residual::init(Settings const& settings,
                     unsigned int layerdisk,
@@ -41,4 +42,6 @@ void Residual::init(Settings const& settings,
   rzresidapprox_ = rzresidapprox;
 
   stubptr_ = stubptr;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
+++ b/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
@@ -2,7 +2,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 void SLHCEvent::addL1SimTrack(
     int eventid, int trackid, int type, double pt, double eta, double phi, double vx, double vy, double vz) {
@@ -213,4 +214,6 @@ unsigned int SLHCEvent::layersHit(int tpid, int& nlayers, int& ndisks) {
   ndisks = d1 + d2 + d3 + d4 + d5;
 
   return l1 + 2 * l2 + 4 * l3 + 8 * l4 + 16 * l5 + 32 * l6 + 64 * d1 + 128 * d2 + 256 * d3 + 512 * d4 + 1024 * d5;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
+++ b/L1Trigger/TrackFindingTracklet/src/SLHCEvent.cc
@@ -5,127 +5,29 @@ using namespace std;
 
 namespace trklet {
 
-void SLHCEvent::addL1SimTrack(
-    int eventid, int trackid, int type, double pt, double eta, double phi, double vx, double vy, double vz) {
-  L1SimTrack simtrack(eventid, trackid, type, pt, eta, phi, vx, vy, vz);
-  simtracks_.push_back(simtrack);
-}
-
-bool SLHCEvent::addStub(string DTClink,
-                        int region,
-                        int layerdisk,
-                        string stubword,
-                        int isPSmodule,
-                        int isFlipped,
-                        bool tiltedBarrel,
-                        unsigned int tiltedRingId,
-                        unsigned int endcapRingId,
-                        unsigned int detId,
-                        double x,
-                        double y,
-                        double z,
-                        double bend,
-                        double strip,
-                        vector<int> tps,
-                        int stubindex) {
-  L1TStub stub(DTClink,
-               region,
-               layerdisk,
-               stubword,
-               isPSmodule,
-               isFlipped,
-               tiltedBarrel,
-               tiltedRingId,
-               endcapRingId,
-               detId,
-               x,
-               y,
-               z,
-               bend,
-               strip,
-               tps);
-
-  stub.setUniqueIndex(stubindex);
-  stubs_.push_back(stub);
-  return true;
-}
-
-SLHCEvent::SLHCEvent(istream& in) {
-  string tmp;
-  in >> tmp;
-  if (tmp != "Event:") {
-    edm::LogVerbatim("Tracklet") << "Expected to read 'Event:' but found:" << tmp;
-    if (tmp.empty()) {
-      edm::LogVerbatim("Tracklet") << "WARNING: fewer events to process than specified!";
-      return;
-    } else {
-      edm::LogVerbatim("Tracklet") << "ERROR, aborting reading file";
-      abort();
-    }
-  }
-  in >> eventnum_;
-
-  // read the SimTracks
-  in >> tmp;
-  while (tmp != "SimTrackEnd") {
-    if (!(tmp == "SimTrack:" || tmp == "SimTrackEnd")) {
-      edm::LogVerbatim("Tracklet") << "Expected to read 'SimTrack:' or 'SimTrackEnd' but found:" << tmp;
-      abort();
-    }
-    int eventid;
-    int trackid;
-    int type;
-    double pt;
-    double eta;
-    double phi;
-    double vx;
-    double vy;
-    double vz;
-    in >> eventid >> trackid >> type >> pt >> eta >> phi >> vx >> vy >> vz;
+  void SLHCEvent::addL1SimTrack(
+      int eventid, int trackid, int type, double pt, double eta, double phi, double vx, double vy, double vz) {
     L1SimTrack simtrack(eventid, trackid, type, pt, eta, phi, vx, vy, vz);
     simtracks_.push_back(simtrack);
-    in >> tmp;
   }
 
-  //read stubs
-  in >> tmp;
-  while (tmp != "Stubend") {
-    if (!in.good()) {
-      edm::LogVerbatim("Tracklet") << "File not good (SLHCEvent)";
-      abort();
-    };
-    if (!(tmp == "Stub:" || tmp == "Stubend")) {
-      edm::LogVerbatim("Tracklet") << "Expected to read 'Stub:' or 'StubEnd' but found:" << tmp;
-      abort();
-    }
-    string DTClink;
-    int region;
-    int layerdisk;
-    string stubword;
-    int isPSmodule;
-    int isFlipped;
-    double x;
-    double y;
-    double z;
-    double bend;
-    double strip;
-    unsigned int ntps;
-    vector<int> tps;
-
-    in >> DTClink >> region >> layerdisk >> stubword >> isPSmodule >> isFlipped >> x >> y >> z >> bend >> strip >> ntps;
-
-    // TO FIX: READ THESE FROM INPUT FILE
-    bool tiltedBarrel = false;
-    unsigned int tiltedRingId = 999999;
-    unsigned int endcapRingId = 999999;
-    unsigned int detId = 999999;  // Lower sensor in module
-
-    for (unsigned int itps = 0; itps < ntps; itps++) {
-      int tp;
-      in >> tp;
-      tps.push_back(tp);
-    }
-
+  bool SLHCEvent::addStub(string DTClink,
+                          int region,
+                          int layerdisk,
+                          string stubword,
+                          int isPSmodule,
+                          int isFlipped,
+                          bool tiltedBarrel,
+                          unsigned int tiltedRingId,
+                          unsigned int endcapRingId,
+                          unsigned int detId,
+                          double x,
+                          double y,
+                          double z,
+                          double bend,
+                          double strip,
+                          vector<int> tps,
+                          int stubindex) {
     L1TStub stub(DTClink,
                  region,
                  layerdisk,
@@ -143,77 +45,176 @@ SLHCEvent::SLHCEvent(istream& in) {
                  strip,
                  tps);
 
+    stub.setUniqueIndex(stubindex);
+    stubs_.push_back(stub);
+    return true;
+  }
+
+  SLHCEvent::SLHCEvent(istream& in) {
+    string tmp;
     in >> tmp;
+    if (tmp != "Event:") {
+      edm::LogVerbatim("Tracklet") << "Expected to read 'Event:' but found:" << tmp;
+      if (tmp.empty()) {
+        edm::LogVerbatim("Tracklet") << "WARNING: fewer events to process than specified!";
+        return;
+      } else {
+        edm::LogVerbatim("Tracklet") << "ERROR, aborting reading file";
+        abort();
+      }
+    }
+    in >> eventnum_;
 
-    double t = std::abs(stub.z()) / stub.r();
-    double eta = asinh(t);
+    // read the SimTracks
+    in >> tmp;
+    while (tmp != "SimTrackEnd") {
+      if (!(tmp == "SimTrack:" || tmp == "SimTrackEnd")) {
+        edm::LogVerbatim("Tracklet") << "Expected to read 'SimTrack:' or 'SimTrackEnd' but found:" << tmp;
+        abort();
+      }
+      int eventid;
+      int trackid;
+      int type;
+      double pt;
+      double eta;
+      double phi;
+      double vx;
+      double vy;
+      double vz;
+      in >> eventid >> trackid >> type >> pt >> eta >> phi >> vx >> vy >> vz;
+      L1SimTrack simtrack(eventid, trackid, type, pt, eta, phi, vx, vy, vz);
+      simtracks_.push_back(simtrack);
+      in >> tmp;
+    }
 
-    if (std::abs(eta) < 2.6) {
-      stubs_.push_back(stub);
+    //read stubs
+    in >> tmp;
+    while (tmp != "Stubend") {
+      if (!in.good()) {
+        edm::LogVerbatim("Tracklet") << "File not good (SLHCEvent)";
+        abort();
+      };
+      if (!(tmp == "Stub:" || tmp == "Stubend")) {
+        edm::LogVerbatim("Tracklet") << "Expected to read 'Stub:' or 'StubEnd' but found:" << tmp;
+        abort();
+      }
+      string DTClink;
+      int region;
+      int layerdisk;
+      string stubword;
+      int isPSmodule;
+      int isFlipped;
+      double x;
+      double y;
+      double z;
+      double bend;
+      double strip;
+      unsigned int ntps;
+      vector<int> tps;
+
+      in >> DTClink >> region >> layerdisk >> stubword >> isPSmodule >> isFlipped >> x >> y >> z >> bend >> strip >>
+          ntps;
+
+      // TO FIX: READ THESE FROM INPUT FILE
+      bool tiltedBarrel = false;
+      unsigned int tiltedRingId = 999999;
+      unsigned int endcapRingId = 999999;
+      unsigned int detId = 999999;  // Lower sensor in module
+
+      for (unsigned int itps = 0; itps < ntps; itps++) {
+        int tp;
+        in >> tp;
+        tps.push_back(tp);
+      }
+
+      L1TStub stub(DTClink,
+                   region,
+                   layerdisk,
+                   stubword,
+                   isPSmodule,
+                   isFlipped,
+                   tiltedBarrel,
+                   tiltedRingId,
+                   endcapRingId,
+                   detId,
+                   x,
+                   y,
+                   z,
+                   bend,
+                   strip,
+                   tps);
+
+      in >> tmp;
+
+      double t = std::abs(stub.z()) / stub.r();
+      double eta = asinh(t);
+
+      if (std::abs(eta) < 2.6) {
+        stubs_.push_back(stub);
+      }
     }
   }
-}
 
-void SLHCEvent::write(ofstream& out) {
-  out << "Event: " << eventnum_ << endl;
+  void SLHCEvent::write(ofstream& out) {
+    out << "Event: " << eventnum_ << endl;
 
-  for (auto& simtrack : simtracks_) {
-    simtrack.write(out);
-  }
-  out << "SimTrackEnd" << endl;
-
-  for (auto& stub : stubs_) {
-    stub.write(out);
-  }
-  out << "Stubend" << endl;
-}
-
-unsigned int SLHCEvent::layersHit(int tpid, int& nlayers, int& ndisks) {
-  int l1 = 0;
-  int l2 = 0;
-  int l3 = 0;
-  int l4 = 0;
-  int l5 = 0;
-  int l6 = 0;
-
-  int d1 = 0;
-  int d2 = 0;
-  int d3 = 0;
-  int d4 = 0;
-  int d5 = 0;
-
-  for (auto& stub : stubs_) {
-    if (stub.tpmatch(tpid)) {
-      if (stub.layer() == 0)
-        l1 = 1;
-      if (stub.layer() == 1)
-        l2 = 1;
-      if (stub.layer() == 2)
-        l3 = 1;
-      if (stub.layer() == 3)
-        l4 = 1;
-      if (stub.layer() == 4)
-        l5 = 1;
-      if (stub.layer() == 5)
-        l6 = 1;
-
-      if (abs(stub.disk()) == 1)
-        d1 = 1;
-      if (abs(stub.disk()) == 2)
-        d2 = 1;
-      if (abs(stub.disk()) == 3)
-        d3 = 1;
-      if (abs(stub.disk()) == 4)
-        d4 = 1;
-      if (abs(stub.disk()) == 5)
-        d5 = 1;
+    for (auto& simtrack : simtracks_) {
+      simtrack.write(out);
     }
+    out << "SimTrackEnd" << endl;
+
+    for (auto& stub : stubs_) {
+      stub.write(out);
+    }
+    out << "Stubend" << endl;
   }
 
-  nlayers = l1 + l2 + l3 + l4 + l5 + l6;
-  ndisks = d1 + d2 + d3 + d4 + d5;
+  unsigned int SLHCEvent::layersHit(int tpid, int& nlayers, int& ndisks) {
+    int l1 = 0;
+    int l2 = 0;
+    int l3 = 0;
+    int l4 = 0;
+    int l5 = 0;
+    int l6 = 0;
 
-  return l1 + 2 * l2 + 4 * l3 + 8 * l4 + 16 * l5 + 32 * l6 + 64 * d1 + 128 * d2 + 256 * d3 + 512 * d4 + 1024 * d5;
-}
+    int d1 = 0;
+    int d2 = 0;
+    int d3 = 0;
+    int d4 = 0;
+    int d5 = 0;
 
-}
+    for (auto& stub : stubs_) {
+      if (stub.tpmatch(tpid)) {
+        if (stub.layer() == 0)
+          l1 = 1;
+        if (stub.layer() == 1)
+          l2 = 1;
+        if (stub.layer() == 2)
+          l3 = 1;
+        if (stub.layer() == 3)
+          l4 = 1;
+        if (stub.layer() == 4)
+          l5 = 1;
+        if (stub.layer() == 5)
+          l6 = 1;
+
+        if (abs(stub.disk()) == 1)
+          d1 = 1;
+        if (abs(stub.disk()) == 2)
+          d2 = 1;
+        if (abs(stub.disk()) == 3)
+          d3 = 1;
+        if (abs(stub.disk()) == 4)
+          d4 = 1;
+        if (abs(stub.disk()) == 5)
+          d5 = 1;
+      }
+    }
+
+    nlayers = l1 + l2 + l3 + l4 + l5 + l6;
+    ndisks = d1 + d2 + d3 + d4 + d5;
+
+    return l1 + 2 * l2 + 4 * l3 + 8 * l4 + 16 * l5 + 32 * l6 + 64 * d1 + 128 * d2 + 256 * d3 + 512 * d4 + 1024 * d5;
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -50,446 +50,447 @@ using namespace std;
 
 namespace trklet {
 
-Sector::Sector(Settings const& settings, Globals* globals) : isector_(-1), settings_(settings), globals_(globals) {}
+  Sector::Sector(Settings const& settings, Globals* globals) : isector_(-1), settings_(settings), globals_(globals) {}
 
-Sector::~Sector() = default;
+  Sector::~Sector() = default;
 
-void Sector::setSector(unsigned int isector) {
-  assert(isector < N_SECTOR);
-  isector_ = isector;
-  double dphi = 2 * M_PI / N_SECTOR;
-  double dphiHG = 0.5 * settings_.dphisectorHG() - M_PI / N_SECTOR;
-  phimin_ = isector_ * dphi - dphiHG;
-  phimax_ = phimin_ + dphi + 2 * dphiHG;
-  phimin_ -= M_PI / N_SECTOR;
-  phimax_ -= M_PI / N_SECTOR;
-  phimin_ = reco::reduceRange(phimin_);
-  phimax_ = reco::reduceRange(phimax_);
-  if (phimin_ > phimax_) {
-    phimin_ -= 2 * M_PI;
-  }
-}
-
-bool Sector::addStub(L1TStub stub, string dtc) {
-  unsigned int layerdisk = stub.layerdisk();
-  int nrbits = 3;
-
-  if (layerdisk < N_LAYER && globals_->phiCorr(layerdisk) == nullptr) {
-    globals_->phiCorr(layerdisk) = new TrackletLUT(settings_);
-    globals_->phiCorr(layerdisk)->initPhiCorrTable(layerdisk, nrbits);
+  void Sector::setSector(unsigned int isector) {
+    assert(isector < N_SECTOR);
+    isector_ = isector;
+    double dphi = 2 * M_PI / N_SECTOR;
+    double dphiHG = 0.5 * settings_.dphisectorHG() - M_PI / N_SECTOR;
+    phimin_ = isector_ * dphi - dphiHG;
+    phimax_ = phimin_ + dphi + 2 * dphiHG;
+    phimin_ -= M_PI / N_SECTOR;
+    phimax_ -= M_PI / N_SECTOR;
+    phimin_ = reco::reduceRange(phimin_);
+    phimax_ = reco::reduceRange(phimax_);
+    if (phimin_ > phimax_) {
+      phimin_ -= 2 * M_PI;
+    }
   }
 
-  Stub fpgastub(stub, settings_, *globals_);
+  bool Sector::addStub(L1TStub stub, string dtc) {
+    unsigned int layerdisk = stub.layerdisk();
+    int nrbits = 3;
 
-  if (layerdisk < N_LAYER) {
-    FPGAWord r = fpgastub.r();
-    int bendbin = fpgastub.bend().value();
-    int rbin = (r.value() + (1 << (r.nbits() - 1))) >> (r.nbits() - nrbits);
-    const TrackletLUT& phiCorrTable = *globals_->phiCorr(layerdisk);
-    int iphicorr = phiCorrTable.lookup(bendbin * (1 << nrbits) + rbin);
-    fpgastub.setPhiCorr(iphicorr);
+    if (layerdisk < N_LAYER && globals_->phiCorr(layerdisk) == nullptr) {
+      globals_->phiCorr(layerdisk) = new TrackletLUT(settings_);
+      globals_->phiCorr(layerdisk)->initPhiCorrTable(layerdisk, nrbits);
+    }
+
+    Stub fpgastub(stub, settings_, *globals_);
+
+    if (layerdisk < N_LAYER) {
+      FPGAWord r = fpgastub.r();
+      int bendbin = fpgastub.bend().value();
+      int rbin = (r.value() + (1 << (r.nbits() - 1))) >> (r.nbits() - nrbits);
+      const TrackletLUT& phiCorrTable = *globals_->phiCorr(layerdisk);
+      int iphicorr = phiCorrTable.lookup(bendbin * (1 << nrbits) + rbin);
+      fpgastub.setPhiCorr(iphicorr);
+    }
+
+    int nadd = 0;
+    for (unsigned int i = 0; i < DL_.size(); i++) {
+      const string& name = DL_[i]->getName();
+      if (name.find("_" + dtc) == string::npos)
+        continue;
+      DL_[i]->addStub(stub, fpgastub);
+      nadd++;
+    }
+
+    if (!(settings_.reduced()))
+      assert(nadd == 1);
+
+    return true;
   }
 
-  int nadd = 0;
-  for (unsigned int i = 0; i < DL_.size(); i++) {
-    const string& name = DL_[i]->getName();
-    if (name.find("_" + dtc) == string::npos)
-      continue;
-    DL_[i]->addStub(stub, fpgastub);
-    nadd++;
+  void Sector::addMem(string memType, string memName) {
+    if (memType == "DTCLink:") {
+      addMemToVec(DL_, memName, settings_, phimin_, phimax_);
+    } else if (memType == "InputLink:") {
+      addMemToVec(IL_, memName, settings_, phimin_, phimax_);
+    } else if (memType == "AllStubs:") {
+      addMemToVec(AS_, memName, settings_);
+    } else if (memType == "AllInnerStubs:") {
+      addMemToVec(AIS_, memName, settings_);
+    } else if (memType == "VMStubsTE:") {
+      addMemToVec(VMSTE_, memName, settings_);
+    } else if (memType == "VMStubsME:") {
+      addMemToVec(VMSME_, memName, settings_);
+    } else if (memType == "StubPairs:" || memType == "StubPairsDisplaced:") {
+      addMemToVec(SP_, memName, settings_);
+    } else if (memType == "StubTriplets:") {
+      addMemToVec(ST_, memName, settings_);
+    } else if (memType == "TrackletParameters:") {
+      addMemToVec(TPAR_, memName, settings_);
+    } else if (memType == "TrackletProjections:") {
+      addMemToVec(TPROJ_, memName, settings_);
+    } else if (memType == "AllProj:") {
+      addMemToVec(AP_, memName, settings_);
+    } else if (memType == "VMProjections:") {
+      addMemToVec(VMPROJ_, memName, settings_);
+    } else if (memType == "CandidateMatch:") {
+      addMemToVec(CM_, memName, settings_);
+    } else if (memType == "FullMatch:") {
+      addMemToVec(FM_, memName, settings_);
+    } else if (memType == "TrackFit:") {
+      addMemToVec(TF_, memName, settings_, phimin_, phimax_);
+    } else if (memType == "CleanTrack:") {
+      addMemToVec(CT_, memName, settings_, phimin_, phimax_);
+    } else {
+      edm::LogPrint("Tracklet") << "Don't know of memory type: " << memType;
+      exit(0);
+    }
   }
 
-  if (!(settings_.reduced()))
-    assert(nadd == 1);
-
-  return true;
-}
-
-void Sector::addMem(string memType, string memName) {
-  if (memType == "DTCLink:") {
-    addMemToVec(DL_, memName, settings_, phimin_, phimax_);
-  } else if (memType == "InputLink:") {
-    addMemToVec(IL_, memName, settings_, phimin_, phimax_);
-  } else if (memType == "AllStubs:") {
-    addMemToVec(AS_, memName, settings_);
-  } else if (memType == "AllInnerStubs:") {
-    addMemToVec(AIS_, memName, settings_);
-  } else if (memType == "VMStubsTE:") {
-    addMemToVec(VMSTE_, memName, settings_);
-  } else if (memType == "VMStubsME:") {
-    addMemToVec(VMSME_, memName, settings_);
-  } else if (memType == "StubPairs:" || memType == "StubPairsDisplaced:") {
-    addMemToVec(SP_, memName, settings_);
-  } else if (memType == "StubTriplets:") {
-    addMemToVec(ST_, memName, settings_);
-  } else if (memType == "TrackletParameters:") {
-    addMemToVec(TPAR_, memName, settings_);
-  } else if (memType == "TrackletProjections:") {
-    addMemToVec(TPROJ_, memName, settings_);
-  } else if (memType == "AllProj:") {
-    addMemToVec(AP_, memName, settings_);
-  } else if (memType == "VMProjections:") {
-    addMemToVec(VMPROJ_, memName, settings_);
-  } else if (memType == "CandidateMatch:") {
-    addMemToVec(CM_, memName, settings_);
-  } else if (memType == "FullMatch:") {
-    addMemToVec(FM_, memName, settings_);
-  } else if (memType == "TrackFit:") {
-    addMemToVec(TF_, memName, settings_, phimin_, phimax_);
-  } else if (memType == "CleanTrack:") {
-    addMemToVec(CT_, memName, settings_, phimin_, phimax_);
-  } else {
-    edm::LogPrint("Tracklet") << "Don't know of memory type: " << memType;
-    exit(0);
-  }
-}
-
-void Sector::addProc(string procType, string procName) {
-  if (procType == "InputRouter:") {
-    addProcToVec(IR_, procName, settings_, globals_);
-  } else if (procType == "VMRouter:") {
-    addProcToVec(VMR_, procName, settings_, globals_);
-  } else if (procType == "VMRouterCM:") {
-    addProcToVec(VMRCM_, procName, settings_, globals_);
-  } else if (procType == "TrackletEngine:") {
-    addProcToVec(TE_, procName, settings_, globals_);
-  } else if (procType == "TrackletEngineDisplaced:") {
-    addProcToVec(TED_, procName, settings_, globals_);
-  } else if (procType == "TripletEngine:") {
-    addProcToVec(TRE_, procName, settings_, globals_);
-  } else if (procType == "TrackletCalculator:") {
-    addProcToVec(TC_, procName, settings_, globals_);
-  } else if (procType == "TrackletProcessor:") {
-    addProcToVec(TP_, procName, settings_, globals_);
-  } else if (procType == "TrackletProcessorDisplaced:") {
-    addProcToVec(TPD_, procName, settings_, globals_);
-  } else if (procType == "TrackletCalculatorDisplaced:") {
-    addProcToVec(TCD_, procName, settings_, globals_);
-  } else if (procType == "ProjectionRouter:") {
-    addProcToVec(PR_, procName, settings_, globals_);
-  } else if (procType == "MatchEngine:") {
-    addProcToVec(ME_, procName, settings_, globals_);
-  } else if (procType == "MatchCalculator:" ||
-             procType == "DiskMatchCalculator:") {  //TODO should not be used in configurations
-    addProcToVec(MC_, procName, settings_, globals_);
-  } else if (procType == "MatchProcessor:") {
-    addProcToVec(MP_, procName, settings_, globals_);
-  } else if (procType == "FitTrack:") {
-    addProcToVec(FT_, procName, settings_, globals_);
-  } else if (procType == "PurgeDuplicate:") {
-    addProcToVec(PD_, procName, settings_, globals_);
-  } else {
-    edm::LogPrint("Tracklet") << "Don't know of processing type: " << procType;
-    exit(0);
-  }
-}
-
-void Sector::addWire(string mem, string procinfull, string procoutfull) {
-  stringstream ss1(procinfull);
-  string procin, output;
-  getline(ss1, procin, '.');
-  getline(ss1, output);
-
-  stringstream ss2(procoutfull);
-  string procout, input;
-  getline(ss2, procout, '.');
-  getline(ss2, input);
-
-  MemoryBase* memory = getMem(mem);
-
-  if (!procin.empty()) {
-    ProcessBase* inProc = getProc(procin);
-    inProc->addOutput(memory, output);
+  void Sector::addProc(string procType, string procName) {
+    if (procType == "InputRouter:") {
+      addProcToVec(IR_, procName, settings_, globals_);
+    } else if (procType == "VMRouter:") {
+      addProcToVec(VMR_, procName, settings_, globals_);
+    } else if (procType == "VMRouterCM:") {
+      addProcToVec(VMRCM_, procName, settings_, globals_);
+    } else if (procType == "TrackletEngine:") {
+      addProcToVec(TE_, procName, settings_, globals_);
+    } else if (procType == "TrackletEngineDisplaced:") {
+      addProcToVec(TED_, procName, settings_, globals_);
+    } else if (procType == "TripletEngine:") {
+      addProcToVec(TRE_, procName, settings_, globals_);
+    } else if (procType == "TrackletCalculator:") {
+      addProcToVec(TC_, procName, settings_, globals_);
+    } else if (procType == "TrackletProcessor:") {
+      addProcToVec(TP_, procName, settings_, globals_);
+    } else if (procType == "TrackletProcessorDisplaced:") {
+      addProcToVec(TPD_, procName, settings_, globals_);
+    } else if (procType == "TrackletCalculatorDisplaced:") {
+      addProcToVec(TCD_, procName, settings_, globals_);
+    } else if (procType == "ProjectionRouter:") {
+      addProcToVec(PR_, procName, settings_, globals_);
+    } else if (procType == "MatchEngine:") {
+      addProcToVec(ME_, procName, settings_, globals_);
+    } else if (procType == "MatchCalculator:" ||
+               procType == "DiskMatchCalculator:") {  //TODO should not be used in configurations
+      addProcToVec(MC_, procName, settings_, globals_);
+    } else if (procType == "MatchProcessor:") {
+      addProcToVec(MP_, procName, settings_, globals_);
+    } else if (procType == "FitTrack:") {
+      addProcToVec(FT_, procName, settings_, globals_);
+    } else if (procType == "PurgeDuplicate:") {
+      addProcToVec(PD_, procName, settings_, globals_);
+    } else {
+      edm::LogPrint("Tracklet") << "Don't know of processing type: " << procType;
+      exit(0);
+    }
   }
 
-  if (!procout.empty()) {
-    ProcessBase* outProc = getProc(procout);
-    outProc->addInput(memory, input);
+  void Sector::addWire(string mem, string procinfull, string procoutfull) {
+    stringstream ss1(procinfull);
+    string procin, output;
+    getline(ss1, procin, '.');
+    getline(ss1, output);
+
+    stringstream ss2(procoutfull);
+    string procout, input;
+    getline(ss2, procout, '.');
+    getline(ss2, input);
+
+    MemoryBase* memory = getMem(mem);
+
+    if (!procin.empty()) {
+      ProcessBase* inProc = getProc(procin);
+      inProc->addOutput(memory, output);
+    }
+
+    if (!procout.empty()) {
+      ProcessBase* outProc = getProc(procout);
+      outProc->addInput(memory, input);
+    }
   }
-}
 
-ProcessBase* Sector::getProc(string procName) {
-  auto it = Processes_.find(procName);
+  ProcessBase* Sector::getProc(string procName) {
+    auto it = Processes_.find(procName);
 
-  if (it != Processes_.end()) {
-    return it->second;
+    if (it != Processes_.end()) {
+      return it->second;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find process : " << procName
+                                      << endl;
+    return nullptr;
   }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find process : " << procName << endl;
-  return nullptr;
-}
 
-MemoryBase* Sector::getMem(string memName) {
-  auto it = Memories_.find(memName);
+  MemoryBase* Sector::getMem(string memName) {
+    auto it = Memories_.find(memName);
 
-  if (it != Memories_.end()) {
-    return it->second;
+    if (it != Memories_.end()) {
+      return it->second;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find memory : " << memName;
+    return nullptr;
   }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find memory : " << memName;
-  return nullptr;
-}
 
-void Sector::writeDTCStubs(bool first) {
-  for (auto& i : DL_) {
-    i->writeStubs(first, isector_);
+  void Sector::writeDTCStubs(bool first) {
+    for (auto& i : DL_) {
+      i->writeStubs(first, isector_);
+    }
   }
-}
 
-void Sector::writeIRStubs(bool first) {
-  for (auto& i : IL_) {
-    i->writeStubs(first, isector_);
-  }
-}
-
-void Sector::writeVMSTE(bool first) {
-  for (auto& i : VMSTE_) {
-    i->writeStubs(first, isector_);
-  }
-}
-
-void Sector::writeVMSME(bool first) {
-  for (auto& i : VMSME_) {
-    i->writeStubs(first, isector_);
-  }
-}
-
-void Sector::writeAS(bool first) {
-  for (auto& i : AS_) {
-    i->writeStubs(first, isector_);
-  }
-}
-
-void Sector::writeAIS(bool first) {
-  for (auto& i : AIS_) {
-    i->writeStubs(first, isector_);
-  }
-}
-
-void Sector::writeSP(bool first) {
-  for (auto& i : SP_) {
-    i->writeSP(first, isector_);
-  }
-}
-
-void Sector::writeST(bool first) {
-  for (auto& i : ST_) {
-    i->writeST(first, isector_);
-  }
-}
-
-void Sector::writeTPAR(bool first) {
-  for (auto& i : TPAR_) {
-    i->writeTPAR(first, isector_);
-  }
-}
-
-void Sector::writeTPROJ(bool first) {
-  for (auto& i : TPROJ_) {
-    i->writeTPROJ(first, isector_);
-  }
-}
-
-void Sector::writeAP(bool first) {
-  for (auto& i : AP_) {
-    i->writeAP(first, isector_);
-  }
-}
-
-void Sector::writeVMPROJ(bool first) {
-  for (auto& i : VMPROJ_) {
-    i->writeVMPROJ(first, isector_);
-  }
-}
-
-void Sector::writeCM(bool first) {
-  for (auto& i : CM_) {
-    i->writeCM(first, isector_);
-  }
-}
-
-void Sector::writeMC(bool first) {
-  for (auto& i : FM_) {
-    i->writeMC(first, isector_);
-  }
-}
-
-void Sector::writeTF(bool first) {
-  for (auto& i : TF_) {
-    i->writeTF(first, isector_);
-  }
-}
-
-void Sector::writeCT(bool first) {
-  for (auto& i : CT_) {
-    i->writeCT(first, isector_);
-  }
-}
-
-void Sector::clean() {
-  for (auto& mem : MemoriesV_) {
-    mem->clean();
-  }
-}
-
-void Sector::executeIR() {
-  for (auto& i : IR_) {
-    i->execute();
-  }
-}
-
-void Sector::executeVMR() {
-  if (settings_.writeMonitorData("IL")) {
-    ofstream& out = globals_->ofstream("inputlink.txt");
+  void Sector::writeIRStubs(bool first) {
     for (auto& i : IL_) {
-      out << i->getName() << " " << i->nStubs() << endl;
+      i->writeStubs(first, isector_);
     }
   }
-  for (auto& i : VMR_) {
-    i->execute();
-  }
-  for (auto& i : VMRCM_) {
-    i->execute(isector_);
-  }
-}
 
-void Sector::executeTE() {
-  for (auto& i : TE_) {
-    i->execute();
-  }
-}
-
-void Sector::executeTED() {
-  for (auto& i : TED_) {
-    i->execute();
-  }
-}
-
-void Sector::executeTRE() {
-  for (auto& i : TRE_) {
-    i->execute();
-  }
-}
-
-void Sector::executeTP() {
-  for (auto& i : TP_) {
-    i->execute(isector_, phimin_, phimax_);
-  }
-}
-
-void Sector::executeTPD() {
-  for (auto& i : TPD_) {
-    i->execute(isector_, phimin_, phimax_);
-  }
-}
-
-void Sector::executeTC() {
-  for (auto& i : TC_) {
-    i->execute(isector_, phimin_, phimax_);
+  void Sector::writeVMSTE(bool first) {
+    for (auto& i : VMSTE_) {
+      i->writeStubs(first, isector_);
+    }
   }
 
-  if (settings_.writeMonitorData("TrackProjOcc")) {
-    ofstream& out = globals_->ofstream("trackprojocc.txt");
+  void Sector::writeVMSME(bool first) {
+    for (auto& i : VMSME_) {
+      i->writeStubs(first, isector_);
+    }
+  }
+
+  void Sector::writeAS(bool first) {
+    for (auto& i : AS_) {
+      i->writeStubs(first, isector_);
+    }
+  }
+
+  void Sector::writeAIS(bool first) {
+    for (auto& i : AIS_) {
+      i->writeStubs(first, isector_);
+    }
+  }
+
+  void Sector::writeSP(bool first) {
+    for (auto& i : SP_) {
+      i->writeSP(first, isector_);
+    }
+  }
+
+  void Sector::writeST(bool first) {
+    for (auto& i : ST_) {
+      i->writeST(first, isector_);
+    }
+  }
+
+  void Sector::writeTPAR(bool first) {
+    for (auto& i : TPAR_) {
+      i->writeTPAR(first, isector_);
+    }
+  }
+
+  void Sector::writeTPROJ(bool first) {
     for (auto& i : TPROJ_) {
-      out << i->getName() << " " << i->nTracklets() << endl;
-    }
-  }
-}
-
-void Sector::executeTCD() {
-  for (auto& i : TCD_) {
-    i->execute(isector_, phimin_, phimax_);
-  }
-}
-
-void Sector::executePR() {
-  for (auto& i : PR_) {
-    i->execute();
-  }
-}
-
-void Sector::executeME() {
-  for (auto& i : ME_) {
-    i->execute(isector_);
-  }
-}
-
-void Sector::executeMC() {
-  for (auto& i : MC_) {
-    i->execute(isector_, phimin_);
-  }
-}
-
-void Sector::executeMP() {
-  for (auto& i : MP_) {
-    i->execute(isector_, phimin_);
-  }
-}
-
-// Order here reflects Tracklet algo that calls FitTrack before PurgeDuplicates.
-// If using Hybrid, then PurgeDuplicates runs both duplicate removal & KF steps.
-// (unless duplicate removal disabled, in which case FitTrack runs KF).
-
-void Sector::executeFT(vector<vector<string>>& streamsTrackRaw, vector<vector<StubStreamData>>& streamsStubRaw) {
-  const int numChannels = streamsTrackRaw.size() / N_SECTOR;
-  const int maxNumProjectionLayers = streamsStubRaw.size() / streamsTrackRaw.size();
-  const int offsetTrack = isector_ * numChannels;
-  int channelTrack(0);
-
-  for (auto& i : FT_) {
-    // Temporary streams for a single TrackBuilder (i.e. seed type)
-    deque<string> streamTrackTmp;
-    vector<deque<StubStreamData>> streamsStubTmp(maxNumProjectionLayers);
-    i->execute(streamTrackTmp, streamsStubTmp, isector_);
-    if (!settings_.storeTrackBuilderOutput())
-      continue;
-    const int offsetStub = (offsetTrack + channelTrack) * maxNumProjectionLayers;
-    streamsTrackRaw[offsetTrack + channelTrack] = vector<string>(streamTrackTmp.begin(), streamTrackTmp.end());
-    channelTrack++;
-    int channelStub(0);
-    for (auto& stream : streamsStubTmp)
-      streamsStubRaw[offsetStub + channelStub++] = vector<StubStreamData>(stream.begin(), stream.end());
-  }
-}
-
-// Returns tracks reconstructed by L1 track chain.
-void Sector::executePD(std::vector<Track>& tracks) {
-  for (auto& i : PD_) {
-    i->execute(tracks, isector_);
-  }
-}
-
-std::vector<Tracklet*> Sector::getAllTracklets() const {
-  std::vector<Tracklet*> tmp;
-  for (auto& tpar : TPAR_) {
-    for (unsigned int j = 0; j < tpar->nTracklets(); j++) {
-      tmp.push_back(tpar->getTracklet(j));
-    }
-  }
-  return tmp;
-}
-
-std::vector<const Stub*> Sector::getStubs() const {
-  std::vector<const Stub*> tmp;
-
-  for (auto& imem : IL_) {
-    for (unsigned int istub = 0; istub < imem->nStubs(); istub++) {
-      tmp.push_back(imem->getStub(istub));
+      i->writeTPROJ(first, isector_);
     }
   }
 
-  return tmp;
-}
+  void Sector::writeAP(bool first) {
+    for (auto& i : AP_) {
+      i->writeAP(first, isector_);
+    }
+  }
 
-std::unordered_set<int> Sector::seedMatch(int itp) const {
-  std::unordered_set<int> tmpSeeds;
-  for (auto& i : TPAR_) {
-    unsigned int nTracklet = i->nTracklets();
-    for (unsigned int j = 0; j < nTracklet; j++) {
-      if (i->getTracklet(j)->tpseed() == itp) {
-        tmpSeeds.insert(i->getTracklet(j)->getISeed());
+  void Sector::writeVMPROJ(bool first) {
+    for (auto& i : VMPROJ_) {
+      i->writeVMPROJ(first, isector_);
+    }
+  }
+
+  void Sector::writeCM(bool first) {
+    for (auto& i : CM_) {
+      i->writeCM(first, isector_);
+    }
+  }
+
+  void Sector::writeMC(bool first) {
+    for (auto& i : FM_) {
+      i->writeMC(first, isector_);
+    }
+  }
+
+  void Sector::writeTF(bool first) {
+    for (auto& i : TF_) {
+      i->writeTF(first, isector_);
+    }
+  }
+
+  void Sector::writeCT(bool first) {
+    for (auto& i : CT_) {
+      i->writeCT(first, isector_);
+    }
+  }
+
+  void Sector::clean() {
+    for (auto& mem : MemoriesV_) {
+      mem->clean();
+    }
+  }
+
+  void Sector::executeIR() {
+    for (auto& i : IR_) {
+      i->execute();
+    }
+  }
+
+  void Sector::executeVMR() {
+    if (settings_.writeMonitorData("IL")) {
+      ofstream& out = globals_->ofstream("inputlink.txt");
+      for (auto& i : IL_) {
+        out << i->getName() << " " << i->nStubs() << endl;
+      }
+    }
+    for (auto& i : VMR_) {
+      i->execute();
+    }
+    for (auto& i : VMRCM_) {
+      i->execute(isector_);
+    }
+  }
+
+  void Sector::executeTE() {
+    for (auto& i : TE_) {
+      i->execute();
+    }
+  }
+
+  void Sector::executeTED() {
+    for (auto& i : TED_) {
+      i->execute();
+    }
+  }
+
+  void Sector::executeTRE() {
+    for (auto& i : TRE_) {
+      i->execute();
+    }
+  }
+
+  void Sector::executeTP() {
+    for (auto& i : TP_) {
+      i->execute(isector_, phimin_, phimax_);
+    }
+  }
+
+  void Sector::executeTPD() {
+    for (auto& i : TPD_) {
+      i->execute(isector_, phimin_, phimax_);
+    }
+  }
+
+  void Sector::executeTC() {
+    for (auto& i : TC_) {
+      i->execute(isector_, phimin_, phimax_);
+    }
+
+    if (settings_.writeMonitorData("TrackProjOcc")) {
+      ofstream& out = globals_->ofstream("trackprojocc.txt");
+      for (auto& i : TPROJ_) {
+        out << i->getName() << " " << i->nTracklets() << endl;
       }
     }
   }
-  return tmpSeeds;
-}
 
-}
+  void Sector::executeTCD() {
+    for (auto& i : TCD_) {
+      i->execute(isector_, phimin_, phimax_);
+    }
+  }
+
+  void Sector::executePR() {
+    for (auto& i : PR_) {
+      i->execute();
+    }
+  }
+
+  void Sector::executeME() {
+    for (auto& i : ME_) {
+      i->execute(isector_);
+    }
+  }
+
+  void Sector::executeMC() {
+    for (auto& i : MC_) {
+      i->execute(isector_, phimin_);
+    }
+  }
+
+  void Sector::executeMP() {
+    for (auto& i : MP_) {
+      i->execute(isector_, phimin_);
+    }
+  }
+
+  // Order here reflects Tracklet algo that calls FitTrack before PurgeDuplicates.
+  // If using Hybrid, then PurgeDuplicates runs both duplicate removal & KF steps.
+  // (unless duplicate removal disabled, in which case FitTrack runs KF).
+
+  void Sector::executeFT(vector<vector<string>>& streamsTrackRaw, vector<vector<StubStreamData>>& streamsStubRaw) {
+    const int numChannels = streamsTrackRaw.size() / N_SECTOR;
+    const int maxNumProjectionLayers = streamsStubRaw.size() / streamsTrackRaw.size();
+    const int offsetTrack = isector_ * numChannels;
+    int channelTrack(0);
+
+    for (auto& i : FT_) {
+      // Temporary streams for a single TrackBuilder (i.e. seed type)
+      deque<string> streamTrackTmp;
+      vector<deque<StubStreamData>> streamsStubTmp(maxNumProjectionLayers);
+      i->execute(streamTrackTmp, streamsStubTmp, isector_);
+      if (!settings_.storeTrackBuilderOutput())
+        continue;
+      const int offsetStub = (offsetTrack + channelTrack) * maxNumProjectionLayers;
+      streamsTrackRaw[offsetTrack + channelTrack] = vector<string>(streamTrackTmp.begin(), streamTrackTmp.end());
+      channelTrack++;
+      int channelStub(0);
+      for (auto& stream : streamsStubTmp)
+        streamsStubRaw[offsetStub + channelStub++] = vector<StubStreamData>(stream.begin(), stream.end());
+    }
+  }
+
+  // Returns tracks reconstructed by L1 track chain.
+  void Sector::executePD(std::vector<Track>& tracks) {
+    for (auto& i : PD_) {
+      i->execute(tracks, isector_);
+    }
+  }
+
+  std::vector<Tracklet*> Sector::getAllTracklets() const {
+    std::vector<Tracklet*> tmp;
+    for (auto& tpar : TPAR_) {
+      for (unsigned int j = 0; j < tpar->nTracklets(); j++) {
+        tmp.push_back(tpar->getTracklet(j));
+      }
+    }
+    return tmp;
+  }
+
+  std::vector<const Stub*> Sector::getStubs() const {
+    std::vector<const Stub*> tmp;
+
+    for (auto& imem : IL_) {
+      for (unsigned int istub = 0; istub < imem->nStubs(); istub++) {
+        tmp.push_back(imem->getStub(istub));
+      }
+    }
+
+    return tmp;
+  }
+
+  std::unordered_set<int> Sector::seedMatch(int itp) const {
+    std::unordered_set<int> tmpSeeds;
+    for (auto& i : TPAR_) {
+      unsigned int nTracklet = i->nTracklets();
+      for (unsigned int j = 0; j < nTracklet; j++) {
+        if (i->getTracklet(j)->tpseed() == itp) {
+          tmpSeeds.insert(i->getTracklet(j)->getISeed());
+        }
+      }
+    }
+    return tmpSeeds;
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -47,7 +47,8 @@
 #include <deque>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 Sector::Sector(Settings const& settings, Globals* globals) : isector_(-1), settings_(settings), globals_(globals) {}
 
@@ -489,4 +490,6 @@ std::unordered_set<int> Sector::seedMatch(int itp) const {
     }
   }
   return tmpSeeds;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/Stub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Stub.cc
@@ -10,7 +10,8 @@
 #include <bitset>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 Stub::Stub(Settings const& settings) : settings_(settings) {}
 
@@ -186,4 +187,6 @@ unsigned int Stub::layerdisk() const {
   if (layer_.value() == -1)
     return N_LAYER - 1 + abs(disk_.value());
   return layer_.value();
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/Stub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Stub.cc
@@ -13,180 +13,180 @@ using namespace std;
 
 namespace trklet {
 
-Stub::Stub(Settings const& settings) : settings_(settings) {}
+  Stub::Stub(Settings const& settings) : settings_(settings) {}
 
-Stub::Stub(L1TStub& stub, Settings const& settings, Globals& globals) : settings_(settings) {
-  const string& stubwordhex = stub.stubword();
+  Stub::Stub(L1TStub& stub, Settings const& settings, Globals& globals) : settings_(settings) {
+    const string& stubwordhex = stub.stubword();
 
-  const string stubwordbin = convertHexToBin(stubwordhex);
+    const string stubwordbin = convertHexToBin(stubwordhex);
 
-  layerdisk_ = stub.layerdisk();
+    layerdisk_ = stub.layerdisk();
 
-  int nbendbits = stub.isPSmodule() ? N_BENDBITS_PS : N_BENDBITS_2S;
+    int nbendbits = stub.isPSmodule() ? N_BENDBITS_PS : N_BENDBITS_2S;
 
-  int nalphabits = 0;
+    int nalphabits = 0;
 
-  int nrbits = settings_.nrbitsstub(layerdisk_);
-  int nzbits = settings_.nzbitsstub(layerdisk_);
-  int nphibits = settings_.nphibitsstub(layerdisk_);
+    int nrbits = settings_.nrbitsstub(layerdisk_);
+    int nzbits = settings_.nzbitsstub(layerdisk_);
+    int nphibits = settings_.nphibitsstub(layerdisk_);
 
-  if (layerdisk_ >= N_LAYER && !stub.isPSmodule()) {
-    nalphabits = settings.nbitsalpha();
-    nrbits = 7;
-  }
-
-  assert(nbendbits + nalphabits + nrbits + nzbits + nphibits == 36);
-
-  bitset<32> rbits(stubwordbin.substr(0, nrbits));
-  bitset<32> zbits(stubwordbin.substr(nrbits, nzbits));
-  bitset<32> phibits(stubwordbin.substr(nrbits + nzbits, nphibits));
-  bitset<32> alphabits(stubwordbin.substr(nphibits + nzbits + nrbits, nalphabits));
-  bitset<32> bendbits(stubwordbin.substr(nphibits + nzbits + nrbits + nalphabits, nbendbits));
-
-  int newbend = bendbits.to_ulong();
-
-  int newr = rbits.to_ulong();
-  if (layerdisk_ < N_LAYER) {
-    if (newr >= (1 << (nrbits - 1)))
-      newr = newr - (1 << nrbits);
-  }
-
-  int newz = zbits.to_ulong();
-  if (newz >= (1 << (nzbits - 1)))
-    newz = newz - (1 << nzbits);
-
-  int newphi = phibits.to_ulong();
-
-  int newalpha = alphabits.to_ulong();
-  if (newalpha >= (1 << (nalphabits - 1)))
-    newalpha = newalpha - (1 << nalphabits);
-
-  l1tstub_ = &stub;
-
-  bend_.set(newbend, nbendbits, true, __LINE__, __FILE__);
-
-  phi_.set(newphi, nphibits, true, __LINE__, __FILE__);
-  phicorr_.set(newphi, nphibits, true, __LINE__, __FILE__);
-  bool pos = false;
-  if (layerdisk_ >= N_LAYER) {
-    pos = true;
-    int disk = layerdisk_ - N_LAYER + 1;
-    if (stub.z() < 0.0)
-      disk = -disk;
-    disk_.set(disk, 4, false, __LINE__, __FILE__);
-    if (!stub.isPSmodule()) {
-      alpha_.set(newalpha, nalphabits, false, __LINE__, __FILE__);
-      nrbits = 4;
+    if (layerdisk_ >= N_LAYER && !stub.isPSmodule()) {
+      nalphabits = settings.nbitsalpha();
+      nrbits = 7;
     }
-  } else {
-    disk_.set(0, 4, false, __LINE__, __FILE__);
-    layer_.set(layerdisk_, 3, true, __LINE__, __FILE__);
-  }
-  r_.set(newr, nrbits, pos, __LINE__, __FILE__);
-  z_.set(newz, nzbits, false, __LINE__, __FILE__);
 
-  if (settings.writeMonitorData("StubBend")) {
-    unsigned int nsimtrks = globals.event()->nsimtracks();
+    assert(nbendbits + nalphabits + nrbits + nzbits + nphibits == 36);
 
-    for (unsigned int isimtrk = 0; isimtrk < nsimtrks; isimtrk++) {
-      const L1SimTrack& simtrk = globals.event()->simtrack(isimtrk);
-      if (stub.tpmatch2(simtrk.trackid())) {
-        double dr = 0.18;
-        double rinv = simtrk.charge() * 0.01 * settings_.c() * settings_.bfield() / simtrk.pt();
-        double pitch = settings_.stripPitch(stub.isPSmodule());
-        double bend = stub.r() * dr * 0.5 * rinv / pitch;
+    bitset<32> rbits(stubwordbin.substr(0, nrbits));
+    bitset<32> zbits(stubwordbin.substr(nrbits, nzbits));
+    bitset<32> phibits(stubwordbin.substr(nrbits + nzbits, nphibits));
+    bitset<32> alphabits(stubwordbin.substr(nphibits + nzbits + nrbits, nalphabits));
+    bitset<32> bendbits(stubwordbin.substr(nphibits + nzbits + nrbits + nalphabits, nbendbits));
 
-        globals.ofstream("stubbend.dat") << layerdisk_ << " " << stub.isPSmodule() << " "
-                                         << simtrk.pt() * simtrk.charge() << " " << bend << " " << newbend << " "
-                                         << settings.benddecode(newbend, layerdisk_, stub.isPSmodule()) << " "
-                                         << settings.bendcut(newbend, layerdisk_, stub.isPSmodule()) << endl;
+    int newbend = bendbits.to_ulong();
+
+    int newr = rbits.to_ulong();
+    if (layerdisk_ < N_LAYER) {
+      if (newr >= (1 << (nrbits - 1)))
+        newr = newr - (1 << nrbits);
+    }
+
+    int newz = zbits.to_ulong();
+    if (newz >= (1 << (nzbits - 1)))
+      newz = newz - (1 << nzbits);
+
+    int newphi = phibits.to_ulong();
+
+    int newalpha = alphabits.to_ulong();
+    if (newalpha >= (1 << (nalphabits - 1)))
+      newalpha = newalpha - (1 << nalphabits);
+
+    l1tstub_ = &stub;
+
+    bend_.set(newbend, nbendbits, true, __LINE__, __FILE__);
+
+    phi_.set(newphi, nphibits, true, __LINE__, __FILE__);
+    phicorr_.set(newphi, nphibits, true, __LINE__, __FILE__);
+    bool pos = false;
+    if (layerdisk_ >= N_LAYER) {
+      pos = true;
+      int disk = layerdisk_ - N_LAYER + 1;
+      if (stub.z() < 0.0)
+        disk = -disk;
+      disk_.set(disk, 4, false, __LINE__, __FILE__);
+      if (!stub.isPSmodule()) {
+        alpha_.set(newalpha, nalphabits, false, __LINE__, __FILE__);
+        nrbits = 4;
+      }
+    } else {
+      disk_.set(0, 4, false, __LINE__, __FILE__);
+      layer_.set(layerdisk_, 3, true, __LINE__, __FILE__);
+    }
+    r_.set(newr, nrbits, pos, __LINE__, __FILE__);
+    z_.set(newz, nzbits, false, __LINE__, __FILE__);
+
+    if (settings.writeMonitorData("StubBend")) {
+      unsigned int nsimtrks = globals.event()->nsimtracks();
+
+      for (unsigned int isimtrk = 0; isimtrk < nsimtrks; isimtrk++) {
+        const L1SimTrack& simtrk = globals.event()->simtrack(isimtrk);
+        if (stub.tpmatch2(simtrk.trackid())) {
+          double dr = 0.18;
+          double rinv = simtrk.charge() * 0.01 * settings_.c() * settings_.bfield() / simtrk.pt();
+          double pitch = settings_.stripPitch(stub.isPSmodule());
+          double bend = stub.r() * dr * 0.5 * rinv / pitch;
+
+          globals.ofstream("stubbend.dat")
+              << layerdisk_ << " " << stub.isPSmodule() << " " << simtrk.pt() * simtrk.charge() << " " << bend << " "
+              << newbend << " " << settings.benddecode(newbend, layerdisk_, stub.isPSmodule()) << " "
+              << settings.bendcut(newbend, layerdisk_, stub.isPSmodule()) << endl;
+        }
       }
     }
   }
-}
 
-FPGAWord Stub::iphivmFineBins(int VMbits, int finebits) const {
-  unsigned int finephi = (phicorr_.value() >> (phicorr_.nbits() - VMbits - finebits)) & ((1 << finebits) - 1);
-  return FPGAWord(finephi, finebits, true, __LINE__, __FILE__);
-}
-
-unsigned int Stub::phiregionaddress() const {
-  int iphi = (phicorr_.value() >> (phicorr_.nbits() - settings_.nbitsallstubs(layerdisk())));
-  return (iphi << 7) + stubindex_.value();
-}
-
-std::string Stub::phiregionaddressstr() const {
-  int iphi = (phicorr_.value() >> (phicorr_.nbits() - settings_.nbitsallstubs(layerdisk())));
-  FPGAWord phiregion(iphi, 3, true, __LINE__, __FILE__);
-  return phiregion.str() + stubindex_.str();
-}
-
-void Stub::setAllStubIndex(int nstub) {
-  if (nstub >= (1 << N_BITSMEMADDRESS)) {
-    if (settings_.debugTracklet())
-      edm::LogPrint("Tracklet") << "Warning too large stubindex!";
-    nstub = (1 << N_BITSMEMADDRESS) - 1;
+  FPGAWord Stub::iphivmFineBins(int VMbits, int finebits) const {
+    unsigned int finephi = (phicorr_.value() >> (phicorr_.nbits() - VMbits - finebits)) & ((1 << finebits) - 1);
+    return FPGAWord(finephi, finebits, true, __LINE__, __FILE__);
   }
 
-  stubindex_.set(nstub, N_BITSMEMADDRESS);
-}
-
-void Stub::setPhiCorr(int phiCorr) {
-  int iphicorr = phi_.value() - phiCorr;
-
-  if (iphicorr < 0)
-    iphicorr = 0;
-  if (iphicorr >= (1 << phi_.nbits()))
-    iphicorr = (1 << phi_.nbits()) - 1;
-
-  phicorr_.set(iphicorr, phi_.nbits(), true, __LINE__, __FILE__);
-}
-
-double Stub::rapprox() const {
-  if (disk_.value() == 0) {
-    int lr = 1 << (8 - settings_.nrbitsstub(layer_.value()));
-    return r_.value() * settings_.kr() * lr + settings_.rmean(layer_.value());
+  unsigned int Stub::phiregionaddress() const {
+    int iphi = (phicorr_.value() >> (phicorr_.nbits() - settings_.nbitsallstubs(layerdisk())));
+    return (iphi << 7) + stubindex_.value();
   }
-  if (!l1tstub_->isPSmodule()) {
-    if (abs(disk_.value()) <= 2)
-      return settings_.rDSSinner(r_.value());
-    else
-      return settings_.rDSSouter(r_.value());
-  }
-  return r_.value() * settings_.kr();
-}
 
-double Stub::zapprox() const {
-  if (disk_.value() == 0) {
-    int lz = 1;
-    if (layer_.value() >= 3) {
-      lz = 16;
+  std::string Stub::phiregionaddressstr() const {
+    int iphi = (phicorr_.value() >> (phicorr_.nbits() - settings_.nbitsallstubs(layerdisk())));
+    FPGAWord phiregion(iphi, 3, true, __LINE__, __FILE__);
+    return phiregion.str() + stubindex_.str();
+  }
+
+  void Stub::setAllStubIndex(int nstub) {
+    if (nstub >= (1 << N_BITSMEMADDRESS)) {
+      if (settings_.debugTracklet())
+        edm::LogPrint("Tracklet") << "Warning too large stubindex!";
+      nstub = (1 << N_BITSMEMADDRESS) - 1;
     }
-    return z_.value() * settings_.kz() * lz;
-  }
-  int sign = 1;
-  if (disk_.value() < 0)
-    sign = -1;
-  if (sign < 0) {
-    //Should understand why this is needed to get agreement with integer calculations
-    return (z_.value() + 1) * settings_.kz() + sign * settings_.zmean(abs(disk_.value()) - 1);
-  } else {
-    return z_.value() * settings_.kz() + sign * settings_.zmean(abs(disk_.value()) - 1);
-  }
-}
 
-double Stub::phiapprox(double phimin, double) const {
-  int lphi = 1;
-  if (layer_.value() >= 3) {
-    lphi = 8;
+    stubindex_.set(nstub, N_BITSMEMADDRESS);
   }
-  return reco::reduceRange(phimin + phi_.value() * settings_.kphi() / lphi);
-}
 
-unsigned int Stub::layerdisk() const {
-  if (layer_.value() == -1)
-    return N_LAYER - 1 + abs(disk_.value());
-  return layer_.value();
-}
+  void Stub::setPhiCorr(int phiCorr) {
+    int iphicorr = phi_.value() - phiCorr;
 
-}
+    if (iphicorr < 0)
+      iphicorr = 0;
+    if (iphicorr >= (1 << phi_.nbits()))
+      iphicorr = (1 << phi_.nbits()) - 1;
+
+    phicorr_.set(iphicorr, phi_.nbits(), true, __LINE__, __FILE__);
+  }
+
+  double Stub::rapprox() const {
+    if (disk_.value() == 0) {
+      int lr = 1 << (8 - settings_.nrbitsstub(layer_.value()));
+      return r_.value() * settings_.kr() * lr + settings_.rmean(layer_.value());
+    }
+    if (!l1tstub_->isPSmodule()) {
+      if (abs(disk_.value()) <= 2)
+        return settings_.rDSSinner(r_.value());
+      else
+        return settings_.rDSSouter(r_.value());
+    }
+    return r_.value() * settings_.kr();
+  }
+
+  double Stub::zapprox() const {
+    if (disk_.value() == 0) {
+      int lz = 1;
+      if (layer_.value() >= 3) {
+        lz = 16;
+      }
+      return z_.value() * settings_.kz() * lz;
+    }
+    int sign = 1;
+    if (disk_.value() < 0)
+      sign = -1;
+    if (sign < 0) {
+      //Should understand why this is needed to get agreement with integer calculations
+      return (z_.value() + 1) * settings_.kz() + sign * settings_.zmean(abs(disk_.value()) - 1);
+    } else {
+      return z_.value() * settings_.kz() + sign * settings_.zmean(abs(disk_.value()) - 1);
+    }
+  }
+
+  double Stub::phiapprox(double phimin, double) const {
+    int lphi = 1;
+    if (layer_.value() >= 3) {
+      lphi = 8;
+    }
+    return reco::reduceRange(phimin + phi_.value() * settings_.kphi() / lphi);
+  }
+
+  unsigned int Stub::layerdisk() const {
+    if (layer_.value() == -1)
+      return N_LAYER - 1 + abs(disk_.value());
+    return layer_.value();
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/StubPairsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/StubPairsMemory.cc
@@ -4,7 +4,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 StubPairsMemory::StubPairsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
 
@@ -32,4 +33,6 @@ void StubPairsMemory::writeSP(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/StubPairsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/StubPairsMemory.cc
@@ -7,32 +7,32 @@ using namespace std;
 
 namespace trklet {
 
-StubPairsMemory::StubPairsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
+  StubPairsMemory::StubPairsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
 
-void StubPairsMemory::writeSP(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirSP = settings_.memPath() + "StubPairs/";
+  void StubPairsMemory::writeSP(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirSP = settings_.memPath() + "StubPairs/";
 
-  std::ostringstream oss;
-  oss << dirSP << "StubPairs_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
+    std::ostringstream oss;
+    oss << dirSP << "StubPairs_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
+    auto const& fname = oss.str();
 
-  openfile(out_, first, dirSP, fname, __FILE__, __LINE__);
+    openfile(out_, first, dirSP, fname, __FILE__, __LINE__);
 
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
 
-  for (unsigned int j = 0; j < stubs_.size(); j++) {
-    string stub1index = stubs_[j].first.stub()->stubindex().str();
-    string stub2index = stubs_[j].second.stub()->stubindex().str();
-    out_ << hexstr(j) << " " << stub1index << "|" << stub2index << " " << trklet::hexFormat(stub1index + stub2index)
-         << endl;
+    for (unsigned int j = 0; j < stubs_.size(); j++) {
+      string stub1index = stubs_[j].first.stub()->stubindex().str();
+      string stub2index = stubs_[j].second.stub()->stubindex().str();
+      out_ << hexstr(j) << " " << stub1index << "|" << stub2index << " " << trklet::hexFormat(stub1index + stub2index)
+           << endl;
+    }
+    out_.close();
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
   }
-  out_.close();
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/StubTripletsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/StubTripletsMemory.cc
@@ -5,7 +5,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 StubTripletsMemory::StubTripletsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
 
@@ -33,4 +34,6 @@ void StubTripletsMemory::writeST(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/StubTripletsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/StubTripletsMemory.cc
@@ -8,32 +8,33 @@ using namespace std;
 
 namespace trklet {
 
-StubTripletsMemory::StubTripletsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
+  StubTripletsMemory::StubTripletsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {}
 
-void StubTripletsMemory::writeST(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirSP = settings_.memPath() + "StubPairs/";
+  void StubTripletsMemory::writeST(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirSP = settings_.memPath() + "StubPairs/";
 
-  std::ostringstream oss;
-  oss << dirSP << "StubTriplets_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
+    std::ostringstream oss;
+    oss << dirSP << "StubTriplets_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1)
+        << ".dat";
+    auto const& fname = oss.str();
 
-  openfile(out_, first, dirSP, fname, __FILE__, __LINE__);
+    openfile(out_, first, dirSP, fname, __FILE__, __LINE__);
 
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
 
-  for (unsigned int j = 0; j < stubs1_.size(); j++) {
-    string stub1index = stubs1_[j]->stubindex().str();
-    string stub2index = stubs2_[j]->stubindex().str();
-    string stub3index = stubs3_[j]->stubindex().str();
-    out_ << hexstr(j) << " " << stub1index << "|" << stub2index << "|" << stub3index << endl;
+    for (unsigned int j = 0; j < stubs1_.size(); j++) {
+      string stub1index = stubs1_[j]->stubindex().str();
+      string stub2index = stubs2_[j]->stubindex().str();
+      string stub3index = stubs3_[j]->stubindex().str();
+      out_ << hexstr(j) << " " << stub1index << "|" << stub2index << "|" << stub3index << endl;
+    }
+    out_.close();
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
   }
-  out_.close();
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/Timer.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Timer.cc
@@ -1,6 +1,6 @@
 #include "L1Trigger/TrackFindingTracklet/interface/Timer.h"
 
-using namespace trklet;
+namespace trklet {
 
 void Timer::start() { tstart_ = std::chrono::high_resolution_clock::now(); }
 void Timer::stop() {
@@ -9,4 +9,6 @@ void Timer::stop() {
   ttot_ += tmp;
   ttotsq_ += tmp * tmp;
   ntimes_++;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/Timer.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Timer.cc
@@ -2,13 +2,13 @@
 
 namespace trklet {
 
-void Timer::start() { tstart_ = std::chrono::high_resolution_clock::now(); }
-void Timer::stop() {
-  auto tstop = std::chrono::high_resolution_clock::now();
-  double tmp = std::chrono::duration<double>(tstop - tstart_).count();
-  ttot_ += tmp;
-  ttotsq_ += tmp * tmp;
-  ntimes_++;
-}
+  void Timer::start() { tstart_ = std::chrono::high_resolution_clock::now(); }
+  void Timer::stop() {
+    auto tstop = std::chrono::high_resolution_clock::now();
+    double tmp = std::chrono::duration<double>(tstop - tstart_).count();
+    ttot_ += tmp;
+    ttotsq_ += tmp * tmp;
+    ntimes_++;
+  }
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/Track.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Track.cc
@@ -8,50 +8,50 @@ using namespace std;
 
 namespace trklet {
 
-Track::Track(TrackPars<int> ipars,
-             int ichisqrphi,
-             int ichisqrz,
-             double chisqrphi,
-             double chisqrz,
-             int hitpattern,
-             std::map<int, int> stubID,
-             const std::vector<L1TStub>& l1stub,
-             int seed) {
-  ipars_ = ipars;
-  ichisqrphi_ = ichisqrphi;
-  ichisqrz_ = ichisqrz;
+  Track::Track(TrackPars<int> ipars,
+               int ichisqrphi,
+               int ichisqrz,
+               double chisqrphi,
+               double chisqrz,
+               int hitpattern,
+               std::map<int, int> stubID,
+               const std::vector<L1TStub>& l1stub,
+               int seed) {
+    ipars_ = ipars;
+    ichisqrphi_ = ichisqrphi;
+    ichisqrz_ = ichisqrz;
 
-  chisqrphi_ = chisqrphi;
-  chisqrz_ = chisqrz;
+    chisqrphi_ = chisqrphi;
+    chisqrz_ = chisqrz;
 
-  hitpattern_ = hitpattern;
+    hitpattern_ = hitpattern;
 
-  nstubs_ = std::max((int)l1stub.size(), (int)N_FITSTUB);
+    nstubs_ = std::max((int)l1stub.size(), (int)N_FITSTUB);
 
-  stubID_ = stubID;
-  l1stub_ = l1stub;
+    stubID_ = stubID;
+    l1stub_ = l1stub;
 
-  seed_ = seed;
-  duplicate_ = false;
-  sector_ = -1;
-}
+    seed_ = seed;
+    duplicate_ = false;
+    sector_ = -1;
+  }
 
-double Track::phi0(Settings const& settings) const {
-  double dphi = 2 * M_PI / N_SECTOR;
-  double dphiHG = 0.5 * settings.dphisectorHG() - M_PI / N_SECTOR;
-  double phimin = sector_ * dphi - dphiHG;
-  double phimax = phimin + dphi + 2 * dphiHG;
-  phimin -= M_PI / N_SECTOR;
-  phimax -= M_PI / N_SECTOR;
-  phimin = reco::reduceRange(phimin);
-  phimax = reco::reduceRange(phimax);
-  if (phimin > phimax)
-    phimin -= 2 * M_PI;
-  double phioffset = phimin;
+  double Track::phi0(Settings const& settings) const {
+    double dphi = 2 * M_PI / N_SECTOR;
+    double dphiHG = 0.5 * settings.dphisectorHG() - M_PI / N_SECTOR;
+    double phimin = sector_ * dphi - dphiHG;
+    double phimax = phimin + dphi + 2 * dphiHG;
+    phimin -= M_PI / N_SECTOR;
+    phimax -= M_PI / N_SECTOR;
+    phimin = reco::reduceRange(phimin);
+    phimax = reco::reduceRange(phimax);
+    if (phimin > phimax)
+      phimin -= 2 * M_PI;
+    double phioffset = phimin;
 
-  double phi0 = ipars_.phi0() * settings.kphi0pars() + phioffset;
-  phi0 = reco::reduceRange(phi0);
-  return phi0;
-}
+    double phi0 = ipars_.phi0() * settings.kphi0pars() + phioffset;
+    phi0 = reco::reduceRange(phi0);
+    return phi0;
+  }
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/Track.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Track.cc
@@ -5,7 +5,8 @@
 #include <algorithm>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 Track::Track(TrackPars<int> ipars,
              int ichisqrphi,
@@ -51,4 +52,6 @@ double Track::phi0(Settings const& settings) const {
   double phi0 = ipars_.phi0() * settings.kphi0pars() + phioffset;
   phi0 = reco::reduceRange(phi0);
   return phi0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackDer.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackDer.cc
@@ -1,7 +1,8 @@
 #include "L1Trigger/TrackFindingTracklet/interface/TrackDer.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackDer::TrackDer() {
   for (unsigned int i = 0; i < N_FITSTUB; i++) {
@@ -85,4 +86,6 @@ void TrackDer::fill(int t, double MinvDt[N_FITPARAM][N_FITSTUB * 2], int iMinvDt
       iMinvDt[3][2 * i + 1] *= sign;
     }
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackDer.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackDer.cc
@@ -4,88 +4,88 @@ using namespace std;
 
 namespace trklet {
 
-TrackDer::TrackDer() {
-  for (unsigned int i = 0; i < N_FITSTUB; i++) {
-    irinvdphi_[i] = 9999999;
-    irinvdzordr_[i] = 9999999;
-    iphi0dphi_[i] = 9999999;
-    iphi0dzordr_[i] = 9999999;
-    itdphi_[i] = 9999999;
-    itdzordr_[i] = 9999999;
-    iz0dphi_[i] = 9999999;
-    iz0dzordr_[i] = 9999999;
+  TrackDer::TrackDer() {
+    for (unsigned int i = 0; i < N_FITSTUB; i++) {
+      irinvdphi_[i] = 9999999;
+      irinvdzordr_[i] = 9999999;
+      iphi0dphi_[i] = 9999999;
+      iphi0dzordr_[i] = 9999999;
+      itdphi_[i] = 9999999;
+      itdzordr_[i] = 9999999;
+      iz0dphi_[i] = 9999999;
+      iz0dzordr_[i] = 9999999;
 
-    rinvdphi_[i] = 0.0;
-    rinvdzordr_[i] = 0.0;
-    phi0dphi_[i] = 0.0;
-    phi0dzordr_[i] = 0.0;
-    tdphi_[i] = 0.0;
-    tdzordr_[i] = 0.0;
-    z0dphi_[i] = 0.0;
-    z0dzordr_[i] = 0.0;
-  }
+      rinvdphi_[i] = 0.0;
+      rinvdzordr_[i] = 0.0;
+      phi0dphi_[i] = 0.0;
+      phi0dzordr_[i] = 0.0;
+      tdphi_[i] = 0.0;
+      tdzordr_[i] = 0.0;
+      z0dphi_[i] = 0.0;
+      z0dzordr_[i] = 0.0;
+    }
 
-  for (unsigned int i = 0; i < N_PSLAYER; i++) {
-    for (unsigned int j = 0; j < N_PSLAYER; j++) {
-      tdzcorr_[i][j] = 0.0;
-      z0dzcorr_[i][j] = 0.0;
+    for (unsigned int i = 0; i < N_PSLAYER; i++) {
+      for (unsigned int j = 0; j < N_PSLAYER; j++) {
+        tdzcorr_[i][j] = 0.0;
+        z0dzcorr_[i][j] = 0.0;
+      }
     }
   }
-}
 
-void TrackDer::setIndex(int layermask, int diskmask, int alphamask, int irinv) {
-  layermask_ = layermask;
-  diskmask_ = diskmask;
-  alphamask_ = alphamask;
-  irinv_ = irinv;
-}
+  void TrackDer::setIndex(int layermask, int diskmask, int alphamask, int irinv) {
+    layermask_ = layermask;
+    diskmask_ = diskmask;
+    alphamask_ = alphamask;
+    irinv_ = irinv;
+  }
 
-void TrackDer::fill(int t, double MinvDt[N_FITPARAM][N_FITSTUB * 2], int iMinvDt[N_FITPARAM][N_FITSTUB * 2]) const {
-  unsigned int nlayer = 0;
-  if (layermask_ & 1)
-    nlayer++;
-  if (layermask_ & 2)
-    nlayer++;
-  if (layermask_ & 4)
-    nlayer++;
-  if (layermask_ & 8)
-    nlayer++;
-  if (layermask_ & 16)
-    nlayer++;
-  if (layermask_ & 32)
-    nlayer++;
-  int sign = 1;
-  if (t < 0)
-    sign = -1;
-  for (unsigned int i = 0; i < N_FITSTUB; i++) {
-    MinvDt[0][2 * i] = rinvdphi_[i];
-    MinvDt[1][2 * i] = phi0dphi_[i];
-    MinvDt[2][2 * i] = sign * tdphi_[i];
-    MinvDt[3][2 * i] = sign * z0dphi_[i];
-    MinvDt[0][2 * i + 1] = rinvdzordr_[i];
-    MinvDt[1][2 * i + 1] = phi0dzordr_[i];
-    MinvDt[2][2 * i + 1] = tdzordr_[i];
-    MinvDt[3][2 * i + 1] = z0dzordr_[i];
-    iMinvDt[0][2 * i] = irinvdphi_[i];
-    iMinvDt[1][2 * i] = iphi0dphi_[i];
-    iMinvDt[2][2 * i] = sign * itdphi_[i];
-    iMinvDt[3][2 * i] = sign * iz0dphi_[i];
-    iMinvDt[0][2 * i + 1] = irinvdzordr_[i];
-    iMinvDt[1][2 * i + 1] = iphi0dzordr_[i];
-    iMinvDt[2][2 * i + 1] = itdzordr_[i];
-    iMinvDt[3][2 * i + 1] = iz0dzordr_[i];
-    if (i < nlayer) {
-      MinvDt[0][2 * i + 1] *= sign;
-      MinvDt[1][2 * i + 1] *= sign;
-      iMinvDt[0][2 * i + 1] *= sign;
-      iMinvDt[1][2 * i + 1] *= sign;
-    } else {
-      MinvDt[2][2 * i + 1] *= sign;
-      MinvDt[3][2 * i + 1] *= sign;
-      iMinvDt[2][2 * i + 1] *= sign;
-      iMinvDt[3][2 * i + 1] *= sign;
+  void TrackDer::fill(int t, double MinvDt[N_FITPARAM][N_FITSTUB * 2], int iMinvDt[N_FITPARAM][N_FITSTUB * 2]) const {
+    unsigned int nlayer = 0;
+    if (layermask_ & 1)
+      nlayer++;
+    if (layermask_ & 2)
+      nlayer++;
+    if (layermask_ & 4)
+      nlayer++;
+    if (layermask_ & 8)
+      nlayer++;
+    if (layermask_ & 16)
+      nlayer++;
+    if (layermask_ & 32)
+      nlayer++;
+    int sign = 1;
+    if (t < 0)
+      sign = -1;
+    for (unsigned int i = 0; i < N_FITSTUB; i++) {
+      MinvDt[0][2 * i] = rinvdphi_[i];
+      MinvDt[1][2 * i] = phi0dphi_[i];
+      MinvDt[2][2 * i] = sign * tdphi_[i];
+      MinvDt[3][2 * i] = sign * z0dphi_[i];
+      MinvDt[0][2 * i + 1] = rinvdzordr_[i];
+      MinvDt[1][2 * i + 1] = phi0dzordr_[i];
+      MinvDt[2][2 * i + 1] = tdzordr_[i];
+      MinvDt[3][2 * i + 1] = z0dzordr_[i];
+      iMinvDt[0][2 * i] = irinvdphi_[i];
+      iMinvDt[1][2 * i] = iphi0dphi_[i];
+      iMinvDt[2][2 * i] = sign * itdphi_[i];
+      iMinvDt[3][2 * i] = sign * iz0dphi_[i];
+      iMinvDt[0][2 * i + 1] = irinvdzordr_[i];
+      iMinvDt[1][2 * i + 1] = iphi0dzordr_[i];
+      iMinvDt[2][2 * i + 1] = itdzordr_[i];
+      iMinvDt[3][2 * i + 1] = iz0dzordr_[i];
+      if (i < nlayer) {
+        MinvDt[0][2 * i + 1] *= sign;
+        MinvDt[1][2 * i + 1] *= sign;
+        iMinvDt[0][2 * i + 1] *= sign;
+        iMinvDt[1][2 * i + 1] *= sign;
+      } else {
+        MinvDt[2][2 * i + 1] *= sign;
+        MinvDt[3][2 * i + 1] *= sign;
+        iMinvDt[2][2 * i + 1] *= sign;
+        iMinvDt[3][2 * i + 1] *= sign;
+      }
     }
   }
-}
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackDerTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackDerTable.cc
@@ -9,1071 +9,1073 @@ using namespace std;
 
 namespace trklet {
 
-TrackDerTable::TrackDerTable(Settings const& settings) : settings_(settings) {
-  Nlay_ = N_LAYER;
-  Ndisk_ = N_DISK;
+  TrackDerTable::TrackDerTable(Settings const& settings) : settings_(settings) {
+    Nlay_ = N_LAYER;
+    Ndisk_ = N_DISK;
 
-  LayerMemBits_ = 6;
-  DiskMemBits_ = 7;
-  LayerDiskMemBits_ = 18;
+    LayerMemBits_ = 6;
+    DiskMemBits_ = 7;
+    LayerDiskMemBits_ = 18;
 
-  alphaBits_ = settings_.alphaBitsTable();
+    alphaBits_ = settings_.alphaBitsTable();
 
-  nextLayerValue_ = 0;
-  nextDiskValue_ = 0;
-  nextLayerDiskValue_ = 0;
-  lastMultiplicity_ = (1 << (3 * alphaBits_));
+    nextLayerValue_ = 0;
+    nextDiskValue_ = 0;
+    nextLayerDiskValue_ = 0;
+    lastMultiplicity_ = (1 << (3 * alphaBits_));
 
-  for (int i = 0; i < (1 << Nlay_); i++) {
-    LayerMem_.push_back(-1);
-  }
-
-  for (int i = 0; i < (1 << (2 * Ndisk_)); i++) {
-    DiskMem_.push_back(-1);
-  }
-
-  for (int i = 0; i < (1 << (LayerMemBits_ + DiskMemBits_)); i++) {
-    LayerDiskMem_.push_back(-1);
-  }
-}
-
-const TrackDer* TrackDerTable::getDerivatives(unsigned int layermask,
-                                              unsigned int diskmask,
-                                              unsigned int alphaindex,
-                                              unsigned int rinvindex) const {
-  int index = getIndex(layermask, diskmask);
-  if (index < 0) {
-    return nullptr;
-  }
-  return &derivatives_[index + alphaindex * (1 << settings_.nrinvBitsTable()) + rinvindex];
-}
-
-int TrackDerTable::getIndex(unsigned int layermask, unsigned int diskmask) const {
-  assert(layermask < LayerMem_.size());
-
-  assert(diskmask < DiskMem_.size());
-
-  int layercode = LayerMem_[layermask];
-  int diskcode = DiskMem_[diskmask];
-
-  if (diskcode < 0 || layercode < 0) {
-    if (settings_.warnNoDer()) {
-      edm::LogPrint("Tracklet") << "layermask diskmask : " << layermask << " " << diskmask;
-    }
-    return -1;
-  }
-
-  assert(layercode >= 0);
-  assert(layercode < (1 << LayerMemBits_));
-  assert(diskcode >= 0);
-  assert(diskcode < (1 << DiskMemBits_));
-
-  int layerdiskaddress = layercode + (diskcode << LayerMemBits_);
-
-  assert(layerdiskaddress >= 0);
-  assert(layerdiskaddress < (1 << (LayerMemBits_ + DiskMemBits_)));
-
-  int address = LayerDiskMem_[layerdiskaddress];
-
-  if (address < 0) {
-    if (settings_.warnNoDer()) {
-      edm::LogVerbatim("Tracklet") << "layermask diskmask : " << layermask << " " << diskmask;
-    }
-    return -1;
-  }
-
-  assert(address >= 0);
-  assert(address < (1 << LayerDiskMemBits_));
-
-  return address;
-}
-
-void TrackDerTable::addEntry(unsigned int layermask, unsigned int diskmask, int multiplicity, int nrinv) {
-  assert(multiplicity <= (1 << (3 * alphaBits_)));
-
-  assert(layermask < (unsigned int)(1 << Nlay_));
-
-  assert(diskmask < (unsigned int)(1 << (2 * Ndisk_)));
-
-  if (LayerMem_[layermask] == -1) {
-    LayerMem_[layermask] = nextLayerValue_++;
-  }
-  if (DiskMem_[diskmask] == -1) {
-    DiskMem_[diskmask] = nextDiskValue_++;
-  }
-
-  int layercode = LayerMem_[layermask];
-  int diskcode = DiskMem_[diskmask];
-
-  assert(layercode >= 0);
-  assert(layercode < (1 << LayerMemBits_));
-  assert(diskcode >= 0);
-  assert(diskcode < (1 << DiskMemBits_));
-
-  int layerdiskaddress = layercode + (diskcode << LayerMemBits_);
-
-  assert(layerdiskaddress >= 0);
-  assert(layerdiskaddress < (1 << (LayerMemBits_ + DiskMemBits_)));
-
-  int address = LayerDiskMem_[layerdiskaddress];
-
-  if (address != -1) {
-    edm::LogPrint("Tracklet") << "Duplicate entry:  layermask=" << layermask << " diskmaks=" << diskmask;
-  }
-
-  assert(address == -1);
-
-  LayerDiskMem_[layerdiskaddress] = nextLayerDiskValue_;
-
-  nextLayerDiskValue_ += multiplicity * nrinv;
-
-  lastMultiplicity_ = multiplicity * nrinv;
-
-  for (int i = 0; i < multiplicity; i++) {
-    for (int irinv = 0; irinv < nrinv; irinv++) {
-      TrackDer tmp;
-      tmp.setIndex(layermask, diskmask, i, irinv);
-      derivatives_.push_back(tmp);
-    }
-  }
-}
-
-void TrackDerTable::readPatternFile(std::string fileName) {
-  ifstream in(fileName.c_str());
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "reading fit pattern file " << fileName;
-    edm::LogVerbatim("Tracklet") << "  flags (good/eof/fail/bad): " << in.good() << " " << in.eof() << " " << in.fail()
-                                 << " " << in.bad();
-  }
-
-  while (in.good()) {
-    std::string layerstr, diskstr;
-    int multiplicity;
-
-    in >> layerstr >> diskstr >> multiplicity;
-
-    //correct multiplicity if you dont want 3 bits of alpha.
-    if (alphaBits_ == 2) {
-      if (multiplicity == 8)
-        multiplicity = 4;
-      if (multiplicity == 64)
-        multiplicity = 16;
-      if (multiplicity == 512)
-        multiplicity = 64;
+    for (int i = 0; i < (1 << Nlay_); i++) {
+      LayerMem_.push_back(-1);
     }
 
-    if (alphaBits_ == 1) {
-      if (multiplicity == 8)
-        multiplicity = 2;
-      if (multiplicity == 64)
-        multiplicity = 4;
-      if (multiplicity == 512)
-        multiplicity = 8;
+    for (int i = 0; i < (1 << (2 * Ndisk_)); i++) {
+      DiskMem_.push_back(-1);
     }
 
-    if (!in.good())
-      continue;
-
-    char** tmpptr = nullptr;
-
-    int layers = strtol(layerstr.c_str(), tmpptr, 2);
-    int disks = strtol(diskstr.c_str(), tmpptr, 2);
-
-    addEntry(layers, disks, multiplicity, (1 << settings_.nrinvBitsTable()));
+    for (int i = 0; i < (1 << (LayerMemBits_ + DiskMemBits_)); i++) {
+      LayerDiskMem_.push_back(-1);
+    }
   }
-}
 
-void TrackDerTable::fillTable() {
-  int nentries = getEntries();
+  const TrackDer* TrackDerTable::getDerivatives(unsigned int layermask,
+                                                unsigned int diskmask,
+                                                unsigned int alphaindex,
+                                                unsigned int rinvindex) const {
+    int index = getIndex(layermask, diskmask);
+    if (index < 0) {
+      return nullptr;
+    }
+    return &derivatives_[index + alphaindex * (1 << settings_.nrinvBitsTable()) + rinvindex];
+  }
 
-  for (int i = 0; i < nentries; i++) {
-    TrackDer& der = derivatives_[i];
-    int layermask = der.layerMask();
-    int diskmask = der.diskMask();
-    int alphamask = der.alphaMask();
-    int irinv = der.irinv();
+  int TrackDerTable::getIndex(unsigned int layermask, unsigned int diskmask) const {
+    assert(layermask < LayerMem_.size());
 
-    double rinv = (irinv - ((1 << (settings_.nrinvBitsTable() - 1)) - 0.5)) * settings_.rinvmax() /
-                  (1 << (settings_.nrinvBitsTable() - 1));
+    assert(diskmask < DiskMem_.size());
 
-    bool print = false;
+    int layercode = LayerMem_[layermask];
+    int diskcode = DiskMem_[diskmask];
 
-    if (print) {
-      edm::LogVerbatim("Tracklet") << "PRINT i " << i << " " << layermask << " " << diskmask << " " << alphamask << " "
-                                   << print;
+    if (diskcode < 0 || layercode < 0) {
+      if (settings_.warnNoDer()) {
+        edm::LogPrint("Tracklet") << "layermask diskmask : " << layermask << " " << diskmask;
+      }
+      return -1;
     }
 
-    int nlayers = 0;
-    double r[N_LAYER];
+    assert(layercode >= 0);
+    assert(layercode < (1 << LayerMemBits_));
+    assert(diskcode >= 0);
+    assert(diskcode < (1 << DiskMemBits_));
 
-    for (unsigned l = 0; l < N_LAYER; l++) {
-      if (layermask & (1 << (N_LAYER - 1 - l))) {
-        r[nlayers] = settings_.rmean(l);
-        nlayers++;
+    int layerdiskaddress = layercode + (diskcode << LayerMemBits_);
+
+    assert(layerdiskaddress >= 0);
+    assert(layerdiskaddress < (1 << (LayerMemBits_ + DiskMemBits_)));
+
+    int address = LayerDiskMem_[layerdiskaddress];
+
+    if (address < 0) {
+      if (settings_.warnNoDer()) {
+        edm::LogVerbatim("Tracklet") << "layermask diskmask : " << layermask << " " << diskmask;
+      }
+      return -1;
+    }
+
+    assert(address >= 0);
+    assert(address < (1 << LayerDiskMemBits_));
+
+    return address;
+  }
+
+  void TrackDerTable::addEntry(unsigned int layermask, unsigned int diskmask, int multiplicity, int nrinv) {
+    assert(multiplicity <= (1 << (3 * alphaBits_)));
+
+    assert(layermask < (unsigned int)(1 << Nlay_));
+
+    assert(diskmask < (unsigned int)(1 << (2 * Ndisk_)));
+
+    if (LayerMem_[layermask] == -1) {
+      LayerMem_[layermask] = nextLayerValue_++;
+    }
+    if (DiskMem_[diskmask] == -1) {
+      DiskMem_[diskmask] = nextDiskValue_++;
+    }
+
+    int layercode = LayerMem_[layermask];
+    int diskcode = DiskMem_[diskmask];
+
+    assert(layercode >= 0);
+    assert(layercode < (1 << LayerMemBits_));
+    assert(diskcode >= 0);
+    assert(diskcode < (1 << DiskMemBits_));
+
+    int layerdiskaddress = layercode + (diskcode << LayerMemBits_);
+
+    assert(layerdiskaddress >= 0);
+    assert(layerdiskaddress < (1 << (LayerMemBits_ + DiskMemBits_)));
+
+    int address = LayerDiskMem_[layerdiskaddress];
+
+    if (address != -1) {
+      edm::LogPrint("Tracklet") << "Duplicate entry:  layermask=" << layermask << " diskmaks=" << diskmask;
+    }
+
+    assert(address == -1);
+
+    LayerDiskMem_[layerdiskaddress] = nextLayerDiskValue_;
+
+    nextLayerDiskValue_ += multiplicity * nrinv;
+
+    lastMultiplicity_ = multiplicity * nrinv;
+
+    for (int i = 0; i < multiplicity; i++) {
+      for (int irinv = 0; irinv < nrinv; irinv++) {
+        TrackDer tmp;
+        tmp.setIndex(layermask, diskmask, i, irinv);
+        derivatives_.push_back(tmp);
       }
     }
+  }
 
-    int ndisks = 0;
-    double z[N_DISK];
-    double alpha[N_DISK];
-
-    double t = tpar(settings_, diskmask, layermask);
-
-    for (unsigned d = 0; d < N_DISK; d++) {
-      if (diskmask & (3 << (2 * (N_DISK - 1 - d)))) {
-        z[ndisks] = settings_.zmean(d);
-        alpha[ndisks] = 0.0;
-        double r = settings_.zmean(d) / t;
-        double r2 = r * r;
-        if (diskmask & (1 << (2 * (N_DISK - 1 - d)))) {
-          if (alphaBits_ == 3) {
-            int ialpha = alphamask & 7;
-            alphamask = alphamask >> 3;
-            alpha[ndisks] = settings_.half2SmoduleWidth() * (ialpha - 3.5) / 4.0 / r2;
-            if (print)
-              edm::LogVerbatim("Tracklet") << "PRINT 3 alpha ialpha : " << alpha[ndisks] << " " << ialpha;
-          }
-          if (alphaBits_ == 2) {
-            int ialpha = alphamask & 3;
-            alphamask = alphamask >> 2;
-            alpha[ndisks] = settings_.half2SmoduleWidth() * (ialpha - 1.5) / 2.0 / r2;
-          }
-          if (alphaBits_ == 1) {
-            int ialpha = alphamask & 1;
-            alphamask = alphamask >> 1;
-            alpha[ndisks] = settings_.half2SmoduleWidth() * (ialpha - 0.5) / r2;
-            if (print)
-              edm::LogVerbatim("Tracklet") << "PRINT 1 alpha ialpha : " << alpha[ndisks] << " " << ialpha;
-          }
-        }
-        ndisks++;
-      }
+  void TrackDerTable::readPatternFile(std::string fileName) {
+    ifstream in(fileName.c_str());
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "reading fit pattern file " << fileName;
+      edm::LogVerbatim("Tracklet") << "  flags (good/eof/fail/bad): " << in.good() << " " << in.eof() << " "
+                                   << in.fail() << " " << in.bad();
     }
 
-    double D[N_FITPARAM][N_FITSTUB * 2];
-    int iD[N_FITPARAM][N_FITSTUB * 2];
-    double MinvDt[N_FITPARAM][N_FITSTUB * 2];
-    double MinvDtDelta[N_FITPARAM][N_FITSTUB * 2];
-    int iMinvDt[N_FITPARAM][N_FITSTUB * 2];
-    double sigma[N_FITSTUB * 2];
-    double kfactor[N_FITSTUB * 2];
+    while (in.good()) {
+      std::string layerstr, diskstr;
+      int multiplicity;
 
-    if (print) {
-      edm::LogVerbatim("Tracklet") << "PRINT ndisks alpha[0] z[0] t: " << ndisks << " " << alpha[0] << " " << z[0]
-                                   << " " << t;
-      for (int iii = 0; iii < nlayers; iii++) {
-        edm::LogVerbatim("Tracklet") << "PRINT iii r: " << iii << " " << r[iii];
+      in >> layerstr >> diskstr >> multiplicity;
+
+      //correct multiplicity if you dont want 3 bits of alpha.
+      if (alphaBits_ == 2) {
+        if (multiplicity == 8)
+          multiplicity = 4;
+        if (multiplicity == 64)
+          multiplicity = 16;
+        if (multiplicity == 512)
+          multiplicity = 64;
       }
-    }
 
-    calculateDerivatives(settings_, nlayers, r, ndisks, z, alpha, t, rinv, D, iD, MinvDt, iMinvDt, sigma, kfactor);
+      if (alphaBits_ == 1) {
+        if (multiplicity == 8)
+          multiplicity = 2;
+        if (multiplicity == 64)
+          multiplicity = 4;
+        if (multiplicity == 512)
+          multiplicity = 8;
+      }
 
-    double delta = 0.1;
-
-    for (int i = 0; i < nlayers; i++) {
-      if (r[i] > settings_.rPS2S())
+      if (!in.good())
         continue;
 
-      r[i] += delta;
+      char** tmpptr = nullptr;
 
-      calculateDerivatives(
-          settings_, nlayers, r, ndisks, z, alpha, t, rinv, D, iD, MinvDtDelta, iMinvDt, sigma, kfactor);
+      int layers = strtol(layerstr.c_str(), tmpptr, 2);
+      int disks = strtol(diskstr.c_str(), tmpptr, 2);
 
-      for (int ii = 0; ii < nlayers; ii++) {
-        if (r[ii] > settings_.rPS2S())
-          continue;
-        double tder = (MinvDtDelta[2][2 * ii + 1] - MinvDt[2][2 * ii + 1]) / delta;
-        int itder = (1 << (settings_.fittbitshift() + settings_.rcorrbits())) * tder * settings_.kr() * settings_.kz() /
-                    settings_.ktpars();
-        double zder = (MinvDtDelta[3][2 * ii + 1] - MinvDt[3][2 * ii + 1]) / delta;
-        int izder = (1 << (settings_.fitz0bitshift() + settings_.rcorrbits())) * zder * settings_.kr() *
-                    settings_.kz() / settings_.kz0pars();
-        der.settdzcorr(i, ii, tder);
-        der.setz0dzcorr(i, ii, zder);
-        der.setitdzcorr(i, ii, itder);
-        der.setiz0dzcorr(i, ii, izder);
-      }
-
-      r[i] -= delta;
+      addEntry(layers, disks, multiplicity, (1 << settings_.nrinvBitsTable()));
     }
+  }
 
-    if (print) {
-      edm::LogVerbatim("Tracklet") << "iMinvDt table build : " << iMinvDt[0][10] << " " << iMinvDt[1][10] << " "
-                                   << iMinvDt[2][10] << " " << iMinvDt[3][10] << " " << t << " " << nlayers << " "
-                                   << ndisks;
+  void TrackDerTable::fillTable() {
+    int nentries = getEntries();
 
-      std::string oss = "alpha :";
-      for (int iii = 0; iii < ndisks; iii++) {
-        oss += " ";
-        oss += std::to_string(alpha[iii]);
-      }
-      edm::LogVerbatim("Tracklet") << oss;
-      oss = "z :";
-      for (int iii = 0; iii < ndisks; iii++) {
-        oss += " ";
-        oss += std::to_string(z[iii]);
-      }
-      edm::LogVerbatim("Tracklet") << oss;
-    }
+    for (int i = 0; i < nentries; i++) {
+      TrackDer& der = derivatives_[i];
+      int layermask = der.layerMask();
+      int diskmask = der.diskMask();
+      int alphamask = der.alphaMask();
+      int irinv = der.irinv();
 
-    if (print) {
-      edm::LogVerbatim("Tracklet") << "PRINT nlayers ndisks : " << nlayers << " " << ndisks;
-    }
+      double rinv = (irinv - ((1 << (settings_.nrinvBitsTable() - 1)) - 0.5)) * settings_.rinvmax() /
+                    (1 << (settings_.nrinvBitsTable() - 1));
 
-    for (int j = 0; j < nlayers + ndisks; j++) {
-      der.settpar(t);
-
-      //integer
-      assert(std::abs(iMinvDt[0][2 * j]) < (1 << 23));
-      assert(std::abs(iMinvDt[0][2 * j + 1]) < (1 << 23));
-      assert(std::abs(iMinvDt[1][2 * j]) < (1 << 23));
-      assert(std::abs(iMinvDt[1][2 * j + 1]) < (1 << 23));
-      assert(std::abs(iMinvDt[2][2 * j]) < (1 << 19));
-      assert(std::abs(iMinvDt[2][2 * j + 1]) < (1 << 19));
-      assert(std::abs(iMinvDt[3][2 * j]) < (1 << 19));
-      assert(std::abs(iMinvDt[3][2 * j + 1]) < (1 << 19));
+      bool print = false;
 
       if (print) {
-        edm::LogVerbatim("Tracklet") << "PRINT i " << i << " " << j << " " << iMinvDt[1][2 * j] << " "
-                                     << std::abs(iMinvDt[1][2 * j]);
+        edm::LogVerbatim("Tracklet") << "PRINT i " << i << " " << layermask << " " << diskmask << " " << alphamask
+                                     << " " << print;
       }
 
-      der.setirinvdphi(j, iMinvDt[0][2 * j]);
-      der.setirinvdzordr(j, iMinvDt[0][2 * j + 1]);
-      der.setiphi0dphi(j, iMinvDt[1][2 * j]);
-      der.setiphi0dzordr(j, iMinvDt[1][2 * j + 1]);
-      der.setitdphi(j, iMinvDt[2][2 * j]);
-      der.setitdzordr(j, iMinvDt[2][2 * j + 1]);
-      der.setiz0dphi(j, iMinvDt[3][2 * j]);
-      der.setiz0dzordr(j, iMinvDt[3][2 * j + 1]);
-      //floating point
-      der.setrinvdphi(j, MinvDt[0][2 * j]);
-      der.setrinvdzordr(j, MinvDt[0][2 * j + 1]);
-      der.setphi0dphi(j, MinvDt[1][2 * j]);
-      der.setphi0dzordr(j, MinvDt[1][2 * j + 1]);
-      der.settdphi(j, MinvDt[2][2 * j]);
-      der.settdzordr(j, MinvDt[2][2 * j + 1]);
-      der.setz0dphi(j, MinvDt[3][2 * j]);
-      der.setz0dzordr(j, MinvDt[3][2 * j + 1]);
-    }
-  }
+      int nlayers = 0;
+      double r[N_LAYER];
 
-  if (settings_.writeTable()) {
-    ofstream outL = openfile(settings_.tablePath(), "FitDerTableNew_LayerMem.tab", __FILE__, __LINE__);
-
-    int nbits = 6;
-    for (unsigned int i = 0; i < LayerMem_.size(); i++) {
-      FPGAWord tmp;
-      int tmp1 = LayerMem_[i];
-      if (tmp1 < 0)
-        tmp1 = (1 << nbits) - 1;
-      tmp.set(tmp1, nbits, true, __LINE__, __FILE__);
-      outL << tmp.str() << endl;
-    }
-    outL.close();
-
-    ofstream outD = openfile(settings_.tablePath(), "FitDerTableNew_DiskMem.tab", __FILE__, __LINE__);
-
-    nbits = 7;
-    for (int tmp1 : DiskMem_) {
-      if (tmp1 < 0)
-        tmp1 = (1 << nbits) - 1;
-      FPGAWord tmp;
-      tmp.set(tmp1, nbits, true, __LINE__, __FILE__);
-      outD << tmp.str() << endl;
-    }
-    outD.close();
-
-    ofstream outLD = openfile(settings_.tablePath(), "FitDerTableNew_LayerDiskMem.tab", __FILE__, __LINE__);
-
-    nbits = 15;
-    for (int tmp1 : LayerDiskMem_) {
-      if (tmp1 < 0)
-        tmp1 = (1 << nbits) - 1;
-      FPGAWord tmp;
-      tmp.set(tmp1, nbits, true, __LINE__, __FILE__);
-      outLD << tmp.str() << endl;
-    }
-    outLD.close();
-
-    const std::array<string, N_TRKLSEED> seedings = {{"L1L2", "L3L4", "L5L6", "D1D2", "D3D4", "D1L1", "D1L2"}};
-    const string prefix = settings_.tablePath() + "FitDerTableNew_";
-
-    // open files for derivative tables
-
-    ofstream outrinvdphi[N_TRKLSEED];
-    for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
-      const string fname = prefix + "Rinvdphi_" + seedings[i] + ".tab";
-      outrinvdphi[i].open(fname);
-      if (outrinvdphi[i].fail())
-        throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
-    }
-
-    ofstream outrinvdzordr[N_TRKLSEED];
-    for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
-      const string fname = prefix + "Rinvdzordr_" + seedings[i] + ".tab";
-      outrinvdzordr[i].open(fname);
-      if (outrinvdzordr[i].fail())
-        throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
-    }
-
-    ofstream outphi0dphi[N_TRKLSEED];
-    for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
-      const string fname = prefix + "Phi0dphi_" + seedings[i] + ".tab";
-      outphi0dphi[i].open(fname);
-      if (outphi0dphi[i].fail())
-        throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
-    }
-
-    ofstream outphi0dzordr[N_TRKLSEED];
-    for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
-      const string fname = prefix + "Phi0dzordr_" + seedings[i] + ".tab";
-      outphi0dzordr[i].open(fname);
-      if (outphi0dzordr[i].fail())
-        throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
-    }
-
-    ofstream outtdphi[N_TRKLSEED];
-    for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
-      const string fname = prefix + "Tdphi_" + seedings[i] + ".tab";
-      outtdphi[i].open(fname);
-      if (outtdphi[i].fail())
-        throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
-    }
-
-    ofstream outtdzordr[N_TRKLSEED];
-    for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
-      const string fname = prefix + "Tdzordr_" + seedings[i] + ".tab";
-      outtdzordr[i].open(fname);
-      if (outtdzordr[i].fail())
-        throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
-    }
-
-    ofstream outz0dphi[N_TRKLSEED];
-    for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
-      const string fname = prefix + "Z0dphi_" + seedings[i] + ".tab";
-      outz0dphi[i].open(fname);
-      if (outz0dphi[i].fail())
-        throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
-    }
-
-    ofstream outz0dzordr[N_TRKLSEED];
-    for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
-      string fname = prefix + "Z0dzordr_" + seedings[i] + ".tab";
-      outz0dzordr[i].open(fname);
-      if (outz0dzordr[i].fail())
-        throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
-    }
-
-    for (auto& der : derivatives_) {
-      unsigned int layerhits = der.layerMask();  // 6 bits layer hit pattern
-      unsigned int diskmask = der.diskMask();    // 10 bits disk hit pattern
-      unsigned int diskhits = 0;
-      if (diskmask & (3 << 8))
-        diskhits += 16;
-      if (diskmask & (3 << 6))
-        diskhits += 8;
-      if (diskmask & (3 << 4))
-        diskhits += 4;
-      if (diskmask & (3 << 2))
-        diskhits += 2;
-      if (diskmask & (3 << 0))
-        diskhits += 1;
-      assert(diskhits < 32);                            // 5 bits
-      unsigned int hits = (layerhits << 5) + diskhits;  // 11 bits hit pattern
-      assert(hits < 4096);
-
-      // loop over all seedings
-      int i = 0;  // seeding index
-      for (const string& seed : seedings) {
-        unsigned int iseed1 = 0;
-        unsigned int iseed2 = 0;
-        // check if the seeding is good for the current hit pattern
-        if (seed == "L1L2") {
-          iseed1 = 1;
-          iseed2 = 2;
+      for (unsigned l = 0; l < N_LAYER; l++) {
+        if (layermask & (1 << (N_LAYER - 1 - l))) {
+          r[nlayers] = settings_.rmean(l);
+          nlayers++;
         }
-        if (seed == "L3L4") {
-          iseed1 = 3;
-          iseed2 = 4;
+      }
+
+      int ndisks = 0;
+      double z[N_DISK];
+      double alpha[N_DISK];
+
+      double t = tpar(settings_, diskmask, layermask);
+
+      for (unsigned d = 0; d < N_DISK; d++) {
+        if (diskmask & (3 << (2 * (N_DISK - 1 - d)))) {
+          z[ndisks] = settings_.zmean(d);
+          alpha[ndisks] = 0.0;
+          double r = settings_.zmean(d) / t;
+          double r2 = r * r;
+          if (diskmask & (1 << (2 * (N_DISK - 1 - d)))) {
+            if (alphaBits_ == 3) {
+              int ialpha = alphamask & 7;
+              alphamask = alphamask >> 3;
+              alpha[ndisks] = settings_.half2SmoduleWidth() * (ialpha - 3.5) / 4.0 / r2;
+              if (print)
+                edm::LogVerbatim("Tracklet") << "PRINT 3 alpha ialpha : " << alpha[ndisks] << " " << ialpha;
+            }
+            if (alphaBits_ == 2) {
+              int ialpha = alphamask & 3;
+              alphamask = alphamask >> 2;
+              alpha[ndisks] = settings_.half2SmoduleWidth() * (ialpha - 1.5) / 2.0 / r2;
+            }
+            if (alphaBits_ == 1) {
+              int ialpha = alphamask & 1;
+              alphamask = alphamask >> 1;
+              alpha[ndisks] = settings_.half2SmoduleWidth() * (ialpha - 0.5) / r2;
+              if (print)
+                edm::LogVerbatim("Tracklet") << "PRINT 1 alpha ialpha : " << alpha[ndisks] << " " << ialpha;
+            }
+          }
+          ndisks++;
         }
-        if (seed == "L5L6") {
-          iseed1 = 5;
-          iseed2 = 6;
+      }
+
+      double D[N_FITPARAM][N_FITSTUB * 2];
+      int iD[N_FITPARAM][N_FITSTUB * 2];
+      double MinvDt[N_FITPARAM][N_FITSTUB * 2];
+      double MinvDtDelta[N_FITPARAM][N_FITSTUB * 2];
+      int iMinvDt[N_FITPARAM][N_FITSTUB * 2];
+      double sigma[N_FITSTUB * 2];
+      double kfactor[N_FITSTUB * 2];
+
+      if (print) {
+        edm::LogVerbatim("Tracklet") << "PRINT ndisks alpha[0] z[0] t: " << ndisks << " " << alpha[0] << " " << z[0]
+                                     << " " << t;
+        for (int iii = 0; iii < nlayers; iii++) {
+          edm::LogVerbatim("Tracklet") << "PRINT iii r: " << iii << " " << r[iii];
         }
-        if (seed == "D1D2") {
-          iseed1 = 7;
-          iseed2 = 8;
-        }
-        if (seed == "D3D4") {
-          iseed1 = 9;
-          iseed2 = 10;
-        }
-        if (seed == "D1L1") {
-          iseed1 = 7;
-          iseed2 = 1;
-        }
-        if (seed == "D1L2") {
-          iseed1 = 7;
-          iseed2 = 2;
+      }
+
+      calculateDerivatives(settings_, nlayers, r, ndisks, z, alpha, t, rinv, D, iD, MinvDt, iMinvDt, sigma, kfactor);
+
+      double delta = 0.1;
+
+      for (int i = 0; i < nlayers; i++) {
+        if (r[i] > settings_.rPS2S())
+          continue;
+
+        r[i] += delta;
+
+        calculateDerivatives(
+            settings_, nlayers, r, ndisks, z, alpha, t, rinv, D, iD, MinvDtDelta, iMinvDt, sigma, kfactor);
+
+        for (int ii = 0; ii < nlayers; ii++) {
+          if (r[ii] > settings_.rPS2S())
+            continue;
+          double tder = (MinvDtDelta[2][2 * ii + 1] - MinvDt[2][2 * ii + 1]) / delta;
+          int itder = (1 << (settings_.fittbitshift() + settings_.rcorrbits())) * tder * settings_.kr() *
+                      settings_.kz() / settings_.ktpars();
+          double zder = (MinvDtDelta[3][2 * ii + 1] - MinvDt[3][2 * ii + 1]) / delta;
+          int izder = (1 << (settings_.fitz0bitshift() + settings_.rcorrbits())) * zder * settings_.kr() *
+                      settings_.kz() / settings_.kz0pars();
+          der.settdzcorr(i, ii, tder);
+          der.setz0dzcorr(i, ii, zder);
+          der.setitdzcorr(i, ii, itder);
+          der.setiz0dzcorr(i, ii, izder);
         }
 
-        bool goodseed = (hits & (1 << (11 - iseed1))) and (hits & (1 << (11 - iseed2)));
+        r[i] -= delta;
+      }
 
-        int itmprinvdphi[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
-        int itmprinvdzordr[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
-        int itmpphi0dphi[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
-        int itmpphi0dzordr[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
-        int itmptdphi[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
-        int itmptdzordr[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
-        int itmpz0dphi[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
-        int itmpz0dzordr[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
+      if (print) {
+        edm::LogVerbatim("Tracklet") << "iMinvDt table build : " << iMinvDt[0][10] << " " << iMinvDt[1][10] << " "
+                                     << iMinvDt[2][10] << " " << iMinvDt[3][10] << " " << t << " " << nlayers << " "
+                                     << ndisks;
 
-        // loop over bits in hit pattern
-        int ider = 0;
-        if (goodseed) {
-          for (unsigned int ihit = 1; ihit < N_FITSTUB * 2; ++ihit) {
-            // skip seeding layers
-            if (ihit == iseed1 or ihit == iseed2) {
+        std::string oss = "alpha :";
+        for (int iii = 0; iii < ndisks; iii++) {
+          oss += " ";
+          oss += std::to_string(alpha[iii]);
+        }
+        edm::LogVerbatim("Tracklet") << oss;
+        oss = "z :";
+        for (int iii = 0; iii < ndisks; iii++) {
+          oss += " ";
+          oss += std::to_string(z[iii]);
+        }
+        edm::LogVerbatim("Tracklet") << oss;
+      }
+
+      if (print) {
+        edm::LogVerbatim("Tracklet") << "PRINT nlayers ndisks : " << nlayers << " " << ndisks;
+      }
+
+      for (int j = 0; j < nlayers + ndisks; j++) {
+        der.settpar(t);
+
+        //integer
+        assert(std::abs(iMinvDt[0][2 * j]) < (1 << 23));
+        assert(std::abs(iMinvDt[0][2 * j + 1]) < (1 << 23));
+        assert(std::abs(iMinvDt[1][2 * j]) < (1 << 23));
+        assert(std::abs(iMinvDt[1][2 * j + 1]) < (1 << 23));
+        assert(std::abs(iMinvDt[2][2 * j]) < (1 << 19));
+        assert(std::abs(iMinvDt[2][2 * j + 1]) < (1 << 19));
+        assert(std::abs(iMinvDt[3][2 * j]) < (1 << 19));
+        assert(std::abs(iMinvDt[3][2 * j + 1]) < (1 << 19));
+
+        if (print) {
+          edm::LogVerbatim("Tracklet") << "PRINT i " << i << " " << j << " " << iMinvDt[1][2 * j] << " "
+                                       << std::abs(iMinvDt[1][2 * j]);
+        }
+
+        der.setirinvdphi(j, iMinvDt[0][2 * j]);
+        der.setirinvdzordr(j, iMinvDt[0][2 * j + 1]);
+        der.setiphi0dphi(j, iMinvDt[1][2 * j]);
+        der.setiphi0dzordr(j, iMinvDt[1][2 * j + 1]);
+        der.setitdphi(j, iMinvDt[2][2 * j]);
+        der.setitdzordr(j, iMinvDt[2][2 * j + 1]);
+        der.setiz0dphi(j, iMinvDt[3][2 * j]);
+        der.setiz0dzordr(j, iMinvDt[3][2 * j + 1]);
+        //floating point
+        der.setrinvdphi(j, MinvDt[0][2 * j]);
+        der.setrinvdzordr(j, MinvDt[0][2 * j + 1]);
+        der.setphi0dphi(j, MinvDt[1][2 * j]);
+        der.setphi0dzordr(j, MinvDt[1][2 * j + 1]);
+        der.settdphi(j, MinvDt[2][2 * j]);
+        der.settdzordr(j, MinvDt[2][2 * j + 1]);
+        der.setz0dphi(j, MinvDt[3][2 * j]);
+        der.setz0dzordr(j, MinvDt[3][2 * j + 1]);
+      }
+    }
+
+    if (settings_.writeTable()) {
+      ofstream outL = openfile(settings_.tablePath(), "FitDerTableNew_LayerMem.tab", __FILE__, __LINE__);
+
+      int nbits = 6;
+      for (unsigned int i = 0; i < LayerMem_.size(); i++) {
+        FPGAWord tmp;
+        int tmp1 = LayerMem_[i];
+        if (tmp1 < 0)
+          tmp1 = (1 << nbits) - 1;
+        tmp.set(tmp1, nbits, true, __LINE__, __FILE__);
+        outL << tmp.str() << endl;
+      }
+      outL.close();
+
+      ofstream outD = openfile(settings_.tablePath(), "FitDerTableNew_DiskMem.tab", __FILE__, __LINE__);
+
+      nbits = 7;
+      for (int tmp1 : DiskMem_) {
+        if (tmp1 < 0)
+          tmp1 = (1 << nbits) - 1;
+        FPGAWord tmp;
+        tmp.set(tmp1, nbits, true, __LINE__, __FILE__);
+        outD << tmp.str() << endl;
+      }
+      outD.close();
+
+      ofstream outLD = openfile(settings_.tablePath(), "FitDerTableNew_LayerDiskMem.tab", __FILE__, __LINE__);
+
+      nbits = 15;
+      for (int tmp1 : LayerDiskMem_) {
+        if (tmp1 < 0)
+          tmp1 = (1 << nbits) - 1;
+        FPGAWord tmp;
+        tmp.set(tmp1, nbits, true, __LINE__, __FILE__);
+        outLD << tmp.str() << endl;
+      }
+      outLD.close();
+
+      const std::array<string, N_TRKLSEED> seedings = {{"L1L2", "L3L4", "L5L6", "D1D2", "D3D4", "D1L1", "D1L2"}};
+      const string prefix = settings_.tablePath() + "FitDerTableNew_";
+
+      // open files for derivative tables
+
+      ofstream outrinvdphi[N_TRKLSEED];
+      for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
+        const string fname = prefix + "Rinvdphi_" + seedings[i] + ".tab";
+        outrinvdphi[i].open(fname);
+        if (outrinvdphi[i].fail())
+          throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
+      }
+
+      ofstream outrinvdzordr[N_TRKLSEED];
+      for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
+        const string fname = prefix + "Rinvdzordr_" + seedings[i] + ".tab";
+        outrinvdzordr[i].open(fname);
+        if (outrinvdzordr[i].fail())
+          throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
+      }
+
+      ofstream outphi0dphi[N_TRKLSEED];
+      for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
+        const string fname = prefix + "Phi0dphi_" + seedings[i] + ".tab";
+        outphi0dphi[i].open(fname);
+        if (outphi0dphi[i].fail())
+          throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
+      }
+
+      ofstream outphi0dzordr[N_TRKLSEED];
+      for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
+        const string fname = prefix + "Phi0dzordr_" + seedings[i] + ".tab";
+        outphi0dzordr[i].open(fname);
+        if (outphi0dzordr[i].fail())
+          throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
+      }
+
+      ofstream outtdphi[N_TRKLSEED];
+      for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
+        const string fname = prefix + "Tdphi_" + seedings[i] + ".tab";
+        outtdphi[i].open(fname);
+        if (outtdphi[i].fail())
+          throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
+      }
+
+      ofstream outtdzordr[N_TRKLSEED];
+      for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
+        const string fname = prefix + "Tdzordr_" + seedings[i] + ".tab";
+        outtdzordr[i].open(fname);
+        if (outtdzordr[i].fail())
+          throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
+      }
+
+      ofstream outz0dphi[N_TRKLSEED];
+      for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
+        const string fname = prefix + "Z0dphi_" + seedings[i] + ".tab";
+        outz0dphi[i].open(fname);
+        if (outz0dphi[i].fail())
+          throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
+      }
+
+      ofstream outz0dzordr[N_TRKLSEED];
+      for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
+        string fname = prefix + "Z0dzordr_" + seedings[i] + ".tab";
+        outz0dzordr[i].open(fname);
+        if (outz0dzordr[i].fail())
+          throw cms::Exception("BadFile") << __FILE__ << " " << __LINE__ << " could not create file " << fname;
+      }
+
+      for (auto& der : derivatives_) {
+        unsigned int layerhits = der.layerMask();  // 6 bits layer hit pattern
+        unsigned int diskmask = der.diskMask();    // 10 bits disk hit pattern
+        unsigned int diskhits = 0;
+        if (diskmask & (3 << 8))
+          diskhits += 16;
+        if (diskmask & (3 << 6))
+          diskhits += 8;
+        if (diskmask & (3 << 4))
+          diskhits += 4;
+        if (diskmask & (3 << 2))
+          diskhits += 2;
+        if (diskmask & (3 << 0))
+          diskhits += 1;
+        assert(diskhits < 32);                            // 5 bits
+        unsigned int hits = (layerhits << 5) + diskhits;  // 11 bits hit pattern
+        assert(hits < 4096);
+
+        // loop over all seedings
+        int i = 0;  // seeding index
+        for (const string& seed : seedings) {
+          unsigned int iseed1 = 0;
+          unsigned int iseed2 = 0;
+          // check if the seeding is good for the current hit pattern
+          if (seed == "L1L2") {
+            iseed1 = 1;
+            iseed2 = 2;
+          }
+          if (seed == "L3L4") {
+            iseed1 = 3;
+            iseed2 = 4;
+          }
+          if (seed == "L5L6") {
+            iseed1 = 5;
+            iseed2 = 6;
+          }
+          if (seed == "D1D2") {
+            iseed1 = 7;
+            iseed2 = 8;
+          }
+          if (seed == "D3D4") {
+            iseed1 = 9;
+            iseed2 = 10;
+          }
+          if (seed == "D1L1") {
+            iseed1 = 7;
+            iseed2 = 1;
+          }
+          if (seed == "D1L2") {
+            iseed1 = 7;
+            iseed2 = 2;
+          }
+
+          bool goodseed = (hits & (1 << (11 - iseed1))) and (hits & (1 << (11 - iseed2)));
+
+          int itmprinvdphi[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
+          int itmprinvdzordr[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
+          int itmpphi0dphi[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
+          int itmpphi0dzordr[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
+          int itmptdphi[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
+          int itmptdzordr[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
+          int itmpz0dphi[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
+          int itmpz0dzordr[N_PROJ] = {9999999, 9999999, 9999999, 9999999};
+
+          // loop over bits in hit pattern
+          int ider = 0;
+          if (goodseed) {
+            for (unsigned int ihit = 1; ihit < N_FITSTUB * 2; ++ihit) {
+              // skip seeding layers
+              if (ihit == iseed1 or ihit == iseed2) {
+                ider++;
+                continue;
+              }
+              // skip if no hit
+              if (not(hits & (1 << (11 - ihit))))
+                continue;
+
+              int inputI = -1;
+              if (seed == "L1L2") {
+                if (ihit == 3 or ihit == 10)
+                  inputI = 0;  // L3 or D4
+                if (ihit == 4 or ihit == 9)
+                  inputI = 1;  // L4 or D3
+                if (ihit == 5 or ihit == 8)
+                  inputI = 2;  // L5 or D2
+                if (ihit == 6 or ihit == 7)
+                  inputI = 3;  // L6 or D1
+              } else if (seed == "L3L4") {
+                if (ihit == 1)
+                  inputI = 0;  // L1
+                if (ihit == 2)
+                  inputI = 1;  // L2
+                if (ihit == 5 or ihit == 8)
+                  inputI = 2;  // L5 or D2
+                if (ihit == 6 or ihit == 7)
+                  inputI = 3;  // L6 or D1
+              } else if (seed == "L5L6") {
+                if (ihit == 1)
+                  inputI = 0;  // L1
+                if (ihit == 2)
+                  inputI = 1;  // L2
+                if (ihit == 3)
+                  inputI = 2;  // L3
+                if (ihit == 4)
+                  inputI = 3;  // L4
+              } else if (seed == "D1D2") {
+                if (ihit == 1)
+                  inputI = 0;  // L1
+                if (ihit == 9)
+                  inputI = 1;  // D3
+                if (ihit == 10)
+                  inputI = 2;  // D4
+                if (ihit == 2 or ihit == 11)
+                  inputI = 3;  // L2 or D5
+              } else if (seed == "D3D4") {
+                if (ihit == 1)
+                  inputI = 0;  // L1
+                if (ihit == 7)
+                  inputI = 1;  // D1
+                if (ihit == 8)
+                  inputI = 2;  // D2
+                if (ihit == 2 or ihit == 11)
+                  inputI = 3;  // L2 or D5
+              } else if (seed == "D1L1" or "D1L2") {
+                if (ihit == 8)
+                  inputI = 0;  // D2
+                if (ihit == 9)
+                  inputI = 1;  // D3
+                if (ihit == 10)
+                  inputI = 2;  // D4
+                if (ihit == 11)
+                  inputI = 3;  // D5
+              }
+              if (inputI >= 0 and inputI < (int)N_PROJ) {
+                itmprinvdphi[inputI] = der.irinvdphi(ider);
+                itmprinvdzordr[inputI] = der.irinvdzordr(ider);
+                itmpphi0dphi[inputI] = der.iphi0dphi(ider);
+                itmpphi0dzordr[inputI] = der.iphi0dzordr(ider);
+                itmptdphi[inputI] = der.itdphi(ider);
+                itmptdzordr[inputI] = der.itdzordr(ider);
+                itmpz0dphi[inputI] = der.iz0dphi(ider);
+                itmpz0dzordr[inputI] = der.iz0dzordr(ider);
+              }
+
               ider++;
-              continue;
-            }
-            // skip if no hit
-            if (not(hits & (1 << (11 - ihit))))
-              continue;
 
-            int inputI = -1;
-            if (seed == "L1L2") {
-              if (ihit == 3 or ihit == 10)
-                inputI = 0;  // L3 or D4
-              if (ihit == 4 or ihit == 9)
-                inputI = 1;  // L4 or D3
-              if (ihit == 5 or ihit == 8)
-                inputI = 2;  // L5 or D2
-              if (ihit == 6 or ihit == 7)
-                inputI = 3;  // L6 or D1
-            } else if (seed == "L3L4") {
-              if (ihit == 1)
-                inputI = 0;  // L1
-              if (ihit == 2)
-                inputI = 1;  // L2
-              if (ihit == 5 or ihit == 8)
-                inputI = 2;  // L5 or D2
-              if (ihit == 6 or ihit == 7)
-                inputI = 3;  // L6 or D1
-            } else if (seed == "L5L6") {
-              if (ihit == 1)
-                inputI = 0;  // L1
-              if (ihit == 2)
-                inputI = 1;  // L2
-              if (ihit == 3)
-                inputI = 2;  // L3
-              if (ihit == 4)
-                inputI = 3;  // L4
-            } else if (seed == "D1D2") {
-              if (ihit == 1)
-                inputI = 0;  // L1
-              if (ihit == 9)
-                inputI = 1;  // D3
-              if (ihit == 10)
-                inputI = 2;  // D4
-              if (ihit == 2 or ihit == 11)
-                inputI = 3;  // L2 or D5
-            } else if (seed == "D3D4") {
-              if (ihit == 1)
-                inputI = 0;  // L1
-              if (ihit == 7)
-                inputI = 1;  // D1
-              if (ihit == 8)
-                inputI = 2;  // D2
-              if (ihit == 2 or ihit == 11)
-                inputI = 3;  // L2 or D5
-            } else if (seed == "D1L1" or "D1L2") {
-              if (ihit == 8)
-                inputI = 0;  // D2
-              if (ihit == 9)
-                inputI = 1;  // D3
-              if (ihit == 10)
-                inputI = 2;  // D4
-              if (ihit == 11)
-                inputI = 3;  // D5
-            }
-            if (inputI >= 0 and inputI < (int)N_PROJ) {
-              itmprinvdphi[inputI] = der.irinvdphi(ider);
-              itmprinvdzordr[inputI] = der.irinvdzordr(ider);
-              itmpphi0dphi[inputI] = der.iphi0dphi(ider);
-              itmpphi0dzordr[inputI] = der.iphi0dzordr(ider);
-              itmptdphi[inputI] = der.itdphi(ider);
-              itmptdzordr[inputI] = der.itdzordr(ider);
-              itmpz0dphi[inputI] = der.iz0dphi(ider);
-              itmpz0dzordr[inputI] = der.iz0dzordr(ider);
-            }
+            }  // for (unsigned int ihit = 1; ihit < 12; ++ihit)
+          }    // if (goodseed)
 
-            ider++;
+          FPGAWord tmprinvdphi[N_PROJ];
+          int nbits = 16;
+          for (unsigned int j = 0; j < N_PROJ; ++j) {
+            if (itmprinvdphi[j] > (1 << nbits))
+              itmprinvdphi[j] = (1 << nbits) - 1;
+            tmprinvdphi[j].set(itmprinvdphi[j], nbits + 1, false, __LINE__, __FILE__);
+          }
+          outrinvdphi[i] << tmprinvdphi[0].str() << tmprinvdphi[1].str() << tmprinvdphi[2].str() << tmprinvdphi[3].str()
+                         << endl;
 
-          }  // for (unsigned int ihit = 1; ihit < 12; ++ihit)
-        }    // if (goodseed)
+          FPGAWord tmprinvdzordr[N_PROJ];
+          nbits = 15;
+          for (unsigned int j = 0; j < N_PROJ; ++j) {
+            if (itmprinvdzordr[j] > (1 << nbits))
+              itmprinvdzordr[j] = (1 << nbits) - 1;
+            tmprinvdzordr[j].set(itmprinvdzordr[j], nbits + 1, false, __LINE__, __FILE__);
+          }
+          outrinvdzordr[i] << tmprinvdzordr[0].str() << tmprinvdzordr[1].str() << tmprinvdzordr[2].str()
+                           << tmprinvdzordr[3].str() << endl;
 
-        FPGAWord tmprinvdphi[N_PROJ];
-        int nbits = 16;
-        for (unsigned int j = 0; j < N_PROJ; ++j) {
-          if (itmprinvdphi[j] > (1 << nbits))
-            itmprinvdphi[j] = (1 << nbits) - 1;
-          tmprinvdphi[j].set(itmprinvdphi[j], nbits + 1, false, __LINE__, __FILE__);
-        }
-        outrinvdphi[i] << tmprinvdphi[0].str() << tmprinvdphi[1].str() << tmprinvdphi[2].str() << tmprinvdphi[3].str()
-                       << endl;
+          FPGAWord tmpphi0dphi[N_PROJ];
+          nbits = 13;
+          for (unsigned int j = 0; j < N_PROJ; ++j) {
+            if (itmpphi0dphi[j] > (1 << nbits))
+              itmpphi0dphi[j] = (1 << nbits) - 1;
+            tmpphi0dphi[j].set(itmpphi0dphi[j], nbits + 1, false, __LINE__, __FILE__);
+          }
+          outphi0dphi[i] << tmpphi0dphi[0].str() << tmpphi0dphi[1].str() << tmpphi0dphi[2].str() << tmpphi0dphi[3].str()
+                         << endl;
 
-        FPGAWord tmprinvdzordr[N_PROJ];
-        nbits = 15;
-        for (unsigned int j = 0; j < N_PROJ; ++j) {
-          if (itmprinvdzordr[j] > (1 << nbits))
-            itmprinvdzordr[j] = (1 << nbits) - 1;
-          tmprinvdzordr[j].set(itmprinvdzordr[j], nbits + 1, false, __LINE__, __FILE__);
-        }
-        outrinvdzordr[i] << tmprinvdzordr[0].str() << tmprinvdzordr[1].str() << tmprinvdzordr[2].str()
-                         << tmprinvdzordr[3].str() << endl;
+          FPGAWord tmpphi0dzordr[N_PROJ];
+          nbits = 15;
+          for (unsigned int j = 0; j < N_PROJ; ++j) {
+            if (itmpphi0dzordr[j] > (1 << nbits))
+              itmpphi0dzordr[j] = (1 << nbits) - 1;
+            tmpphi0dzordr[j].set(itmpphi0dzordr[j], nbits + 1, false, __LINE__, __FILE__);
+          }
+          outphi0dzordr[i] << tmpphi0dzordr[0].str() << tmpphi0dzordr[1].str() << tmpphi0dzordr[2].str()
+                           << tmpphi0dzordr[3].str() << endl;
 
-        FPGAWord tmpphi0dphi[N_PROJ];
-        nbits = 13;
-        for (unsigned int j = 0; j < N_PROJ; ++j) {
-          if (itmpphi0dphi[j] > (1 << nbits))
-            itmpphi0dphi[j] = (1 << nbits) - 1;
-          tmpphi0dphi[j].set(itmpphi0dphi[j], nbits + 1, false, __LINE__, __FILE__);
-        }
-        outphi0dphi[i] << tmpphi0dphi[0].str() << tmpphi0dphi[1].str() << tmpphi0dphi[2].str() << tmpphi0dphi[3].str()
-                       << endl;
+          FPGAWord tmptdphi[N_PROJ];
+          nbits = 14;
+          for (unsigned int j = 0; j < N_PROJ; ++j) {
+            if (itmptdphi[j] > (1 << nbits))
+              itmptdphi[j] = (1 << nbits) - 1;
+            tmptdphi[j].set(itmptdphi[j], nbits + 1, false, __LINE__, __FILE__);
+          }
+          outtdphi[i] << tmptdphi[0].str() << tmptdphi[1].str() << tmptdphi[2].str() << tmptdphi[3].str() << endl;
 
-        FPGAWord tmpphi0dzordr[N_PROJ];
-        nbits = 15;
-        for (unsigned int j = 0; j < N_PROJ; ++j) {
-          if (itmpphi0dzordr[j] > (1 << nbits))
-            itmpphi0dzordr[j] = (1 << nbits) - 1;
-          tmpphi0dzordr[j].set(itmpphi0dzordr[j], nbits + 1, false, __LINE__, __FILE__);
-        }
-        outphi0dzordr[i] << tmpphi0dzordr[0].str() << tmpphi0dzordr[1].str() << tmpphi0dzordr[2].str()
-                         << tmpphi0dzordr[3].str() << endl;
+          FPGAWord tmptdzordr[N_PROJ];
+          nbits = 15;
+          for (unsigned int j = 0; j < N_PROJ; ++j) {
+            if (itmptdzordr[j] > (1 << nbits))
+              itmptdzordr[j] = (1 << nbits) - 1;
+            tmptdzordr[j].set(itmptdzordr[j], nbits + 1, false, __LINE__, __FILE__);
+          }
+          outtdzordr[i] << tmptdzordr[0].str() << tmptdzordr[1].str() << tmptdzordr[2].str() << tmptdzordr[3].str()
+                        << endl;
 
-        FPGAWord tmptdphi[N_PROJ];
-        nbits = 14;
-        for (unsigned int j = 0; j < N_PROJ; ++j) {
-          if (itmptdphi[j] > (1 << nbits))
-            itmptdphi[j] = (1 << nbits) - 1;
-          tmptdphi[j].set(itmptdphi[j], nbits + 1, false, __LINE__, __FILE__);
-        }
-        outtdphi[i] << tmptdphi[0].str() << tmptdphi[1].str() << tmptdphi[2].str() << tmptdphi[3].str() << endl;
+          FPGAWord tmpz0dphi[N_PROJ];
+          nbits = 13;
+          for (unsigned int j = 0; j < N_PROJ; ++j) {
+            if (itmpz0dphi[j] > (1 << nbits))
+              itmpz0dphi[j] = (1 << nbits) - 1;
+            tmpz0dphi[j].set(itmpz0dphi[j], nbits + 1, false, __LINE__, __FILE__);
+          }
+          outz0dphi[i] << tmpz0dphi[0].str() << tmpz0dphi[1].str() << tmpz0dphi[2].str() << tmpz0dphi[3].str() << endl;
 
-        FPGAWord tmptdzordr[N_PROJ];
-        nbits = 15;
-        for (unsigned int j = 0; j < N_PROJ; ++j) {
-          if (itmptdzordr[j] > (1 << nbits))
-            itmptdzordr[j] = (1 << nbits) - 1;
-          tmptdzordr[j].set(itmptdzordr[j], nbits + 1, false, __LINE__, __FILE__);
-        }
-        outtdzordr[i] << tmptdzordr[0].str() << tmptdzordr[1].str() << tmptdzordr[2].str() << tmptdzordr[3].str()
-                      << endl;
+          FPGAWord tmpz0dzordr[N_PROJ];
+          nbits = 15;
+          for (unsigned int j = 0; j < N_PROJ; ++j) {
+            if (itmpz0dzordr[j] > (1 << nbits))
+              itmpz0dzordr[j] = (1 << nbits) - 1;
+            tmpz0dzordr[j].set(itmpz0dzordr[j], nbits + 1, false, __LINE__, __FILE__);
+          }
+          outz0dzordr[i] << tmpz0dzordr[0].str() << tmpz0dzordr[1].str() << tmpz0dzordr[2].str() << tmpz0dzordr[3].str()
+                         << endl;
 
-        FPGAWord tmpz0dphi[N_PROJ];
-        nbits = 13;
-        for (unsigned int j = 0; j < N_PROJ; ++j) {
-          if (itmpz0dphi[j] > (1 << nbits))
-            itmpz0dphi[j] = (1 << nbits) - 1;
-          tmpz0dphi[j].set(itmpz0dphi[j], nbits + 1, false, __LINE__, __FILE__);
-        }
-        outz0dphi[i] << tmpz0dphi[0].str() << tmpz0dphi[1].str() << tmpz0dphi[2].str() << tmpz0dphi[3].str() << endl;
+          i++;
+        }  // for (const string & seed : seedings)
 
-        FPGAWord tmpz0dzordr[N_PROJ];
-        nbits = 15;
-        for (unsigned int j = 0; j < N_PROJ; ++j) {
-          if (itmpz0dzordr[j] > (1 << nbits))
-            itmpz0dzordr[j] = (1 << nbits) - 1;
-          tmpz0dzordr[j].set(itmpz0dzordr[j], nbits + 1, false, __LINE__, __FILE__);
-        }
-        outz0dzordr[i] << tmpz0dzordr[0].str() << tmpz0dzordr[1].str() << tmpz0dzordr[2].str() << tmpz0dzordr[3].str()
-                       << endl;
+      }  // for (auto & der : derivatives_)
 
-        i++;
-      }  // for (const string & seed : seedings)
+      // close files
+      for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
+        outrinvdphi[i].close();
+        outrinvdzordr[i].close();
+        outphi0dphi[i].close();
+        outphi0dzordr[i].close();
+        outtdphi[i].close();
+        outtdzordr[i].close();
+        outz0dphi[i].close();
+        outz0dzordr[i].close();
+      }
 
-    }  // for (auto & der : derivatives_)
-
-    // close files
-    for (unsigned int i = 0; i < N_TRKLSEED; ++i) {
-      outrinvdphi[i].close();
-      outrinvdzordr[i].close();
-      outphi0dphi[i].close();
-      outphi0dzordr[i].close();
-      outtdphi[i].close();
-      outtdzordr[i].close();
-      outz0dphi[i].close();
-      outz0dzordr[i].close();
-    }
-
-  }  // if (writeFitDerTable)
-}
-
-void TrackDerTable::invert(double M[4][8], unsigned int n) {
-  assert(n <= 4);
-
-  unsigned int i, j, k;
-  double ratio, a;
-
-  for (i = 0; i < n; i++) {
-    for (j = n; j < 2 * n; j++) {
-      if (i == (j - n))
-        M[i][j] = 1.0;
-      else
-        M[i][j] = 0.0;
-    }
+    }  // if (writeFitDerTable)
   }
 
-  for (i = 0; i < n; i++) {
-    for (j = 0; j < n; j++) {
-      if (i != j) {
-        ratio = M[j][i] / M[i][i];
-        for (k = 0; k < 2 * n; k++) {
-          M[j][k] -= ratio * M[i][k];
+  void TrackDerTable::invert(double M[4][8], unsigned int n) {
+    assert(n <= 4);
+
+    unsigned int i, j, k;
+    double ratio, a;
+
+    for (i = 0; i < n; i++) {
+      for (j = n; j < 2 * n; j++) {
+        if (i == (j - n))
+          M[i][j] = 1.0;
+        else
+          M[i][j] = 0.0;
+      }
+    }
+
+    for (i = 0; i < n; i++) {
+      for (j = 0; j < n; j++) {
+        if (i != j) {
+          ratio = M[j][i] / M[i][i];
+          for (k = 0; k < 2 * n; k++) {
+            M[j][k] -= ratio * M[i][k];
+          }
         }
+      }
+    }
+
+    for (i = 0; i < n; i++) {
+      a = M[i][i];
+      for (j = 0; j < 2 * n; j++) {
+        M[i][j] /= a;
       }
     }
   }
 
-  for (i = 0; i < n; i++) {
-    a = M[i][i];
-    for (j = 0; j < 2 * n; j++) {
-      M[i][j] /= a;
+  void TrackDerTable::invert(std::vector<std::vector<double> >& M, unsigned int n) {
+    assert(M.size() == n);
+    assert(M[0].size() == 2 * n);
+
+    unsigned int i, j, k;
+    double ratio, a;
+
+    for (i = 0; i < n; i++) {
+      for (j = n; j < 2 * n; j++) {
+        if (i == (j - n))
+          M[i][j] = 1.0;
+        else
+          M[i][j] = 0.0;
+      }
     }
-  }
-}
 
-void TrackDerTable::invert(std::vector<std::vector<double> >& M, unsigned int n) {
-  assert(M.size() == n);
-  assert(M[0].size() == 2 * n);
-
-  unsigned int i, j, k;
-  double ratio, a;
-
-  for (i = 0; i < n; i++) {
-    for (j = n; j < 2 * n; j++) {
-      if (i == (j - n))
-        M[i][j] = 1.0;
-      else
-        M[i][j] = 0.0;
-    }
-  }
-
-  for (i = 0; i < n; i++) {
-    for (j = 0; j < n; j++) {
-      if (i != j) {
-        ratio = M[j][i] / M[i][i];
-        for (k = 0; k < 2 * n; k++) {
-          M[j][k] -= ratio * M[i][k];
+    for (i = 0; i < n; i++) {
+      for (j = 0; j < n; j++) {
+        if (i != j) {
+          ratio = M[j][i] / M[i][i];
+          for (k = 0; k < 2 * n; k++) {
+            M[j][k] -= ratio * M[i][k];
+          }
         }
       }
     }
-  }
 
-  for (i = 0; i < n; i++) {
-    a = M[i][i];
-    for (j = 0; j < 2 * n; j++) {
-      M[i][j] /= a;
-    }
-  }
-}
-
-void TrackDerTable::calculateDerivatives(Settings const& settings,
-                                         unsigned int nlayers,
-                                         double r[N_LAYER],
-                                         unsigned int ndisks,
-                                         double z[N_DISK],
-                                         double alpha[N_DISK],
-                                         double t,
-                                         double rinv,
-                                         double D[N_FITPARAM][N_FITSTUB * 2],
-                                         int iD[N_FITPARAM][N_FITSTUB * 2],
-                                         double MinvDt[N_FITPARAM][N_FITSTUB * 2],
-                                         int iMinvDt[N_FITPARAM][N_FITSTUB * 2],
-                                         double sigma[N_FITSTUB * 2],
-                                         double kfactor[N_FITSTUB * 2]) {
-  double sigmax = settings.stripPitch(true) / sqrt(12.0);
-  double sigmaz = settings.stripLength(true) / sqrt(12.0);
-  double sigmaz2 = settings.stripLength(false) / sqrt(12.0);
-
-  double sigmazpsbarrel = sigmaz;  //This is a bit of a hack - these weights should be properly determined
-  if (std::abs(t) > 2.0)
-    sigmazpsbarrel = sigmaz * std::abs(t) / 2.0;
-  if (std::abs(t) > 3.8)
-    sigmazpsbarrel = sigmaz * std::abs(t);
-
-  double sigmax2sdisk = settings.stripPitch(false) / sqrt(12.0);
-  double sigmaz2sdisk = settings.stripLength(false) / sqrt(12.0);
-
-  double sigmaxpsdisk = settings.stripPitch(true) / sqrt(12.0);
-  double sigmazpsdisk = settings.stripLength(true) / sqrt(12.0);
-
-  unsigned int n = nlayers + ndisks;
-
-  assert(n <= N_FITSTUB);
-
-  double rnew[N_FITSTUB];
-
-  int j = 0;
-
-  //here we handle a barrel hit
-  for (unsigned int i = 0; i < nlayers; i++) {
-    double ri = r[i];
-
-    rnew[i] = ri;
-
-    //first we have the phi position
-    D[0][j] = -0.5 * ri * ri / sqrt(1 - 0.25 * ri * ri * rinv * rinv) / sigmax;
-    D[1][j] = ri / sigmax;
-    D[2][j] = 0.0;
-    D[3][j] = 0.0;
-    sigma[j] = sigmax;
-    kfactor[j] = settings.kphi1();
-    j++;
-    //second the z position
-    D[0][j] = 0.0;
-    D[1][j] = 0.0;
-    if (ri < settings.rPS2S()) {
-      D[2][j] = (2 / rinv) * asin(0.5 * ri * rinv) / sigmazpsbarrel;
-      D[3][j] = 1.0 / sigmazpsbarrel;
-      sigma[j] = sigmazpsbarrel;
-      kfactor[j] = settings.kz();
-    } else {
-      D[2][j] = (2 / rinv) * asin(0.5 * ri * rinv) / sigmaz2;
-      D[3][j] = 1.0 / sigmaz2;
-      sigma[j] = sigmaz2;
-      kfactor[j] = settings.kz();
-    }
-
-    j++;
-  }
-
-  for (unsigned int i = 0; i < ndisks; i++) {
-    double zi = z[i];
-
-    double z0 = 0.0;
-
-    double rmultiplier = alpha[i] * zi / t;
-
-    double phimultiplier = zi / t;
-
-    double drdrinv = -2.0 * sin(0.5 * rinv * (zi - z0) / t) / (rinv * rinv) +
-                     (zi - z0) * cos(0.5 * rinv * (zi - z0) / t) / (rinv * t);
-    double drdphi0 = 0;
-    double drdt = -(zi - z0) * cos(0.5 * rinv * (zi - z0) / t) / (t * t);
-    double drdz0 = -cos(0.5 * rinv * (zi - z0) / t) / t;
-
-    double dphidrinv = -0.5 * (zi - z0) / t;
-    double dphidphi0 = 1.0;
-    double dphidt = 0.5 * rinv * (zi - z0) / (t * t);
-    double dphidz0 = 0.5 * rinv / t;
-
-    double r = (zi - z0) / t;
-
-    rnew[i + nlayers] = r;
-
-    sigma[j] = sigmax2sdisk;
-    if (std::abs(alpha[i]) < 1e-10) {
-      sigma[j] = sigmaxpsdisk;
-    }
-
-    D[0][j] = (phimultiplier * dphidrinv + rmultiplier * drdrinv) / sigma[j];
-    D[1][j] = (phimultiplier * dphidphi0 + rmultiplier * drdphi0) / sigma[j];
-    D[2][j] = (phimultiplier * dphidt + rmultiplier * drdt) / sigma[j];
-    D[3][j] = (phimultiplier * dphidz0 + rmultiplier * drdz0) / sigma[j];
-    kfactor[j] = settings.kphi();
-
-    j++;
-
-    if (std::abs(alpha[i]) < 1e-10) {
-      D[0][j] = drdrinv / sigmazpsdisk;
-      D[1][j] = drdphi0 / sigmazpsdisk;
-      D[2][j] = drdt / sigmazpsdisk;
-      D[3][j] = drdz0 / sigmazpsdisk;
-      sigma[j] = sigmazpsdisk;
-      kfactor[j] = settings.kr();
-    } else {
-      D[0][j] = drdrinv / sigmaz2sdisk;
-      D[1][j] = drdphi0 / sigmaz2sdisk;
-      D[2][j] = drdt / sigmaz2sdisk;
-      D[3][j] = drdz0 / sigmaz2sdisk;
-      sigma[j] = sigmaz2sdisk;
-      kfactor[j] = settings.kr();
-    }
-
-    j++;
-  }
-
-  double M[4][8];
-
-  for (unsigned int i1 = 0; i1 < 4; i1++) {
-    for (unsigned int i2 = 0; i2 < 4; i2++) {
-      M[i1][i2] = 0.0;
-      for (unsigned int j = 0; j < 2 * n; j++) {
-        M[i1][i2] += D[i1][j] * D[i2][j];
+    for (i = 0; i < n; i++) {
+      a = M[i][i];
+      for (j = 0; j < 2 * n; j++) {
+        M[i][j] /= a;
       }
     }
   }
 
-  invert(M, 4);
+  void TrackDerTable::calculateDerivatives(Settings const& settings,
+                                           unsigned int nlayers,
+                                           double r[N_LAYER],
+                                           unsigned int ndisks,
+                                           double z[N_DISK],
+                                           double alpha[N_DISK],
+                                           double t,
+                                           double rinv,
+                                           double D[N_FITPARAM][N_FITSTUB * 2],
+                                           int iD[N_FITPARAM][N_FITSTUB * 2],
+                                           double MinvDt[N_FITPARAM][N_FITSTUB * 2],
+                                           int iMinvDt[N_FITPARAM][N_FITSTUB * 2],
+                                           double sigma[N_FITSTUB * 2],
+                                           double kfactor[N_FITSTUB * 2]) {
+    double sigmax = settings.stripPitch(true) / sqrt(12.0);
+    double sigmaz = settings.stripLength(true) / sqrt(12.0);
+    double sigmaz2 = settings.stripLength(false) / sqrt(12.0);
 
-  for (unsigned int j = 0; j < N_FITSTUB * 2; j++) {
-    for (unsigned int i1 = 0; i1 < N_FITPARAM; i1++) {
-      MinvDt[i1][j] = 0.0;
-      iMinvDt[i1][j] = 0;
+    double sigmazpsbarrel = sigmaz;  //This is a bit of a hack - these weights should be properly determined
+    if (std::abs(t) > 2.0)
+      sigmazpsbarrel = sigmaz * std::abs(t) / 2.0;
+    if (std::abs(t) > 3.8)
+      sigmazpsbarrel = sigmaz * std::abs(t);
+
+    double sigmax2sdisk = settings.stripPitch(false) / sqrt(12.0);
+    double sigmaz2sdisk = settings.stripLength(false) / sqrt(12.0);
+
+    double sigmaxpsdisk = settings.stripPitch(true) / sqrt(12.0);
+    double sigmazpsdisk = settings.stripLength(true) / sqrt(12.0);
+
+    unsigned int n = nlayers + ndisks;
+
+    assert(n <= N_FITSTUB);
+
+    double rnew[N_FITSTUB];
+
+    int j = 0;
+
+    //here we handle a barrel hit
+    for (unsigned int i = 0; i < nlayers; i++) {
+      double ri = r[i];
+
+      rnew[i] = ri;
+
+      //first we have the phi position
+      D[0][j] = -0.5 * ri * ri / sqrt(1 - 0.25 * ri * ri * rinv * rinv) / sigmax;
+      D[1][j] = ri / sigmax;
+      D[2][j] = 0.0;
+      D[3][j] = 0.0;
+      sigma[j] = sigmax;
+      kfactor[j] = settings.kphi1();
+      j++;
+      //second the z position
+      D[0][j] = 0.0;
+      D[1][j] = 0.0;
+      if (ri < settings.rPS2S()) {
+        D[2][j] = (2 / rinv) * asin(0.5 * ri * rinv) / sigmazpsbarrel;
+        D[3][j] = 1.0 / sigmazpsbarrel;
+        sigma[j] = sigmazpsbarrel;
+        kfactor[j] = settings.kz();
+      } else {
+        D[2][j] = (2 / rinv) * asin(0.5 * ri * rinv) / sigmaz2;
+        D[3][j] = 1.0 / sigmaz2;
+        sigma[j] = sigmaz2;
+        kfactor[j] = settings.kz();
+      }
+
+      j++;
     }
-  }
 
-  for (unsigned int j = 0; j < 2 * n; j++) {
+    for (unsigned int i = 0; i < ndisks; i++) {
+      double zi = z[i];
+
+      double z0 = 0.0;
+
+      double rmultiplier = alpha[i] * zi / t;
+
+      double phimultiplier = zi / t;
+
+      double drdrinv = -2.0 * sin(0.5 * rinv * (zi - z0) / t) / (rinv * rinv) +
+                       (zi - z0) * cos(0.5 * rinv * (zi - z0) / t) / (rinv * t);
+      double drdphi0 = 0;
+      double drdt = -(zi - z0) * cos(0.5 * rinv * (zi - z0) / t) / (t * t);
+      double drdz0 = -cos(0.5 * rinv * (zi - z0) / t) / t;
+
+      double dphidrinv = -0.5 * (zi - z0) / t;
+      double dphidphi0 = 1.0;
+      double dphidt = 0.5 * rinv * (zi - z0) / (t * t);
+      double dphidz0 = 0.5 * rinv / t;
+
+      double r = (zi - z0) / t;
+
+      rnew[i + nlayers] = r;
+
+      sigma[j] = sigmax2sdisk;
+      if (std::abs(alpha[i]) < 1e-10) {
+        sigma[j] = sigmaxpsdisk;
+      }
+
+      D[0][j] = (phimultiplier * dphidrinv + rmultiplier * drdrinv) / sigma[j];
+      D[1][j] = (phimultiplier * dphidphi0 + rmultiplier * drdphi0) / sigma[j];
+      D[2][j] = (phimultiplier * dphidt + rmultiplier * drdt) / sigma[j];
+      D[3][j] = (phimultiplier * dphidz0 + rmultiplier * drdz0) / sigma[j];
+      kfactor[j] = settings.kphi();
+
+      j++;
+
+      if (std::abs(alpha[i]) < 1e-10) {
+        D[0][j] = drdrinv / sigmazpsdisk;
+        D[1][j] = drdphi0 / sigmazpsdisk;
+        D[2][j] = drdt / sigmazpsdisk;
+        D[3][j] = drdz0 / sigmazpsdisk;
+        sigma[j] = sigmazpsdisk;
+        kfactor[j] = settings.kr();
+      } else {
+        D[0][j] = drdrinv / sigmaz2sdisk;
+        D[1][j] = drdphi0 / sigmaz2sdisk;
+        D[2][j] = drdt / sigmaz2sdisk;
+        D[3][j] = drdz0 / sigmaz2sdisk;
+        sigma[j] = sigmaz2sdisk;
+        kfactor[j] = settings.kr();
+      }
+
+      j++;
+    }
+
+    double M[4][8];
+
     for (unsigned int i1 = 0; i1 < 4; i1++) {
       for (unsigned int i2 = 0; i2 < 4; i2++) {
-        MinvDt[i1][j] += M[i1][i2 + 4] * D[i2][j];
+        M[i1][i2] = 0.0;
+        for (unsigned int j = 0; j < 2 * n; j++) {
+          M[i1][i2] += D[i1][j] * D[i2][j];
+        }
+      }
+    }
+
+    invert(M, 4);
+
+    for (unsigned int j = 0; j < N_FITSTUB * 2; j++) {
+      for (unsigned int i1 = 0; i1 < N_FITPARAM; i1++) {
+        MinvDt[i1][j] = 0.0;
+        iMinvDt[i1][j] = 0;
+      }
+    }
+
+    for (unsigned int j = 0; j < 2 * n; j++) {
+      for (unsigned int i1 = 0; i1 < 4; i1++) {
+        for (unsigned int i2 = 0; i2 < 4; i2++) {
+          MinvDt[i1][j] += M[i1][i2 + 4] * D[i2][j];
+        }
+      }
+    }
+
+    for (unsigned int i = 0; i < n; i++) {
+      iD[0][2 * i] =
+          D[0][2 * i] * (1 << settings.chisqphifactbits()) * settings.krinvpars() / (1 << settings.fitrinvbitshift());
+      iD[1][2 * i] =
+          D[1][2 * i] * (1 << settings.chisqphifactbits()) * settings.kphi0pars() / (1 << settings.fitphi0bitshift());
+      iD[2][2 * i] =
+          D[2][2 * i] * (1 << settings.chisqphifactbits()) * settings.ktpars() / (1 << settings.fittbitshift());
+      iD[3][2 * i] =
+          D[3][2 * i] * (1 << settings.chisqphifactbits()) * settings.kz0pars() / (1 << settings.fitz0bitshift());
+
+      iD[0][2 * i + 1] =
+          D[0][2 * i + 1] * (1 << settings.chisqzfactbits()) * settings.krinvpars() / (1 << settings.fitrinvbitshift());
+      iD[1][2 * i + 1] =
+          D[1][2 * i + 1] * (1 << settings.chisqzfactbits()) * settings.kphi0pars() / (1 << settings.fitphi0bitshift());
+      iD[2][2 * i + 1] =
+          D[2][2 * i + 1] * (1 << settings.chisqzfactbits()) * settings.ktpars() / (1 << settings.fittbitshift());
+      iD[3][2 * i + 1] =
+          D[3][2 * i + 1] * (1 << settings.chisqzfactbits()) * settings.kz0pars() / (1 << settings.fitz0bitshift());
+
+      //First the barrel
+      if (i < nlayers) {
+        MinvDt[0][2 * i] *= rnew[i] / sigmax;
+        MinvDt[1][2 * i] *= rnew[i] / sigmax;
+        MinvDt[2][2 * i] *= rnew[i] / sigmax;
+        MinvDt[3][2 * i] *= rnew[i] / sigmax;
+
+        iMinvDt[0][2 * i] =
+            (1 << settings.fitrinvbitshift()) * MinvDt[0][2 * i] * settings.kphi1() / settings.krinvpars();
+        iMinvDt[1][2 * i] =
+            (1 << settings.fitphi0bitshift()) * MinvDt[1][2 * i] * settings.kphi1() / settings.kphi0pars();
+        iMinvDt[2][2 * i] = (1 << settings.fittbitshift()) * MinvDt[2][2 * i] * settings.kphi1() / settings.ktpars();
+        iMinvDt[3][2 * i] = (1 << settings.fitz0bitshift()) * MinvDt[3][2 * i] * settings.kphi1() / settings.kz0pars();
+
+        if (rnew[i] < settings.rPS2S()) {
+          MinvDt[0][2 * i + 1] /= sigmazpsbarrel;
+          MinvDt[1][2 * i + 1] /= sigmazpsbarrel;
+          MinvDt[2][2 * i + 1] /= sigmazpsbarrel;
+          MinvDt[3][2 * i + 1] /= sigmazpsbarrel;
+
+          iMinvDt[0][2 * i + 1] =
+              (1 << settings.fitrinvbitshift()) * MinvDt[0][2 * i + 1] * settings.kz() / settings.krinvpars();
+          iMinvDt[1][2 * i + 1] =
+              (1 << settings.fitphi0bitshift()) * MinvDt[1][2 * i + 1] * settings.kz() / settings.kphi0pars();
+          iMinvDt[2][2 * i + 1] =
+              (1 << settings.fittbitshift()) * MinvDt[2][2 * i + 1] * settings.kz() / settings.ktpars();
+          iMinvDt[3][2 * i + 1] =
+              (1 << settings.fitz0bitshift()) * MinvDt[3][2 * i + 1] * settings.kz() / settings.kz0pars();
+        } else {
+          MinvDt[0][2 * i + 1] /= sigmaz2;
+          MinvDt[1][2 * i + 1] /= sigmaz2;
+          MinvDt[2][2 * i + 1] /= sigmaz2;
+          MinvDt[3][2 * i + 1] /= sigmaz2;
+
+          int fact = (1 << (settings.nzbitsstub(0) - settings.nzbitsstub(5)));
+
+          iMinvDt[0][2 * i + 1] =
+              (1 << settings.fitrinvbitshift()) * MinvDt[0][2 * i + 1] * fact * settings.kz() / settings.krinvpars();
+          iMinvDt[1][2 * i + 1] =
+              (1 << settings.fitphi0bitshift()) * MinvDt[1][2 * i + 1] * fact * settings.kz() / settings.kphi0pars();
+          iMinvDt[2][2 * i + 1] =
+              (1 << settings.fittbitshift()) * MinvDt[2][2 * i + 1] * fact * settings.kz() / settings.ktpars();
+          iMinvDt[3][2 * i + 1] =
+              (1 << settings.fitz0bitshift()) * MinvDt[3][2 * i + 1] * fact * settings.kz() / settings.kz0pars();
+        }
+      }
+
+      //Secondly the disks
+      else {
+        double denom = (std::abs(alpha[i - nlayers]) < 1e-10) ? sigmaxpsdisk : sigmax2sdisk;
+
+        MinvDt[0][2 * i] *= (rnew[i] / denom);
+        MinvDt[1][2 * i] *= (rnew[i] / denom);
+        MinvDt[2][2 * i] *= (rnew[i] / denom);
+        MinvDt[3][2 * i] *= (rnew[i] / denom);
+
+        assert(MinvDt[0][2 * i] == MinvDt[0][2 * i]);
+
+        iMinvDt[0][2 * i] =
+            (1 << settings.fitrinvbitshift()) * MinvDt[0][2 * i] * settings.kphi() / settings.krinvpars();
+        iMinvDt[1][2 * i] =
+            (1 << settings.fitphi0bitshift()) * MinvDt[1][2 * i] * settings.kphi() / settings.kphi0pars();
+        iMinvDt[2][2 * i] = (1 << settings.fittbitshift()) * MinvDt[2][2 * i] * settings.kphi() / settings.ktpars();
+        iMinvDt[3][2 * i] = (1 << settings.fitz0bitshift()) * MinvDt[3][2 * i] * settings.kphi() / settings.kz();
+
+        denom = (std::abs(alpha[i - nlayers]) < 1e-10) ? sigmazpsdisk : sigmaz2sdisk;
+
+        MinvDt[0][2 * i + 1] /= denom;
+        MinvDt[1][2 * i + 1] /= denom;
+        MinvDt[2][2 * i + 1] /= denom;
+        MinvDt[3][2 * i + 1] /= denom;
+
+        iMinvDt[0][2 * i + 1] = (1 << settings.fitrinvbitshift()) * MinvDt[0][2 * i + 1] * settings.krprojshiftdisk() /
+                                settings.krinvpars();
+        iMinvDt[1][2 * i + 1] = (1 << settings.fitphi0bitshift()) * MinvDt[1][2 * i + 1] * settings.krprojshiftdisk() /
+                                settings.kphi0pars();
+        iMinvDt[2][2 * i + 1] =
+            (1 << settings.fittbitshift()) * MinvDt[2][2 * i + 1] * settings.krprojshiftdisk() / settings.ktpars();
+        iMinvDt[3][2 * i + 1] =
+            (1 << settings.fitz0bitshift()) * MinvDt[3][2 * i + 1] * settings.krprojshiftdisk() / settings.kz();
       }
     }
   }
 
-  for (unsigned int i = 0; i < n; i++) {
-    iD[0][2 * i] =
-        D[0][2 * i] * (1 << settings.chisqphifactbits()) * settings.krinvpars() / (1 << settings.fitrinvbitshift());
-    iD[1][2 * i] =
-        D[1][2 * i] * (1 << settings.chisqphifactbits()) * settings.kphi0pars() / (1 << settings.fitphi0bitshift());
-    iD[2][2 * i] =
-        D[2][2 * i] * (1 << settings.chisqphifactbits()) * settings.ktpars() / (1 << settings.fittbitshift());
-    iD[3][2 * i] =
-        D[3][2 * i] * (1 << settings.chisqphifactbits()) * settings.kz0pars() / (1 << settings.fitz0bitshift());
+  double TrackDerTable::tpar(Settings const& settings, int diskmask, int layermask) {
+    if (diskmask == 0)
+      return 0.0;
 
-    iD[0][2 * i + 1] =
-        D[0][2 * i + 1] * (1 << settings.chisqzfactbits()) * settings.krinvpars() / (1 << settings.fitrinvbitshift());
-    iD[1][2 * i + 1] =
-        D[1][2 * i + 1] * (1 << settings.chisqzfactbits()) * settings.kphi0pars() / (1 << settings.fitphi0bitshift());
-    iD[2][2 * i + 1] =
-        D[2][2 * i + 1] * (1 << settings.chisqzfactbits()) * settings.ktpars() / (1 << settings.fittbitshift());
-    iD[3][2 * i + 1] =
-        D[3][2 * i + 1] * (1 << settings.chisqzfactbits()) * settings.kz0pars() / (1 << settings.fitz0bitshift());
+    double tmax = 1000.0;
+    double tmin = 0.0;
 
-    //First the barrel
-    if (i < nlayers) {
-      MinvDt[0][2 * i] *= rnew[i] / sigmax;
-      MinvDt[1][2 * i] *= rnew[i] / sigmax;
-      MinvDt[2][2 * i] *= rnew[i] / sigmax;
-      MinvDt[3][2 * i] *= rnew[i] / sigmax;
+    for (int d = 1; d <= (int)N_DISK; d++) {
+      if (diskmask & (1 << (2 * (5 - d) + 1))) {  //PS hit
+        double dmax = settings.zmean(d - 1) / 22.0;
+        if (dmax > sinh(2.4))
+          dmax = sinh(2.4);
+        double dmin = settings.zmean(d - 1) / 65.0;
+        if (dmax < tmax)
+          tmax = dmax;
+        if (dmin > tmin)
+          tmin = dmin;
+      }
 
-      iMinvDt[0][2 * i] =
-          (1 << settings.fitrinvbitshift()) * MinvDt[0][2 * i] * settings.kphi1() / settings.krinvpars();
-      iMinvDt[1][2 * i] =
-          (1 << settings.fitphi0bitshift()) * MinvDt[1][2 * i] * settings.kphi1() / settings.kphi0pars();
-      iMinvDt[2][2 * i] = (1 << settings.fittbitshift()) * MinvDt[2][2 * i] * settings.kphi1() / settings.ktpars();
-      iMinvDt[3][2 * i] = (1 << settings.fitz0bitshift()) * MinvDt[3][2 * i] * settings.kphi1() / settings.kz0pars();
-
-      if (rnew[i] < settings.rPS2S()) {
-        MinvDt[0][2 * i + 1] /= sigmazpsbarrel;
-        MinvDt[1][2 * i + 1] /= sigmazpsbarrel;
-        MinvDt[2][2 * i + 1] /= sigmazpsbarrel;
-        MinvDt[3][2 * i + 1] /= sigmazpsbarrel;
-
-        iMinvDt[0][2 * i + 1] =
-            (1 << settings.fitrinvbitshift()) * MinvDt[0][2 * i + 1] * settings.kz() / settings.krinvpars();
-        iMinvDt[1][2 * i + 1] =
-            (1 << settings.fitphi0bitshift()) * MinvDt[1][2 * i + 1] * settings.kz() / settings.kphi0pars();
-        iMinvDt[2][2 * i + 1] =
-            (1 << settings.fittbitshift()) * MinvDt[2][2 * i + 1] * settings.kz() / settings.ktpars();
-        iMinvDt[3][2 * i + 1] =
-            (1 << settings.fitz0bitshift()) * MinvDt[3][2 * i + 1] * settings.kz() / settings.kz0pars();
-      } else {
-        MinvDt[0][2 * i + 1] /= sigmaz2;
-        MinvDt[1][2 * i + 1] /= sigmaz2;
-        MinvDt[2][2 * i + 1] /= sigmaz2;
-        MinvDt[3][2 * i + 1] /= sigmaz2;
-
-        int fact = (1 << (settings.nzbitsstub(0) - settings.nzbitsstub(5)));
-
-        iMinvDt[0][2 * i + 1] =
-            (1 << settings.fitrinvbitshift()) * MinvDt[0][2 * i + 1] * fact * settings.kz() / settings.krinvpars();
-        iMinvDt[1][2 * i + 1] =
-            (1 << settings.fitphi0bitshift()) * MinvDt[1][2 * i + 1] * fact * settings.kz() / settings.kphi0pars();
-        iMinvDt[2][2 * i + 1] =
-            (1 << settings.fittbitshift()) * MinvDt[2][2 * i + 1] * fact * settings.kz() / settings.ktpars();
-        iMinvDt[3][2 * i + 1] =
-            (1 << settings.fitz0bitshift()) * MinvDt[3][2 * i + 1] * fact * settings.kz() / settings.kz0pars();
+      if (diskmask & (1 << (2 * (5 - d)))) {  //2S hit
+        double dmax = settings.zmean(d - 1) / 65.0;
+        double dmin = settings.zmean(d - 1) / 105.0;
+        if (dmax < tmax)
+          tmax = dmax;
+        if (dmin > tmin)
+          tmin = dmin;
       }
     }
 
-    //Secondly the disks
-    else {
-      double denom = (std::abs(alpha[i - nlayers]) < 1e-10) ? sigmaxpsdisk : sigmax2sdisk;
-
-      MinvDt[0][2 * i] *= (rnew[i] / denom);
-      MinvDt[1][2 * i] *= (rnew[i] / denom);
-      MinvDt[2][2 * i] *= (rnew[i] / denom);
-      MinvDt[3][2 * i] *= (rnew[i] / denom);
-
-      assert(MinvDt[0][2 * i] == MinvDt[0][2 * i]);
-
-      iMinvDt[0][2 * i] = (1 << settings.fitrinvbitshift()) * MinvDt[0][2 * i] * settings.kphi() / settings.krinvpars();
-      iMinvDt[1][2 * i] = (1 << settings.fitphi0bitshift()) * MinvDt[1][2 * i] * settings.kphi() / settings.kphi0pars();
-      iMinvDt[2][2 * i] = (1 << settings.fittbitshift()) * MinvDt[2][2 * i] * settings.kphi() / settings.ktpars();
-      iMinvDt[3][2 * i] = (1 << settings.fitz0bitshift()) * MinvDt[3][2 * i] * settings.kphi() / settings.kz();
-
-      denom = (std::abs(alpha[i - nlayers]) < 1e-10) ? sigmazpsdisk : sigmaz2sdisk;
-
-      MinvDt[0][2 * i + 1] /= denom;
-      MinvDt[1][2 * i + 1] /= denom;
-      MinvDt[2][2 * i + 1] /= denom;
-      MinvDt[3][2 * i + 1] /= denom;
-
-      iMinvDt[0][2 * i + 1] =
-          (1 << settings.fitrinvbitshift()) * MinvDt[0][2 * i + 1] * settings.krprojshiftdisk() / settings.krinvpars();
-      iMinvDt[1][2 * i + 1] =
-          (1 << settings.fitphi0bitshift()) * MinvDt[1][2 * i + 1] * settings.krprojshiftdisk() / settings.kphi0pars();
-      iMinvDt[2][2 * i + 1] =
-          (1 << settings.fittbitshift()) * MinvDt[2][2 * i + 1] * settings.krprojshiftdisk() / settings.ktpars();
-      iMinvDt[3][2 * i + 1] =
-          (1 << settings.fitz0bitshift()) * MinvDt[3][2 * i + 1] * settings.krprojshiftdisk() / settings.kz();
-    }
-  }
-}
-
-double TrackDerTable::tpar(Settings const& settings, int diskmask, int layermask) {
-  if (diskmask == 0)
-    return 0.0;
-
-  double tmax = 1000.0;
-  double tmin = 0.0;
-
-  for (int d = 1; d <= (int)N_DISK; d++) {
-    if (diskmask & (1 << (2 * (5 - d) + 1))) {  //PS hit
-      double dmax = settings.zmean(d - 1) / 22.0;
-      if (dmax > sinh(2.4))
-        dmax = sinh(2.4);
-      double dmin = settings.zmean(d - 1) / 65.0;
-      if (dmax < tmax)
-        tmax = dmax;
-      if (dmin > tmin)
-        tmin = dmin;
+    for (int l = 1; l <= (int)N_LAYER; l++) {
+      if (layermask & (1 << (6 - l))) {
+        double lmax = settings.zlength() / settings.rmean(l - 1);
+        if (lmax < tmax)
+          tmax = lmax;
+      }
     }
 
-    if (diskmask & (1 << (2 * (5 - d)))) {  //2S hit
-      double dmax = settings.zmean(d - 1) / 65.0;
-      double dmin = settings.zmean(d - 1) / 105.0;
-      if (dmax < tmax)
-        tmax = dmax;
-      if (dmin > tmin)
-        tmin = dmin;
-    }
+    return 0.5 * (tmax + tmin) * 1.07;
   }
 
-  for (int l = 1; l <= (int)N_LAYER; l++) {
-    if (layermask & (1 << (6 - l))) {
-      double lmax = settings.zlength() / settings.rmean(l - 1);
-      if (lmax < tmax)
-        tmax = lmax;
-    }
-  }
-
-  return 0.5 * (tmax + tmin) * 1.07;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackDerTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackDerTable.cc
@@ -6,7 +6,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackDerTable::TrackDerTable(Settings const& settings) : settings_(settings) {
   Nlay_ = N_LAYER;
@@ -1073,4 +1074,6 @@ double TrackDerTable::tpar(Settings const& settings, int diskmask, int layermask
   }
 
   return 0.5 * (tmax + tmin) * 1.07;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackFitMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackFitMemory.cc
@@ -8,34 +8,34 @@ using namespace std;
 
 namespace trklet {
 
-TrackFitMemory::TrackFitMemory(string name, Settings const& settings, double phimin, double phimax)
-    : MemoryBase(name, settings) {
-  phimin_ = phimin;
-  phimax_ = phimax;
-}
-
-void TrackFitMemory::writeTF(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirFT = settings_.memPath() + "FitTrack/";
-
-  std::ostringstream oss;
-  oss << dirFT << "TrackFit_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirFT, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
-
-  for (unsigned int j = 0; j < tracks_.size(); j++) {
-    out_ << hexstr(j) << " " << tracks_[j]->trackfitstr() << " " << trklet::hexFormat(tracks_[j]->trackfitstr());
-    out_ << "\n";
+  TrackFitMemory::TrackFitMemory(string name, Settings const& settings, double phimin, double phimax)
+      : MemoryBase(name, settings) {
+    phimin_ = phimin;
+    phimax_ = phimax;
   }
-  out_.close();
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
+  void TrackFitMemory::writeTF(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirFT = settings_.memPath() + "FitTrack/";
 
-}
+    std::ostringstream oss;
+    oss << dirFT << "TrackFit_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
+    auto const& fname = oss.str();
+
+    openfile(out_, first, dirFT, fname, __FILE__, __LINE__);
+
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+
+    for (unsigned int j = 0; j < tracks_.size(); j++) {
+      out_ << hexstr(j) << " " << tracks_[j]->trackfitstr() << " " << trklet::hexFormat(tracks_[j]->trackfitstr());
+      out_ << "\n";
+    }
+    out_.close();
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackFitMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackFitMemory.cc
@@ -5,7 +5,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackFitMemory::TrackFitMemory(string name, Settings const& settings, double phimin, double phimax)
     : MemoryBase(name, settings) {
@@ -35,4 +36,6 @@ void TrackFitMemory::writeTF(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -11,7 +11,8 @@
 #include <sstream>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 Tracklet::Tracklet(Settings const& settings,
                    unsigned int iSeed,
@@ -816,3 +817,5 @@ void Tracklet::setTrackIndex(int index) {
 }
 
 int Tracklet::trackIndex() const { return trackIndex_; }
+
+}

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -14,808 +14,811 @@ using namespace std;
 
 namespace trklet {
 
-Tracklet::Tracklet(Settings const& settings,
-                   unsigned int iSeed,
-                   const Stub* innerFPGAStub,
-                   const Stub* middleFPGAStub,
-                   const Stub* outerFPGAStub,
-                   double rinv,
-                   double phi0,
-                   double d0,
-                   double z0,
-                   double t,
-                   double rinvapprox,
-                   double phi0approx,
-                   double d0approx,
-                   double z0approx,
-                   double tapprox,
-                   int irinv,
-                   int iphi0,
-                   int id0,
-                   int iz0,
-                   int it,
-                   Projection projs[N_LAYER + N_DISK],
-                   bool disk,
-                   bool overlap)
-    : settings_(settings) {
-  seedIndex_ = iSeed;
+  Tracklet::Tracklet(Settings const& settings,
+                     unsigned int iSeed,
+                     const Stub* innerFPGAStub,
+                     const Stub* middleFPGAStub,
+                     const Stub* outerFPGAStub,
+                     double rinv,
+                     double phi0,
+                     double d0,
+                     double z0,
+                     double t,
+                     double rinvapprox,
+                     double phi0approx,
+                     double d0approx,
+                     double z0approx,
+                     double tapprox,
+                     int irinv,
+                     int iphi0,
+                     int id0,
+                     int iz0,
+                     int it,
+                     Projection projs[N_LAYER + N_DISK],
+                     bool disk,
+                     bool overlap)
+      : settings_(settings) {
+    seedIndex_ = iSeed;
 
-  overlap_ = overlap;
-  disk_ = disk;
-  assert(!(disk && overlap));
-  barrel_ = (!disk) && (!overlap);
-  triplet_ = false;
+    overlap_ = overlap;
+    disk_ = disk;
+    assert(!(disk && overlap));
+    barrel_ = (!disk) && (!overlap);
+    triplet_ = false;
 
-  trackletIndex_ = -1;
-  TCIndex_ = -1;
+    trackletIndex_ = -1;
+    TCIndex_ = -1;
 
-  assert(disk_ || barrel_ || overlap_);
+    assert(disk_ || barrel_ || overlap_);
 
-  if (barrel_ && middleFPGAStub == nullptr)
-    assert(innerFPGAStub->l1tstub()->layer() < N_LAYER);
+    if (barrel_ && middleFPGAStub == nullptr)
+      assert(innerFPGAStub->l1tstub()->layer() < N_LAYER);
 
-  innerFPGAStub_ = innerFPGAStub;
-  middleFPGAStub_ = middleFPGAStub;
-  outerFPGAStub_ = outerFPGAStub;
+    innerFPGAStub_ = innerFPGAStub;
+    middleFPGAStub_ = middleFPGAStub;
+    outerFPGAStub_ = outerFPGAStub;
 
-  trackpars_.init(rinv, phi0, d0, t, z0);
+    trackpars_.init(rinv, phi0, d0, t, z0);
 
-  trackparsapprox_.init(rinvapprox, phi0approx, d0approx, tapprox, z0approx);
+    trackparsapprox_.init(rinvapprox, phi0approx, d0approx, tapprox, z0approx);
 
-  fpgapars_.rinv().set(irinv, settings_.nbitsrinv(), false, __LINE__, __FILE__);
-  fpgapars_.phi0().set(iphi0, settings_.nbitsphi0(), false, __LINE__, __FILE__);
-  fpgapars_.d0().set(id0, settings_.nbitsd0(), false, __LINE__, __FILE__);
-  fpgapars_.z0().set(iz0, settings_.nbitsz0(), false, __LINE__, __FILE__);
-  fpgapars_.t().set(it, settings_.nbitst(), false, __LINE__, __FILE__);
+    fpgapars_.rinv().set(irinv, settings_.nbitsrinv(), false, __LINE__, __FILE__);
+    fpgapars_.phi0().set(iphi0, settings_.nbitsphi0(), false, __LINE__, __FILE__);
+    fpgapars_.d0().set(id0, settings_.nbitsd0(), false, __LINE__, __FILE__);
+    fpgapars_.z0().set(iz0, settings_.nbitsz0(), false, __LINE__, __FILE__);
+    fpgapars_.t().set(it, settings_.nbitst(), false, __LINE__, __FILE__);
 
-  fpgatrack_ = nullptr;
+    fpgatrack_ = nullptr;
 
-  triplet_ = (seedIndex_ >= 8);
+    triplet_ = (seedIndex_ >= 8);
 
-  //fill projection layers
-  for (unsigned int i = 0; i < N_LAYER - 2; i++) {
-    projlayer_[i] = settings.projlayers(seedIndex_, i);
-  }
-
-  //fill projection disks
-  for (unsigned int i = 0; i < N_DISK; i++) {
-    projdisk_[i] = settings.projdisks(seedIndex_, i);
-  }
-
-  //Handle projections to the layers
-  for (unsigned int i = 0; i < N_LAYER - 2; i++) {
-    if (projlayer_[i] == 0)
-      continue;
-    if (!projs[projlayer_[i] - 1].valid())
-      continue;
-
-    proj_[projlayer_[i] - 1] = projs[projlayer_[i] - 1];
-  }
-  //Now handle projections to the disks
-  for (unsigned int i = 0; i < N_DISK; i++) {
-    if (projdisk_[i] == 0)
-      continue;
-    if (!projs[N_LAYER + projdisk_[i] - 1].valid())
-      continue;
-
-    proj_[N_LAYER + projdisk_[i] - 1] = projs[N_LAYER + projdisk_[i] - 1];
-  }
-
-  ichisqrphifit_.set(-1, 8, false);
-  ichisqrzfit_.set(-1, 8, false);
-}
-
-int Tracklet::tpseed() {
-  set<int> tpset;
-
-  set<int> tpsetstubinner;
-  set<int> tpsetstubouter;
-
-  vector<int> tps = innerFPGAStub_->l1tstub()->tps();
-  for (auto tp : tps) {
-    if (tp != 0) {
-      tpsetstubinner.insert(tp);
-      tpset.insert(abs(tp));
+    //fill projection layers
+    for (unsigned int i = 0; i < N_LAYER - 2; i++) {
+      projlayer_[i] = settings.projlayers(seedIndex_, i);
     }
-  }
 
-  tps = outerFPGAStub_->l1tstub()->tps();
-  for (auto tp : tps) {
-    if (tp != 0) {
-      tpsetstubouter.insert(tp);
-      tpset.insert(abs(tp));
+    //fill projection disks
+    for (unsigned int i = 0; i < N_DISK; i++) {
+      projdisk_[i] = settings.projdisks(seedIndex_, i);
     }
-  }
 
-  for (auto& tp : tpset) {
-    if (tpsetstubinner.find(tp) != tpsetstubinner.end() && tpsetstubinner.find(-tp) != tpsetstubinner.end() &&
-        tpsetstubouter.find(tp) != tpsetstubouter.end() && tpsetstubouter.find(-tp) != tpsetstubouter.end()) {
-      return tp;
+    //Handle projections to the layers
+    for (unsigned int i = 0; i < N_LAYER - 2; i++) {
+      if (projlayer_[i] == 0)
+        continue;
+      if (!projs[projlayer_[i] - 1].valid())
+        continue;
+
+      proj_[projlayer_[i] - 1] = projs[projlayer_[i] - 1];
     }
-  }
-  return 0;
-}
+    //Now handle projections to the disks
+    for (unsigned int i = 0; i < N_DISK; i++) {
+      if (projdisk_[i] == 0)
+        continue;
+      if (!projs[N_LAYER + projdisk_[i] - 1].valid())
+        continue;
 
-bool Tracklet::stubtruthmatch(const L1TStub* stub) {
-  set<int> tpset;
-  set<int> tpsetstub;
-  set<int> tpsetstubinner;
-  set<int> tpsetstubouter;
-
-  vector<int> tps = stub->tps();
-  for (auto tp : tps) {
-    if (tp != 0) {
-      tpsetstub.insert(tp);
-      tpset.insert(abs(tp));
+      proj_[N_LAYER + projdisk_[i] - 1] = projs[N_LAYER + projdisk_[i] - 1];
     }
+
+    ichisqrphifit_.set(-1, 8, false);
+    ichisqrzfit_.set(-1, 8, false);
   }
-  tps = innerFPGAStub_->l1tstub()->tps();
-  for (auto tp : tps) {
-    if (tp != 0) {
-      tpsetstubinner.insert(tp);
-      tpset.insert(abs(tp));
+
+  int Tracklet::tpseed() {
+    set<int> tpset;
+
+    set<int> tpsetstubinner;
+    set<int> tpsetstubouter;
+
+    vector<int> tps = innerFPGAStub_->l1tstub()->tps();
+    for (auto tp : tps) {
+      if (tp != 0) {
+        tpsetstubinner.insert(tp);
+        tpset.insert(abs(tp));
+      }
     }
-  }
-  tps = outerFPGAStub_->l1tstub()->tps();
-  for (auto tp : tps) {
-    if (tp != 0) {
-      tpsetstubouter.insert(tp);
-      tpset.insert(abs(tp));
+
+    tps = outerFPGAStub_->l1tstub()->tps();
+    for (auto tp : tps) {
+      if (tp != 0) {
+        tpsetstubouter.insert(tp);
+        tpset.insert(abs(tp));
+      }
     }
-  }
 
-  for (auto tp : tpset) {
-    if (tpsetstub.find(tp) != tpsetstub.end() && tpsetstub.find(-tp) != tpsetstub.end() &&
-        tpsetstubinner.find(tp) != tpsetstubinner.end() && tpsetstubinner.find(-tp) != tpsetstubinner.end() &&
-        tpsetstubouter.find(tp) != tpsetstubouter.end() && tpsetstubouter.find(-tp) != tpsetstubouter.end()) {
-      return true;
+    for (auto& tp : tpset) {
+      if (tpsetstubinner.find(tp) != tpsetstubinner.end() && tpsetstubinner.find(-tp) != tpsetstubinner.end() &&
+          tpsetstubouter.find(tp) != tpsetstubouter.end() && tpsetstubouter.find(-tp) != tpsetstubouter.end()) {
+        return tp;
+      }
     }
+    return 0;
   }
 
-  return false;
-}
+  bool Tracklet::stubtruthmatch(const L1TStub* stub) {
+    set<int> tpset;
+    set<int> tpsetstub;
+    set<int> tpsetstubinner;
+    set<int> tpsetstubouter;
 
-std::string Tracklet::addressstr() {
-  std::string str;
-  str = innerFPGAStub_->phiregionaddressstr() + "|";
-  if (middleFPGAStub_) {
-    str += middleFPGAStub_->phiregionaddressstr() + "|";
+    vector<int> tps = stub->tps();
+    for (auto tp : tps) {
+      if (tp != 0) {
+        tpsetstub.insert(tp);
+        tpset.insert(abs(tp));
+      }
+    }
+    tps = innerFPGAStub_->l1tstub()->tps();
+    for (auto tp : tps) {
+      if (tp != 0) {
+        tpsetstubinner.insert(tp);
+        tpset.insert(abs(tp));
+      }
+    }
+    tps = outerFPGAStub_->l1tstub()->tps();
+    for (auto tp : tps) {
+      if (tp != 0) {
+        tpsetstubouter.insert(tp);
+        tpset.insert(abs(tp));
+      }
+    }
+
+    for (auto tp : tpset) {
+      if (tpsetstub.find(tp) != tpsetstub.end() && tpsetstub.find(-tp) != tpsetstub.end() &&
+          tpsetstubinner.find(tp) != tpsetstubinner.end() && tpsetstubinner.find(-tp) != tpsetstubinner.end() &&
+          tpsetstubouter.find(tp) != tpsetstubouter.end() && tpsetstubouter.find(-tp) != tpsetstubouter.end()) {
+        return true;
+      }
+    }
+
+    return false;
   }
-  str += outerFPGAStub_->phiregionaddressstr();
 
-  return str;
-}
-
-std::string Tracklet::trackletparstr() {
-  if (settings_.writeoutReal()) {
-    std::string oss = std::to_string(fpgapars_.rinv().value() * settings_.krinvpars()) + " " +
-                      std::to_string(fpgapars_.phi0().value() * settings_.kphi0pars()) + " " +
-                      std::to_string(fpgapars_.d0().value() * settings_.kd0pars()) + " " +
-                      std::to_string(fpgapars_.z0().value() * settings_.kz()) + " " +
-                      std::to_string(fpgapars_.t().value() * settings_.ktpars());
-    return oss;
-  } else {
-    std::string str = innerFPGAStub_->stubindex().str() + "|";
+  std::string Tracklet::addressstr() {
+    std::string str;
+    str = innerFPGAStub_->phiregionaddressstr() + "|";
     if (middleFPGAStub_) {
-      str += middleFPGAStub_->stubindex().str() + "|";
+      str += middleFPGAStub_->phiregionaddressstr() + "|";
     }
-    str += outerFPGAStub_->stubindex().str() + "|" + fpgapars_.rinv().str() + "|" + fpgapars_.phi0().str() + "|";
-    if (middleFPGAStub_)
-      str += fpgapars_.d0().str() + "|";
-    str += fpgapars_.z0().str() + "|" + fpgapars_.t().str();
+    str += outerFPGAStub_->phiregionaddressstr();
+
     return str;
   }
-}
 
-std::string Tracklet::vmstrlayer(int layer, unsigned int allstubindex) {
-  FPGAWord index;
-  if (allstubindex >= (1 << 7)) {
-    edm::LogPrint("Tracklet") << "Warning projection number too large!";
-    index.set((1 << 7) - 1, 7, true, __LINE__, __FILE__);
-  } else {
-    index.set(allstubindex, 7, true, __LINE__, __FILE__);
-  }
-
-  // This is a shortcut.
-  //int irinvvm=16+(fpgarinv().value()>>(fpgarinv().nbits()-5));
-  // rinv is not directly available in the TrackletProjection.
-  // can be inferred from phi derivative: rinv = - phider * 2
-  int tmp_irinv = proj_[layer - 1].fpgaphiprojder().value() * (-2);
-  int nbits_irinv = proj_[layer - 1].fpgaphiprojder().nbits() + 1;
-
-  // irinv in VMProjection:
-  // top 5 bits of rinv and shifted to be positive
-  int irinvvm = 16 + (tmp_irinv >> (nbits_irinv - 5));
-
-  if (settings_.extended() && (irinvvm > 31)) {  //TODO - displaced tracking should protect against this
-    edm::LogPrint("Tracklet") << "Warning irinvvm too large:" << irinvvm;
-    irinvvm = 31;
-  }
-
-  assert(irinvvm >= 0);
-  assert(irinvvm < 32);
-  FPGAWord tmp;
-  tmp.set(irinvvm, 5, true, __LINE__, __FILE__);
-  std::string oss = index.str() + "|" + proj_[layer - 1].fpgarzbin1projvm().str() + "|" +
-                    proj_[layer - 1].fpgarzbin2projvm().str() + "|" + proj_[layer - 1].fpgafinerzvm().str() + "|" +
-                    proj_[layer - 1].fpgafinephivm().str() + "|" + tmp.str() + "|" + std::to_string(PSseed());
-  return oss;
-}
-
-std::string Tracklet::vmstrdisk(int disk, unsigned int allstubindex) {
-  FPGAWord index;
-  if (allstubindex >= (1 << 7)) {
-    edm::LogPrint("Tracklet") << "Warning projection number too large!";
-    index.set((1 << 7) - 1, 7, true, __LINE__, __FILE__);
-  } else {
-    index.set(allstubindex, 7, true, __LINE__, __FILE__);
-  }
-  std::string oss =
-      index.str() + "|" + proj_[N_LAYER + disk - 1].fpgarzbin1projvm().str() + "|" +
-      proj_[N_LAYER + disk - 1].fpgarzbin2projvm().str() + "|" + proj_[N_LAYER + disk - 1].fpgafinerzvm().str() + "|" +
-      proj_[N_LAYER + disk - 1].fpgafinephivm().str() + "|" + proj_[N_LAYER + disk - 1].getBendIndex().str();
-  return oss;
-}
-
-std::string Tracklet::trackletprojstr(int layer) const {
-  assert(layer > 0 && layer <= N_LAYER);
-  FPGAWord tmp;
-  if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
-    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
-  }
-  tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
-  FPGAWord tcid;
-  tcid.set(TCIndex_, settings_.nbitstcindex(), true, __LINE__, __FILE__);
-
-  std::string oss = tcid.str() + "|" + tmp.str() + "|" + proj_[layer - 1].fpgaphiproj().str() + "|" +
-                    proj_[layer - 1].fpgarzproj().str() + "|" + proj_[layer - 1].fpgaphiprojder().str() + "|" +
-                    proj_[layer - 1].fpgarzprojder().str();
-  return oss;
-}
-
-std::string Tracklet::trackletprojstrD(int disk) const {
-  assert(abs(disk) <= N_DISK);
-  FPGAWord tmp;
-  if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
-    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
-  }
-  tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
-  FPGAWord tcid;
-  if (settings_.extended()) {
-    tcid.set(TCIndex_, 8, true, __LINE__, __FILE__);
-  } else {
-    tcid.set(TCIndex_, 7, true, __LINE__, __FILE__);
-  }
-  std::string oss = tcid.str() + "|" + tmp.str() + "|" + proj_[N_LAYER + abs(disk) - 1].fpgaphiproj().str() + "|" +
-                    proj_[N_LAYER + abs(disk) - 1].fpgarzproj().str() + "|" +
-                    proj_[N_LAYER + abs(disk) - 1].fpgaphiprojder().str() + "|" +
-                    proj_[N_LAYER + abs(disk) - 1].fpgarzprojder().str();
-  return oss;
-}
-
-void Tracklet::addMatch(unsigned int layerdisk,
-                        int ideltaphi,
-                        int ideltarz,
-                        double dphi,
-                        double drz,
-                        double dphiapprox,
-                        double drzapprox,
-                        int stubid,
-                        const trklet::Stub* stubptr) {
-  assert(layerdisk < N_LAYER + N_DISK);
-  resid_[layerdisk].init(settings_, layerdisk, ideltaphi, ideltarz, stubid, dphi, drz, dphiapprox, drzapprox, stubptr);
-}
-
-std::string Tracklet::fullmatchstr(int layer) {
-  assert(layer > 0 && layer <= N_LAYER);
-
-  FPGAWord tmp;
-  if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
-    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
-  }
-  tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
-  FPGAWord tcid;
-  tcid.set(TCIndex_, settings_.nbitstcindex(), true, __LINE__, __FILE__);
-  std::string oss = tcid.str() + "|" + tmp.str() + "|" + resid_[layer - 1].fpgastubid().str() + "|" +
-                    resid_[layer - 1].stubptr()->r().str() + "|" + resid_[layer - 1].fpgaphiresid().str() + "|" +
-                    resid_[layer - 1].fpgarzresid().str();
-  return oss;
-}
-
-std::string Tracklet::fullmatchdiskstr(int disk) {
-  assert(disk > 0 && disk <= N_DISK);
-
-  FPGAWord tmp;
-  if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
-    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
-  }
-  tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
-  FPGAWord tcid;
-  tcid.set(TCIndex_, settings_.nbitstcindex(), true, __LINE__, __FILE__);
-  const FPGAWord& stubr = resid_[N_LAYER + disk - 1].stubptr()->r();
-  const bool isPS = resid_[N_LAYER + disk - 1].stubptr()->isPSmodule();
-  std::string oss = tcid.str() + "|" + tmp.str() + "|" + resid_[N_LAYER + disk - 1].fpgastubid().str() + "|" +
-                    (isPS ? stubr.str() : ("00000000" + stubr.str())) + "|" +
-                    resid_[N_LAYER + disk - 1].fpgaphiresid().str() + "|" +
-                    resid_[N_LAYER + disk - 1].fpgarzresid().str();
-  return oss;
-}
-
-std::vector<const L1TStub*> Tracklet::getL1Stubs() {
-  std::vector<const L1TStub*> tmp;
-
-  if (innerFPGAStub_)
-    tmp.push_back(innerFPGAStub_->l1tstub());
-  if (middleFPGAStub_)
-    tmp.push_back(middleFPGAStub_->l1tstub());
-  if (outerFPGAStub_)
-    tmp.push_back(outerFPGAStub_->l1tstub());
-
-  for (const auto& iresid : resid_) {
-    if (iresid.valid())
-      tmp.push_back(iresid.stubptr()->l1tstub());
-  }
-
-  return tmp;
-}
-
-std::map<int, int> Tracklet::getStubIDs() {
-  std::map<int, int> stubIDs;
-
-  // For future reference, *resid_[i] uses i as the absolute stub index. (0-5 for barrel, 0-4 for disk)
-  // On the other hand, proj*_[i] uses i almost like *resid_[i], except the *seeding* layer indices are removed entirely.
-  // E.g. An L3L4 track has 0=L1, 1=L2, 2=L4, 3=L5 for the barrels (for proj*_[i])
-
-  if (innerFPGAStub_)
-    assert(innerFPGAStub_->stubindex().nbits() == N_BITSMEMADDRESS);
-  if (middleFPGAStub_)
-    assert(middleFPGAStub_->stubindex().nbits() == N_BITSMEMADDRESS);
-  if (outerFPGAStub_)
-    assert(outerFPGAStub_->stubindex().nbits() == N_BITSMEMADDRESS);
-
-  if (barrel_) {
-    for (int i = 0; i < N_LAYER; i++) {
-      //check barrel
-      if (resid_[i].valid()) {
-        // two extra bits to indicate if the matched stub is local or from neighbor
-        int location = 1;  // local
-        location <<= resid_[i].fpgastubid().nbits();
-
-        stubIDs[1 + i] = resid_[i].fpgastubid().value() + location;
+  std::string Tracklet::trackletparstr() {
+    if (settings_.writeoutReal()) {
+      std::string oss = std::to_string(fpgapars_.rinv().value() * settings_.krinvpars()) + " " +
+                        std::to_string(fpgapars_.phi0().value() * settings_.kphi0pars()) + " " +
+                        std::to_string(fpgapars_.d0().value() * settings_.kd0pars()) + " " +
+                        std::to_string(fpgapars_.z0().value() * settings_.kz()) + " " +
+                        std::to_string(fpgapars_.t().value() * settings_.ktpars());
+      return oss;
+    } else {
+      std::string str = innerFPGAStub_->stubindex().str() + "|";
+      if (middleFPGAStub_) {
+        str += middleFPGAStub_->stubindex().str() + "|";
       }
+      str += outerFPGAStub_->stubindex().str() + "|" + fpgapars_.rinv().str() + "|" + fpgapars_.phi0().str() + "|";
+      if (middleFPGAStub_)
+        str += fpgapars_.d0().str() + "|";
+      str += fpgapars_.z0().str() + "|" + fpgapars_.t().str();
+      return str;
+    }
+  }
 
-      //check disk
-      if (i >= N_DISK)
-        continue;  //i=[0..4] for disks
-      if (resid_[N_LAYER + i].valid()) {
-        if (i == 3 && resid_[0].valid() && innerFPGAStub_->layer().value() == 1)
-          continue;  // Don't add D4 if track has L1 stub
-        // two extra bits to indicate if the matched stub is local or from neighbor
-        int location = 1;  // local
-        location <<= resid_[N_LAYER + i].fpgastubid().nbits();
-
-        if (itfit().value() < 0) {
-          stubIDs[-(N_LAYER + N_DISK) - i] = resid_[N_LAYER + i].fpgastubid().value() + location;
-        } else {
-          stubIDs[N_LAYER + N_DISK + i] = resid_[N_LAYER + i].fpgastubid().value() + location;
-        }
-      }
+  std::string Tracklet::vmstrlayer(int layer, unsigned int allstubindex) {
+    FPGAWord index;
+    if (allstubindex >= (1 << 7)) {
+      edm::LogPrint("Tracklet") << "Warning projection number too large!";
+      index.set((1 << 7) - 1, 7, true, __LINE__, __FILE__);
+    } else {
+      index.set(allstubindex, 7, true, __LINE__, __FILE__);
     }
 
-    //get stubs making up tracklet
+    // This is a shortcut.
+    //int irinvvm=16+(fpgarinv().value()>>(fpgarinv().nbits()-5));
+    // rinv is not directly available in the TrackletProjection.
+    // can be inferred from phi derivative: rinv = - phider * 2
+    int tmp_irinv = proj_[layer - 1].fpgaphiprojder().value() * (-2);
+    int nbits_irinv = proj_[layer - 1].fpgaphiprojder().nbits() + 1;
+
+    // irinv in VMProjection:
+    // top 5 bits of rinv and shifted to be positive
+    int irinvvm = 16 + (tmp_irinv >> (nbits_irinv - 5));
+
+    if (settings_.extended() && (irinvvm > 31)) {  //TODO - displaced tracking should protect against this
+      edm::LogPrint("Tracklet") << "Warning irinvvm too large:" << irinvvm;
+      irinvvm = 31;
+    }
+
+    assert(irinvvm >= 0);
+    assert(irinvvm < 32);
+    FPGAWord tmp;
+    tmp.set(irinvvm, 5, true, __LINE__, __FILE__);
+    std::string oss = index.str() + "|" + proj_[layer - 1].fpgarzbin1projvm().str() + "|" +
+                      proj_[layer - 1].fpgarzbin2projvm().str() + "|" + proj_[layer - 1].fpgafinerzvm().str() + "|" +
+                      proj_[layer - 1].fpgafinephivm().str() + "|" + tmp.str() + "|" + std::to_string(PSseed());
+    return oss;
+  }
+
+  std::string Tracklet::vmstrdisk(int disk, unsigned int allstubindex) {
+    FPGAWord index;
+    if (allstubindex >= (1 << 7)) {
+      edm::LogPrint("Tracklet") << "Warning projection number too large!";
+      index.set((1 << 7) - 1, 7, true, __LINE__, __FILE__);
+    } else {
+      index.set(allstubindex, 7, true, __LINE__, __FILE__);
+    }
+    std::string oss =
+        index.str() + "|" + proj_[N_LAYER + disk - 1].fpgarzbin1projvm().str() + "|" +
+        proj_[N_LAYER + disk - 1].fpgarzbin2projvm().str() + "|" + proj_[N_LAYER + disk - 1].fpgafinerzvm().str() +
+        "|" + proj_[N_LAYER + disk - 1].fpgafinephivm().str() + "|" + proj_[N_LAYER + disk - 1].getBendIndex().str();
+    return oss;
+  }
+
+  std::string Tracklet::trackletprojstr(int layer) const {
+    assert(layer > 0 && layer <= N_LAYER);
+    FPGAWord tmp;
+    if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
+      throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
+    }
+    tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
+    FPGAWord tcid;
+    tcid.set(TCIndex_, settings_.nbitstcindex(), true, __LINE__, __FILE__);
+
+    std::string oss = tcid.str() + "|" + tmp.str() + "|" + proj_[layer - 1].fpgaphiproj().str() + "|" +
+                      proj_[layer - 1].fpgarzproj().str() + "|" + proj_[layer - 1].fpgaphiprojder().str() + "|" +
+                      proj_[layer - 1].fpgarzprojder().str();
+    return oss;
+  }
+
+  std::string Tracklet::trackletprojstrD(int disk) const {
+    assert(abs(disk) <= N_DISK);
+    FPGAWord tmp;
+    if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
+      throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
+    }
+    tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
+    FPGAWord tcid;
+    if (settings_.extended()) {
+      tcid.set(TCIndex_, 8, true, __LINE__, __FILE__);
+    } else {
+      tcid.set(TCIndex_, 7, true, __LINE__, __FILE__);
+    }
+    std::string oss = tcid.str() + "|" + tmp.str() + "|" + proj_[N_LAYER + abs(disk) - 1].fpgaphiproj().str() + "|" +
+                      proj_[N_LAYER + abs(disk) - 1].fpgarzproj().str() + "|" +
+                      proj_[N_LAYER + abs(disk) - 1].fpgaphiprojder().str() + "|" +
+                      proj_[N_LAYER + abs(disk) - 1].fpgarzprojder().str();
+    return oss;
+  }
+
+  void Tracklet::addMatch(unsigned int layerdisk,
+                          int ideltaphi,
+                          int ideltarz,
+                          double dphi,
+                          double drz,
+                          double dphiapprox,
+                          double drzapprox,
+                          int stubid,
+                          const trklet::Stub* stubptr) {
+    assert(layerdisk < N_LAYER + N_DISK);
+    resid_[layerdisk].init(
+        settings_, layerdisk, ideltaphi, ideltarz, stubid, dphi, drz, dphiapprox, drzapprox, stubptr);
+  }
+
+  std::string Tracklet::fullmatchstr(int layer) {
+    assert(layer > 0 && layer <= N_LAYER);
+
+    FPGAWord tmp;
+    if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
+      throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
+    }
+    tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
+    FPGAWord tcid;
+    tcid.set(TCIndex_, settings_.nbitstcindex(), true, __LINE__, __FILE__);
+    std::string oss = tcid.str() + "|" + tmp.str() + "|" + resid_[layer - 1].fpgastubid().str() + "|" +
+                      resid_[layer - 1].stubptr()->r().str() + "|" + resid_[layer - 1].fpgaphiresid().str() + "|" +
+                      resid_[layer - 1].fpgarzresid().str();
+    return oss;
+  }
+
+  std::string Tracklet::fullmatchdiskstr(int disk) {
+    assert(disk > 0 && disk <= N_DISK);
+
+    FPGAWord tmp;
+    if (trackletIndex_ < 0 || trackletIndex_ > (int)settings_.ntrackletmax()) {
+      throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " trackletIndex_ = " << trackletIndex_;
+    }
+    tmp.set(trackletIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
+    FPGAWord tcid;
+    tcid.set(TCIndex_, settings_.nbitstcindex(), true, __LINE__, __FILE__);
+    const FPGAWord& stubr = resid_[N_LAYER + disk - 1].stubptr()->r();
+    const bool isPS = resid_[N_LAYER + disk - 1].stubptr()->isPSmodule();
+    std::string oss = tcid.str() + "|" + tmp.str() + "|" + resid_[N_LAYER + disk - 1].fpgastubid().str() + "|" +
+                      (isPS ? stubr.str() : ("00000000" + stubr.str())) + "|" +
+                      resid_[N_LAYER + disk - 1].fpgaphiresid().str() + "|" +
+                      resid_[N_LAYER + disk - 1].fpgarzresid().str();
+    return oss;
+  }
+
+  std::vector<const L1TStub*> Tracklet::getL1Stubs() {
+    std::vector<const L1TStub*> tmp;
+
     if (innerFPGAStub_)
-      stubIDs[innerFPGAStub_->layer().value() + 1] = innerFPGAStub_->phiregionaddress() + (1 << 10);
+      tmp.push_back(innerFPGAStub_->l1tstub());
     if (middleFPGAStub_)
-      stubIDs[middleFPGAStub_->layer().value() + 1] = middleFPGAStub_->phiregionaddress() + (1 << 10);
+      tmp.push_back(middleFPGAStub_->l1tstub());
     if (outerFPGAStub_)
-      stubIDs[outerFPGAStub_->layer().value() + 1] = outerFPGAStub_->phiregionaddress() + (1 << 10);
+      tmp.push_back(outerFPGAStub_->l1tstub());
 
-  } else if (disk_) {
-    for (int i = 0; i < N_DISK; i++) {
-      //check barrel
-      if (resid_[i].valid()) {
-        // two extra bits to indicate if the matched stub is local or from neighbor
-        int location = 1;  // local
-        location <<= resid_[i].fpgastubid().nbits();
+    for (const auto& iresid : resid_) {
+      if (iresid.valid())
+        tmp.push_back(iresid.stubptr()->l1tstub());
+    }
 
-        stubIDs[1 + i] = resid_[i].fpgastubid().value() + location;
-      }
+    return tmp;
+  }
 
-      //check disks
-      if (i == 4 && resid_[1].valid())
-        continue;  // Don't add D5 if track has L2 stub
-      if (resid_[N_LAYER + i].valid()) {
-        // two extra bits to indicate if the matched stub is local or from neighbor
-        int location = 1;  // local
-        location <<= resid_[N_LAYER + i].fpgastubid().nbits();
+  std::map<int, int> Tracklet::getStubIDs() {
+    std::map<int, int> stubIDs;
 
-        if (innerFPGAStub_->l1tstub()->disk() < 0) {
-          stubIDs[-11 - i] = resid_[N_LAYER + i].fpgastubid().value() + location;
-        } else {
-          stubIDs[11 + i] = resid_[N_LAYER + i].fpgastubid().value() + location;
+    // For future reference, *resid_[i] uses i as the absolute stub index. (0-5 for barrel, 0-4 for disk)
+    // On the other hand, proj*_[i] uses i almost like *resid_[i], except the *seeding* layer indices are removed entirely.
+    // E.g. An L3L4 track has 0=L1, 1=L2, 2=L4, 3=L5 for the barrels (for proj*_[i])
+
+    if (innerFPGAStub_)
+      assert(innerFPGAStub_->stubindex().nbits() == N_BITSMEMADDRESS);
+    if (middleFPGAStub_)
+      assert(middleFPGAStub_->stubindex().nbits() == N_BITSMEMADDRESS);
+    if (outerFPGAStub_)
+      assert(outerFPGAStub_->stubindex().nbits() == N_BITSMEMADDRESS);
+
+    if (barrel_) {
+      for (int i = 0; i < N_LAYER; i++) {
+        //check barrel
+        if (resid_[i].valid()) {
+          // two extra bits to indicate if the matched stub is local or from neighbor
+          int location = 1;  // local
+          location <<= resid_[i].fpgastubid().nbits();
+
+          stubIDs[1 + i] = resid_[i].fpgastubid().value() + location;
         }
-      }
-    }
 
-    //get stubs making up tracklet
-    if (innerFPGAStub_->disk().value() < 0) {  //negative side runs 6-10
-      if (innerFPGAStub_)
-        stubIDs[innerFPGAStub_->disk().value() - 10] = innerFPGAStub_->phiregionaddress() + (1 << 10);
-      if (middleFPGAStub_)
-        stubIDs[middleFPGAStub_->disk().value() - 10] = middleFPGAStub_->phiregionaddress() + (1 << 10);
-      if (outerFPGAStub_)
-        stubIDs[outerFPGAStub_->disk().value() - 10] = outerFPGAStub_->phiregionaddress() + (1 << 10);
-    } else {  // positive side runs 11-15]
-      if (innerFPGAStub_)
-        stubIDs[innerFPGAStub_->disk().value() + 10] = innerFPGAStub_->phiregionaddress() + (1 << 10);
-      if (middleFPGAStub_)
-        stubIDs[middleFPGAStub_->disk().value() + 10] = middleFPGAStub_->phiregionaddress() + (1 << 10);
-      if (outerFPGAStub_)
-        stubIDs[outerFPGAStub_->disk().value() + 10] = outerFPGAStub_->phiregionaddress() + (1 << 10);
-    }
+        //check disk
+        if (i >= N_DISK)
+          continue;  //i=[0..4] for disks
+        if (resid_[N_LAYER + i].valid()) {
+          if (i == 3 && resid_[0].valid() && innerFPGAStub_->layer().value() == 1)
+            continue;  // Don't add D4 if track has L1 stub
+          // two extra bits to indicate if the matched stub is local or from neighbor
+          int location = 1;  // local
+          location <<= resid_[N_LAYER + i].fpgastubid().nbits();
 
-  } else if (overlap_) {
-    for (int i = 0; i < N_DISK; i++) {
-      //check barrel
-      if (resid_[i].valid()) {
-        // two extra bits to indicate if the matched stub is local or from neighbor
-        int location = 1;  // local
-        location <<= resid_[i].fpgastubid().nbits();
-
-        stubIDs[1 + i] = resid_[i].fpgastubid().value() + location;
-      }
-
-      //check disks
-      if (resid_[N_LAYER + i].valid()) {
-        // two extra bits to indicate if the matched stub is local or from neighbor
-        int location = 1;  // local
-        location <<= resid_[N_LAYER + i].fpgastubid().nbits();
-
-        if (innerFPGAStub_->l1tstub()->disk() < 0) {  // if negative overlap
-          if (innerFPGAStub_->layer().value() != 2 || !resid_[0].valid() ||
-              i != 3) {  // Don't add D4 if this is an L3L2 track with an L1 stub
-            stubIDs[-11 - i] = resid_[N_LAYER + i].fpgastubid().value() + location;
-          }
-        } else {
-          if (innerFPGAStub_->layer().value() != 2 || !resid_[0].valid() || i != 3) {
-            stubIDs[11 + i] = resid_[N_LAYER + i].fpgastubid().value() + location;
+          if (itfit().value() < 0) {
+            stubIDs[-(N_LAYER + N_DISK) - i] = resid_[N_LAYER + i].fpgastubid().value() + location;
+          } else {
+            stubIDs[N_LAYER + N_DISK + i] = resid_[N_LAYER + i].fpgastubid().value() + location;
           }
         }
       }
-    }
 
-    //get stubs making up tracklet
-
-    if (innerFPGAStub_->layer().value() == 2) {  // L3L2 track
+      //get stubs making up tracklet
       if (innerFPGAStub_)
         stubIDs[innerFPGAStub_->layer().value() + 1] = innerFPGAStub_->phiregionaddress() + (1 << 10);
       if (middleFPGAStub_)
         stubIDs[middleFPGAStub_->layer().value() + 1] = middleFPGAStub_->phiregionaddress() + (1 << 10);
       if (outerFPGAStub_)
         stubIDs[outerFPGAStub_->layer().value() + 1] = outerFPGAStub_->phiregionaddress() + (1 << 10);
-    } else if (innerFPGAStub_->disk().value() < 0) {  //negative side runs -11 - -15
-      if (innerFPGAStub_)
-        stubIDs[innerFPGAStub_->disk().value() - 10] = innerFPGAStub_->phiregionaddress() + (1 << 10);
-      if (middleFPGAStub_)
-        stubIDs[middleFPGAStub_->layer().value() + 1] = middleFPGAStub_->phiregionaddress() + (1 << 10);
-      if (outerFPGAStub_)
-        stubIDs[outerFPGAStub_->layer().value() + 1] = outerFPGAStub_->phiregionaddress() + (1 << 10);
-    } else {  // positive side runs 11-15]
-      if (innerFPGAStub_)
-        stubIDs[innerFPGAStub_->disk().value() + 10] = innerFPGAStub_->phiregionaddress() + (1 << 10);
-      if (middleFPGAStub_)
-        stubIDs[middleFPGAStub_->layer().value() + 1] = middleFPGAStub_->phiregionaddress() + (1 << 10);
-      if (outerFPGAStub_)
-        stubIDs[outerFPGAStub_->layer().value() + 1] = outerFPGAStub_->phiregionaddress() + (1 << 10);
+
+    } else if (disk_) {
+      for (int i = 0; i < N_DISK; i++) {
+        //check barrel
+        if (resid_[i].valid()) {
+          // two extra bits to indicate if the matched stub is local or from neighbor
+          int location = 1;  // local
+          location <<= resid_[i].fpgastubid().nbits();
+
+          stubIDs[1 + i] = resid_[i].fpgastubid().value() + location;
+        }
+
+        //check disks
+        if (i == 4 && resid_[1].valid())
+          continue;  // Don't add D5 if track has L2 stub
+        if (resid_[N_LAYER + i].valid()) {
+          // two extra bits to indicate if the matched stub is local or from neighbor
+          int location = 1;  // local
+          location <<= resid_[N_LAYER + i].fpgastubid().nbits();
+
+          if (innerFPGAStub_->l1tstub()->disk() < 0) {
+            stubIDs[-11 - i] = resid_[N_LAYER + i].fpgastubid().value() + location;
+          } else {
+            stubIDs[11 + i] = resid_[N_LAYER + i].fpgastubid().value() + location;
+          }
+        }
+      }
+
+      //get stubs making up tracklet
+      if (innerFPGAStub_->disk().value() < 0) {  //negative side runs 6-10
+        if (innerFPGAStub_)
+          stubIDs[innerFPGAStub_->disk().value() - 10] = innerFPGAStub_->phiregionaddress() + (1 << 10);
+        if (middleFPGAStub_)
+          stubIDs[middleFPGAStub_->disk().value() - 10] = middleFPGAStub_->phiregionaddress() + (1 << 10);
+        if (outerFPGAStub_)
+          stubIDs[outerFPGAStub_->disk().value() - 10] = outerFPGAStub_->phiregionaddress() + (1 << 10);
+      } else {  // positive side runs 11-15]
+        if (innerFPGAStub_)
+          stubIDs[innerFPGAStub_->disk().value() + 10] = innerFPGAStub_->phiregionaddress() + (1 << 10);
+        if (middleFPGAStub_)
+          stubIDs[middleFPGAStub_->disk().value() + 10] = middleFPGAStub_->phiregionaddress() + (1 << 10);
+        if (outerFPGAStub_)
+          stubIDs[outerFPGAStub_->disk().value() + 10] = outerFPGAStub_->phiregionaddress() + (1 << 10);
+      }
+
+    } else if (overlap_) {
+      for (int i = 0; i < N_DISK; i++) {
+        //check barrel
+        if (resid_[i].valid()) {
+          // two extra bits to indicate if the matched stub is local or from neighbor
+          int location = 1;  // local
+          location <<= resid_[i].fpgastubid().nbits();
+
+          stubIDs[1 + i] = resid_[i].fpgastubid().value() + location;
+        }
+
+        //check disks
+        if (resid_[N_LAYER + i].valid()) {
+          // two extra bits to indicate if the matched stub is local or from neighbor
+          int location = 1;  // local
+          location <<= resid_[N_LAYER + i].fpgastubid().nbits();
+
+          if (innerFPGAStub_->l1tstub()->disk() < 0) {  // if negative overlap
+            if (innerFPGAStub_->layer().value() != 2 || !resid_[0].valid() ||
+                i != 3) {  // Don't add D4 if this is an L3L2 track with an L1 stub
+              stubIDs[-11 - i] = resid_[N_LAYER + i].fpgastubid().value() + location;
+            }
+          } else {
+            if (innerFPGAStub_->layer().value() != 2 || !resid_[0].valid() || i != 3) {
+              stubIDs[11 + i] = resid_[N_LAYER + i].fpgastubid().value() + location;
+            }
+          }
+        }
+      }
+
+      //get stubs making up tracklet
+
+      if (innerFPGAStub_->layer().value() == 2) {  // L3L2 track
+        if (innerFPGAStub_)
+          stubIDs[innerFPGAStub_->layer().value() + 1] = innerFPGAStub_->phiregionaddress() + (1 << 10);
+        if (middleFPGAStub_)
+          stubIDs[middleFPGAStub_->layer().value() + 1] = middleFPGAStub_->phiregionaddress() + (1 << 10);
+        if (outerFPGAStub_)
+          stubIDs[outerFPGAStub_->layer().value() + 1] = outerFPGAStub_->phiregionaddress() + (1 << 10);
+      } else if (innerFPGAStub_->disk().value() < 0) {  //negative side runs -11 - -15
+        if (innerFPGAStub_)
+          stubIDs[innerFPGAStub_->disk().value() - 10] = innerFPGAStub_->phiregionaddress() + (1 << 10);
+        if (middleFPGAStub_)
+          stubIDs[middleFPGAStub_->layer().value() + 1] = middleFPGAStub_->phiregionaddress() + (1 << 10);
+        if (outerFPGAStub_)
+          stubIDs[outerFPGAStub_->layer().value() + 1] = outerFPGAStub_->phiregionaddress() + (1 << 10);
+      } else {  // positive side runs 11-15]
+        if (innerFPGAStub_)
+          stubIDs[innerFPGAStub_->disk().value() + 10] = innerFPGAStub_->phiregionaddress() + (1 << 10);
+        if (middleFPGAStub_)
+          stubIDs[middleFPGAStub_->layer().value() + 1] = middleFPGAStub_->phiregionaddress() + (1 << 10);
+        if (outerFPGAStub_)
+          stubIDs[outerFPGAStub_->layer().value() + 1] = outerFPGAStub_->phiregionaddress() + (1 << 10);
+      }
     }
+
+    return stubIDs;
   }
 
-  return stubIDs;
-}
+  void Tracklet::setFitPars(double rinvfit,
+                            double phi0fit,
+                            double d0fit,
+                            double tfit,
+                            double z0fit,
+                            double chisqrphifit,
+                            double chisqrzfit,
+                            double rinvfitexact,
+                            double phi0fitexact,
+                            double d0fitexact,
+                            double tfitexact,
+                            double z0fitexact,
+                            double chisqrphifitexact,
+                            double chisqrzfitexact,
+                            int irinvfit,
+                            int iphi0fit,
+                            int id0fit,
+                            int itfit,
+                            int iz0fit,
+                            int ichisqrphifit,
+                            int ichisqrzfit,
+                            int hitpattern,
+                            const vector<const L1TStub*>& l1stubs) {
+    fitpars_.init(rinvfit, phi0fit, d0fit, tfit, z0fit);
+    chisqrphifit_ = chisqrphifit;
+    chisqrzfit_ = chisqrzfit;
 
-void Tracklet::setFitPars(double rinvfit,
-                          double phi0fit,
-                          double d0fit,
-                          double tfit,
-                          double z0fit,
-                          double chisqrphifit,
-                          double chisqrzfit,
-                          double rinvfitexact,
-                          double phi0fitexact,
-                          double d0fitexact,
-                          double tfitexact,
-                          double z0fitexact,
-                          double chisqrphifitexact,
-                          double chisqrzfitexact,
-                          int irinvfit,
-                          int iphi0fit,
-                          int id0fit,
-                          int itfit,
-                          int iz0fit,
-                          int ichisqrphifit,
-                          int ichisqrzfit,
-                          int hitpattern,
-                          const vector<const L1TStub*>& l1stubs) {
-  fitpars_.init(rinvfit, phi0fit, d0fit, tfit, z0fit);
-  chisqrphifit_ = chisqrphifit;
-  chisqrzfit_ = chisqrzfit;
+    fitparsexact_.init(rinvfitexact, phi0fitexact, d0fitexact, tfitexact, z0fitexact);
+    chisqrphifitexact_ = chisqrphifitexact;
+    chisqrzfitexact_ = chisqrzfitexact;
 
-  fitparsexact_.init(rinvfitexact, phi0fitexact, d0fitexact, tfitexact, z0fitexact);
-  chisqrphifitexact_ = chisqrphifitexact;
-  chisqrzfitexact_ = chisqrzfitexact;
+    if (irinvfit > (1 << 14))
+      irinvfit = (1 << 14);
+    if (irinvfit <= -(1 << 14))
+      irinvfit = -(1 << 14) + 1;
+    fpgafitpars_.rinv().set(irinvfit, 15, false, __LINE__, __FILE__);
+    fpgafitpars_.phi0().set(iphi0fit, 19, false, __LINE__, __FILE__);
+    fpgafitpars_.d0().set(id0fit, 19, false, __LINE__, __FILE__);
+    fpgafitpars_.t().set(itfit, 14, false, __LINE__, __FILE__);
 
-  if (irinvfit > (1 << 14))
-    irinvfit = (1 << 14);
-  if (irinvfit <= -(1 << 14))
-    irinvfit = -(1 << 14) + 1;
-  fpgafitpars_.rinv().set(irinvfit, 15, false, __LINE__, __FILE__);
-  fpgafitpars_.phi0().set(iphi0fit, 19, false, __LINE__, __FILE__);
-  fpgafitpars_.d0().set(id0fit, 19, false, __LINE__, __FILE__);
-  fpgafitpars_.t().set(itfit, 14, false, __LINE__, __FILE__);
-
-  if (iz0fit >= (1 << (settings_.nbitsz0() - 1))) {
-    iz0fit = (1 << (settings_.nbitsz0() - 1)) - 1;
-  }
-
-  if (iz0fit <= -(1 << (settings_.nbitsz0() - 1))) {
-    iz0fit = 1 - (1 << (settings_.nbitsz0() - 1));
-  }
-
-  fpgafitpars_.z0().set(iz0fit, settings_.nbitsz0(), false, __LINE__, __FILE__);
-  ichisqrphifit_.set(ichisqrphifit, 8, true, __LINE__, __FILE__);
-  ichisqrzfit_.set(ichisqrzfit, 8, true, __LINE__, __FILE__);
-
-  hitpattern_ = hitpattern;
-
-  fpgatrack_ = std::make_unique<Track>(makeTrack(l1stubs));
-}
-
-const std::string Tracklet::layerstubstr(const unsigned layer) const {
-  assert(layer < N_LAYER);
-
-  std::stringstream oss("");
-  if (!resid_[layer].valid())
-    oss << "0|0000000|0000000000|0000000|000000000000|000000000";
-  else {
-    if (trackIndex_ < 0 || trackIndex_ > (int)settings_.ntrackletmax()) {
-      cout << "trackIndex_ = " << trackIndex_ << endl;
-      assert(0);
+    if (iz0fit >= (1 << (settings_.nbitsz0() - 1))) {
+      iz0fit = (1 << (settings_.nbitsz0() - 1)) - 1;
     }
-    const FPGAWord tmp(trackIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
-    oss << "1|";  // valid bit
-    oss << tmp.str() << "|";
-    oss << resid_[layer].fpgastubid().str() << "|";
-    oss << resid_[layer].stubptr()->r().str() << "|";
-    oss << resid_[layer].fpgaphiresid().str() << "|";
-    oss << resid_[layer].fpgarzresid().str();
-  }
 
-  return oss.str();
-}
-
-const std::string Tracklet::diskstubstr(const unsigned disk) const {
-  assert(disk < N_DISK);
-
-  std::stringstream oss("");
-  if (!resid_[N_LAYER + disk].valid())
-    oss << "0|0000000|0000000000|000000000000|000000000000|0000000";
-  else {
-    if (trackIndex_ < 0 || trackIndex_ > (int)settings_.ntrackletmax()) {
-      cout << "trackIndex_ = " << trackIndex_ << endl;
-      assert(0);
+    if (iz0fit <= -(1 << (settings_.nbitsz0() - 1))) {
+      iz0fit = 1 - (1 << (settings_.nbitsz0() - 1));
     }
-    const FPGAWord tmp(trackIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
-    const FPGAWord& stubr = resid_[N_LAYER + disk].stubptr()->r();
-    const bool isPS = resid_[N_LAYER + disk].stubptr()->isPSmodule();
-    oss << "1|";  // valid bit
-    oss << tmp.str() << "|";
-    oss << resid_[N_LAYER + disk].fpgastubid().str() << "|";
-    oss << (isPS ? stubr.str() : ("00000000" + stubr.str())) << "|";
-    oss << resid_[N_LAYER + disk].fpgaphiresid().str() << "|";
-    oss << resid_[N_LAYER + disk].fpgarzresid().str();
+
+    fpgafitpars_.z0().set(iz0fit, settings_.nbitsz0(), false, __LINE__, __FILE__);
+    ichisqrphifit_.set(ichisqrphifit, 8, true, __LINE__, __FILE__);
+    ichisqrzfit_.set(ichisqrzfit, 8, true, __LINE__, __FILE__);
+
+    hitpattern_ = hitpattern;
+
+    fpgatrack_ = std::make_unique<Track>(makeTrack(l1stubs));
   }
 
-  return oss.str();
-}
+  const std::string Tracklet::layerstubstr(const unsigned layer) const {
+    assert(layer < N_LAYER);
 
-std::string Tracklet::trackfitstr() const {
-  const unsigned maxNHits = 8;
-  const unsigned nBitsPerHit = 3;
-  vector<string> stub(maxNHits, "0");
-  string hitmap(maxNHits * nBitsPerHit, '0');
+    std::stringstream oss("");
+    if (!resid_[layer].valid())
+      oss << "0|0000000|0000000000|0000000|000000000000|000000000";
+    else {
+      if (trackIndex_ < 0 || trackIndex_ > (int)settings_.ntrackletmax()) {
+        cout << "trackIndex_ = " << trackIndex_ << endl;
+        assert(0);
+      }
+      const FPGAWord tmp(trackIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
+      oss << "1|";  // valid bit
+      oss << tmp.str() << "|";
+      oss << resid_[layer].fpgastubid().str() << "|";
+      oss << resid_[layer].stubptr()->r().str() << "|";
+      oss << resid_[layer].fpgaphiresid().str() << "|";
+      oss << resid_[layer].fpgarzresid().str();
+    }
 
-  // Assign stub strings for each of the possible projections for each seed.
-  // The specific layers/disks for a given seed are determined by the wiring.
-  switch (seedIndex()) {
-    case 0:                       // L1L2
-      stub[0] = layerstubstr(2);  // L3
-      stub[1] = layerstubstr(3);  // L4
-      stub[2] = layerstubstr(4);  // L5
-      stub[3] = layerstubstr(5);  // L6
-
-      stub[4] = diskstubstr(0);  // D1
-      stub[5] = diskstubstr(1);  // D2
-      stub[6] = diskstubstr(2);  // D3
-      stub[7] = diskstubstr(3);  // D4
-
-      break;
-
-    case 1:                       // L2L3
-      stub[0] = layerstubstr(0);  // L1
-      stub[1] = layerstubstr(3);  // L4
-      stub[2] = layerstubstr(4);  // L5
-
-      stub[3] = diskstubstr(0);  // D1
-      stub[4] = diskstubstr(1);  // D2
-      stub[5] = diskstubstr(2);  // D3
-      stub[6] = diskstubstr(3);  // D4
-
-      break;
-
-    case 2:                       // L3L4
-      stub[0] = layerstubstr(0);  // L1
-      stub[1] = layerstubstr(1);  // L2
-      stub[2] = layerstubstr(4);  // L5
-      stub[3] = layerstubstr(5);  // L6
-
-      stub[4] = diskstubstr(0);  // D1
-      stub[5] = diskstubstr(1);  // D2
-
-      break;
-
-    case 3:                       // L5L6
-      stub[0] = layerstubstr(0);  // L1
-      stub[1] = layerstubstr(1);  // L2
-      stub[2] = layerstubstr(2);  // L3
-      stub[3] = layerstubstr(3);  // L4
-
-      break;
-
-    case 4:                       // D1D2
-      stub[0] = layerstubstr(0);  // L1
-      stub[1] = layerstubstr(1);  // L2
-
-      stub[2] = diskstubstr(2);  // D3
-      stub[3] = diskstubstr(3);  // D4
-      stub[4] = diskstubstr(4);  // D5
-
-      break;
-
-    case 5:                       // D3D4
-      stub[0] = layerstubstr(0);  // L1
-
-      stub[1] = diskstubstr(0);  // D1
-      stub[2] = diskstubstr(1);  // D2
-      stub[3] = diskstubstr(4);  // D5
-
-      break;
-
-    case 6:                      // L1D1
-      stub[0] = diskstubstr(1);  // D2
-      stub[1] = diskstubstr(2);  // D3
-      stub[2] = diskstubstr(3);  // D4
-      stub[3] = diskstubstr(4);  // D5
-
-      break;
-
-    case 7:                       // L2D1
-      stub[0] = layerstubstr(0);  // L1
-
-      stub[1] = diskstubstr(1);  // D2
-      stub[2] = diskstubstr(2);  // D3
-      stub[3] = diskstubstr(3);  // D4
-
-      break;
+    return oss.str();
   }
 
-  // Only one hit per layer/disk is allowed currently, so the hit map for a
-  // given layer/disk is just equal to the valid bit of the corresponding stub
-  // string, which is the first character.
-  for (unsigned i = 0; i < maxNHits; i++)
-    hitmap[i * nBitsPerHit + 2] = stub[i][0];
+  const std::string Tracklet::diskstubstr(const unsigned disk) const {
+    assert(disk < N_DISK);
 
-  std::string oss("");
-  //Binary print out
-  if (!settings_.writeoutReal()) {
-    const FPGAWord tmp(getISeed(), settings_.nbitsseed(), true, __LINE__, __FILE__);
+    std::stringstream oss("");
+    if (!resid_[N_LAYER + disk].valid())
+      oss << "0|0000000|0000000000|000000000000|000000000000|0000000";
+    else {
+      if (trackIndex_ < 0 || trackIndex_ > (int)settings_.ntrackletmax()) {
+        cout << "trackIndex_ = " << trackIndex_ << endl;
+        assert(0);
+      }
+      const FPGAWord tmp(trackIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
+      const FPGAWord& stubr = resid_[N_LAYER + disk].stubptr()->r();
+      const bool isPS = resid_[N_LAYER + disk].stubptr()->isPSmodule();
+      oss << "1|";  // valid bit
+      oss << tmp.str() << "|";
+      oss << resid_[N_LAYER + disk].fpgastubid().str() << "|";
+      oss << (isPS ? stubr.str() : ("00000000" + stubr.str())) << "|";
+      oss << resid_[N_LAYER + disk].fpgaphiresid().str() << "|";
+      oss << resid_[N_LAYER + disk].fpgarzresid().str();
+    }
 
-    oss += "1|";  // valid bit
-    oss += tmp.str() + "|";
-    oss += fpgapars_.rinv().str() + "|";
-    oss += fpgapars_.phi0().str() + "|";
-    oss += fpgapars_.z0().str() + "|";
-    oss += fpgapars_.t().str() + "|";
-    oss += hitmap;
+    return oss.str();
+  }
+
+  std::string Tracklet::trackfitstr() const {
+    const unsigned maxNHits = 8;
+    const unsigned nBitsPerHit = 3;
+    vector<string> stub(maxNHits, "0");
+    string hitmap(maxNHits * nBitsPerHit, '0');
+
+    // Assign stub strings for each of the possible projections for each seed.
+    // The specific layers/disks for a given seed are determined by the wiring.
+    switch (seedIndex()) {
+      case 0:                       // L1L2
+        stub[0] = layerstubstr(2);  // L3
+        stub[1] = layerstubstr(3);  // L4
+        stub[2] = layerstubstr(4);  // L5
+        stub[3] = layerstubstr(5);  // L6
+
+        stub[4] = diskstubstr(0);  // D1
+        stub[5] = diskstubstr(1);  // D2
+        stub[6] = diskstubstr(2);  // D3
+        stub[7] = diskstubstr(3);  // D4
+
+        break;
+
+      case 1:                       // L2L3
+        stub[0] = layerstubstr(0);  // L1
+        stub[1] = layerstubstr(3);  // L4
+        stub[2] = layerstubstr(4);  // L5
+
+        stub[3] = diskstubstr(0);  // D1
+        stub[4] = diskstubstr(1);  // D2
+        stub[5] = diskstubstr(2);  // D3
+        stub[6] = diskstubstr(3);  // D4
+
+        break;
+
+      case 2:                       // L3L4
+        stub[0] = layerstubstr(0);  // L1
+        stub[1] = layerstubstr(1);  // L2
+        stub[2] = layerstubstr(4);  // L5
+        stub[3] = layerstubstr(5);  // L6
+
+        stub[4] = diskstubstr(0);  // D1
+        stub[5] = diskstubstr(1);  // D2
+
+        break;
+
+      case 3:                       // L5L6
+        stub[0] = layerstubstr(0);  // L1
+        stub[1] = layerstubstr(1);  // L2
+        stub[2] = layerstubstr(2);  // L3
+        stub[3] = layerstubstr(3);  // L4
+
+        break;
+
+      case 4:                       // D1D2
+        stub[0] = layerstubstr(0);  // L1
+        stub[1] = layerstubstr(1);  // L2
+
+        stub[2] = diskstubstr(2);  // D3
+        stub[3] = diskstubstr(3);  // D4
+        stub[4] = diskstubstr(4);  // D5
+
+        break;
+
+      case 5:                       // D3D4
+        stub[0] = layerstubstr(0);  // L1
+
+        stub[1] = diskstubstr(0);  // D1
+        stub[2] = diskstubstr(1);  // D2
+        stub[3] = diskstubstr(4);  // D5
+
+        break;
+
+      case 6:                      // L1D1
+        stub[0] = diskstubstr(1);  // D2
+        stub[1] = diskstubstr(2);  // D3
+        stub[2] = diskstubstr(3);  // D4
+        stub[3] = diskstubstr(4);  // D5
+
+        break;
+
+      case 7:                       // L2D1
+        stub[0] = layerstubstr(0);  // L1
+
+        stub[1] = diskstubstr(1);  // D2
+        stub[2] = diskstubstr(2);  // D3
+        stub[3] = diskstubstr(3);  // D4
+
+        break;
+    }
+
+    // Only one hit per layer/disk is allowed currently, so the hit map for a
+    // given layer/disk is just equal to the valid bit of the corresponding stub
+    // string, which is the first character.
     for (unsigned i = 0; i < maxNHits; i++)
-      // If a valid stub string was never assigned, then that stub is not
-      // included in the output.
-      if (stub[i] != "0")
-        oss += "|" + stub[i];
+      hitmap[i * nBitsPerHit + 2] = stub[i][0];
+
+    std::string oss("");
+    //Binary print out
+    if (!settings_.writeoutReal()) {
+      const FPGAWord tmp(getISeed(), settings_.nbitsseed(), true, __LINE__, __FILE__);
+
+      oss += "1|";  // valid bit
+      oss += tmp.str() + "|";
+      oss += fpgapars_.rinv().str() + "|";
+      oss += fpgapars_.phi0().str() + "|";
+      oss += fpgapars_.z0().str() + "|";
+      oss += fpgapars_.t().str() + "|";
+      oss += hitmap;
+      for (unsigned i = 0; i < maxNHits; i++)
+        // If a valid stub string was never assigned, then that stub is not
+        // included in the output.
+        if (stub[i] != "0")
+          oss += "|" + stub[i];
+    }
+
+    return oss;
   }
 
-  return oss;
-}
+  // Create a Track object from stubs & digitized track helix params
 
-// Create a Track object from stubs & digitized track helix params
+  Track Tracklet::makeTrack(const vector<const L1TStub*>& l1stubs) {
+    assert(fit());
 
-Track Tracklet::makeTrack(const vector<const L1TStub*>& l1stubs) {
-  assert(fit());
+    // Digitized track helix params
+    TrackPars<int> ipars(fpgafitpars_.rinv().value(),
+                         fpgafitpars_.phi0().value(),
+                         fpgafitpars_.d0().value(),
+                         fpgafitpars_.t().value(),
+                         fpgafitpars_.z0().value());
 
-  // Digitized track helix params
-  TrackPars<int> ipars(fpgafitpars_.rinv().value(),
-                       fpgafitpars_.phi0().value(),
-                       fpgafitpars_.d0().value(),
-                       fpgafitpars_.t().value(),
-                       fpgafitpars_.z0().value());
+    // If fitter produced no stub list, take it from original tracklet.
+    vector<const L1TStub*> tmp = l1stubs.empty() ? getL1Stubs() : l1stubs;
 
-  // If fitter produced no stub list, take it from original tracklet.
-  vector<const L1TStub*> tmp = l1stubs.empty() ? getL1Stubs() : l1stubs;
+    vector<L1TStub> tmp2;
 
-  vector<L1TStub> tmp2;
+    tmp2.reserve(tmp.size());
+    for (auto stub : tmp) {
+      tmp2.push_back(*stub);
+    }
 
-  tmp2.reserve(tmp.size());
-  for (auto stub : tmp) {
-    tmp2.push_back(*stub);
+    Track tmpTrack(ipars,
+                   ichisqrphifit_.value(),
+                   ichisqrzfit_.value(),
+                   chisqrphifit_,
+                   chisqrzfit_,
+                   hitpattern_,
+                   getStubIDs(),
+                   tmp2,
+                   getISeed());
+
+    return tmpTrack;
   }
 
-  Track tmpTrack(ipars,
-                 ichisqrphifit_.value(),
-                 ichisqrzfit_.value(),
-                 chisqrphifit_,
-                 chisqrzfit_,
-                 hitpattern_,
-                 getStubIDs(),
-                 tmp2,
-                 getISeed());
-
-  return tmpTrack;
-}
-
-int Tracklet::layer() const {
-  int l1 = (innerFPGAStub_ && innerFPGAStub_->layerdisk() < N_LAYER) ? innerFPGAStub_->l1tstub()->layerdisk() + 1 : 999,
-      l2 = (middleFPGAStub_ && middleFPGAStub_->layerdisk() < N_LAYER) ? middleFPGAStub_->l1tstub()->layerdisk() + 1
+  int Tracklet::layer() const {
+    int l1 = (innerFPGAStub_ && innerFPGAStub_->layerdisk() < N_LAYER) ? innerFPGAStub_->l1tstub()->layerdisk() + 1
                                                                        : 999,
-      l3 = (outerFPGAStub_ && outerFPGAStub_->layerdisk() < N_LAYER) ? outerFPGAStub_->l1tstub()->layerdisk() + 1 : 999,
-      l = min(min(l1, l2), l3);
-  return (l < 999 ? l : 0);
-}
+        l2 = (middleFPGAStub_ && middleFPGAStub_->layerdisk() < N_LAYER) ? middleFPGAStub_->l1tstub()->layerdisk() + 1
+                                                                         : 999,
+        l3 = (outerFPGAStub_ && outerFPGAStub_->layerdisk() < N_LAYER) ? outerFPGAStub_->l1tstub()->layerdisk() + 1
+                                                                       : 999,
+        l = min(min(l1, l2), l3);
+    return (l < 999 ? l : 0);
+  }
 
-int Tracklet::disk() const {
-  int d1 = (innerFPGAStub_ && (innerFPGAStub_->layerdisk() >= N_LAYER)) ? innerFPGAStub_->l1tstub()->disk() : 999,
-      d2 = (middleFPGAStub_ && (middleFPGAStub_->layerdisk() >= N_LAYER)) ? middleFPGAStub_->l1tstub()->disk() : 999,
-      d3 = (outerFPGAStub_ && (outerFPGAStub_->layerdisk() >= N_LAYER)) ? outerFPGAStub_->l1tstub()->disk() : 999,
-      d = 999;
-  if (abs(d1) < min(abs(d2), abs(d3)))
-    d = d1;
-  if (abs(d2) < min(abs(d1), abs(d3)))
-    d = d2;
-  if (abs(d3) < min(abs(d1), abs(d2)))
-    d = d3;
-  return (d < 999 ? d : 0);
-}
+  int Tracklet::disk() const {
+    int d1 = (innerFPGAStub_ && (innerFPGAStub_->layerdisk() >= N_LAYER)) ? innerFPGAStub_->l1tstub()->disk() : 999,
+        d2 = (middleFPGAStub_ && (middleFPGAStub_->layerdisk() >= N_LAYER)) ? middleFPGAStub_->l1tstub()->disk() : 999,
+        d3 = (outerFPGAStub_ && (outerFPGAStub_->layerdisk() >= N_LAYER)) ? outerFPGAStub_->l1tstub()->disk() : 999,
+        d = 999;
+    if (abs(d1) < min(abs(d2), abs(d3)))
+      d = d1;
+    if (abs(d2) < min(abs(d1), abs(d3)))
+      d = d2;
+    if (abs(d3) < min(abs(d1), abs(d2)))
+      d = d3;
+    return (d < 999 ? d : 0);
+  }
 
-void Tracklet::setTrackletIndex(unsigned int index) {
-  trackletIndex_ = index;
-  assert(index <= settings_.ntrackletmax());
-}
+  void Tracklet::setTrackletIndex(unsigned int index) {
+    trackletIndex_ = index;
+    assert(index <= settings_.ntrackletmax());
+  }
 
-int Tracklet::getISeed() const {
-  const int iSeed = TCIndex_ >> settings_.nbitsitc();
-  assert(iSeed >= 0 && iSeed <= (int)N_SEED);
-  return iSeed;
-}
+  int Tracklet::getISeed() const {
+    const int iSeed = TCIndex_ >> settings_.nbitsitc();
+    assert(iSeed >= 0 && iSeed <= (int)N_SEED);
+    return iSeed;
+  }
 
-int Tracklet::getITC() const {
-  const int iSeed = getISeed(), iTC = TCIndex_ - (iSeed << settings_.nbitsitc());
-  assert(iTC >= 0 && iTC <= 14);
-  return iTC;
-}
+  int Tracklet::getITC() const {
+    const int iSeed = getISeed(), iTC = TCIndex_ - (iSeed << settings_.nbitsitc());
+    assert(iTC >= 0 && iTC <= 14);
+    return iTC;
+  }
 
-void Tracklet::setTrackIndex(int index) {
-  trackIndex_ = index;
-  assert(index <= (int)settings_.ntrackletmax());
-}
+  void Tracklet::setTrackIndex(int index) {
+    trackIndex_ = index;
+    assert(index <= (int)settings_.ntrackletmax());
+  }
 
-int Tracklet::trackIndex() const { return trackIndex_; }
+  int Tracklet::trackIndex() const { return trackIndex_; }
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculator.cc
@@ -15,461 +15,461 @@ using namespace std;
 
 namespace trklet {
 
-TrackletCalculator::TrackletCalculator(string name, Settings const& settings, Globals* globals)
-    : TrackletCalculatorBase(name, settings, globals) {
-  for (unsigned int ilayer = 0; ilayer < N_LAYER; ilayer++) {
-    vector<TrackletProjectionsMemory*> tmp(settings.nallstubs(ilayer), nullptr);
-    trackletprojlayers_.push_back(tmp);
-  }
-
-  for (unsigned int idisk = 0; idisk < N_DISK; idisk++) {
-    vector<TrackletProjectionsMemory*> tmp(settings.nallstubs(idisk + N_LAYER), nullptr);
-    trackletprojdisks_.push_back(tmp);
-  }
-
-  initLayerDisksandISeed(layerdisk1_, layerdisk2_, iSeed_);
-
-  // set TC index
-  iTC_ = name_[7] - 'A';
-
-  TCIndex_ = (iSeed_ << 4) + iTC_;
-  assert(TCIndex_ >= 0 && TCIndex_ <= (int)settings_.ntrackletmax());
-
-  if (settings_.usephicritapprox()) {
-    double phicritFactor =
-        0.5 * settings_.rcrit() * globals_->ITC_L1L2()->rinv_final.K() / globals_->ITC_L1L2()->phi0_final.K();
-    if (std::abs(phicritFactor - 2.) > 0.25)
-      edm::LogPrint("Tracklet")
-          << "TrackletCalculator::TrackletCalculator phicrit approximation may be invalid! Please check.";
-  }
-
-  // reduced config has only one TC, so this must be the first
-  const bool isFirstTC = (iTC_ == 0 || settings_.reduced());
-
-  // write the drinv and invt inverse tables
-  if ((settings_.writeInvTable() || settings_.writeHLSInvTable() || settings_.writeTable()) && isFirstTC) {
-    void (*writeLUT)(const VarInv&, const string&) = nullptr;
-    if (settings.writeInvTable()) {  // Verilog version
-      writeLUT = [](const VarInv& x, const string& basename) -> void {
-        ofstream fs(basename + ".tab");
-        return x.writeLUT(fs, VarBase::verilog);
-      };
-    } else {  // HLS version
-      writeLUT = [](const VarInv& x, const string& basename) -> void {
-        ofstream fs(basename + ".tab");
-        return x.writeLUT(fs, VarBase::hls);
-      };
+  TrackletCalculator::TrackletCalculator(string name, Settings const& settings, Globals* globals)
+      : TrackletCalculatorBase(name, settings, globals) {
+    for (unsigned int ilayer = 0; ilayer < N_LAYER; ilayer++) {
+      vector<TrackletProjectionsMemory*> tmp(settings.nallstubs(ilayer), nullptr);
+      trackletprojlayers_.push_back(tmp);
     }
-    writeInvTable(writeLUT);
-  }
 
-  // write the firmware design for the calculation of the tracklet parameters
-  // and projections
-  if ((settings_.writeVerilog() || settings_.writeHLS()) && isFirstTC) {
-    void (*writeDesign)(const vector<VarBase*>&, const string&) = nullptr;
-    if (settings.writeVerilog()) {  // Verilog version
-      writeDesign = [](const vector<VarBase*>& v, const string& basename) -> void {
-        ofstream fs(basename + ".v");
-        return VarBase::verilog_print(v, fs);
-      };
-    } else {  // HLS version
-      writeDesign = [](const vector<VarBase*>& v, const string& basename) -> void {
-        ofstream fs(basename + ".cpp");
-        return VarBase::hls_print(v, fs);
-      };
+    for (unsigned int idisk = 0; idisk < N_DISK; idisk++) {
+      vector<TrackletProjectionsMemory*> tmp(settings.nallstubs(idisk + N_LAYER), nullptr);
+      trackletprojdisks_.push_back(tmp);
     }
-    writeFirmwareDesign(writeDesign);
+
+    initLayerDisksandISeed(layerdisk1_, layerdisk2_, iSeed_);
+
+    // set TC index
+    iTC_ = name_[7] - 'A';
+
+    TCIndex_ = (iSeed_ << 4) + iTC_;
+    assert(TCIndex_ >= 0 && TCIndex_ <= (int)settings_.ntrackletmax());
+
+    if (settings_.usephicritapprox()) {
+      double phicritFactor =
+          0.5 * settings_.rcrit() * globals_->ITC_L1L2()->rinv_final.K() / globals_->ITC_L1L2()->phi0_final.K();
+      if (std::abs(phicritFactor - 2.) > 0.25)
+        edm::LogPrint("Tracklet")
+            << "TrackletCalculator::TrackletCalculator phicrit approximation may be invalid! Please check.";
+    }
+
+    // reduced config has only one TC, so this must be the first
+    const bool isFirstTC = (iTC_ == 0 || settings_.reduced());
+
+    // write the drinv and invt inverse tables
+    if ((settings_.writeInvTable() || settings_.writeHLSInvTable() || settings_.writeTable()) && isFirstTC) {
+      void (*writeLUT)(const VarInv&, const string&) = nullptr;
+      if (settings.writeInvTable()) {  // Verilog version
+        writeLUT = [](const VarInv& x, const string& basename) -> void {
+          ofstream fs(basename + ".tab");
+          return x.writeLUT(fs, VarBase::verilog);
+        };
+      } else {  // HLS version
+        writeLUT = [](const VarInv& x, const string& basename) -> void {
+          ofstream fs(basename + ".tab");
+          return x.writeLUT(fs, VarBase::hls);
+        };
+      }
+      writeInvTable(writeLUT);
+    }
+
+    // write the firmware design for the calculation of the tracklet parameters
+    // and projections
+    if ((settings_.writeVerilog() || settings_.writeHLS()) && isFirstTC) {
+      void (*writeDesign)(const vector<VarBase*>&, const string&) = nullptr;
+      if (settings.writeVerilog()) {  // Verilog version
+        writeDesign = [](const vector<VarBase*>& v, const string& basename) -> void {
+          ofstream fs(basename + ".v");
+          return VarBase::verilog_print(v, fs);
+        };
+      } else {  // HLS version
+        writeDesign = [](const vector<VarBase*>& v, const string& basename) -> void {
+          ofstream fs(basename + ".cpp");
+          return VarBase::hls_print(v, fs);
+        };
+      }
+      writeFirmwareDesign(writeDesign);
+    }
   }
-}
 
-void TrackletCalculator::addOutputProjection(TrackletProjectionsMemory*& outputProj, MemoryBase* memory) {
-  outputProj = dynamic_cast<TrackletProjectionsMemory*>(memory);
-  assert(outputProj != nullptr);
-}
-
-void TrackletCalculator::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-  if (output == "trackpar") {
-    auto* tmp = dynamic_cast<TrackletParametersMemory*>(memory);
-    assert(tmp != nullptr);
-    trackletpars_ = tmp;
-    return;
+  void TrackletCalculator::addOutputProjection(TrackletProjectionsMemory*& outputProj, MemoryBase* memory) {
+    outputProj = dynamic_cast<TrackletProjectionsMemory*>(memory);
+    assert(outputProj != nullptr);
   }
 
-  if (output.substr(0, 7) == "projout") {
-    //output is on the form 'projoutL2PHIC' or 'projoutD3PHIB'
-    auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
-    assert(tmp != nullptr);
-
-    unsigned int layerdisk = output[8] - '1';   //layer or disk counting from 0
-    unsigned int phiregion = output[12] - 'A';  //phiregion counting from 0
-
-    if (output[7] == 'L') {
-      assert(layerdisk < N_LAYER);
-      assert(phiregion < trackletprojlayers_[layerdisk].size());
-      //check that phiregion not already initialized
-      assert(trackletprojlayers_[layerdisk][phiregion] == nullptr);
-      trackletprojlayers_[layerdisk][phiregion] = tmp;
+  void TrackletCalculator::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
+    if (output == "trackpar") {
+      auto* tmp = dynamic_cast<TrackletParametersMemory*>(memory);
+      assert(tmp != nullptr);
+      trackletpars_ = tmp;
       return;
     }
 
-    if (output[7] == 'D') {
-      assert(layerdisk < N_DISK);
-      assert(phiregion < trackletprojdisks_[layerdisk].size());
-      //check that phiregion not already initialized
-      assert(trackletprojdisks_[layerdisk][phiregion] == nullptr);
-      trackletprojdisks_[layerdisk][phiregion] = tmp;
+    if (output.substr(0, 7) == "projout") {
+      //output is on the form 'projoutL2PHIC' or 'projoutD3PHIB'
+      auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
+      assert(tmp != nullptr);
+
+      unsigned int layerdisk = output[8] - '1';   //layer or disk counting from 0
+      unsigned int phiregion = output[12] - 'A';  //phiregion counting from 0
+
+      if (output[7] == 'L') {
+        assert(layerdisk < N_LAYER);
+        assert(phiregion < trackletprojlayers_[layerdisk].size());
+        //check that phiregion not already initialized
+        assert(trackletprojlayers_[layerdisk][phiregion] == nullptr);
+        trackletprojlayers_[layerdisk][phiregion] = tmp;
+        return;
+      }
+
+      if (output[7] == 'D') {
+        assert(layerdisk < N_DISK);
+        assert(phiregion < trackletprojdisks_[layerdisk].size());
+        //check that phiregion not already initialized
+        assert(trackletprojdisks_[layerdisk][phiregion] == nullptr);
+        trackletprojdisks_[layerdisk][phiregion] = tmp;
+        return;
+      }
+    }
+
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
+  }
+
+  void TrackletCalculator::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input == "innerallstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      innerallstubs_.push_back(tmp);
       return;
     }
-  }
-
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
-}
-
-void TrackletCalculator::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input == "innerallstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    innerallstubs_.push_back(tmp);
-    return;
-  }
-  if (input == "outerallstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    outerallstubs_.push_back(tmp);
-    return;
-  }
-  if (input.substr(0, 8) == "stubpair") {
-    auto* tmp = dynamic_cast<StubPairsMemory*>(memory);
-    assert(tmp != nullptr);
-    stubpairs_.push_back(tmp);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find intput : " << input;
-}
-
-void TrackletCalculator::execute(unsigned int iSector, double phimin, double phimax) {
-  unsigned int countall = 0;
-  unsigned int countsel = 0;
-
-  phimin_ = phimin;
-  phimax_ = phimax;
-  iSector_ = iSector;
-
-  //Helpfull to have for debugging the HLS code - will keep here for now.
-  //bool print = (iSector == 3) && (getName() == "TC_L1L2G");
-  //print = false;
-
-  for (auto& stubpair : stubpairs_) {
-    if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
-      edm::LogVerbatim("Tracklet") << "Will break on too many tracklets in " << getName();
-      break;
+    if (input == "outerallstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      outerallstubs_.push_back(tmp);
+      return;
     }
-    for (unsigned int i = 0; i < stubpair->nStubPairs(); i++) {
-      countall++;
-      const Stub* innerFPGAStub = stubpair->getVMStub1(i).stub();
-      const L1TStub* innerStub = innerFPGAStub->l1tstub();
+    if (input.substr(0, 8) == "stubpair") {
+      auto* tmp = dynamic_cast<StubPairsMemory*>(memory);
+      assert(tmp != nullptr);
+      stubpairs_.push_back(tmp);
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find intput : " << input;
+  }
 
-      const Stub* outerFPGAStub = stubpair->getVMStub2(i).stub();
-      const L1TStub* outerStub = outerFPGAStub->l1tstub();
+  void TrackletCalculator::execute(unsigned int iSector, double phimin, double phimax) {
+    unsigned int countall = 0;
+    unsigned int countsel = 0;
 
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "TrackletCalculator execute " << getName() << "[" << iSector << "]";
-      }
+    phimin_ = phimin;
+    phimax_ = phimax;
+    iSector_ = iSector;
 
-      if (innerFPGAStub->layerdisk() < N_LAYER && (getName() != "TC_D1L2A" && getName() != "TC_D1L2B")) {
-        if (outerFPGAStub->layerdisk() >= N_LAYER) {
-          //overlap seeding
-          bool accept = overlapSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub);
-          if (accept)
-            countsel++;
-        } else {
-          //barrel+barrel seeding
-          bool accept = barrelSeeding(innerFPGAStub, innerStub, outerFPGAStub, outerStub);
-          if (accept)
-            countsel++;
-        }
-      } else {
-        if (outerFPGAStub->layerdisk() >= N_LAYER) {
-          //disk+disk seeding
-          bool accept = diskSeeding(innerFPGAStub, innerStub, outerFPGAStub, outerStub);
-          if (accept)
-            countsel++;
-        } else if (innerFPGAStub->layerdisk() >= N_LAYER) {
-          //layer+disk seeding
-          bool accept = overlapSeeding(innerFPGAStub, innerStub, outerFPGAStub, outerStub);
-          if (accept)
-            countsel++;
-        } else {
-          throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " invalid seeding";
-        }
-      }
+    //Helpfull to have for debugging the HLS code - will keep here for now.
+    //bool print = (iSector == 3) && (getName() == "TC_L1L2G");
+    //print = false;
 
+    for (auto& stubpair : stubpairs_) {
       if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
-        edm::LogVerbatim("Tracklet") << "Will break on number of tracklets in " << getName();
+        edm::LogVerbatim("Tracklet") << "Will break on too many tracklets in " << getName();
         break;
       }
+      for (unsigned int i = 0; i < stubpair->nStubPairs(); i++) {
+        countall++;
+        const Stub* innerFPGAStub = stubpair->getVMStub1(i).stub();
+        const L1TStub* innerStub = innerFPGAStub->l1tstub();
 
+        const Stub* outerFPGAStub = stubpair->getVMStub2(i).stub();
+        const L1TStub* outerStub = outerFPGAStub->l1tstub();
+
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << "TrackletCalculator execute " << getName() << "[" << iSector << "]";
+        }
+
+        if (innerFPGAStub->layerdisk() < N_LAYER && (getName() != "TC_D1L2A" && getName() != "TC_D1L2B")) {
+          if (outerFPGAStub->layerdisk() >= N_LAYER) {
+            //overlap seeding
+            bool accept = overlapSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub);
+            if (accept)
+              countsel++;
+          } else {
+            //barrel+barrel seeding
+            bool accept = barrelSeeding(innerFPGAStub, innerStub, outerFPGAStub, outerStub);
+            if (accept)
+              countsel++;
+          }
+        } else {
+          if (outerFPGAStub->layerdisk() >= N_LAYER) {
+            //disk+disk seeding
+            bool accept = diskSeeding(innerFPGAStub, innerStub, outerFPGAStub, outerStub);
+            if (accept)
+              countsel++;
+          } else if (innerFPGAStub->layerdisk() >= N_LAYER) {
+            //layer+disk seeding
+            bool accept = overlapSeeding(innerFPGAStub, innerStub, outerFPGAStub, outerStub);
+            if (accept)
+              countsel++;
+          } else {
+            throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " invalid seeding";
+          }
+        }
+
+        if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
+          edm::LogVerbatim("Tracklet") << "Will break on number of tracklets in " << getName();
+          break;
+        }
+
+        if (countall >= settings_.maxStep("TC")) {
+          if (settings_.debugTracklet())
+            edm::LogVerbatim("Tracklet") << "Will break on MAXTC 1";
+          break;
+        }
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << "TrackletCalculator execute done";
+        }
+      }
       if (countall >= settings_.maxStep("TC")) {
         if (settings_.debugTracklet())
-          edm::LogVerbatim("Tracklet") << "Will break on MAXTC 1";
+          edm::LogVerbatim("Tracklet") << "Will break on MAXTC 2";
         break;
       }
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "TrackletCalculator execute done";
-      }
     }
-    if (countall >= settings_.maxStep("TC")) {
-      if (settings_.debugTracklet())
-        edm::LogVerbatim("Tracklet") << "Will break on MAXTC 2";
-      break;
+
+    if (settings_.writeMonitorData("TC")) {
+      globals_->ofstream("trackletcalculator.txt") << getName() << " " << countall << " " << countsel << endl;
     }
   }
 
-  if (settings_.writeMonitorData("TC")) {
-    globals_->ofstream("trackletcalculator.txt") << getName() << " " << countall << " " << countsel << endl;
+  void TrackletCalculator::writeInvTable(void (*writeLUT)(const VarInv&, const string&)) {
+    switch (iSeed_) {
+      case 0:  // L1L2
+        writeLUT(globals_->ITC_L1L2()->drinv, settings_.tablePath() + "TC_L1L2_drinv");
+        writeLUT(globals_->ITC_L1L2()->invt, settings_.tablePath() + "TC_L1L2_invt");
+        break;
+      case 1:  // L2L3
+        writeLUT(globals_->ITC_L2L3()->drinv, settings_.tablePath() + "TC_L2L3_drinv");
+        writeLUT(globals_->ITC_L2L3()->invt, settings_.tablePath() + "TC_L2L3_invt");
+        break;
+      case 2:  // L3L4
+        writeLUT(globals_->ITC_L3L4()->drinv, settings_.tablePath() + "TC_L3L4_drinv");
+        writeLUT(globals_->ITC_L3L4()->invt, settings_.tablePath() + "TC_L3L4_invt");
+        break;
+      case 3:  // L5L6
+        writeLUT(globals_->ITC_L5L6()->drinv, settings_.tablePath() + "TC_L5L6_drinv");
+        writeLUT(globals_->ITC_L5L6()->invt, settings_.tablePath() + "TC_L5L6_invt");
+        break;
+      case 4:  // D1D2
+        writeLUT(globals_->ITC_F1F2()->drinv, settings_.tablePath() + "TC_F1F2_drinv");
+        writeLUT(globals_->ITC_F1F2()->invt, settings_.tablePath() + "TC_F1F2_invt");
+        writeLUT(globals_->ITC_B1B2()->drinv, settings_.tablePath() + "TC_B1B2_drinv");
+        writeLUT(globals_->ITC_B1B2()->invt, settings_.tablePath() + "TC_B1B2_invt");
+        break;
+      case 5:  // D3D4
+        writeLUT(globals_->ITC_F3F4()->drinv, settings_.tablePath() + "TC_F3F4_drinv");
+        writeLUT(globals_->ITC_F3F4()->invt, settings_.tablePath() + "TC_F3F4_invt");
+        writeLUT(globals_->ITC_B3B4()->drinv, settings_.tablePath() + "TC_B3B4_drinv");
+        writeLUT(globals_->ITC_B3B4()->invt, settings_.tablePath() + "TC_B3B4_invt");
+        break;
+      case 6:  // L1D1
+        writeLUT(globals_->ITC_L1F1()->drinv, settings_.tablePath() + "TC_L1F1_drinv");
+        writeLUT(globals_->ITC_L1F1()->invt, settings_.tablePath() + "TC_L1F1_invt");
+        writeLUT(globals_->ITC_L1B1()->drinv, settings_.tablePath() + "TC_L1B1_drinv");
+        writeLUT(globals_->ITC_L1B1()->invt, settings_.tablePath() + "TC_L1B1_invt");
+        break;
+      case 7:  // L2D1
+        writeLUT(globals_->ITC_L2F1()->drinv, settings_.tablePath() + "TC_L2F1_drinv");
+        writeLUT(globals_->ITC_L2F1()->invt, settings_.tablePath() + "TC_L2F1_invt");
+        writeLUT(globals_->ITC_L2B1()->drinv, settings_.tablePath() + "TC_L2B1_drinv");
+        writeLUT(globals_->ITC_L2B1()->invt, settings_.tablePath() + "TC_L2B1_invt");
+        break;
+    }
   }
-}
 
-void TrackletCalculator::writeInvTable(void (*writeLUT)(const VarInv&, const string&)) {
-  switch (iSeed_) {
-    case 0:  // L1L2
-      writeLUT(globals_->ITC_L1L2()->drinv, settings_.tablePath() + "TC_L1L2_drinv");
-      writeLUT(globals_->ITC_L1L2()->invt, settings_.tablePath() + "TC_L1L2_invt");
-      break;
-    case 1:  // L2L3
-      writeLUT(globals_->ITC_L2L3()->drinv, settings_.tablePath() + "TC_L2L3_drinv");
-      writeLUT(globals_->ITC_L2L3()->invt, settings_.tablePath() + "TC_L2L3_invt");
-      break;
-    case 2:  // L3L4
-      writeLUT(globals_->ITC_L3L4()->drinv, settings_.tablePath() + "TC_L3L4_drinv");
-      writeLUT(globals_->ITC_L3L4()->invt, settings_.tablePath() + "TC_L3L4_invt");
-      break;
-    case 3:  // L5L6
-      writeLUT(globals_->ITC_L5L6()->drinv, settings_.tablePath() + "TC_L5L6_drinv");
-      writeLUT(globals_->ITC_L5L6()->invt, settings_.tablePath() + "TC_L5L6_invt");
-      break;
-    case 4:  // D1D2
-      writeLUT(globals_->ITC_F1F2()->drinv, settings_.tablePath() + "TC_F1F2_drinv");
-      writeLUT(globals_->ITC_F1F2()->invt, settings_.tablePath() + "TC_F1F2_invt");
-      writeLUT(globals_->ITC_B1B2()->drinv, settings_.tablePath() + "TC_B1B2_drinv");
-      writeLUT(globals_->ITC_B1B2()->invt, settings_.tablePath() + "TC_B1B2_invt");
-      break;
-    case 5:  // D3D4
-      writeLUT(globals_->ITC_F3F4()->drinv, settings_.tablePath() + "TC_F3F4_drinv");
-      writeLUT(globals_->ITC_F3F4()->invt, settings_.tablePath() + "TC_F3F4_invt");
-      writeLUT(globals_->ITC_B3B4()->drinv, settings_.tablePath() + "TC_B3B4_drinv");
-      writeLUT(globals_->ITC_B3B4()->invt, settings_.tablePath() + "TC_B3B4_invt");
-      break;
-    case 6:  // L1D1
-      writeLUT(globals_->ITC_L1F1()->drinv, settings_.tablePath() + "TC_L1F1_drinv");
-      writeLUT(globals_->ITC_L1F1()->invt, settings_.tablePath() + "TC_L1F1_invt");
-      writeLUT(globals_->ITC_L1B1()->drinv, settings_.tablePath() + "TC_L1B1_drinv");
-      writeLUT(globals_->ITC_L1B1()->invt, settings_.tablePath() + "TC_L1B1_invt");
-      break;
-    case 7:  // L2D1
-      writeLUT(globals_->ITC_L2F1()->drinv, settings_.tablePath() + "TC_L2F1_drinv");
-      writeLUT(globals_->ITC_L2F1()->invt, settings_.tablePath() + "TC_L2F1_invt");
-      writeLUT(globals_->ITC_L2B1()->drinv, settings_.tablePath() + "TC_L2B1_drinv");
-      writeLUT(globals_->ITC_L2B1()->invt, settings_.tablePath() + "TC_L2B1_invt");
-      break;
+  void TrackletCalculator::writeFirmwareDesign(void (*writeDesign)(const vector<VarBase*>&, const string&)) {
+    switch (iSeed_) {
+      case 0:  // L1L2
+      {
+        const vector<VarBase*> v = {&globals_->ITC_L1L2()->rinv_final,     &globals_->ITC_L1L2()->phi0_final,
+                                    &globals_->ITC_L1L2()->t_final,        &globals_->ITC_L1L2()->z0_final,
+                                    &globals_->ITC_L1L2()->phiL_0_final,   &globals_->ITC_L1L2()->phiL_1_final,
+                                    &globals_->ITC_L1L2()->phiL_2_final,   &globals_->ITC_L1L2()->phiL_3_final,
+                                    &globals_->ITC_L1L2()->zL_0_final,     &globals_->ITC_L1L2()->zL_1_final,
+                                    &globals_->ITC_L1L2()->zL_2_final,     &globals_->ITC_L1L2()->zL_3_final,
+                                    &globals_->ITC_L1L2()->der_phiL_final, &globals_->ITC_L1L2()->der_zL_final,
+                                    &globals_->ITC_L1L2()->phiD_0_final,   &globals_->ITC_L1L2()->phiD_1_final,
+                                    &globals_->ITC_L1L2()->phiD_2_final,   &globals_->ITC_L1L2()->phiD_3_final,
+                                    &globals_->ITC_L1L2()->phiD_4_final,   &globals_->ITC_L1L2()->rD_0_final,
+                                    &globals_->ITC_L1L2()->rD_1_final,     &globals_->ITC_L1L2()->rD_2_final,
+                                    &globals_->ITC_L1L2()->rD_3_final,     &globals_->ITC_L1L2()->rD_4_final,
+                                    &globals_->ITC_L1L2()->der_phiD_final, &globals_->ITC_L1L2()->der_rD_final};
+        writeDesign(v, "TC_L1L2");
+      } break;
+      case 1:  // L2L3
+      {
+        const vector<VarBase*> v = {&globals_->ITC_L2L3()->rinv_final,     &globals_->ITC_L2L3()->phi0_final,
+                                    &globals_->ITC_L2L3()->t_final,        &globals_->ITC_L2L3()->z0_final,
+                                    &globals_->ITC_L2L3()->phiL_0_final,   &globals_->ITC_L2L3()->phiL_1_final,
+                                    &globals_->ITC_L2L3()->phiL_2_final,   &globals_->ITC_L2L3()->phiL_3_final,
+                                    &globals_->ITC_L2L3()->zL_0_final,     &globals_->ITC_L2L3()->zL_1_final,
+                                    &globals_->ITC_L2L3()->zL_2_final,     &globals_->ITC_L2L3()->zL_3_final,
+                                    &globals_->ITC_L2L3()->der_phiL_final, &globals_->ITC_L2L3()->der_zL_final,
+                                    &globals_->ITC_L2L3()->phiD_0_final,   &globals_->ITC_L2L3()->phiD_1_final,
+                                    &globals_->ITC_L2L3()->phiD_2_final,   &globals_->ITC_L2L3()->phiD_3_final,
+                                    &globals_->ITC_L2L3()->phiD_4_final,   &globals_->ITC_L2L3()->rD_0_final,
+                                    &globals_->ITC_L2L3()->rD_1_final,     &globals_->ITC_L2L3()->rD_2_final,
+                                    &globals_->ITC_L2L3()->rD_3_final,     &globals_->ITC_L2L3()->rD_4_final,
+                                    &globals_->ITC_L2L3()->der_phiD_final, &globals_->ITC_L2L3()->der_rD_final};
+        writeDesign(v, "TC_L2L3");
+      } break;
+      case 2:  // L3L4
+      {
+        const vector<VarBase*> v = {&globals_->ITC_L3L4()->rinv_final,     &globals_->ITC_L3L4()->phi0_final,
+                                    &globals_->ITC_L3L4()->t_final,        &globals_->ITC_L3L4()->z0_final,
+                                    &globals_->ITC_L3L4()->phiL_0_final,   &globals_->ITC_L3L4()->phiL_1_final,
+                                    &globals_->ITC_L3L4()->phiL_2_final,   &globals_->ITC_L3L4()->phiL_3_final,
+                                    &globals_->ITC_L3L4()->zL_0_final,     &globals_->ITC_L3L4()->zL_1_final,
+                                    &globals_->ITC_L3L4()->zL_2_final,     &globals_->ITC_L3L4()->zL_3_final,
+                                    &globals_->ITC_L3L4()->der_phiL_final, &globals_->ITC_L3L4()->der_zL_final,
+                                    &globals_->ITC_L3L4()->phiD_0_final,   &globals_->ITC_L3L4()->phiD_1_final,
+                                    &globals_->ITC_L3L4()->phiD_2_final,   &globals_->ITC_L3L4()->phiD_3_final,
+                                    &globals_->ITC_L3L4()->phiD_4_final,   &globals_->ITC_L3L4()->rD_0_final,
+                                    &globals_->ITC_L3L4()->rD_1_final,     &globals_->ITC_L3L4()->rD_2_final,
+                                    &globals_->ITC_L3L4()->rD_3_final,     &globals_->ITC_L3L4()->rD_4_final,
+                                    &globals_->ITC_L3L4()->der_phiD_final, &globals_->ITC_L3L4()->der_rD_final};
+        writeDesign(v, "TC_L3L4");
+      } break;
+      case 3:  // L5L6
+      {
+        const vector<VarBase*> v = {&globals_->ITC_L5L6()->rinv_final,     &globals_->ITC_L5L6()->phi0_final,
+                                    &globals_->ITC_L5L6()->t_final,        &globals_->ITC_L5L6()->z0_final,
+                                    &globals_->ITC_L5L6()->phiL_0_final,   &globals_->ITC_L5L6()->phiL_1_final,
+                                    &globals_->ITC_L5L6()->phiL_2_final,   &globals_->ITC_L5L6()->phiL_3_final,
+                                    &globals_->ITC_L5L6()->zL_0_final,     &globals_->ITC_L5L6()->zL_1_final,
+                                    &globals_->ITC_L5L6()->zL_2_final,     &globals_->ITC_L5L6()->zL_3_final,
+                                    &globals_->ITC_L5L6()->der_phiL_final, &globals_->ITC_L5L6()->der_zL_final,
+                                    &globals_->ITC_L5L6()->phiD_0_final,   &globals_->ITC_L5L6()->phiD_1_final,
+                                    &globals_->ITC_L5L6()->phiD_2_final,   &globals_->ITC_L5L6()->phiD_3_final,
+                                    &globals_->ITC_L5L6()->phiD_4_final,   &globals_->ITC_L5L6()->rD_0_final,
+                                    &globals_->ITC_L5L6()->rD_1_final,     &globals_->ITC_L5L6()->rD_2_final,
+                                    &globals_->ITC_L5L6()->rD_3_final,     &globals_->ITC_L5L6()->rD_4_final,
+                                    &globals_->ITC_L5L6()->der_phiD_final, &globals_->ITC_L5L6()->der_rD_final};
+        writeDesign(v, "TC_L5L6");
+      } break;
+      case 4:  // D1D2
+      {
+        const vector<VarBase*> v = {&globals_->ITC_F1F2()->rinv_final,     &globals_->ITC_F1F2()->phi0_final,
+                                    &globals_->ITC_F1F2()->t_final,        &globals_->ITC_F1F2()->z0_final,
+                                    &globals_->ITC_F1F2()->phiL_0_final,   &globals_->ITC_F1F2()->phiL_1_final,
+                                    &globals_->ITC_F1F2()->phiL_2_final,   &globals_->ITC_F1F2()->zL_0_final,
+                                    &globals_->ITC_F1F2()->zL_1_final,     &globals_->ITC_F1F2()->zL_2_final,
+                                    &globals_->ITC_F1F2()->der_phiL_final, &globals_->ITC_F1F2()->der_zL_final,
+                                    &globals_->ITC_F1F2()->phiD_0_final,   &globals_->ITC_F1F2()->phiD_1_final,
+                                    &globals_->ITC_F1F2()->phiD_2_final,   &globals_->ITC_F1F2()->rD_0_final,
+                                    &globals_->ITC_F1F2()->rD_1_final,     &globals_->ITC_F1F2()->rD_2_final,
+                                    &globals_->ITC_F1F2()->der_phiD_final, &globals_->ITC_F1F2()->der_rD_final};
+        writeDesign(v, "TC_F1F2");
+      }
+        {
+          const vector<VarBase*> v = {&globals_->ITC_B1B2()->rinv_final,     &globals_->ITC_B1B2()->phi0_final,
+                                      &globals_->ITC_B1B2()->t_final,        &globals_->ITC_B1B2()->z0_final,
+                                      &globals_->ITC_B1B2()->phiL_0_final,   &globals_->ITC_B1B2()->phiL_1_final,
+                                      &globals_->ITC_B1B2()->phiL_2_final,   &globals_->ITC_B1B2()->zL_0_final,
+                                      &globals_->ITC_B1B2()->zL_1_final,     &globals_->ITC_B1B2()->zL_2_final,
+                                      &globals_->ITC_B1B2()->der_phiL_final, &globals_->ITC_B1B2()->der_zL_final,
+                                      &globals_->ITC_B1B2()->phiD_0_final,   &globals_->ITC_B1B2()->phiD_1_final,
+                                      &globals_->ITC_B1B2()->phiD_2_final,   &globals_->ITC_B1B2()->rD_0_final,
+                                      &globals_->ITC_B1B2()->rD_1_final,     &globals_->ITC_B1B2()->rD_2_final,
+                                      &globals_->ITC_B1B2()->der_phiD_final, &globals_->ITC_B1B2()->der_rD_final};
+          writeDesign(v, "TC_B1B2");
+        }
+        break;
+      case 5:  // D3D4
+      {
+        const vector<VarBase*> v = {&globals_->ITC_F3F4()->rinv_final,     &globals_->ITC_F3F4()->phi0_final,
+                                    &globals_->ITC_F3F4()->t_final,        &globals_->ITC_F3F4()->z0_final,
+                                    &globals_->ITC_F3F4()->phiL_0_final,   &globals_->ITC_F3F4()->phiL_1_final,
+                                    &globals_->ITC_F3F4()->phiL_2_final,   &globals_->ITC_F3F4()->zL_0_final,
+                                    &globals_->ITC_F3F4()->zL_1_final,     &globals_->ITC_F3F4()->zL_2_final,
+                                    &globals_->ITC_F3F4()->der_phiL_final, &globals_->ITC_F3F4()->der_zL_final,
+                                    &globals_->ITC_F3F4()->phiD_0_final,   &globals_->ITC_F3F4()->phiD_1_final,
+                                    &globals_->ITC_F3F4()->phiD_2_final,   &globals_->ITC_F3F4()->rD_0_final,
+                                    &globals_->ITC_F3F4()->rD_1_final,     &globals_->ITC_F3F4()->rD_2_final,
+                                    &globals_->ITC_F3F4()->der_phiD_final, &globals_->ITC_F3F4()->der_rD_final};
+        writeDesign(v, "TC_F3F4");
+      }
+        {
+          const vector<VarBase*> v = {&globals_->ITC_B3B4()->rinv_final,     &globals_->ITC_B3B4()->phi0_final,
+                                      &globals_->ITC_B3B4()->t_final,        &globals_->ITC_B3B4()->z0_final,
+                                      &globals_->ITC_B3B4()->phiL_0_final,   &globals_->ITC_B3B4()->phiL_1_final,
+                                      &globals_->ITC_B3B4()->phiL_2_final,   &globals_->ITC_B3B4()->zL_0_final,
+                                      &globals_->ITC_B3B4()->zL_1_final,     &globals_->ITC_B3B4()->zL_2_final,
+                                      &globals_->ITC_B3B4()->der_phiL_final, &globals_->ITC_B3B4()->der_zL_final,
+                                      &globals_->ITC_B3B4()->phiD_0_final,   &globals_->ITC_B3B4()->phiD_1_final,
+                                      &globals_->ITC_B3B4()->phiD_2_final,   &globals_->ITC_B3B4()->rD_0_final,
+                                      &globals_->ITC_B3B4()->rD_1_final,     &globals_->ITC_B3B4()->rD_2_final,
+                                      &globals_->ITC_B3B4()->der_phiD_final, &globals_->ITC_B3B4()->der_rD_final};
+          writeDesign(v, "TC_B3B4");
+        }
+        break;
+      case 6:  // L1D1
+      {
+        const vector<VarBase*> v = {&globals_->ITC_L1F1()->rinv_final,     &globals_->ITC_L1F1()->phi0_final,
+                                    &globals_->ITC_L1F1()->t_final,        &globals_->ITC_L1F1()->z0_final,
+                                    &globals_->ITC_L1F1()->phiL_0_final,   &globals_->ITC_L1F1()->phiL_1_final,
+                                    &globals_->ITC_L1F1()->phiL_2_final,   &globals_->ITC_L1F1()->zL_0_final,
+                                    &globals_->ITC_L1F1()->zL_1_final,     &globals_->ITC_L1F1()->zL_2_final,
+                                    &globals_->ITC_L1F1()->der_phiL_final, &globals_->ITC_L1F1()->der_zL_final,
+                                    &globals_->ITC_L1F1()->phiD_0_final,   &globals_->ITC_L1F1()->phiD_1_final,
+                                    &globals_->ITC_L1F1()->phiD_2_final,   &globals_->ITC_L1F1()->phiD_3_final,
+                                    &globals_->ITC_L1F1()->rD_0_final,     &globals_->ITC_L1F1()->rD_1_final,
+                                    &globals_->ITC_L1F1()->rD_2_final,     &globals_->ITC_L1F1()->rD_3_final,
+                                    &globals_->ITC_L1F1()->der_phiD_final, &globals_->ITC_L1F1()->der_rD_final};
+        writeDesign(v, "TC_L1F1");
+      }
+        {
+          const vector<VarBase*> v = {&globals_->ITC_L1B1()->rinv_final,     &globals_->ITC_L1B1()->phi0_final,
+                                      &globals_->ITC_L1B1()->t_final,        &globals_->ITC_L1B1()->z0_final,
+                                      &globals_->ITC_L1B1()->phiL_0_final,   &globals_->ITC_L1B1()->phiL_1_final,
+                                      &globals_->ITC_L1B1()->phiL_2_final,   &globals_->ITC_L1B1()->zL_0_final,
+                                      &globals_->ITC_L1B1()->zL_1_final,     &globals_->ITC_L1B1()->zL_2_final,
+                                      &globals_->ITC_L1B1()->der_phiL_final, &globals_->ITC_L1B1()->der_zL_final,
+                                      &globals_->ITC_L1B1()->phiD_0_final,   &globals_->ITC_L1B1()->phiD_1_final,
+                                      &globals_->ITC_L1B1()->phiD_2_final,   &globals_->ITC_L1B1()->phiD_3_final,
+                                      &globals_->ITC_L1B1()->rD_0_final,     &globals_->ITC_L1B1()->rD_1_final,
+                                      &globals_->ITC_L1B1()->rD_2_final,     &globals_->ITC_L1B1()->rD_3_final,
+                                      &globals_->ITC_L1B1()->der_phiD_final, &globals_->ITC_L1B1()->der_rD_final};
+          writeDesign(v, "TC_L1B1");
+        }
+        break;
+      case 7:  // L2D1
+      {
+        const vector<VarBase*> v = {&globals_->ITC_L2F1()->rinv_final,     &globals_->ITC_L2F1()->phi0_final,
+                                    &globals_->ITC_L2F1()->t_final,        &globals_->ITC_L2F1()->z0_final,
+                                    &globals_->ITC_L2F1()->phiL_0_final,   &globals_->ITC_L2F1()->phiL_1_final,
+                                    &globals_->ITC_L2F1()->phiL_2_final,   &globals_->ITC_L2F1()->zL_0_final,
+                                    &globals_->ITC_L2F1()->zL_1_final,     &globals_->ITC_L2F1()->zL_2_final,
+                                    &globals_->ITC_L2F1()->der_phiL_final, &globals_->ITC_L2F1()->der_zL_final,
+                                    &globals_->ITC_L2F1()->phiD_0_final,   &globals_->ITC_L2F1()->phiD_1_final,
+                                    &globals_->ITC_L2F1()->phiD_2_final,   &globals_->ITC_L2F1()->phiD_3_final,
+                                    &globals_->ITC_L2F1()->rD_0_final,     &globals_->ITC_L2F1()->rD_1_final,
+                                    &globals_->ITC_L2F1()->rD_2_final,     &globals_->ITC_L2F1()->rD_3_final,
+                                    &globals_->ITC_L2F1()->der_phiD_final, &globals_->ITC_L2F1()->der_rD_final};
+        writeDesign(v, "TC_L2F1");
+      }
+        {
+          const vector<VarBase*> v = {&globals_->ITC_L2B1()->rinv_final,     &globals_->ITC_L2B1()->phi0_final,
+                                      &globals_->ITC_L2B1()->t_final,        &globals_->ITC_L2B1()->z0_final,
+                                      &globals_->ITC_L2B1()->phiL_0_final,   &globals_->ITC_L2B1()->phiL_1_final,
+                                      &globals_->ITC_L2B1()->phiL_2_final,   &globals_->ITC_L2B1()->zL_0_final,
+                                      &globals_->ITC_L2B1()->zL_1_final,     &globals_->ITC_L2B1()->zL_2_final,
+                                      &globals_->ITC_L2B1()->der_phiL_final, &globals_->ITC_L2B1()->der_zL_final,
+                                      &globals_->ITC_L2B1()->phiD_0_final,   &globals_->ITC_L2B1()->phiD_1_final,
+                                      &globals_->ITC_L2B1()->phiD_2_final,   &globals_->ITC_L2B1()->phiD_3_final,
+                                      &globals_->ITC_L2B1()->rD_0_final,     &globals_->ITC_L2B1()->rD_1_final,
+                                      &globals_->ITC_L2B1()->rD_2_final,     &globals_->ITC_L2B1()->rD_3_final,
+                                      &globals_->ITC_L2B1()->der_phiD_final, &globals_->ITC_L2B1()->der_rD_final};
+          writeDesign(v, "TC_L2B1");
+        }
+        break;
+    }
   }
-}
 
-void TrackletCalculator::writeFirmwareDesign(void (*writeDesign)(const vector<VarBase*>&, const string&)) {
-  switch (iSeed_) {
-    case 0:  // L1L2
-    {
-      const vector<VarBase*> v = {&globals_->ITC_L1L2()->rinv_final,     &globals_->ITC_L1L2()->phi0_final,
-                                  &globals_->ITC_L1L2()->t_final,        &globals_->ITC_L1L2()->z0_final,
-                                  &globals_->ITC_L1L2()->phiL_0_final,   &globals_->ITC_L1L2()->phiL_1_final,
-                                  &globals_->ITC_L1L2()->phiL_2_final,   &globals_->ITC_L1L2()->phiL_3_final,
-                                  &globals_->ITC_L1L2()->zL_0_final,     &globals_->ITC_L1L2()->zL_1_final,
-                                  &globals_->ITC_L1L2()->zL_2_final,     &globals_->ITC_L1L2()->zL_3_final,
-                                  &globals_->ITC_L1L2()->der_phiL_final, &globals_->ITC_L1L2()->der_zL_final,
-                                  &globals_->ITC_L1L2()->phiD_0_final,   &globals_->ITC_L1L2()->phiD_1_final,
-                                  &globals_->ITC_L1L2()->phiD_2_final,   &globals_->ITC_L1L2()->phiD_3_final,
-                                  &globals_->ITC_L1L2()->phiD_4_final,   &globals_->ITC_L1L2()->rD_0_final,
-                                  &globals_->ITC_L1L2()->rD_1_final,     &globals_->ITC_L1L2()->rD_2_final,
-                                  &globals_->ITC_L1L2()->rD_3_final,     &globals_->ITC_L1L2()->rD_4_final,
-                                  &globals_->ITC_L1L2()->der_phiD_final, &globals_->ITC_L1L2()->der_rD_final};
-      writeDesign(v, "TC_L1L2");
-    } break;
-    case 1:  // L2L3
-    {
-      const vector<VarBase*> v = {&globals_->ITC_L2L3()->rinv_final,     &globals_->ITC_L2L3()->phi0_final,
-                                  &globals_->ITC_L2L3()->t_final,        &globals_->ITC_L2L3()->z0_final,
-                                  &globals_->ITC_L2L3()->phiL_0_final,   &globals_->ITC_L2L3()->phiL_1_final,
-                                  &globals_->ITC_L2L3()->phiL_2_final,   &globals_->ITC_L2L3()->phiL_3_final,
-                                  &globals_->ITC_L2L3()->zL_0_final,     &globals_->ITC_L2L3()->zL_1_final,
-                                  &globals_->ITC_L2L3()->zL_2_final,     &globals_->ITC_L2L3()->zL_3_final,
-                                  &globals_->ITC_L2L3()->der_phiL_final, &globals_->ITC_L2L3()->der_zL_final,
-                                  &globals_->ITC_L2L3()->phiD_0_final,   &globals_->ITC_L2L3()->phiD_1_final,
-                                  &globals_->ITC_L2L3()->phiD_2_final,   &globals_->ITC_L2L3()->phiD_3_final,
-                                  &globals_->ITC_L2L3()->phiD_4_final,   &globals_->ITC_L2L3()->rD_0_final,
-                                  &globals_->ITC_L2L3()->rD_1_final,     &globals_->ITC_L2L3()->rD_2_final,
-                                  &globals_->ITC_L2L3()->rD_3_final,     &globals_->ITC_L2L3()->rD_4_final,
-                                  &globals_->ITC_L2L3()->der_phiD_final, &globals_->ITC_L2L3()->der_rD_final};
-      writeDesign(v, "TC_L2L3");
-    } break;
-    case 2:  // L3L4
-    {
-      const vector<VarBase*> v = {&globals_->ITC_L3L4()->rinv_final,     &globals_->ITC_L3L4()->phi0_final,
-                                  &globals_->ITC_L3L4()->t_final,        &globals_->ITC_L3L4()->z0_final,
-                                  &globals_->ITC_L3L4()->phiL_0_final,   &globals_->ITC_L3L4()->phiL_1_final,
-                                  &globals_->ITC_L3L4()->phiL_2_final,   &globals_->ITC_L3L4()->phiL_3_final,
-                                  &globals_->ITC_L3L4()->zL_0_final,     &globals_->ITC_L3L4()->zL_1_final,
-                                  &globals_->ITC_L3L4()->zL_2_final,     &globals_->ITC_L3L4()->zL_3_final,
-                                  &globals_->ITC_L3L4()->der_phiL_final, &globals_->ITC_L3L4()->der_zL_final,
-                                  &globals_->ITC_L3L4()->phiD_0_final,   &globals_->ITC_L3L4()->phiD_1_final,
-                                  &globals_->ITC_L3L4()->phiD_2_final,   &globals_->ITC_L3L4()->phiD_3_final,
-                                  &globals_->ITC_L3L4()->phiD_4_final,   &globals_->ITC_L3L4()->rD_0_final,
-                                  &globals_->ITC_L3L4()->rD_1_final,     &globals_->ITC_L3L4()->rD_2_final,
-                                  &globals_->ITC_L3L4()->rD_3_final,     &globals_->ITC_L3L4()->rD_4_final,
-                                  &globals_->ITC_L3L4()->der_phiD_final, &globals_->ITC_L3L4()->der_rD_final};
-      writeDesign(v, "TC_L3L4");
-    } break;
-    case 3:  // L5L6
-    {
-      const vector<VarBase*> v = {&globals_->ITC_L5L6()->rinv_final,     &globals_->ITC_L5L6()->phi0_final,
-                                  &globals_->ITC_L5L6()->t_final,        &globals_->ITC_L5L6()->z0_final,
-                                  &globals_->ITC_L5L6()->phiL_0_final,   &globals_->ITC_L5L6()->phiL_1_final,
-                                  &globals_->ITC_L5L6()->phiL_2_final,   &globals_->ITC_L5L6()->phiL_3_final,
-                                  &globals_->ITC_L5L6()->zL_0_final,     &globals_->ITC_L5L6()->zL_1_final,
-                                  &globals_->ITC_L5L6()->zL_2_final,     &globals_->ITC_L5L6()->zL_3_final,
-                                  &globals_->ITC_L5L6()->der_phiL_final, &globals_->ITC_L5L6()->der_zL_final,
-                                  &globals_->ITC_L5L6()->phiD_0_final,   &globals_->ITC_L5L6()->phiD_1_final,
-                                  &globals_->ITC_L5L6()->phiD_2_final,   &globals_->ITC_L5L6()->phiD_3_final,
-                                  &globals_->ITC_L5L6()->phiD_4_final,   &globals_->ITC_L5L6()->rD_0_final,
-                                  &globals_->ITC_L5L6()->rD_1_final,     &globals_->ITC_L5L6()->rD_2_final,
-                                  &globals_->ITC_L5L6()->rD_3_final,     &globals_->ITC_L5L6()->rD_4_final,
-                                  &globals_->ITC_L5L6()->der_phiD_final, &globals_->ITC_L5L6()->der_rD_final};
-      writeDesign(v, "TC_L5L6");
-    } break;
-    case 4:  // D1D2
-    {
-      const vector<VarBase*> v = {&globals_->ITC_F1F2()->rinv_final,     &globals_->ITC_F1F2()->phi0_final,
-                                  &globals_->ITC_F1F2()->t_final,        &globals_->ITC_F1F2()->z0_final,
-                                  &globals_->ITC_F1F2()->phiL_0_final,   &globals_->ITC_F1F2()->phiL_1_final,
-                                  &globals_->ITC_F1F2()->phiL_2_final,   &globals_->ITC_F1F2()->zL_0_final,
-                                  &globals_->ITC_F1F2()->zL_1_final,     &globals_->ITC_F1F2()->zL_2_final,
-                                  &globals_->ITC_F1F2()->der_phiL_final, &globals_->ITC_F1F2()->der_zL_final,
-                                  &globals_->ITC_F1F2()->phiD_0_final,   &globals_->ITC_F1F2()->phiD_1_final,
-                                  &globals_->ITC_F1F2()->phiD_2_final,   &globals_->ITC_F1F2()->rD_0_final,
-                                  &globals_->ITC_F1F2()->rD_1_final,     &globals_->ITC_F1F2()->rD_2_final,
-                                  &globals_->ITC_F1F2()->der_phiD_final, &globals_->ITC_F1F2()->der_rD_final};
-      writeDesign(v, "TC_F1F2");
-    }
-      {
-        const vector<VarBase*> v = {&globals_->ITC_B1B2()->rinv_final,     &globals_->ITC_B1B2()->phi0_final,
-                                    &globals_->ITC_B1B2()->t_final,        &globals_->ITC_B1B2()->z0_final,
-                                    &globals_->ITC_B1B2()->phiL_0_final,   &globals_->ITC_B1B2()->phiL_1_final,
-                                    &globals_->ITC_B1B2()->phiL_2_final,   &globals_->ITC_B1B2()->zL_0_final,
-                                    &globals_->ITC_B1B2()->zL_1_final,     &globals_->ITC_B1B2()->zL_2_final,
-                                    &globals_->ITC_B1B2()->der_phiL_final, &globals_->ITC_B1B2()->der_zL_final,
-                                    &globals_->ITC_B1B2()->phiD_0_final,   &globals_->ITC_B1B2()->phiD_1_final,
-                                    &globals_->ITC_B1B2()->phiD_2_final,   &globals_->ITC_B1B2()->rD_0_final,
-                                    &globals_->ITC_B1B2()->rD_1_final,     &globals_->ITC_B1B2()->rD_2_final,
-                                    &globals_->ITC_B1B2()->der_phiD_final, &globals_->ITC_B1B2()->der_rD_final};
-        writeDesign(v, "TC_B1B2");
-      }
-      break;
-    case 5:  // D3D4
-    {
-      const vector<VarBase*> v = {&globals_->ITC_F3F4()->rinv_final,     &globals_->ITC_F3F4()->phi0_final,
-                                  &globals_->ITC_F3F4()->t_final,        &globals_->ITC_F3F4()->z0_final,
-                                  &globals_->ITC_F3F4()->phiL_0_final,   &globals_->ITC_F3F4()->phiL_1_final,
-                                  &globals_->ITC_F3F4()->phiL_2_final,   &globals_->ITC_F3F4()->zL_0_final,
-                                  &globals_->ITC_F3F4()->zL_1_final,     &globals_->ITC_F3F4()->zL_2_final,
-                                  &globals_->ITC_F3F4()->der_phiL_final, &globals_->ITC_F3F4()->der_zL_final,
-                                  &globals_->ITC_F3F4()->phiD_0_final,   &globals_->ITC_F3F4()->phiD_1_final,
-                                  &globals_->ITC_F3F4()->phiD_2_final,   &globals_->ITC_F3F4()->rD_0_final,
-                                  &globals_->ITC_F3F4()->rD_1_final,     &globals_->ITC_F3F4()->rD_2_final,
-                                  &globals_->ITC_F3F4()->der_phiD_final, &globals_->ITC_F3F4()->der_rD_final};
-      writeDesign(v, "TC_F3F4");
-    }
-      {
-        const vector<VarBase*> v = {&globals_->ITC_B3B4()->rinv_final,     &globals_->ITC_B3B4()->phi0_final,
-                                    &globals_->ITC_B3B4()->t_final,        &globals_->ITC_B3B4()->z0_final,
-                                    &globals_->ITC_B3B4()->phiL_0_final,   &globals_->ITC_B3B4()->phiL_1_final,
-                                    &globals_->ITC_B3B4()->phiL_2_final,   &globals_->ITC_B3B4()->zL_0_final,
-                                    &globals_->ITC_B3B4()->zL_1_final,     &globals_->ITC_B3B4()->zL_2_final,
-                                    &globals_->ITC_B3B4()->der_phiL_final, &globals_->ITC_B3B4()->der_zL_final,
-                                    &globals_->ITC_B3B4()->phiD_0_final,   &globals_->ITC_B3B4()->phiD_1_final,
-                                    &globals_->ITC_B3B4()->phiD_2_final,   &globals_->ITC_B3B4()->rD_0_final,
-                                    &globals_->ITC_B3B4()->rD_1_final,     &globals_->ITC_B3B4()->rD_2_final,
-                                    &globals_->ITC_B3B4()->der_phiD_final, &globals_->ITC_B3B4()->der_rD_final};
-        writeDesign(v, "TC_B3B4");
-      }
-      break;
-    case 6:  // L1D1
-    {
-      const vector<VarBase*> v = {&globals_->ITC_L1F1()->rinv_final,     &globals_->ITC_L1F1()->phi0_final,
-                                  &globals_->ITC_L1F1()->t_final,        &globals_->ITC_L1F1()->z0_final,
-                                  &globals_->ITC_L1F1()->phiL_0_final,   &globals_->ITC_L1F1()->phiL_1_final,
-                                  &globals_->ITC_L1F1()->phiL_2_final,   &globals_->ITC_L1F1()->zL_0_final,
-                                  &globals_->ITC_L1F1()->zL_1_final,     &globals_->ITC_L1F1()->zL_2_final,
-                                  &globals_->ITC_L1F1()->der_phiL_final, &globals_->ITC_L1F1()->der_zL_final,
-                                  &globals_->ITC_L1F1()->phiD_0_final,   &globals_->ITC_L1F1()->phiD_1_final,
-                                  &globals_->ITC_L1F1()->phiD_2_final,   &globals_->ITC_L1F1()->phiD_3_final,
-                                  &globals_->ITC_L1F1()->rD_0_final,     &globals_->ITC_L1F1()->rD_1_final,
-                                  &globals_->ITC_L1F1()->rD_2_final,     &globals_->ITC_L1F1()->rD_3_final,
-                                  &globals_->ITC_L1F1()->der_phiD_final, &globals_->ITC_L1F1()->der_rD_final};
-      writeDesign(v, "TC_L1F1");
-    }
-      {
-        const vector<VarBase*> v = {&globals_->ITC_L1B1()->rinv_final,     &globals_->ITC_L1B1()->phi0_final,
-                                    &globals_->ITC_L1B1()->t_final,        &globals_->ITC_L1B1()->z0_final,
-                                    &globals_->ITC_L1B1()->phiL_0_final,   &globals_->ITC_L1B1()->phiL_1_final,
-                                    &globals_->ITC_L1B1()->phiL_2_final,   &globals_->ITC_L1B1()->zL_0_final,
-                                    &globals_->ITC_L1B1()->zL_1_final,     &globals_->ITC_L1B1()->zL_2_final,
-                                    &globals_->ITC_L1B1()->der_phiL_final, &globals_->ITC_L1B1()->der_zL_final,
-                                    &globals_->ITC_L1B1()->phiD_0_final,   &globals_->ITC_L1B1()->phiD_1_final,
-                                    &globals_->ITC_L1B1()->phiD_2_final,   &globals_->ITC_L1B1()->phiD_3_final,
-                                    &globals_->ITC_L1B1()->rD_0_final,     &globals_->ITC_L1B1()->rD_1_final,
-                                    &globals_->ITC_L1B1()->rD_2_final,     &globals_->ITC_L1B1()->rD_3_final,
-                                    &globals_->ITC_L1B1()->der_phiD_final, &globals_->ITC_L1B1()->der_rD_final};
-        writeDesign(v, "TC_L1B1");
-      }
-      break;
-    case 7:  // L2D1
-    {
-      const vector<VarBase*> v = {&globals_->ITC_L2F1()->rinv_final,     &globals_->ITC_L2F1()->phi0_final,
-                                  &globals_->ITC_L2F1()->t_final,        &globals_->ITC_L2F1()->z0_final,
-                                  &globals_->ITC_L2F1()->phiL_0_final,   &globals_->ITC_L2F1()->phiL_1_final,
-                                  &globals_->ITC_L2F1()->phiL_2_final,   &globals_->ITC_L2F1()->zL_0_final,
-                                  &globals_->ITC_L2F1()->zL_1_final,     &globals_->ITC_L2F1()->zL_2_final,
-                                  &globals_->ITC_L2F1()->der_phiL_final, &globals_->ITC_L2F1()->der_zL_final,
-                                  &globals_->ITC_L2F1()->phiD_0_final,   &globals_->ITC_L2F1()->phiD_1_final,
-                                  &globals_->ITC_L2F1()->phiD_2_final,   &globals_->ITC_L2F1()->phiD_3_final,
-                                  &globals_->ITC_L2F1()->rD_0_final,     &globals_->ITC_L2F1()->rD_1_final,
-                                  &globals_->ITC_L2F1()->rD_2_final,     &globals_->ITC_L2F1()->rD_3_final,
-                                  &globals_->ITC_L2F1()->der_phiD_final, &globals_->ITC_L2F1()->der_rD_final};
-      writeDesign(v, "TC_L2F1");
-    }
-      {
-        const vector<VarBase*> v = {&globals_->ITC_L2B1()->rinv_final,     &globals_->ITC_L2B1()->phi0_final,
-                                    &globals_->ITC_L2B1()->t_final,        &globals_->ITC_L2B1()->z0_final,
-                                    &globals_->ITC_L2B1()->phiL_0_final,   &globals_->ITC_L2B1()->phiL_1_final,
-                                    &globals_->ITC_L2B1()->phiL_2_final,   &globals_->ITC_L2B1()->zL_0_final,
-                                    &globals_->ITC_L2B1()->zL_1_final,     &globals_->ITC_L2B1()->zL_2_final,
-                                    &globals_->ITC_L2B1()->der_phiL_final, &globals_->ITC_L2B1()->der_zL_final,
-                                    &globals_->ITC_L2B1()->phiD_0_final,   &globals_->ITC_L2B1()->phiD_1_final,
-                                    &globals_->ITC_L2B1()->phiD_2_final,   &globals_->ITC_L2B1()->phiD_3_final,
-                                    &globals_->ITC_L2B1()->rD_0_final,     &globals_->ITC_L2B1()->rD_1_final,
-                                    &globals_->ITC_L2B1()->rD_2_final,     &globals_->ITC_L2B1()->rD_3_final,
-                                    &globals_->ITC_L2B1()->der_phiD_final, &globals_->ITC_L2B1()->der_rD_final};
-        writeDesign(v, "TC_L2B1");
-      }
-      break;
-  }
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculator.cc
@@ -12,7 +12,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletCalculator::TrackletCalculator(string name, Settings const& settings, Globals* globals)
     : TrackletCalculatorBase(name, settings, globals) {
@@ -469,4 +470,6 @@ void TrackletCalculator::writeFirmwareDesign(void (*writeDesign)(const vector<Va
       }
       break;
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
@@ -16,1380 +16,626 @@ using namespace std;
 
 namespace trklet {
 
-TrackletCalculatorBase::TrackletCalculatorBase(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global) {}
-
-void TrackletCalculatorBase::exacttracklet(double r1,
-                                           double z1,
-                                           double phi1,
-                                           double r2,
-                                           double z2,
-                                           double phi2,
-                                           double,
-                                           double& rinv,
-                                           double& phi0,
-                                           double& t,
-                                           double& z0,
-                                           double phiproj[N_LAYER - 2],
-                                           double zproj[N_LAYER - 2],
-                                           double phider[N_LAYER - 2],
-                                           double zder[N_LAYER - 2],
-                                           double phiprojdisk[N_DISK],
-                                           double rprojdisk[N_DISK],
-                                           double phiderdisk[N_DISK],
-                                           double rderdisk[N_DISK]) {
-  double deltaphi = reco::reduceRange(phi1 - phi2);
-
-  double dist = sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
-
-  rinv = 2 * sin(deltaphi) / dist;
-
-  double phi1tmp = phi1 - phimin_;
-
-  phi0 = reco::reduceRange(phi1tmp + asin(0.5 * r1 * rinv));
-
-  double rhopsi1 = 2 * asin(0.5 * r1 * rinv) / rinv;
-  double rhopsi2 = 2 * asin(0.5 * r2 * rinv) / rinv;
-
-  t = (z1 - z2) / (rhopsi1 - rhopsi2);
-
-  z0 = z1 - t * rhopsi1;
-
-  for (unsigned int i = 0; i < N_LAYER - 2; i++) {
-    exactproj(settings_.rmean(settings_.projlayers(iSeed_, i) - 1),
-              rinv,
-              phi0,
-              t,
-              z0,
-              phiproj[i],
-              zproj[i],
-              phider[i],
-              zder[i]);
-  }
-
-  for (unsigned int i = 0; i < N_DISK; i++) {
-    exactprojdisk(settings_.zmean(i), rinv, phi0, t, z0, phiprojdisk[i], rprojdisk[i], phiderdisk[i], rderdisk[i]);
-  }
-}
-
-void TrackletCalculatorBase::exacttrackletdisk(double r1,
-                                               double z1,
-                                               double phi1,
-                                               double r2,
-                                               double z2,
-                                               double phi2,
-                                               double,
-                                               double& rinv,
-                                               double& phi0,
-                                               double& t,
-                                               double& z0,
-                                               double phiprojLayer[N_PSLAYER],  //=3 (project to PS barrel layers only)
-                                               double zprojLayer[N_PSLAYER],
-                                               double phiderLayer[N_PSLAYER],
-                                               double zderLayer[N_PSLAYER],
-                                               double phiproj[N_DISK - 2],  //=3 (max project to 3 other disks)
-                                               double rproj[N_DISK - 2],
-                                               double phider[N_DISK - 2],
-                                               double rder[N_DISK - 2]) {
-  double deltaphi = reco::reduceRange(phi1 - phi2);
-
-  double dist = sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
-
-  rinv = 2 * sin(deltaphi) / dist;
-
-  double phi1tmp = phi1 - phimin_;
-
-  phi0 = reco::reduceRange(phi1tmp + asin(0.5 * r1 * rinv));
-
-  double rhopsi1 = 2 * asin(0.5 * r1 * rinv) / rinv;
-  double rhopsi2 = 2 * asin(0.5 * r2 * rinv) / rinv;
-
-  t = (z1 - z2) / (rhopsi1 - rhopsi2);
-
-  z0 = z1 - t * rhopsi1;
-
-  for (unsigned int i = 0; i < N_DISK - 2; i++) {
-    exactprojdisk(settings_.zmean(settings_.projdisks(iSeed_, i) - 1),
-                  rinv,
-                  phi0,
-                  t,
-                  z0,
-                  phiproj[i],
-                  rproj[i],
-                  phider[i],
-                  rder[i]);
-  }
-
-  for (unsigned int i = 0; i < N_DISK - 2; i++) {
-    exactproj(settings_.rmean(i), rinv, phi0, t, z0, phiprojLayer[i], zprojLayer[i], phiderLayer[i], zderLayer[i]);
-  }
-}
-
-void TrackletCalculatorBase::exacttrackletOverlap(double r1,
-                                                  double z1,
-                                                  double phi1,
-                                                  double r2,
-                                                  double z2,
-                                                  double phi2,
-                                                  double,
-                                                  double& rinv,
-                                                  double& phi0,
-                                                  double& t,
-                                                  double& z0,
-                                                  double phiprojLayer[N_PSLAYER],
-                                                  double zprojLayer[N_PSLAYER],
-                                                  double phiderLayer[N_PSLAYER],
-                                                  double zderLayer[N_PSLAYER],
-                                                  double phiproj[N_DISK - 2],
-                                                  double rproj[N_DISK - 2],
-                                                  double phider[N_DISK - 2],
-                                                  double rder[N_DISK - 2]) {
-  double deltaphi = reco::reduceRange(phi1 - phi2);
-
-  double dist = sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
-
-  rinv = 2 * sin(deltaphi) / dist;
-
-  if (r1 > r2)
-    rinv = -rinv;
-
-  double phi1tmp = phi1 - phimin_;
-
-  phi0 = reco::reduceRange(phi1tmp + asin(0.5 * r1 * rinv));
-
-  double rhopsi1 = 2 * asin(0.5 * r1 * rinv) / rinv;
-  double rhopsi2 = 2 * asin(0.5 * r2 * rinv) / rinv;
-
-  t = (z1 - z2) / (rhopsi1 - rhopsi2);
-
-  z0 = z1 - t * rhopsi1;
-
-  for (int i = 0; i < 4; i++) {
-    exactprojdisk(settings_.zmean(i + 1), rinv, phi0, t, z0, phiproj[i], rproj[i], phider[i], rder[i]);
-  }
-
-  for (int i = 0; i < 1; i++) {
-    exactproj(settings_.rmean(i), rinv, phi0, t, z0, phiprojLayer[i], zprojLayer[i], phiderLayer[i], zderLayer[i]);
-  }
-}
-
-void TrackletCalculatorBase::exactproj(double rproj,
-                                       double rinv,
-                                       double phi0,
-                                       double t,
-                                       double z0,
-                                       double& phiproj,
-                                       double& zproj,
-                                       double& phider,
-                                       double& zder) {
-  phiproj = phi0 - asin(0.5 * rproj * rinv);
-  zproj = z0 + (2 * t / rinv) * asin(0.5 * rproj * rinv);
-
-  phider = -0.5 * rinv / sqrt(1 - pow(0.5 * rproj * rinv, 2));
-  zder = t / sqrt(1 - pow(0.5 * rproj * rinv, 2));
-}
-
-void TrackletCalculatorBase::exactprojdisk(double zproj,
-                                           double rinv,
-                                           double phi0,
-                                           double t,
-                                           double z0,
-                                           double& phiproj,
-                                           double& rproj,
-                                           double& phider,
-                                           double& rder) {
-  if (t < 0)
-    zproj = -zproj;
-
-  double tmp = rinv * (zproj - z0) / (2.0 * t);
-  rproj = (2.0 / rinv) * sin(tmp);
-  phiproj = phi0 - tmp;
-
-  phider = -rinv / (2 * t);
-  rder = cos(tmp) / t;
-}
-
-void TrackletCalculatorBase::addDiskProj(Tracklet* tracklet, int disk) {
-  disk = std::abs(disk);
-
-  FPGAWord fpgar = tracklet->proj(N_LAYER + disk - 1).fpgarzproj();
-
-  if (fpgar.value() * settings_.krprojshiftdisk() < settings_.rmindiskvm())
-    return;
-  if (fpgar.value() * settings_.krprojshiftdisk() > settings_.rmaxdisk())
-    return;
-
-  FPGAWord fpgaphi = tracklet->proj(N_LAYER + disk - 1).fpgaphiproj();
-
-  int iphivmRaw = fpgaphi.value() >> (fpgaphi.nbits() - 5);
-
-  int iphi = iphivmRaw / (32 / settings_.nallstubs(disk + N_LAYER - 1));
-
-  addProjectionDisk(disk, iphi, trackletprojdisks_[disk - 1][iphi], tracklet);
-}
-
-bool TrackletCalculatorBase::addLayerProj(Tracklet* tracklet, int layer) {
-  assert(layer > 0);
-
-  FPGAWord fpgaz = tracklet->proj(layer - 1).fpgarzproj();
-  FPGAWord fpgaphi = tracklet->proj(layer - 1).fpgaphiproj();
-
-  if (fpgaphi.atExtreme())
-    edm::LogProblem("Tracklet") << "at extreme! " << fpgaphi.value();
-
-  assert(!fpgaphi.atExtreme());
-
-  if (fpgaz.atExtreme())
-    return false;
-
-  if (std::abs(fpgaz.value() * settings_.kz()) > settings_.zlength())
-    return false;
-
-  int iphivmRaw = fpgaphi.value() >> (fpgaphi.nbits() - 5);
-  int iphi = iphivmRaw / (32 / settings_.nallstubs(layer - 1));
-
-  addProjection(layer, iphi, trackletprojlayers_[layer - 1][iphi], tracklet);
-
-  return true;
-}
-
-void TrackletCalculatorBase::addProjection(int layer,
-                                           int iphi,
-                                           TrackletProjectionsMemory* trackletprojs,
-                                           Tracklet* tracklet) {
-  if (trackletprojs == nullptr) {
-    if (settings_.warnNoMem()) {
-      edm::LogVerbatim("Tracklet") << "No projection memory exists in " << getName() << " for layer = " << layer
-                                   << " iphi = " << iphi + 1;
-    }
-    return;
-  }
-  assert(trackletprojs != nullptr);
-  trackletprojs->addProj(tracklet);
-}
-
-void TrackletCalculatorBase::addProjectionDisk(int disk,
-                                               int iphi,
-                                               TrackletProjectionsMemory* trackletprojs,
-                                               Tracklet* tracklet) {
-  if (iSeed_ == Seed::L3L4 && abs(disk) == 4)
-    return;  //L3L4 projections to D3 are not used. Should be in configuration
-  if (trackletprojs == nullptr) {
-    if (iSeed_ == Seed::L3L4 && abs(disk) == 3)
-      return;  //L3L4 projections to D3 are not used.
-    if (settings_.warnNoMem()) {
-      edm::LogVerbatim("Tracklet") << "No projection memory exists in " << getName() << " for disk = " << abs(disk)
-                                   << " iphi = " << iphi + 1;
-    }
-    return;
-  }
-  assert(trackletprojs != nullptr);
-  trackletprojs->addProj(tracklet);
-}
-
-bool TrackletCalculatorBase::goodTrackPars(bool goodrinv, bool goodz0) {
-  bool success = true;
-  if (!goodrinv) {
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << getName() << " TrackletCalculatorBase irinv too large";
-    }
-    success = false;
-  }
-  if (!goodz0) {
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << getName() << " TrackletCalculatorBase z0 cut to large";
-    }
-    success = false;
-  }
-  return success;
-}
-
-bool TrackletCalculatorBase::inSector(int iphi0, int irinv, double phi0approx, double rinvapprox) {
-  double phicritapprox = phi0approx - asin(0.5 * settings_.rcrit() * rinvapprox);
-
-  int ifactor = 0.5 * settings_.rcrit() * settings_.krinvpars() / settings_.kphi0pars() * (1 << 8);
-  int iphicrit = iphi0 - (irinv >> 8) * ifactor;
-
-  int iphicritmincut = settings_.phicritminmc() / globals_->ITC_L1L2()->phi0_final.K();
-  int iphicritmaxcut = settings_.phicritmaxmc() / globals_->ITC_L1L2()->phi0_final.K();
-
-  bool keepapprox = (phicritapprox > settings_.phicritminmc()) && (phicritapprox < settings_.phicritmaxmc()),
-       keep = (iphicrit > iphicritmincut) && (iphicrit < iphicritmaxcut);
-  if (settings_.debugTracklet())
-    if (keepapprox && !keep)
-      edm::LogVerbatim("Tracklet") << getName()
-                                   << " Tracklet kept with exact phicrit cut but not approximate, phicritapprox: "
-                                   << phicritapprox;
-  if (settings_.usephicritapprox()) {
-    return keepapprox;
-  } else {
-    return keep;
-  }
-
-  return true;
-}
-
-bool TrackletCalculatorBase::barrelSeeding(const Stub* innerFPGAStub,
-                                           const L1TStub* innerStub,
-                                           const Stub* outerFPGAStub,
-                                           const L1TStub* outerStub) {
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "TrackletCalculatorBase " << getName()
-                                 << " trying stub pair in layer (inner outer): " << innerFPGAStub->layer().value()
-                                 << " " << outerFPGAStub->layer().value();
-  }
-
-  assert(outerFPGAStub->layerdisk() < N_LAYER);
-  assert(layerdisk1_ == (unsigned int)innerFPGAStub->layer().value());
-  assert(layerdisk1_ < N_LAYER && layerdisk2_ < N_LAYER);
-
-  double r1 = innerStub->r();
-  double z1 = innerStub->z();
-  double phi1 = innerStub->phi();
-
-  double r2 = outerStub->r();
-  double z2 = outerStub->z();
-  double phi2 = outerStub->phi();
-
-  double rinv, phi0, t, z0;
-
-  double phiproj[N_LAYER - 2], zproj[N_LAYER - 2], phider[N_LAYER - 2], zder[N_LAYER - 2];
-  double phiprojdisk[N_DISK], rprojdisk[N_DISK], phiderdisk[N_DISK], rderdisk[N_DISK];
-
-  exacttracklet(r1,
-                z1,
-                phi1,
-                r2,
-                z2,
-                phi2,
-                outerStub->sigmaz(),
+  TrackletCalculatorBase::TrackletCalculatorBase(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global) {}
+
+  void TrackletCalculatorBase::exacttracklet(double r1,
+                                             double z1,
+                                             double phi1,
+                                             double r2,
+                                             double z2,
+                                             double phi2,
+                                             double,
+                                             double& rinv,
+                                             double& phi0,
+                                             double& t,
+                                             double& z0,
+                                             double phiproj[N_LAYER - 2],
+                                             double zproj[N_LAYER - 2],
+                                             double phider[N_LAYER - 2],
+                                             double zder[N_LAYER - 2],
+                                             double phiprojdisk[N_DISK],
+                                             double rprojdisk[N_DISK],
+                                             double phiderdisk[N_DISK],
+                                             double rderdisk[N_DISK]) {
+    double deltaphi = reco::reduceRange(phi1 - phi2);
+
+    double dist = sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
+
+    rinv = 2 * sin(deltaphi) / dist;
+
+    double phi1tmp = phi1 - phimin_;
+
+    phi0 = reco::reduceRange(phi1tmp + asin(0.5 * r1 * rinv));
+
+    double rhopsi1 = 2 * asin(0.5 * r1 * rinv) / rinv;
+    double rhopsi2 = 2 * asin(0.5 * r2 * rinv) / rinv;
+
+    t = (z1 - z2) / (rhopsi1 - rhopsi2);
+
+    z0 = z1 - t * rhopsi1;
+
+    for (unsigned int i = 0; i < N_LAYER - 2; i++) {
+      exactproj(settings_.rmean(settings_.projlayers(iSeed_, i) - 1),
                 rinv,
                 phi0,
                 t,
                 z0,
-                phiproj,
-                zproj,
-                phider,
-                zder,
-                phiprojdisk,
-                rprojdisk,
-                phiderdisk,
-                rderdisk);
-
-  if (settings_.useapprox()) {
-    phi1 = innerFPGAStub->phiapprox(phimin_, phimax_);
-    z1 = innerFPGAStub->zapprox();
-    r1 = innerFPGAStub->rapprox();
-
-    phi2 = outerFPGAStub->phiapprox(phimin_, phimax_);
-    z2 = outerFPGAStub->zapprox();
-    r2 = outerFPGAStub->rapprox();
-  }
-
-  double rinvapprox, phi0approx, tapprox, z0approx;
-  double phiprojapprox[N_LAYER - 2], zprojapprox[N_LAYER - 2];
-  double phiprojdiskapprox[N_DISK], rprojdiskapprox[N_DISK];
-
-  IMATH_TrackletCalculator* ITC;
-  if (iSeed_ == 0)
-    ITC = globals_->ITC_L1L2();
-  else if (iSeed_ == 1)
-    ITC = globals_->ITC_L2L3();
-  else if (iSeed_ == 2)
-    ITC = globals_->ITC_L3L4();
-  else
-    ITC = globals_->ITC_L5L6();
-
-  ITC->r1.set_fval(r1 - settings_.rmean(layerdisk1_));
-  ITC->r2.set_fval(r2 - settings_.rmean(layerdisk2_));
-  ITC->z1.set_fval(z1);
-  ITC->z2.set_fval(z2);
-  double sphi1 = angle0to2pi::make0To2pi(phi1 - phimin_);
-  double sphi2 = angle0to2pi::make0To2pi(phi2 - phimin_);
-
-  ITC->phi1.set_fval(sphi1);
-  ITC->phi2.set_fval(sphi2);
-
-  ITC->rproj0.set_fval(settings_.rmean(settings_.projlayers(iSeed_, 0) - 1));
-  ITC->rproj1.set_fval(settings_.rmean(settings_.projlayers(iSeed_, 1) - 1));
-  ITC->rproj2.set_fval(settings_.rmean(settings_.projlayers(iSeed_, 2) - 1));
-  ITC->rproj3.set_fval(settings_.rmean(settings_.projlayers(iSeed_, 3) - 1));
-
-  ITC->zproj0.set_fval(t > 0 ? settings_.zmean(0) : -settings_.zmean(0));
-  ITC->zproj1.set_fval(t > 0 ? settings_.zmean(1) : -settings_.zmean(1));
-  ITC->zproj2.set_fval(t > 0 ? settings_.zmean(2) : -settings_.zmean(2));
-  ITC->zproj3.set_fval(t > 0 ? settings_.zmean(3) : -settings_.zmean(3));
-  ITC->zproj4.set_fval(t > 0 ? settings_.zmean(4) : -settings_.zmean(4));
-
-  ITC->rinv_final.calculate();
-  ITC->phi0_final.calculate();
-  ITC->t_final.calculate();
-  ITC->z0_final.calculate();
-
-  ITC->phiL_0_final.calculate();
-  ITC->phiL_1_final.calculate();
-  ITC->phiL_2_final.calculate();
-  ITC->phiL_3_final.calculate();
-
-  ITC->zL_0_final.calculate();
-  ITC->zL_1_final.calculate();
-  ITC->zL_2_final.calculate();
-  ITC->zL_3_final.calculate();
-
-  ITC->phiD_0_final.calculate();
-  ITC->phiD_1_final.calculate();
-  ITC->phiD_2_final.calculate();
-  ITC->phiD_3_final.calculate();
-  ITC->phiD_4_final.calculate();
-
-  ITC->rD_0_final.calculate();
-  ITC->rD_1_final.calculate();
-  ITC->rD_2_final.calculate();
-  ITC->rD_3_final.calculate();
-  ITC->rD_4_final.calculate();
-
-  ITC->der_phiL_final.calculate();
-  ITC->der_zL_final.calculate();
-  ITC->der_phiD_final.calculate();
-  ITC->der_rD_final.calculate();
-
-  //store the approximate results
-  rinvapprox = ITC->rinv_final.fval();
-  phi0approx = ITC->phi0_final.fval();
-  tapprox = ITC->t_final.fval();
-  z0approx = ITC->z0_final.fval();
-
-  phiprojapprox[0] = ITC->phiL_0_final.fval();
-  phiprojapprox[1] = ITC->phiL_1_final.fval();
-  phiprojapprox[2] = ITC->phiL_2_final.fval();
-  phiprojapprox[3] = ITC->phiL_3_final.fval();
-
-  zprojapprox[0] = ITC->zL_0_final.fval();
-  zprojapprox[1] = ITC->zL_1_final.fval();
-  zprojapprox[2] = ITC->zL_2_final.fval();
-  zprojapprox[3] = ITC->zL_3_final.fval();
-
-  phiprojdiskapprox[0] = ITC->phiD_0_final.fval();
-  phiprojdiskapprox[1] = ITC->phiD_1_final.fval();
-  phiprojdiskapprox[2] = ITC->phiD_2_final.fval();
-  phiprojdiskapprox[3] = ITC->phiD_3_final.fval();
-  phiprojdiskapprox[4] = ITC->phiD_4_final.fval();
-
-  rprojdiskapprox[0] = ITC->rD_0_final.fval();
-  rprojdiskapprox[1] = ITC->rD_1_final.fval();
-  rprojdiskapprox[2] = ITC->rD_2_final.fval();
-  rprojdiskapprox[3] = ITC->rD_3_final.fval();
-  rprojdiskapprox[4] = ITC->rD_4_final.fval();
-
-  //now binary
-
-  int irinv, iphi0, it, iz0;
-  Projection projs[N_LAYER + N_DISK];
-
-  int iphiproj[N_LAYER - 2], izproj[N_LAYER - 2];
-  int iphiprojdisk[N_DISK], irprojdisk[N_DISK];
-
-  int ir1 = innerFPGAStub->r().value();
-  int iphi1 = innerFPGAStub->phi().value();
-  int iz1 = innerFPGAStub->z().value();
-
-  int ir2 = outerFPGAStub->r().value();
-  int iphi2 = outerFPGAStub->phi().value();
-  int iz2 = outerFPGAStub->z().value();
-
-  iphi1 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(layerdisk1_));
-  iphi2 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(layerdisk2_));
-  ir1 <<= (8 - settings_.nrbitsstub(layerdisk1_));
-  ir2 <<= (8 - settings_.nrbitsstub(layerdisk2_));
-
-  iz1 <<= (settings_.nzbitsstub(0) - settings_.nzbitsstub(layerdisk1_));
-  iz2 <<= (settings_.nzbitsstub(0) - settings_.nzbitsstub(layerdisk2_));
-
-  ITC->r1.set_ival(ir1);
-  ITC->r2.set_ival(ir2);
-  ITC->z1.set_ival(iz1);
-  ITC->z2.set_ival(iz2);
-  ITC->phi1.set_ival(iphi1);
-  ITC->phi2.set_ival(iphi2);
-
-  ITC->rinv_final.calculate();
-  ITC->phi0_final.calculate();
-  ITC->t_final.calculate();
-  ITC->z0_final.calculate();
-
-  ITC->phiL_0_final.calculate();
-  ITC->phiL_1_final.calculate();
-  ITC->phiL_2_final.calculate();
-  ITC->phiL_3_final.calculate();
-
-  ITC->zL_0_final.calculate();
-  ITC->zL_1_final.calculate();
-  ITC->zL_2_final.calculate();
-  ITC->zL_3_final.calculate();
-
-  ITC->phiD_0_final.calculate();
-  ITC->phiD_1_final.calculate();
-  ITC->phiD_2_final.calculate();
-  ITC->phiD_3_final.calculate();
-  ITC->phiD_4_final.calculate();
-
-  ITC->rD_0_final.calculate();
-  ITC->rD_1_final.calculate();
-  ITC->rD_2_final.calculate();
-  ITC->rD_3_final.calculate();
-  ITC->rD_4_final.calculate();
-
-  ITC->der_phiL_final.calculate();
-  ITC->der_zL_final.calculate();
-  ITC->der_phiD_final.calculate();
-  ITC->der_rD_final.calculate();
-
-  //store the binary results
-  irinv = ITC->rinv_final.ival();
-  iphi0 = ITC->phi0_final.ival();
-  it = ITC->t_final.ival();
-  iz0 = ITC->z0_final.ival();
-
-  iphiproj[0] = ITC->phiL_0_final.ival();
-  iphiproj[1] = ITC->phiL_1_final.ival();
-  iphiproj[2] = ITC->phiL_2_final.ival();
-  iphiproj[3] = ITC->phiL_3_final.ival();
-
-  izproj[0] = ITC->zL_0_final.ival();
-  izproj[1] = ITC->zL_1_final.ival();
-  izproj[2] = ITC->zL_2_final.ival();
-  izproj[3] = ITC->zL_3_final.ival();
-
-  if (!goodTrackPars(ITC->rinv_final.local_passes(), ITC->z0_final.local_passes())) {
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << getName() << " Failed rinv or z0 cut";
-    }
-    return false;
-  }
-
-  if (!inSector(iphi0, irinv, phi0approx, rinvapprox)) {
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << getName() << " Failed in sector check";
-    }
-    return false;
-  }
-
-  for (unsigned int i = 0; i < N_LAYER - 2; ++i) {
-    //reject projection if z is out of range
-    if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-    if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-
-    //reject projection if phi is out of range
-    if (iphiproj[i] >= (1 << settings_.nphibitsstub(5)) - 1)
-      continue;
-    if (iphiproj[i] <= 0)
-      continue;
-
-    //Adjust bits for r and z projection depending on layer
-    if (settings_.projlayers(iSeed_, i) <= 3) {  //TODO clean up logic
-      iphiproj[i] >>= (settings_.nphibitsstub(5) - settings_.nphibitsstub(settings_.projlayers(iSeed_, i) - 1));
-    } else {
-      izproj[i] >>= (settings_.nzbitsstub(0) - settings_.nzbitsstub(5));
+                phiproj[i],
+                zproj[i],
+                phider[i],
+                zder[i]);
     }
 
-    projs[settings_.projlayers(iSeed_, i) - 1].init(settings_,
-                                                    settings_.projlayers(iSeed_, i) - 1,
-                                                    iphiproj[i],
-                                                    izproj[i],
-                                                    ITC->der_phiL_final.ival(),
-                                                    ITC->der_zL_final.ival(),
-                                                    phiproj[i],
-                                                    zproj[i],
-                                                    phider[i],
-                                                    zder[i],
-                                                    phiprojapprox[i],
-                                                    zprojapprox[i],
-                                                    ITC->der_phiL_final.fval(),
-                                                    ITC->der_zL_final.fval(),
-                                                    !(iSeed_ == 2 || iSeed_ == 3));
-  }
-
-  iphiprojdisk[0] = ITC->phiD_0_final.ival();
-  iphiprojdisk[1] = ITC->phiD_1_final.ival();
-  iphiprojdisk[2] = ITC->phiD_2_final.ival();
-  iphiprojdisk[3] = ITC->phiD_3_final.ival();
-  iphiprojdisk[4] = ITC->phiD_4_final.ival();
-
-  irprojdisk[0] = ITC->rD_0_final.ival();
-  irprojdisk[1] = ITC->rD_1_final.ival();
-  irprojdisk[2] = ITC->rD_2_final.ival();
-  irprojdisk[3] = ITC->rD_3_final.ival();
-  irprojdisk[4] = ITC->rD_4_final.ival();
-
-  if (std::abs(it * ITC->t_final.K()) > 1.0) {
-    for (unsigned int i = 0; i < N_DISK; ++i) {
-      if (iphiprojdisk[i] <= 0)
-        continue;
-      if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
-        continue;
-
-      if (irprojdisk[i] < settings_.rmindisk() / ITC->rD_0_final.K() ||
-          irprojdisk[i] >= settings_.rmaxdisk() / ITC->rD_0_final.K())
-        continue;
-
-      projs[i + N_LAYER].init(settings_,
-                              i + N_LAYER,
-                              iphiprojdisk[i],
-                              irprojdisk[i],
-                              ITC->der_phiD_final.ival(),
-                              ITC->der_rD_final.ival(),
-                              phiprojdisk[i],
-                              rprojdisk[i],
-                              phiderdisk[i],
-                              rderdisk[i],
-                              phiprojdiskapprox[i],
-                              rprojdiskapprox[i],
-                              ITC->der_phiD_final.fval(),
-                              ITC->der_rD_final.fval(),
-                              !(iSeed_ == 2 || iSeed_ == 3));
+    for (unsigned int i = 0; i < N_DISK; i++) {
+      exactprojdisk(settings_.zmean(i), rinv, phi0, t, z0, phiprojdisk[i], rprojdisk[i], phiderdisk[i], rderdisk[i]);
     }
   }
 
-  if (settings_.writeMonitorData("TPars")) {
-    globals_->ofstream("trackletpars.txt")
-        << "Trackpars " << layerdisk1_ + 1 << "   " << rinv << " " << rinvapprox << " " << ITC->rinv_final.fval()
-        << "   " << phi0 << " " << phi0approx << " " << ITC->phi0_final.fval() << "   " << t << " " << tapprox << " "
-        << ITC->t_final.fval() << "   " << z0 << " " << z0approx << " " << ITC->z0_final.fval() << endl;
-  }
+  void TrackletCalculatorBase::exacttrackletdisk(double r1,
+                                                 double z1,
+                                                 double phi1,
+                                                 double r2,
+                                                 double z2,
+                                                 double phi2,
+                                                 double,
+                                                 double& rinv,
+                                                 double& phi0,
+                                                 double& t,
+                                                 double& z0,
+                                                 double phiprojLayer[N_PSLAYER],  //=3 (project to PS barrel layers only)
+                                                 double zprojLayer[N_PSLAYER],
+                                                 double phiderLayer[N_PSLAYER],
+                                                 double zderLayer[N_PSLAYER],
+                                                 double phiproj[N_DISK - 2],  //=3 (max project to 3 other disks)
+                                                 double rproj[N_DISK - 2],
+                                                 double phider[N_DISK - 2],
+                                                 double rder[N_DISK - 2]) {
+    double deltaphi = reco::reduceRange(phi1 - phi2);
 
-  Tracklet* tracklet = new Tracklet(settings_,
-                                    iSeed_,
-                                    innerFPGAStub,
-                                    nullptr,
-                                    outerFPGAStub,
-                                    rinv,
-                                    phi0,
-                                    0.0,
-                                    z0,
-                                    t,
-                                    rinvapprox,
-                                    phi0approx,
-                                    0.0,
-                                    z0approx,
-                                    tapprox,
-                                    irinv,
-                                    iphi0,
-                                    0,
-                                    iz0,
-                                    it,
-                                    projs,
-                                    false);
+    double dist = sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
 
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "TrackletCalculator " << getName() << " Found tracklet for seed = " << iSeed_ << " "
-                                 << iSector_ << " phi0 = " << phi0;
-  }
+    rinv = 2 * sin(deltaphi) / dist;
 
-  tracklet->setTrackletIndex(trackletpars_->nTracklets());
-  tracklet->setTCIndex(TCIndex_);
+    double phi1tmp = phi1 - phimin_;
 
-  if (settings_.writeMonitorData("Seeds")) {
-    ofstream fout("seeds.txt", ofstream::app);
-    fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
-    fout.close();
-  }
-  trackletpars_->addTracklet(tracklet);
+    phi0 = reco::reduceRange(phi1tmp + asin(0.5 * r1 * rinv));
 
-  if (settings_.bookHistos()) {
-    HistBase* hists = globals_->histograms();
-    int tp = tracklet->tpseed();
-    hists->fillTrackletParams(settings_,
-                              globals_,
-                              iSeed_,
-                              iSector_,
-                              rinvapprox,
-                              irinv * ITC->rinv_final.K(),
-                              phi0approx,
-                              iphi0 * ITC->phi0_final.K(),
-                              asinh(tapprox),
-                              asinh(it * ITC->t_final.K()),
-                              z0approx,
-                              iz0 * ITC->z0_final.K(),
-                              tp);
-  }
+    double rhopsi1 = 2 * asin(0.5 * r1 * rinv) / rinv;
+    double rhopsi2 = 2 * asin(0.5 * r2 * rinv) / rinv;
 
-  bool addL3 = false;
-  bool addL4 = false;
-  bool addL5 = false;
-  bool addL6 = false;
-  for (unsigned int j = 0; j < N_LAYER - 2; j++) {
-    int lproj = settings_.projlayers(iSeed_, j);
-    bool added = false;
-    if (tracklet->validProj(lproj - 1)) {
-      added = addLayerProj(tracklet, lproj);
-      if (added && lproj == 3)
-        addL3 = true;
-      if (added && lproj == 4)
-        addL4 = true;
-      if (added && lproj == 5)
-        addL5 = true;
-      if (added && lproj == 6)
-        addL6 = true;
-    }
-  }
+    t = (z1 - z2) / (rhopsi1 - rhopsi2);
 
-  for (unsigned int j = 0; j < N_DISK - 1; j++) {  //no projections to 5th disk!!
-    int disk = j + 1;
-    if (disk == 4 && addL3)
-      continue;
-    if (disk == 3 && addL4)
-      continue;
-    if (disk == 2 && addL5)
-      continue;
-    if (disk == 1 && addL6)
-      continue;
-    if (it < 0)
-      disk = -disk;
-    if (tracklet->validProj(N_LAYER + abs(disk) - 1)) {
-      addDiskProj(tracklet, disk);
-    }
-  }
+    z0 = z1 - t * rhopsi1;
 
-  return true;
-}
-
-bool TrackletCalculatorBase::diskSeeding(const Stub* innerFPGAStub,
-                                         const L1TStub* innerStub,
-                                         const Stub* outerFPGAStub,
-                                         const L1TStub* outerStub) {
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "TrackletCalculator::execute calculate disk seeds";
-  }
-
-  int sign = 1;
-  if (innerFPGAStub->disk().value() < 0)
-    sign = -1;
-
-  int disk = innerFPGAStub->disk().value();
-  assert(abs(disk) == 1 || abs(disk) == 3);
-
-  assert(innerStub->isPSmodule());
-  assert(outerStub->isPSmodule());
-
-  double r1 = innerStub->r();
-  double z1 = innerStub->z();
-  double phi1 = innerStub->phi();
-
-  double r2 = outerStub->r();
-  double z2 = outerStub->z();
-  double phi2 = outerStub->phi();
-
-  if (r2 < r1 + 2.0) {
-    return false;  //Protection... Should be handled cleaner to avoid problem with floating point calculation
-  }
-
-  double rinv, phi0, t, z0;
-
-  double phiproj[N_PSLAYER], zproj[N_PSLAYER], phider[N_PSLAYER], zder[N_PSLAYER];
-  double phiprojdisk[N_DISK - 2], rprojdisk[N_DISK - 2], phiderdisk[N_DISK - 2], rderdisk[N_DISK - 2];
-
-  exacttrackletdisk(r1,
-                    z1,
-                    phi1,
-                    r2,
-                    z2,
-                    phi2,
-                    outerStub->sigmaz(),
+    for (unsigned int i = 0; i < N_DISK - 2; i++) {
+      exactprojdisk(settings_.zmean(settings_.projdisks(iSeed_, i) - 1),
                     rinv,
                     phi0,
                     t,
                     z0,
-                    phiproj,
-                    zproj,
-                    phider,
-                    zder,
-                    phiprojdisk,
-                    rprojdisk,
-                    phiderdisk,
-                    rderdisk);
+                    phiproj[i],
+                    rproj[i],
+                    phider[i],
+                    rder[i]);
+    }
 
-  //Truncates floating point positions to integer representation precision
-  if (settings_.useapprox()) {
-    phi1 = innerFPGAStub->phiapprox(phimin_, phimax_);
-    z1 = innerFPGAStub->zapprox();
-    r1 = innerFPGAStub->rapprox();
-
-    phi2 = outerFPGAStub->phiapprox(phimin_, phimax_);
-    z2 = outerFPGAStub->zapprox();
-    r2 = outerFPGAStub->rapprox();
-  }
-
-  double rinvapprox, phi0approx, tapprox, z0approx;
-  double phiprojapprox[N_PSLAYER], zprojapprox[N_PSLAYER];
-  double phiprojdiskapprox[N_DISK - 2], rprojdiskapprox[N_DISK - 2];
-
-  IMATH_TrackletCalculatorDisk* ITC;
-  if (disk == 1)
-    ITC = globals_->ITC_F1F2();
-  else if (disk == 3)
-    ITC = globals_->ITC_F3F4();
-  else if (disk == -1)
-    ITC = globals_->ITC_B1B2();
-  else
-    ITC = globals_->ITC_B3B4();
-
-  ITC->r1.set_fval(r1);
-  ITC->r2.set_fval(r2);
-  int signt = t > 0 ? 1 : -1;
-  ITC->z1.set_fval(z1 - signt * settings_.zmean(layerdisk1_ - N_LAYER));
-  ITC->z2.set_fval(z2 - signt * settings_.zmean(layerdisk2_ - N_LAYER));
-  double sphi1 = angle0to2pi::make0To2pi(phi1 - phimin_);
-  double sphi2 = angle0to2pi::make0To2pi(phi2 - phimin_);
-  ITC->phi1.set_fval(sphi1);
-  ITC->phi2.set_fval(sphi2);
-
-  ITC->rproj0.set_fval(settings_.rmean(0));
-  ITC->rproj1.set_fval(settings_.rmean(1));
-  ITC->rproj2.set_fval(settings_.rmean(2));
-
-  ITC->zproj0.set_fval(signt * settings_.zmean(settings_.projdisks(iSeed_, 0) - 1));
-  ITC->zproj1.set_fval(signt * settings_.zmean(settings_.projdisks(iSeed_, 1) - 1));
-  ITC->zproj2.set_fval(signt * settings_.zmean(settings_.projdisks(iSeed_, 2) - 1));
-
-  ITC->rinv_final.calculate();
-  ITC->phi0_final.calculate();
-  ITC->t_final.calculate();
-  ITC->z0_final.calculate();
-
-  ITC->phiL_0_final.calculate();
-  ITC->phiL_1_final.calculate();
-  ITC->phiL_2_final.calculate();
-
-  ITC->zL_0_final.calculate();
-  ITC->zL_1_final.calculate();
-  ITC->zL_2_final.calculate();
-
-  ITC->phiD_0_final.calculate();
-  ITC->phiD_1_final.calculate();
-  ITC->phiD_2_final.calculate();
-
-  ITC->rD_0_final.calculate();
-  ITC->rD_1_final.calculate();
-  ITC->rD_2_final.calculate();
-
-  ITC->der_phiL_final.calculate();
-  ITC->der_zL_final.calculate();
-  ITC->der_phiD_final.calculate();
-  ITC->der_rD_final.calculate();
-
-  //store the approximate results
-  rinvapprox = ITC->rinv_final.fval();
-  phi0approx = ITC->phi0_final.fval();
-  tapprox = ITC->t_final.fval();
-  z0approx = ITC->z0_final.fval();
-
-  phiprojapprox[0] = ITC->phiL_0_final.fval();
-  phiprojapprox[1] = ITC->phiL_1_final.fval();
-  phiprojapprox[2] = ITC->phiL_2_final.fval();
-
-  zprojapprox[0] = ITC->zL_0_final.fval();
-  zprojapprox[1] = ITC->zL_1_final.fval();
-  zprojapprox[2] = ITC->zL_2_final.fval();
-
-  phiprojdiskapprox[0] = ITC->phiD_0_final.fval();
-  phiprojdiskapprox[1] = ITC->phiD_1_final.fval();
-  phiprojdiskapprox[2] = ITC->phiD_2_final.fval();
-
-  rprojdiskapprox[0] = ITC->rD_0_final.fval();
-  rprojdiskapprox[1] = ITC->rD_1_final.fval();
-  rprojdiskapprox[2] = ITC->rD_2_final.fval();
-
-  //now binary
-
-  int irinv, iphi0, it, iz0;
-  int iphiproj[N_PSLAYER], izproj[N_PSLAYER];
-
-  int iphiprojdisk[N_DISK - 2], irprojdisk[N_DISK - 2];
-
-  int ir1 = innerFPGAStub->r().value();
-  int iphi1 = innerFPGAStub->phi().value();
-  int iz1 = innerFPGAStub->z().value();
-
-  int ir2 = outerFPGAStub->r().value();
-  int iphi2 = outerFPGAStub->phi().value();
-  int iz2 = outerFPGAStub->z().value();
-
-  //To get same precission as for layers.
-  iphi1 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
-  iphi2 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
-
-  ITC->r1.set_ival(ir1);
-  ITC->r2.set_ival(ir2);
-  ITC->z1.set_ival(iz1);
-  ITC->z2.set_ival(iz2);
-  ITC->phi1.set_ival(iphi1);
-  ITC->phi2.set_ival(iphi2);
-
-  ITC->rinv_final.calculate();
-  ITC->phi0_final.calculate();
-  ITC->t_final.calculate();
-  ITC->z0_final.calculate();
-
-  ITC->phiL_0_final.calculate();
-  ITC->phiL_1_final.calculate();
-  ITC->phiL_2_final.calculate();
-
-  ITC->zL_0_final.calculate();
-  ITC->zL_1_final.calculate();
-  ITC->zL_2_final.calculate();
-
-  ITC->phiD_0_final.calculate();
-  ITC->phiD_1_final.calculate();
-  ITC->phiD_2_final.calculate();
-
-  ITC->rD_0_final.calculate();
-  ITC->rD_1_final.calculate();
-  ITC->rD_2_final.calculate();
-
-  ITC->der_phiL_final.calculate();
-  ITC->der_zL_final.calculate();
-  ITC->der_phiD_final.calculate();
-  ITC->der_rD_final.calculate();
-
-  //store the binary results
-  irinv = ITC->rinv_final.ival();
-  iphi0 = ITC->phi0_final.ival();
-  it = ITC->t_final.ival();
-  iz0 = ITC->z0_final.ival();
-
-  iphiproj[0] = ITC->phiL_0_final.ival();
-  iphiproj[1] = ITC->phiL_1_final.ival();
-  iphiproj[2] = ITC->phiL_2_final.ival();
-
-  izproj[0] = ITC->zL_0_final.ival();
-  izproj[1] = ITC->zL_1_final.ival();
-  izproj[2] = ITC->zL_2_final.ival();
-
-  if (!goodTrackPars(ITC->rinv_final.local_passes(), ITC->z0_final.local_passes()))
-    return false;
-
-  if (!inSector(iphi0, irinv, phi0approx, rinvapprox))
-    return false;
-
-  Projection projs[N_LAYER + N_DISK];
-
-  for (unsigned int i = 0; i < N_DISK - 2; ++i) {
-    //Check is outside z range
-    if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-    if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-
-    //Check if outside phi range
-    if (iphiproj[i] >= (1 << settings_.nphibitsstub(5)) - 1)
-      continue;
-    if (iphiproj[i] <= 0)
-      continue;
-
-    //shift bits - allways in PS modules for disk seeding
-    iphiproj[i] >>= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
-
-    projs[i].init(settings_,
-                  i,
-                  iphiproj[i],
-                  izproj[i],
-                  ITC->der_phiL_final.ival(),
-                  ITC->der_zL_final.ival(),
-                  phiproj[i],
-                  zproj[i],
-                  phider[i],
-                  zder[i],
-                  phiprojapprox[i],
-                  zprojapprox[i],
-                  ITC->der_phiL_final.fval(),
-                  ITC->der_zL_final.fval(),
-                  true);
-  }
-
-  iphiprojdisk[0] = ITC->phiD_0_final.ival();
-  iphiprojdisk[1] = ITC->phiD_1_final.ival();
-  iphiprojdisk[2] = ITC->phiD_2_final.ival();
-
-  irprojdisk[0] = ITC->rD_0_final.ival();
-  irprojdisk[1] = ITC->rD_1_final.ival();
-  irprojdisk[2] = ITC->rD_2_final.ival();
-
-  for (unsigned int i = 0; i < N_DISK - 2; ++i) {
-    //check that phi projection in range
-    if (iphiprojdisk[i] <= 0)
-      continue;
-    if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
-      continue;
-
-    //check that r projection in range
-    if (irprojdisk[i] <= 0 || irprojdisk[i] >= settings_.rmaxdisk() / ITC->rD_0_final.K())
-      continue;
-
-    projs[settings_.projdisks(iSeed_, i) + N_LAYER - 1].init(settings_,
-                                                             settings_.projdisks(iSeed_, i) + N_LAYER - 1,
-                                                             iphiprojdisk[i],
-                                                             irprojdisk[i],
-                                                             ITC->der_phiD_final.ival(),
-                                                             ITC->der_rD_final.ival(),
-                                                             phiprojdisk[i],
-                                                             rprojdisk[i],
-                                                             phiderdisk[i],
-                                                             rderdisk[i],
-                                                             phiprojdiskapprox[i],
-                                                             rprojdiskapprox[i],
-                                                             ITC->der_phiD_final.fval(),
-                                                             ITC->der_rD_final.fval(),
-                                                             true);
-  }
-
-  if (settings_.writeMonitorData("TPars")) {
-    globals_->ofstream("trackletparsdisk.txt")
-        << "Trackpars         " << layerdisk1_ - 5 << "   " << rinv << " " << rinvapprox << " "
-        << ITC->rinv_final.fval() << "   " << phi0 << " " << phi0approx << " " << ITC->phi0_final.fval() << "   " << t
-        << " " << tapprox << " " << ITC->t_final.fval() << "   " << z0 << " " << z0approx << " " << ITC->z0_final.fval()
-        << endl;
-  }
-
-  Tracklet* tracklet = new Tracklet(settings_,
-                                    iSeed_,
-                                    innerFPGAStub,
-                                    nullptr,
-                                    outerFPGAStub,
-                                    rinv,
-                                    phi0,
-                                    0.0,
-                                    z0,
-                                    t,
-                                    rinvapprox,
-                                    phi0approx,
-                                    0.0,
-                                    z0approx,
-                                    tapprox,
-                                    irinv,
-                                    iphi0,
-                                    0,
-                                    iz0,
-                                    it,
-                                    projs,
-                                    true);
-
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "Found tracklet for disk seed = " << iSeed_ << " " << tracklet << " " << iSector_;
-  }
-
-  tracklet->setTrackletIndex(trackletpars_->nTracklets());
-  tracklet->setTCIndex(TCIndex_);
-
-  if (settings_.writeMonitorData("Seeds")) {
-    ofstream fout("seeds.txt", ofstream::app);
-    fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
-    fout.close();
-  }
-  trackletpars_->addTracklet(tracklet);
-
-  if (tracklet->validProj(0)) {
-    addLayerProj(tracklet, 1);
-  }
-
-  if (tracklet->validProj(1)) {
-    addLayerProj(tracklet, 2);
-  }
-
-  for (unsigned int j = 0; j < N_DISK - 2; j++) {
-    if (tracklet->validProj(N_LAYER + settings_.projdisks(iSeed_, j) - 1)) {
-      addDiskProj(tracklet, sign * settings_.projdisks(iSeed_, j));
+    for (unsigned int i = 0; i < N_DISK - 2; i++) {
+      exactproj(settings_.rmean(i), rinv, phi0, t, z0, phiprojLayer[i], zprojLayer[i], phiderLayer[i], zderLayer[i]);
     }
   }
 
-  return true;
-}
+  void TrackletCalculatorBase::exacttrackletOverlap(double r1,
+                                                    double z1,
+                                                    double phi1,
+                                                    double r2,
+                                                    double z2,
+                                                    double phi2,
+                                                    double,
+                                                    double& rinv,
+                                                    double& phi0,
+                                                    double& t,
+                                                    double& z0,
+                                                    double phiprojLayer[N_PSLAYER],
+                                                    double zprojLayer[N_PSLAYER],
+                                                    double phiderLayer[N_PSLAYER],
+                                                    double zderLayer[N_PSLAYER],
+                                                    double phiproj[N_DISK - 2],
+                                                    double rproj[N_DISK - 2],
+                                                    double phider[N_DISK - 2],
+                                                    double rder[N_DISK - 2]) {
+    double deltaphi = reco::reduceRange(phi1 - phi2);
 
-bool TrackletCalculatorBase::overlapSeeding(const Stub* innerFPGAStub,
-                                            const L1TStub* innerStub,
-                                            const Stub* outerFPGAStub,
-                                            const L1TStub* outerStub) {
-  //Deal with overlap stubs here
-  assert(outerFPGAStub->layerdisk() < N_LAYER);
+    double dist = sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
 
-  assert(innerFPGAStub->layerdisk() >= N_LAYER);
+    rinv = 2 * sin(deltaphi) / dist;
 
-  int disk = innerFPGAStub->disk().value();
+    if (r1 > r2)
+      rinv = -rinv;
 
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "trying to make overlap tracklet for seed = " << iSeed_ << " " << getName();
+    double phi1tmp = phi1 - phimin_;
+
+    phi0 = reco::reduceRange(phi1tmp + asin(0.5 * r1 * rinv));
+
+    double rhopsi1 = 2 * asin(0.5 * r1 * rinv) / rinv;
+    double rhopsi2 = 2 * asin(0.5 * r2 * rinv) / rinv;
+
+    t = (z1 - z2) / (rhopsi1 - rhopsi2);
+
+    z0 = z1 - t * rhopsi1;
+
+    for (int i = 0; i < 4; i++) {
+      exactprojdisk(settings_.zmean(i + 1), rinv, phi0, t, z0, phiproj[i], rproj[i], phider[i], rder[i]);
+    }
+
+    for (int i = 0; i < 1; i++) {
+      exactproj(settings_.rmean(i), rinv, phi0, t, z0, phiprojLayer[i], zprojLayer[i], phiderLayer[i], zderLayer[i]);
+    }
   }
 
-  double r1 = innerStub->r();
-  double z1 = innerStub->z();
-  double phi1 = innerStub->phi();
+  void TrackletCalculatorBase::exactproj(double rproj,
+                                         double rinv,
+                                         double phi0,
+                                         double t,
+                                         double z0,
+                                         double& phiproj,
+                                         double& zproj,
+                                         double& phider,
+                                         double& zder) {
+    phiproj = phi0 - asin(0.5 * rproj * rinv);
+    zproj = z0 + (2 * t / rinv) * asin(0.5 * rproj * rinv);
 
-  double r2 = outerStub->r();
-  double z2 = outerStub->z();
-  double phi2 = outerStub->phi();
-
-  //Protection for wrong radii. Could be handled cleaner to avoid problem with floating point calculation and with overflows in the integer calculation.
-  if (r1 < r2 + 1.5) {
-    return false;
+    phider = -0.5 * rinv / sqrt(1 - pow(0.5 * rproj * rinv, 2));
+    zder = t / sqrt(1 - pow(0.5 * rproj * rinv, 2));
   }
 
-  double rinv, phi0, t, z0;
+  void TrackletCalculatorBase::exactprojdisk(double zproj,
+                                             double rinv,
+                                             double phi0,
+                                             double t,
+                                             double z0,
+                                             double& phiproj,
+                                             double& rproj,
+                                             double& phider,
+                                             double& rder) {
+    if (t < 0)
+      zproj = -zproj;
 
-  double phiproj[N_PSLAYER], zproj[N_PSLAYER], phider[N_PSLAYER], zder[N_PSLAYER];
-  double phiprojdisk[N_DISK - 1], rprojdisk[N_DISK - 1], phiderdisk[N_DISK - 1], rderdisk[N_DISK - 1];
+    double tmp = rinv * (zproj - z0) / (2.0 * t);
+    rproj = (2.0 / rinv) * sin(tmp);
+    phiproj = phi0 - tmp;
 
-  exacttrackletOverlap(r1,
-                       z1,
-                       phi1,
-                       r2,
-                       z2,
-                       phi2,
-                       outerStub->sigmaz(),
-                       rinv,
-                       phi0,
-                       t,
-                       z0,
-                       phiproj,
-                       zproj,
-                       phider,
-                       zder,
-                       phiprojdisk,
-                       rprojdisk,
-                       phiderdisk,
-                       rderdisk);
-
-  //Truncates floating point positions to integer representation precision
-  if (settings_.useapprox()) {
-    phi1 = innerFPGAStub->phiapprox(phimin_, phimax_);
-    z1 = innerFPGAStub->zapprox();
-    r1 = innerFPGAStub->rapprox();
-
-    phi2 = outerFPGAStub->phiapprox(phimin_, phimax_);
-    z2 = outerFPGAStub->zapprox();
-    r2 = outerFPGAStub->rapprox();
+    phider = -rinv / (2 * t);
+    rder = cos(tmp) / t;
   }
 
-  double rinvapprox, phi0approx, tapprox, z0approx;
-  double phiprojapprox[N_PSLAYER], zprojapprox[N_PSLAYER];
-  double phiprojdiskapprox[N_DISK - 1], rprojdiskapprox[N_DISK - 1];
+  void TrackletCalculatorBase::addDiskProj(Tracklet* tracklet, int disk) {
+    disk = std::abs(disk);
 
-  IMATH_TrackletCalculatorOverlap* ITC;
-  int ll = outerFPGAStub->layer().value() + 1;
-  if (ll == 1 && disk == 1)
-    ITC = globals_->ITC_L1F1();
-  else if (ll == 2 && disk == 1)
-    ITC = globals_->ITC_L2F1();
-  else if (ll == 1 && disk == -1)
-    ITC = globals_->ITC_L1B1();
-  else if (ll == 2 && disk == -1)
-    ITC = globals_->ITC_L2B1();
-  else
-    throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
+    FPGAWord fpgar = tracklet->proj(N_LAYER + disk - 1).fpgarzproj();
 
-  ITC->r1.set_fval(r2 - settings_.rmean(ll - 1));
-  ITC->r2.set_fval(r1);
-  int signt = t > 0 ? 1 : -1;
-  ITC->z1.set_fval(z2);
-  ITC->z2.set_fval(z1 - signt * settings_.zmean(layerdisk2_ - N_LAYER));
-  double sphi1 = angle0to2pi::make0To2pi(phi1 - phimin_);
-  double sphi2 = angle0to2pi::make0To2pi(phi2 - phimin_);
-  ITC->phi1.set_fval(sphi2);
-  ITC->phi2.set_fval(sphi1);
+    if (fpgar.value() * settings_.krprojshiftdisk() < settings_.rmindiskvm())
+      return;
+    if (fpgar.value() * settings_.krprojshiftdisk() > settings_.rmaxdisk())
+      return;
 
-  ITC->rproj0.set_fval(settings_.rmean(0));
-  ITC->rproj1.set_fval(settings_.rmean(1));
-  ITC->rproj2.set_fval(settings_.rmean(2));
+    FPGAWord fpgaphi = tracklet->proj(N_LAYER + disk - 1).fpgaphiproj();
 
-  ITC->zproj0.set_fval(signt * settings_.zmean(1));
-  ITC->zproj1.set_fval(signt * settings_.zmean(2));
-  ITC->zproj2.set_fval(signt * settings_.zmean(3));
-  ITC->zproj3.set_fval(signt * settings_.zmean(4));
+    int iphivmRaw = fpgaphi.value() >> (fpgaphi.nbits() - 5);
 
-  ITC->rinv_final.calculate();
-  ITC->phi0_final.calculate();
-  ITC->t_final.calculate();
-  ITC->z0_final.calculate();
+    int iphi = iphivmRaw / (32 / settings_.nallstubs(disk + N_LAYER - 1));
 
-  ITC->phiL_0_final.calculate();
-  ITC->phiL_1_final.calculate();
-  ITC->phiL_2_final.calculate();
-
-  ITC->zL_0_final.calculate();
-  ITC->zL_1_final.calculate();
-  ITC->zL_2_final.calculate();
-
-  ITC->phiD_0_final.calculate();
-  ITC->phiD_1_final.calculate();
-  ITC->phiD_2_final.calculate();
-  ITC->phiD_3_final.calculate();
-
-  ITC->rD_0_final.calculate();
-  ITC->rD_1_final.calculate();
-  ITC->rD_2_final.calculate();
-  ITC->rD_3_final.calculate();
-
-  ITC->der_phiL_final.calculate();
-  ITC->der_zL_final.calculate();
-  ITC->der_phiD_final.calculate();
-  ITC->der_rD_final.calculate();
-
-  //store the approximate results
-  rinvapprox = ITC->rinv_final.fval();
-  phi0approx = ITC->phi0_final.fval();
-  tapprox = ITC->t_final.fval();
-  z0approx = ITC->z0_final.fval();
-
-  phiprojapprox[0] = ITC->phiL_0_final.fval();
-  phiprojapprox[1] = ITC->phiL_1_final.fval();
-  phiprojapprox[2] = ITC->phiL_2_final.fval();
-
-  zprojapprox[0] = ITC->zL_0_final.fval();
-  zprojapprox[1] = ITC->zL_1_final.fval();
-  zprojapprox[2] = ITC->zL_2_final.fval();
-
-  phiprojdiskapprox[0] = ITC->phiD_0_final.fval();
-  phiprojdiskapprox[1] = ITC->phiD_1_final.fval();
-  phiprojdiskapprox[2] = ITC->phiD_2_final.fval();
-  phiprojdiskapprox[3] = ITC->phiD_3_final.fval();
-
-  rprojdiskapprox[0] = ITC->rD_0_final.fval();
-  rprojdiskapprox[1] = ITC->rD_1_final.fval();
-  rprojdiskapprox[2] = ITC->rD_2_final.fval();
-  rprojdiskapprox[3] = ITC->rD_3_final.fval();
-
-  //now binary
-
-  int irinv, iphi0, it, iz0;
-  int iphiproj[N_LAYER - 2], izproj[N_LAYER - 2];
-  int iphiprojdisk[N_DISK], irprojdisk[N_DISK];
-
-  int ir2 = innerFPGAStub->r().value();
-  int iphi2 = innerFPGAStub->phi().value();
-  int iz2 = innerFPGAStub->z().value();
-
-  int ir1 = outerFPGAStub->r().value();
-  int iphi1 = outerFPGAStub->phi().value();
-  int iz1 = outerFPGAStub->z().value();
-
-  //To get global precission
-  ir1 = l1t::bitShift(ir1, (8 - settings_.nrbitsstub(ll - 1)));
-  iphi1 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
-  iphi2 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
-
-  ITC->r1.set_ival(ir1);
-  ITC->r2.set_ival(ir2);
-  ITC->z1.set_ival(iz1);
-  ITC->z2.set_ival(iz2);
-  ITC->phi1.set_ival(iphi1);
-  ITC->phi2.set_ival(iphi2);
-
-  ITC->rinv_final.calculate();
-  ITC->phi0_final.calculate();
-  ITC->t_final.calculate();
-  ITC->z0_final.calculate();
-
-  ITC->phiL_0_final.calculate();
-  ITC->phiL_1_final.calculate();
-  ITC->phiL_2_final.calculate();
-
-  ITC->zL_0_final.calculate();
-  ITC->zL_1_final.calculate();
-  ITC->zL_2_final.calculate();
-
-  ITC->phiD_0_final.calculate();
-  ITC->phiD_1_final.calculate();
-  ITC->phiD_2_final.calculate();
-  ITC->phiD_3_final.calculate();
-
-  ITC->rD_0_final.calculate();
-  ITC->rD_1_final.calculate();
-  ITC->rD_2_final.calculate();
-  ITC->rD_3_final.calculate();
-
-  ITC->der_phiL_final.calculate();
-  ITC->der_zL_final.calculate();
-  ITC->der_phiD_final.calculate();
-  ITC->der_rD_final.calculate();
-
-  //store the binary results
-  irinv = ITC->rinv_final.ival();
-  iphi0 = ITC->phi0_final.ival();
-  it = ITC->t_final.ival();
-  iz0 = ITC->z0_final.ival();
-
-  iphiproj[0] = ITC->phiL_0_final.ival();
-  iphiproj[1] = ITC->phiL_1_final.ival();
-  iphiproj[2] = ITC->phiL_2_final.ival();
-
-  izproj[0] = ITC->zL_0_final.ival();
-  izproj[1] = ITC->zL_1_final.ival();
-  izproj[2] = ITC->zL_2_final.ival();
-
-  iphiprojdisk[0] = ITC->phiD_0_final.ival();
-  iphiprojdisk[1] = ITC->phiD_1_final.ival();
-  iphiprojdisk[2] = ITC->phiD_2_final.ival();
-  iphiprojdisk[3] = ITC->phiD_3_final.ival();
-
-  irprojdisk[0] = ITC->rD_0_final.ival();
-  irprojdisk[1] = ITC->rD_1_final.ival();
-  irprojdisk[2] = ITC->rD_2_final.ival();
-  irprojdisk[3] = ITC->rD_3_final.ival();
-
-  if (!goodTrackPars(ITC->rinv_final.local_passes(), ITC->z0_final.local_passes()))
-    return false;
-
-  if (!inSector(iphi0, irinv, phi0approx, rinvapprox))
-    return false;
-
-  Projection projs[N_LAYER + N_DISK];
-
-  for (unsigned int i = 0; i < N_DISK - 2; ++i) {
-    //check that zproj is in range
-    if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-    if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-
-    //check that phiproj is in range
-    if (iphiproj[i] >= (1 << settings_.nphibitsstub(5)) - 1)
-      continue;
-    if (iphiproj[i] <= 0)
-      continue;
-
-    //adjust bits for PS modules (no 2S modules in overlap seeds)
-    iphiproj[i] >>= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
-
-    projs[i].init(settings_,
-                  i,
-                  iphiproj[i],
-                  izproj[i],
-                  ITC->der_phiL_final.ival(),
-                  ITC->der_zL_final.ival(),
-                  phiproj[i],
-                  zproj[i],
-                  phider[i],
-                  zder[i],
-                  phiprojapprox[i],
-                  zprojapprox[i],
-                  ITC->der_phiL_final.fval(),
-                  ITC->der_zL_final.fval(),
-                  true);
+    addProjectionDisk(disk, iphi, trackletprojdisks_[disk - 1][iphi], tracklet);
   }
 
-  for (int i = 0; i < 4; ++i) {
-    //check that phi projection in range
-    if (iphiprojdisk[i] <= 0)
-      continue;
-    if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
-      continue;
+  bool TrackletCalculatorBase::addLayerProj(Tracklet* tracklet, int layer) {
+    assert(layer > 0);
 
-    //check that r projection in range
-    if (irprojdisk[i] <= 0 || irprojdisk[i] >= settings_.rmaxdisk() / ITC->rD_0_final.K())
-      continue;
+    FPGAWord fpgaz = tracklet->proj(layer - 1).fpgarzproj();
+    FPGAWord fpgaphi = tracklet->proj(layer - 1).fpgaphiproj();
 
-    projs[N_LAYER + i + 1].init(settings_,
-                                N_LAYER + i + 1,
+    if (fpgaphi.atExtreme())
+      edm::LogProblem("Tracklet") << "at extreme! " << fpgaphi.value();
+
+    assert(!fpgaphi.atExtreme());
+
+    if (fpgaz.atExtreme())
+      return false;
+
+    if (std::abs(fpgaz.value() * settings_.kz()) > settings_.zlength())
+      return false;
+
+    int iphivmRaw = fpgaphi.value() >> (fpgaphi.nbits() - 5);
+    int iphi = iphivmRaw / (32 / settings_.nallstubs(layer - 1));
+
+    addProjection(layer, iphi, trackletprojlayers_[layer - 1][iphi], tracklet);
+
+    return true;
+  }
+
+  void TrackletCalculatorBase::addProjection(int layer,
+                                             int iphi,
+                                             TrackletProjectionsMemory* trackletprojs,
+                                             Tracklet* tracklet) {
+    if (trackletprojs == nullptr) {
+      if (settings_.warnNoMem()) {
+        edm::LogVerbatim("Tracklet") << "No projection memory exists in " << getName() << " for layer = " << layer
+                                     << " iphi = " << iphi + 1;
+      }
+      return;
+    }
+    assert(trackletprojs != nullptr);
+    trackletprojs->addProj(tracklet);
+  }
+
+  void TrackletCalculatorBase::addProjectionDisk(int disk,
+                                                 int iphi,
+                                                 TrackletProjectionsMemory* trackletprojs,
+                                                 Tracklet* tracklet) {
+    if (iSeed_ == Seed::L3L4 && abs(disk) == 4)
+      return;  //L3L4 projections to D3 are not used. Should be in configuration
+    if (trackletprojs == nullptr) {
+      if (iSeed_ == Seed::L3L4 && abs(disk) == 3)
+        return;  //L3L4 projections to D3 are not used.
+      if (settings_.warnNoMem()) {
+        edm::LogVerbatim("Tracklet") << "No projection memory exists in " << getName() << " for disk = " << abs(disk)
+                                     << " iphi = " << iphi + 1;
+      }
+      return;
+    }
+    assert(trackletprojs != nullptr);
+    trackletprojs->addProj(tracklet);
+  }
+
+  bool TrackletCalculatorBase::goodTrackPars(bool goodrinv, bool goodz0) {
+    bool success = true;
+    if (!goodrinv) {
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << getName() << " TrackletCalculatorBase irinv too large";
+      }
+      success = false;
+    }
+    if (!goodz0) {
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << getName() << " TrackletCalculatorBase z0 cut to large";
+      }
+      success = false;
+    }
+    return success;
+  }
+
+  bool TrackletCalculatorBase::inSector(int iphi0, int irinv, double phi0approx, double rinvapprox) {
+    double phicritapprox = phi0approx - asin(0.5 * settings_.rcrit() * rinvapprox);
+
+    int ifactor = 0.5 * settings_.rcrit() * settings_.krinvpars() / settings_.kphi0pars() * (1 << 8);
+    int iphicrit = iphi0 - (irinv >> 8) * ifactor;
+
+    int iphicritmincut = settings_.phicritminmc() / globals_->ITC_L1L2()->phi0_final.K();
+    int iphicritmaxcut = settings_.phicritmaxmc() / globals_->ITC_L1L2()->phi0_final.K();
+
+    bool keepapprox = (phicritapprox > settings_.phicritminmc()) && (phicritapprox < settings_.phicritmaxmc()),
+         keep = (iphicrit > iphicritmincut) && (iphicrit < iphicritmaxcut);
+    if (settings_.debugTracklet())
+      if (keepapprox && !keep)
+        edm::LogVerbatim("Tracklet") << getName()
+                                     << " Tracklet kept with exact phicrit cut but not approximate, phicritapprox: "
+                                     << phicritapprox;
+    if (settings_.usephicritapprox()) {
+      return keepapprox;
+    } else {
+      return keep;
+    }
+
+    return true;
+  }
+
+  bool TrackletCalculatorBase::barrelSeeding(const Stub* innerFPGAStub,
+                                             const L1TStub* innerStub,
+                                             const Stub* outerFPGAStub,
+                                             const L1TStub* outerStub) {
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "TrackletCalculatorBase " << getName()
+                                   << " trying stub pair in layer (inner outer): " << innerFPGAStub->layer().value()
+                                   << " " << outerFPGAStub->layer().value();
+    }
+
+    assert(outerFPGAStub->layerdisk() < N_LAYER);
+    assert(layerdisk1_ == (unsigned int)innerFPGAStub->layer().value());
+    assert(layerdisk1_ < N_LAYER && layerdisk2_ < N_LAYER);
+
+    double r1 = innerStub->r();
+    double z1 = innerStub->z();
+    double phi1 = innerStub->phi();
+
+    double r2 = outerStub->r();
+    double z2 = outerStub->z();
+    double phi2 = outerStub->phi();
+
+    double rinv, phi0, t, z0;
+
+    double phiproj[N_LAYER - 2], zproj[N_LAYER - 2], phider[N_LAYER - 2], zder[N_LAYER - 2];
+    double phiprojdisk[N_DISK], rprojdisk[N_DISK], phiderdisk[N_DISK], rderdisk[N_DISK];
+
+    exacttracklet(r1,
+                  z1,
+                  phi1,
+                  r2,
+                  z2,
+                  phi2,
+                  outerStub->sigmaz(),
+                  rinv,
+                  phi0,
+                  t,
+                  z0,
+                  phiproj,
+                  zproj,
+                  phider,
+                  zder,
+                  phiprojdisk,
+                  rprojdisk,
+                  phiderdisk,
+                  rderdisk);
+
+    if (settings_.useapprox()) {
+      phi1 = innerFPGAStub->phiapprox(phimin_, phimax_);
+      z1 = innerFPGAStub->zapprox();
+      r1 = innerFPGAStub->rapprox();
+
+      phi2 = outerFPGAStub->phiapprox(phimin_, phimax_);
+      z2 = outerFPGAStub->zapprox();
+      r2 = outerFPGAStub->rapprox();
+    }
+
+    double rinvapprox, phi0approx, tapprox, z0approx;
+    double phiprojapprox[N_LAYER - 2], zprojapprox[N_LAYER - 2];
+    double phiprojdiskapprox[N_DISK], rprojdiskapprox[N_DISK];
+
+    IMATH_TrackletCalculator* ITC;
+    if (iSeed_ == 0)
+      ITC = globals_->ITC_L1L2();
+    else if (iSeed_ == 1)
+      ITC = globals_->ITC_L2L3();
+    else if (iSeed_ == 2)
+      ITC = globals_->ITC_L3L4();
+    else
+      ITC = globals_->ITC_L5L6();
+
+    ITC->r1.set_fval(r1 - settings_.rmean(layerdisk1_));
+    ITC->r2.set_fval(r2 - settings_.rmean(layerdisk2_));
+    ITC->z1.set_fval(z1);
+    ITC->z2.set_fval(z2);
+    double sphi1 = angle0to2pi::make0To2pi(phi1 - phimin_);
+    double sphi2 = angle0to2pi::make0To2pi(phi2 - phimin_);
+
+    ITC->phi1.set_fval(sphi1);
+    ITC->phi2.set_fval(sphi2);
+
+    ITC->rproj0.set_fval(settings_.rmean(settings_.projlayers(iSeed_, 0) - 1));
+    ITC->rproj1.set_fval(settings_.rmean(settings_.projlayers(iSeed_, 1) - 1));
+    ITC->rproj2.set_fval(settings_.rmean(settings_.projlayers(iSeed_, 2) - 1));
+    ITC->rproj3.set_fval(settings_.rmean(settings_.projlayers(iSeed_, 3) - 1));
+
+    ITC->zproj0.set_fval(t > 0 ? settings_.zmean(0) : -settings_.zmean(0));
+    ITC->zproj1.set_fval(t > 0 ? settings_.zmean(1) : -settings_.zmean(1));
+    ITC->zproj2.set_fval(t > 0 ? settings_.zmean(2) : -settings_.zmean(2));
+    ITC->zproj3.set_fval(t > 0 ? settings_.zmean(3) : -settings_.zmean(3));
+    ITC->zproj4.set_fval(t > 0 ? settings_.zmean(4) : -settings_.zmean(4));
+
+    ITC->rinv_final.calculate();
+    ITC->phi0_final.calculate();
+    ITC->t_final.calculate();
+    ITC->z0_final.calculate();
+
+    ITC->phiL_0_final.calculate();
+    ITC->phiL_1_final.calculate();
+    ITC->phiL_2_final.calculate();
+    ITC->phiL_3_final.calculate();
+
+    ITC->zL_0_final.calculate();
+    ITC->zL_1_final.calculate();
+    ITC->zL_2_final.calculate();
+    ITC->zL_3_final.calculate();
+
+    ITC->phiD_0_final.calculate();
+    ITC->phiD_1_final.calculate();
+    ITC->phiD_2_final.calculate();
+    ITC->phiD_3_final.calculate();
+    ITC->phiD_4_final.calculate();
+
+    ITC->rD_0_final.calculate();
+    ITC->rD_1_final.calculate();
+    ITC->rD_2_final.calculate();
+    ITC->rD_3_final.calculate();
+    ITC->rD_4_final.calculate();
+
+    ITC->der_phiL_final.calculate();
+    ITC->der_zL_final.calculate();
+    ITC->der_phiD_final.calculate();
+    ITC->der_rD_final.calculate();
+
+    //store the approximate results
+    rinvapprox = ITC->rinv_final.fval();
+    phi0approx = ITC->phi0_final.fval();
+    tapprox = ITC->t_final.fval();
+    z0approx = ITC->z0_final.fval();
+
+    phiprojapprox[0] = ITC->phiL_0_final.fval();
+    phiprojapprox[1] = ITC->phiL_1_final.fval();
+    phiprojapprox[2] = ITC->phiL_2_final.fval();
+    phiprojapprox[3] = ITC->phiL_3_final.fval();
+
+    zprojapprox[0] = ITC->zL_0_final.fval();
+    zprojapprox[1] = ITC->zL_1_final.fval();
+    zprojapprox[2] = ITC->zL_2_final.fval();
+    zprojapprox[3] = ITC->zL_3_final.fval();
+
+    phiprojdiskapprox[0] = ITC->phiD_0_final.fval();
+    phiprojdiskapprox[1] = ITC->phiD_1_final.fval();
+    phiprojdiskapprox[2] = ITC->phiD_2_final.fval();
+    phiprojdiskapprox[3] = ITC->phiD_3_final.fval();
+    phiprojdiskapprox[4] = ITC->phiD_4_final.fval();
+
+    rprojdiskapprox[0] = ITC->rD_0_final.fval();
+    rprojdiskapprox[1] = ITC->rD_1_final.fval();
+    rprojdiskapprox[2] = ITC->rD_2_final.fval();
+    rprojdiskapprox[3] = ITC->rD_3_final.fval();
+    rprojdiskapprox[4] = ITC->rD_4_final.fval();
+
+    //now binary
+
+    int irinv, iphi0, it, iz0;
+    Projection projs[N_LAYER + N_DISK];
+
+    int iphiproj[N_LAYER - 2], izproj[N_LAYER - 2];
+    int iphiprojdisk[N_DISK], irprojdisk[N_DISK];
+
+    int ir1 = innerFPGAStub->r().value();
+    int iphi1 = innerFPGAStub->phi().value();
+    int iz1 = innerFPGAStub->z().value();
+
+    int ir2 = outerFPGAStub->r().value();
+    int iphi2 = outerFPGAStub->phi().value();
+    int iz2 = outerFPGAStub->z().value();
+
+    iphi1 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(layerdisk1_));
+    iphi2 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(layerdisk2_));
+    ir1 <<= (8 - settings_.nrbitsstub(layerdisk1_));
+    ir2 <<= (8 - settings_.nrbitsstub(layerdisk2_));
+
+    iz1 <<= (settings_.nzbitsstub(0) - settings_.nzbitsstub(layerdisk1_));
+    iz2 <<= (settings_.nzbitsstub(0) - settings_.nzbitsstub(layerdisk2_));
+
+    ITC->r1.set_ival(ir1);
+    ITC->r2.set_ival(ir2);
+    ITC->z1.set_ival(iz1);
+    ITC->z2.set_ival(iz2);
+    ITC->phi1.set_ival(iphi1);
+    ITC->phi2.set_ival(iphi2);
+
+    ITC->rinv_final.calculate();
+    ITC->phi0_final.calculate();
+    ITC->t_final.calculate();
+    ITC->z0_final.calculate();
+
+    ITC->phiL_0_final.calculate();
+    ITC->phiL_1_final.calculate();
+    ITC->phiL_2_final.calculate();
+    ITC->phiL_3_final.calculate();
+
+    ITC->zL_0_final.calculate();
+    ITC->zL_1_final.calculate();
+    ITC->zL_2_final.calculate();
+    ITC->zL_3_final.calculate();
+
+    ITC->phiD_0_final.calculate();
+    ITC->phiD_1_final.calculate();
+    ITC->phiD_2_final.calculate();
+    ITC->phiD_3_final.calculate();
+    ITC->phiD_4_final.calculate();
+
+    ITC->rD_0_final.calculate();
+    ITC->rD_1_final.calculate();
+    ITC->rD_2_final.calculate();
+    ITC->rD_3_final.calculate();
+    ITC->rD_4_final.calculate();
+
+    ITC->der_phiL_final.calculate();
+    ITC->der_zL_final.calculate();
+    ITC->der_phiD_final.calculate();
+    ITC->der_rD_final.calculate();
+
+    //store the binary results
+    irinv = ITC->rinv_final.ival();
+    iphi0 = ITC->phi0_final.ival();
+    it = ITC->t_final.ival();
+    iz0 = ITC->z0_final.ival();
+
+    iphiproj[0] = ITC->phiL_0_final.ival();
+    iphiproj[1] = ITC->phiL_1_final.ival();
+    iphiproj[2] = ITC->phiL_2_final.ival();
+    iphiproj[3] = ITC->phiL_3_final.ival();
+
+    izproj[0] = ITC->zL_0_final.ival();
+    izproj[1] = ITC->zL_1_final.ival();
+    izproj[2] = ITC->zL_2_final.ival();
+    izproj[3] = ITC->zL_3_final.ival();
+
+    if (!goodTrackPars(ITC->rinv_final.local_passes(), ITC->z0_final.local_passes())) {
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << getName() << " Failed rinv or z0 cut";
+      }
+      return false;
+    }
+
+    if (!inSector(iphi0, irinv, phi0approx, rinvapprox)) {
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << getName() << " Failed in sector check";
+      }
+      return false;
+    }
+
+    for (unsigned int i = 0; i < N_LAYER - 2; ++i) {
+      //reject projection if z is out of range
+      if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
+        continue;
+      if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
+        continue;
+
+      //reject projection if phi is out of range
+      if (iphiproj[i] >= (1 << settings_.nphibitsstub(5)) - 1)
+        continue;
+      if (iphiproj[i] <= 0)
+        continue;
+
+      //Adjust bits for r and z projection depending on layer
+      if (settings_.projlayers(iSeed_, i) <= 3) {  //TODO clean up logic
+        iphiproj[i] >>= (settings_.nphibitsstub(5) - settings_.nphibitsstub(settings_.projlayers(iSeed_, i) - 1));
+      } else {
+        izproj[i] >>= (settings_.nzbitsstub(0) - settings_.nzbitsstub(5));
+      }
+
+      projs[settings_.projlayers(iSeed_, i) - 1].init(settings_,
+                                                      settings_.projlayers(iSeed_, i) - 1,
+                                                      iphiproj[i],
+                                                      izproj[i],
+                                                      ITC->der_phiL_final.ival(),
+                                                      ITC->der_zL_final.ival(),
+                                                      phiproj[i],
+                                                      zproj[i],
+                                                      phider[i],
+                                                      zder[i],
+                                                      phiprojapprox[i],
+                                                      zprojapprox[i],
+                                                      ITC->der_phiL_final.fval(),
+                                                      ITC->der_zL_final.fval(),
+                                                      !(iSeed_ == 2 || iSeed_ == 3));
+    }
+
+    iphiprojdisk[0] = ITC->phiD_0_final.ival();
+    iphiprojdisk[1] = ITC->phiD_1_final.ival();
+    iphiprojdisk[2] = ITC->phiD_2_final.ival();
+    iphiprojdisk[3] = ITC->phiD_3_final.ival();
+    iphiprojdisk[4] = ITC->phiD_4_final.ival();
+
+    irprojdisk[0] = ITC->rD_0_final.ival();
+    irprojdisk[1] = ITC->rD_1_final.ival();
+    irprojdisk[2] = ITC->rD_2_final.ival();
+    irprojdisk[3] = ITC->rD_3_final.ival();
+    irprojdisk[4] = ITC->rD_4_final.ival();
+
+    if (std::abs(it * ITC->t_final.K()) > 1.0) {
+      for (unsigned int i = 0; i < N_DISK; ++i) {
+        if (iphiprojdisk[i] <= 0)
+          continue;
+        if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
+          continue;
+
+        if (irprojdisk[i] < settings_.rmindisk() / ITC->rD_0_final.K() ||
+            irprojdisk[i] >= settings_.rmaxdisk() / ITC->rD_0_final.K())
+          continue;
+
+        projs[i + N_LAYER].init(settings_,
+                                i + N_LAYER,
                                 iphiprojdisk[i],
                                 irprojdisk[i],
                                 ITC->der_phiD_final.ival(),
@@ -1402,71 +648,826 @@ bool TrackletCalculatorBase::overlapSeeding(const Stub* innerFPGAStub,
                                 rprojdiskapprox[i],
                                 ITC->der_phiD_final.fval(),
                                 ITC->der_rD_final.fval(),
-                                true);
+                                !(iSeed_ == 2 || iSeed_ == 3));
+      }
+    }
+
+    if (settings_.writeMonitorData("TPars")) {
+      globals_->ofstream("trackletpars.txt")
+          << "Trackpars " << layerdisk1_ + 1 << "   " << rinv << " " << rinvapprox << " " << ITC->rinv_final.fval()
+          << "   " << phi0 << " " << phi0approx << " " << ITC->phi0_final.fval() << "   " << t << " " << tapprox << " "
+          << ITC->t_final.fval() << "   " << z0 << " " << z0approx << " " << ITC->z0_final.fval() << endl;
+    }
+
+    Tracklet* tracklet = new Tracklet(settings_,
+                                      iSeed_,
+                                      innerFPGAStub,
+                                      nullptr,
+                                      outerFPGAStub,
+                                      rinv,
+                                      phi0,
+                                      0.0,
+                                      z0,
+                                      t,
+                                      rinvapprox,
+                                      phi0approx,
+                                      0.0,
+                                      z0approx,
+                                      tapprox,
+                                      irinv,
+                                      iphi0,
+                                      0,
+                                      iz0,
+                                      it,
+                                      projs,
+                                      false);
+
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "TrackletCalculator " << getName() << " Found tracklet for seed = " << iSeed_
+                                   << " " << iSector_ << " phi0 = " << phi0;
+    }
+
+    tracklet->setTrackletIndex(trackletpars_->nTracklets());
+    tracklet->setTCIndex(TCIndex_);
+
+    if (settings_.writeMonitorData("Seeds")) {
+      ofstream fout("seeds.txt", ofstream::app);
+      fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
+      fout.close();
+    }
+    trackletpars_->addTracklet(tracklet);
+
+    if (settings_.bookHistos()) {
+      HistBase* hists = globals_->histograms();
+      int tp = tracklet->tpseed();
+      hists->fillTrackletParams(settings_,
+                                globals_,
+                                iSeed_,
+                                iSector_,
+                                rinvapprox,
+                                irinv * ITC->rinv_final.K(),
+                                phi0approx,
+                                iphi0 * ITC->phi0_final.K(),
+                                asinh(tapprox),
+                                asinh(it * ITC->t_final.K()),
+                                z0approx,
+                                iz0 * ITC->z0_final.K(),
+                                tp);
+    }
+
+    bool addL3 = false;
+    bool addL4 = false;
+    bool addL5 = false;
+    bool addL6 = false;
+    for (unsigned int j = 0; j < N_LAYER - 2; j++) {
+      int lproj = settings_.projlayers(iSeed_, j);
+      bool added = false;
+      if (tracklet->validProj(lproj - 1)) {
+        added = addLayerProj(tracklet, lproj);
+        if (added && lproj == 3)
+          addL3 = true;
+        if (added && lproj == 4)
+          addL4 = true;
+        if (added && lproj == 5)
+          addL5 = true;
+        if (added && lproj == 6)
+          addL6 = true;
+      }
+    }
+
+    for (unsigned int j = 0; j < N_DISK - 1; j++) {  //no projections to 5th disk!!
+      int disk = j + 1;
+      if (disk == 4 && addL3)
+        continue;
+      if (disk == 3 && addL4)
+        continue;
+      if (disk == 2 && addL5)
+        continue;
+      if (disk == 1 && addL6)
+        continue;
+      if (it < 0)
+        disk = -disk;
+      if (tracklet->validProj(N_LAYER + abs(disk) - 1)) {
+        addDiskProj(tracklet, disk);
+      }
+    }
+
+    return true;
   }
 
-  if (settings_.writeMonitorData("TPars")) {
-    globals_->ofstream("trackletparsoverlap.txt")
-        << "Trackpars " << layerdisk1_ - 5 << "   " << rinv << " " << irinv << " " << ITC->rinv_final.fval() << "   "
-        << phi0 << " " << iphi0 << " " << ITC->phi0_final.fval() << "   " << t << " " << it << " "
-        << ITC->t_final.fval() << "   " << z0 << " " << iz0 << " " << ITC->z0_final.fval() << endl;
-  }
+  bool TrackletCalculatorBase::diskSeeding(const Stub* innerFPGAStub,
+                                           const L1TStub* innerStub,
+                                           const Stub* outerFPGAStub,
+                                           const L1TStub* outerStub) {
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "TrackletCalculator::execute calculate disk seeds";
+    }
 
-  Tracklet* tracklet = new Tracklet(settings_,
-                                    iSeed_,
-                                    innerFPGAStub,
-                                    nullptr,
-                                    outerFPGAStub,
-                                    rinv,
-                                    phi0,
-                                    0.0,
-                                    z0,
-                                    t,
-                                    rinvapprox,
-                                    phi0approx,
-                                    0.0,
-                                    z0approx,
-                                    tapprox,
-                                    irinv,
-                                    iphi0,
-                                    0,
-                                    iz0,
-                                    it,
-                                    projs,
-                                    false,
-                                    true);
+    int sign = 1;
+    if (innerFPGAStub->disk().value() < 0)
+      sign = -1;
 
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "Found tracklet in overlap seed = " << iSeed_ << " " << tracklet << " " << iSector_;
-  }
+    int disk = innerFPGAStub->disk().value();
+    assert(abs(disk) == 1 || abs(disk) == 3);
 
-  tracklet->setTrackletIndex(trackletpars_->nTracklets());
-  tracklet->setTCIndex(TCIndex_);
+    assert(innerStub->isPSmodule());
+    assert(outerStub->isPSmodule());
 
-  if (settings_.writeMonitorData("Seeds")) {
-    ofstream fout("seeds.txt", ofstream::app);
-    fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
-    fout.close();
-  }
-  trackletpars_->addTracklet(tracklet);
+    double r1 = innerStub->r();
+    double z1 = innerStub->z();
+    double phi1 = innerStub->phi();
 
-  int layer = outerFPGAStub->layer().value() + 1;
+    double r2 = outerStub->r();
+    double z2 = outerStub->z();
+    double phi2 = outerStub->phi();
 
-  if (layer == 2) {
+    if (r2 < r1 + 2.0) {
+      return false;  //Protection... Should be handled cleaner to avoid problem with floating point calculation
+    }
+
+    double rinv, phi0, t, z0;
+
+    double phiproj[N_PSLAYER], zproj[N_PSLAYER], phider[N_PSLAYER], zder[N_PSLAYER];
+    double phiprojdisk[N_DISK - 2], rprojdisk[N_DISK - 2], phiderdisk[N_DISK - 2], rderdisk[N_DISK - 2];
+
+    exacttrackletdisk(r1,
+                      z1,
+                      phi1,
+                      r2,
+                      z2,
+                      phi2,
+                      outerStub->sigmaz(),
+                      rinv,
+                      phi0,
+                      t,
+                      z0,
+                      phiproj,
+                      zproj,
+                      phider,
+                      zder,
+                      phiprojdisk,
+                      rprojdisk,
+                      phiderdisk,
+                      rderdisk);
+
+    //Truncates floating point positions to integer representation precision
+    if (settings_.useapprox()) {
+      phi1 = innerFPGAStub->phiapprox(phimin_, phimax_);
+      z1 = innerFPGAStub->zapprox();
+      r1 = innerFPGAStub->rapprox();
+
+      phi2 = outerFPGAStub->phiapprox(phimin_, phimax_);
+      z2 = outerFPGAStub->zapprox();
+      r2 = outerFPGAStub->rapprox();
+    }
+
+    double rinvapprox, phi0approx, tapprox, z0approx;
+    double phiprojapprox[N_PSLAYER], zprojapprox[N_PSLAYER];
+    double phiprojdiskapprox[N_DISK - 2], rprojdiskapprox[N_DISK - 2];
+
+    IMATH_TrackletCalculatorDisk* ITC;
+    if (disk == 1)
+      ITC = globals_->ITC_F1F2();
+    else if (disk == 3)
+      ITC = globals_->ITC_F3F4();
+    else if (disk == -1)
+      ITC = globals_->ITC_B1B2();
+    else
+      ITC = globals_->ITC_B3B4();
+
+    ITC->r1.set_fval(r1);
+    ITC->r2.set_fval(r2);
+    int signt = t > 0 ? 1 : -1;
+    ITC->z1.set_fval(z1 - signt * settings_.zmean(layerdisk1_ - N_LAYER));
+    ITC->z2.set_fval(z2 - signt * settings_.zmean(layerdisk2_ - N_LAYER));
+    double sphi1 = angle0to2pi::make0To2pi(phi1 - phimin_);
+    double sphi2 = angle0to2pi::make0To2pi(phi2 - phimin_);
+    ITC->phi1.set_fval(sphi1);
+    ITC->phi2.set_fval(sphi2);
+
+    ITC->rproj0.set_fval(settings_.rmean(0));
+    ITC->rproj1.set_fval(settings_.rmean(1));
+    ITC->rproj2.set_fval(settings_.rmean(2));
+
+    ITC->zproj0.set_fval(signt * settings_.zmean(settings_.projdisks(iSeed_, 0) - 1));
+    ITC->zproj1.set_fval(signt * settings_.zmean(settings_.projdisks(iSeed_, 1) - 1));
+    ITC->zproj2.set_fval(signt * settings_.zmean(settings_.projdisks(iSeed_, 2) - 1));
+
+    ITC->rinv_final.calculate();
+    ITC->phi0_final.calculate();
+    ITC->t_final.calculate();
+    ITC->z0_final.calculate();
+
+    ITC->phiL_0_final.calculate();
+    ITC->phiL_1_final.calculate();
+    ITC->phiL_2_final.calculate();
+
+    ITC->zL_0_final.calculate();
+    ITC->zL_1_final.calculate();
+    ITC->zL_2_final.calculate();
+
+    ITC->phiD_0_final.calculate();
+    ITC->phiD_1_final.calculate();
+    ITC->phiD_2_final.calculate();
+
+    ITC->rD_0_final.calculate();
+    ITC->rD_1_final.calculate();
+    ITC->rD_2_final.calculate();
+
+    ITC->der_phiL_final.calculate();
+    ITC->der_zL_final.calculate();
+    ITC->der_phiD_final.calculate();
+    ITC->der_rD_final.calculate();
+
+    //store the approximate results
+    rinvapprox = ITC->rinv_final.fval();
+    phi0approx = ITC->phi0_final.fval();
+    tapprox = ITC->t_final.fval();
+    z0approx = ITC->z0_final.fval();
+
+    phiprojapprox[0] = ITC->phiL_0_final.fval();
+    phiprojapprox[1] = ITC->phiL_1_final.fval();
+    phiprojapprox[2] = ITC->phiL_2_final.fval();
+
+    zprojapprox[0] = ITC->zL_0_final.fval();
+    zprojapprox[1] = ITC->zL_1_final.fval();
+    zprojapprox[2] = ITC->zL_2_final.fval();
+
+    phiprojdiskapprox[0] = ITC->phiD_0_final.fval();
+    phiprojdiskapprox[1] = ITC->phiD_1_final.fval();
+    phiprojdiskapprox[2] = ITC->phiD_2_final.fval();
+
+    rprojdiskapprox[0] = ITC->rD_0_final.fval();
+    rprojdiskapprox[1] = ITC->rD_1_final.fval();
+    rprojdiskapprox[2] = ITC->rD_2_final.fval();
+
+    //now binary
+
+    int irinv, iphi0, it, iz0;
+    int iphiproj[N_PSLAYER], izproj[N_PSLAYER];
+
+    int iphiprojdisk[N_DISK - 2], irprojdisk[N_DISK - 2];
+
+    int ir1 = innerFPGAStub->r().value();
+    int iphi1 = innerFPGAStub->phi().value();
+    int iz1 = innerFPGAStub->z().value();
+
+    int ir2 = outerFPGAStub->r().value();
+    int iphi2 = outerFPGAStub->phi().value();
+    int iz2 = outerFPGAStub->z().value();
+
+    //To get same precission as for layers.
+    iphi1 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
+    iphi2 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
+
+    ITC->r1.set_ival(ir1);
+    ITC->r2.set_ival(ir2);
+    ITC->z1.set_ival(iz1);
+    ITC->z2.set_ival(iz2);
+    ITC->phi1.set_ival(iphi1);
+    ITC->phi2.set_ival(iphi2);
+
+    ITC->rinv_final.calculate();
+    ITC->phi0_final.calculate();
+    ITC->t_final.calculate();
+    ITC->z0_final.calculate();
+
+    ITC->phiL_0_final.calculate();
+    ITC->phiL_1_final.calculate();
+    ITC->phiL_2_final.calculate();
+
+    ITC->zL_0_final.calculate();
+    ITC->zL_1_final.calculate();
+    ITC->zL_2_final.calculate();
+
+    ITC->phiD_0_final.calculate();
+    ITC->phiD_1_final.calculate();
+    ITC->phiD_2_final.calculate();
+
+    ITC->rD_0_final.calculate();
+    ITC->rD_1_final.calculate();
+    ITC->rD_2_final.calculate();
+
+    ITC->der_phiL_final.calculate();
+    ITC->der_zL_final.calculate();
+    ITC->der_phiD_final.calculate();
+    ITC->der_rD_final.calculate();
+
+    //store the binary results
+    irinv = ITC->rinv_final.ival();
+    iphi0 = ITC->phi0_final.ival();
+    it = ITC->t_final.ival();
+    iz0 = ITC->z0_final.ival();
+
+    iphiproj[0] = ITC->phiL_0_final.ival();
+    iphiproj[1] = ITC->phiL_1_final.ival();
+    iphiproj[2] = ITC->phiL_2_final.ival();
+
+    izproj[0] = ITC->zL_0_final.ival();
+    izproj[1] = ITC->zL_1_final.ival();
+    izproj[2] = ITC->zL_2_final.ival();
+
+    if (!goodTrackPars(ITC->rinv_final.local_passes(), ITC->z0_final.local_passes()))
+      return false;
+
+    if (!inSector(iphi0, irinv, phi0approx, rinvapprox))
+      return false;
+
+    Projection projs[N_LAYER + N_DISK];
+
+    for (unsigned int i = 0; i < N_DISK - 2; ++i) {
+      //Check is outside z range
+      if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
+        continue;
+      if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
+        continue;
+
+      //Check if outside phi range
+      if (iphiproj[i] >= (1 << settings_.nphibitsstub(5)) - 1)
+        continue;
+      if (iphiproj[i] <= 0)
+        continue;
+
+      //shift bits - allways in PS modules for disk seeding
+      iphiproj[i] >>= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
+
+      projs[i].init(settings_,
+                    i,
+                    iphiproj[i],
+                    izproj[i],
+                    ITC->der_phiL_final.ival(),
+                    ITC->der_zL_final.ival(),
+                    phiproj[i],
+                    zproj[i],
+                    phider[i],
+                    zder[i],
+                    phiprojapprox[i],
+                    zprojapprox[i],
+                    ITC->der_phiL_final.fval(),
+                    ITC->der_zL_final.fval(),
+                    true);
+    }
+
+    iphiprojdisk[0] = ITC->phiD_0_final.ival();
+    iphiprojdisk[1] = ITC->phiD_1_final.ival();
+    iphiprojdisk[2] = ITC->phiD_2_final.ival();
+
+    irprojdisk[0] = ITC->rD_0_final.ival();
+    irprojdisk[1] = ITC->rD_1_final.ival();
+    irprojdisk[2] = ITC->rD_2_final.ival();
+
+    for (unsigned int i = 0; i < N_DISK - 2; ++i) {
+      //check that phi projection in range
+      if (iphiprojdisk[i] <= 0)
+        continue;
+      if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
+        continue;
+
+      //check that r projection in range
+      if (irprojdisk[i] <= 0 || irprojdisk[i] >= settings_.rmaxdisk() / ITC->rD_0_final.K())
+        continue;
+
+      projs[settings_.projdisks(iSeed_, i) + N_LAYER - 1].init(settings_,
+                                                               settings_.projdisks(iSeed_, i) + N_LAYER - 1,
+                                                               iphiprojdisk[i],
+                                                               irprojdisk[i],
+                                                               ITC->der_phiD_final.ival(),
+                                                               ITC->der_rD_final.ival(),
+                                                               phiprojdisk[i],
+                                                               rprojdisk[i],
+                                                               phiderdisk[i],
+                                                               rderdisk[i],
+                                                               phiprojdiskapprox[i],
+                                                               rprojdiskapprox[i],
+                                                               ITC->der_phiD_final.fval(),
+                                                               ITC->der_rD_final.fval(),
+                                                               true);
+    }
+
+    if (settings_.writeMonitorData("TPars")) {
+      globals_->ofstream("trackletparsdisk.txt")
+          << "Trackpars         " << layerdisk1_ - 5 << "   " << rinv << " " << rinvapprox << " "
+          << ITC->rinv_final.fval() << "   " << phi0 << " " << phi0approx << " " << ITC->phi0_final.fval() << "   " << t
+          << " " << tapprox << " " << ITC->t_final.fval() << "   " << z0 << " " << z0approx << " "
+          << ITC->z0_final.fval() << endl;
+    }
+
+    Tracklet* tracklet = new Tracklet(settings_,
+                                      iSeed_,
+                                      innerFPGAStub,
+                                      nullptr,
+                                      outerFPGAStub,
+                                      rinv,
+                                      phi0,
+                                      0.0,
+                                      z0,
+                                      t,
+                                      rinvapprox,
+                                      phi0approx,
+                                      0.0,
+                                      z0approx,
+                                      tapprox,
+                                      irinv,
+                                      iphi0,
+                                      0,
+                                      iz0,
+                                      it,
+                                      projs,
+                                      true);
+
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "Found tracklet for disk seed = " << iSeed_ << " " << tracklet << " " << iSector_;
+    }
+
+    tracklet->setTrackletIndex(trackletpars_->nTracklets());
+    tracklet->setTCIndex(TCIndex_);
+
+    if (settings_.writeMonitorData("Seeds")) {
+      ofstream fout("seeds.txt", ofstream::app);
+      fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
+      fout.close();
+    }
+    trackletpars_->addTracklet(tracklet);
+
     if (tracklet->validProj(0)) {
       addLayerProj(tracklet, 1);
     }
-  }
 
-  for (unsigned int disk = 2; disk < 6; disk++) {
-    if (layer == 2 && disk == 5)
-      continue;
-    if (tracklet->validProj(N_LAYER + disk - 1)) {
-      addDiskProj(tracklet, disk);
+    if (tracklet->validProj(1)) {
+      addLayerProj(tracklet, 2);
     }
+
+    for (unsigned int j = 0; j < N_DISK - 2; j++) {
+      if (tracklet->validProj(N_LAYER + settings_.projdisks(iSeed_, j) - 1)) {
+        addDiskProj(tracklet, sign * settings_.projdisks(iSeed_, j));
+      }
+    }
+
+    return true;
   }
 
-  return true;
-}
+  bool TrackletCalculatorBase::overlapSeeding(const Stub* innerFPGAStub,
+                                              const L1TStub* innerStub,
+                                              const Stub* outerFPGAStub,
+                                              const L1TStub* outerStub) {
+    //Deal with overlap stubs here
+    assert(outerFPGAStub->layerdisk() < N_LAYER);
 
-}
+    assert(innerFPGAStub->layerdisk() >= N_LAYER);
+
+    int disk = innerFPGAStub->disk().value();
+
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "trying to make overlap tracklet for seed = " << iSeed_ << " " << getName();
+    }
+
+    double r1 = innerStub->r();
+    double z1 = innerStub->z();
+    double phi1 = innerStub->phi();
+
+    double r2 = outerStub->r();
+    double z2 = outerStub->z();
+    double phi2 = outerStub->phi();
+
+    //Protection for wrong radii. Could be handled cleaner to avoid problem with floating point calculation and with overflows in the integer calculation.
+    if (r1 < r2 + 1.5) {
+      return false;
+    }
+
+    double rinv, phi0, t, z0;
+
+    double phiproj[N_PSLAYER], zproj[N_PSLAYER], phider[N_PSLAYER], zder[N_PSLAYER];
+    double phiprojdisk[N_DISK - 1], rprojdisk[N_DISK - 1], phiderdisk[N_DISK - 1], rderdisk[N_DISK - 1];
+
+    exacttrackletOverlap(r1,
+                         z1,
+                         phi1,
+                         r2,
+                         z2,
+                         phi2,
+                         outerStub->sigmaz(),
+                         rinv,
+                         phi0,
+                         t,
+                         z0,
+                         phiproj,
+                         zproj,
+                         phider,
+                         zder,
+                         phiprojdisk,
+                         rprojdisk,
+                         phiderdisk,
+                         rderdisk);
+
+    //Truncates floating point positions to integer representation precision
+    if (settings_.useapprox()) {
+      phi1 = innerFPGAStub->phiapprox(phimin_, phimax_);
+      z1 = innerFPGAStub->zapprox();
+      r1 = innerFPGAStub->rapprox();
+
+      phi2 = outerFPGAStub->phiapprox(phimin_, phimax_);
+      z2 = outerFPGAStub->zapprox();
+      r2 = outerFPGAStub->rapprox();
+    }
+
+    double rinvapprox, phi0approx, tapprox, z0approx;
+    double phiprojapprox[N_PSLAYER], zprojapprox[N_PSLAYER];
+    double phiprojdiskapprox[N_DISK - 1], rprojdiskapprox[N_DISK - 1];
+
+    IMATH_TrackletCalculatorOverlap* ITC;
+    int ll = outerFPGAStub->layer().value() + 1;
+    if (ll == 1 && disk == 1)
+      ITC = globals_->ITC_L1F1();
+    else if (ll == 2 && disk == 1)
+      ITC = globals_->ITC_L2F1();
+    else if (ll == 1 && disk == -1)
+      ITC = globals_->ITC_L1B1();
+    else if (ll == 2 && disk == -1)
+      ITC = globals_->ITC_L2B1();
+    else
+      throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
+
+    ITC->r1.set_fval(r2 - settings_.rmean(ll - 1));
+    ITC->r2.set_fval(r1);
+    int signt = t > 0 ? 1 : -1;
+    ITC->z1.set_fval(z2);
+    ITC->z2.set_fval(z1 - signt * settings_.zmean(layerdisk2_ - N_LAYER));
+    double sphi1 = angle0to2pi::make0To2pi(phi1 - phimin_);
+    double sphi2 = angle0to2pi::make0To2pi(phi2 - phimin_);
+    ITC->phi1.set_fval(sphi2);
+    ITC->phi2.set_fval(sphi1);
+
+    ITC->rproj0.set_fval(settings_.rmean(0));
+    ITC->rproj1.set_fval(settings_.rmean(1));
+    ITC->rproj2.set_fval(settings_.rmean(2));
+
+    ITC->zproj0.set_fval(signt * settings_.zmean(1));
+    ITC->zproj1.set_fval(signt * settings_.zmean(2));
+    ITC->zproj2.set_fval(signt * settings_.zmean(3));
+    ITC->zproj3.set_fval(signt * settings_.zmean(4));
+
+    ITC->rinv_final.calculate();
+    ITC->phi0_final.calculate();
+    ITC->t_final.calculate();
+    ITC->z0_final.calculate();
+
+    ITC->phiL_0_final.calculate();
+    ITC->phiL_1_final.calculate();
+    ITC->phiL_2_final.calculate();
+
+    ITC->zL_0_final.calculate();
+    ITC->zL_1_final.calculate();
+    ITC->zL_2_final.calculate();
+
+    ITC->phiD_0_final.calculate();
+    ITC->phiD_1_final.calculate();
+    ITC->phiD_2_final.calculate();
+    ITC->phiD_3_final.calculate();
+
+    ITC->rD_0_final.calculate();
+    ITC->rD_1_final.calculate();
+    ITC->rD_2_final.calculate();
+    ITC->rD_3_final.calculate();
+
+    ITC->der_phiL_final.calculate();
+    ITC->der_zL_final.calculate();
+    ITC->der_phiD_final.calculate();
+    ITC->der_rD_final.calculate();
+
+    //store the approximate results
+    rinvapprox = ITC->rinv_final.fval();
+    phi0approx = ITC->phi0_final.fval();
+    tapprox = ITC->t_final.fval();
+    z0approx = ITC->z0_final.fval();
+
+    phiprojapprox[0] = ITC->phiL_0_final.fval();
+    phiprojapprox[1] = ITC->phiL_1_final.fval();
+    phiprojapprox[2] = ITC->phiL_2_final.fval();
+
+    zprojapprox[0] = ITC->zL_0_final.fval();
+    zprojapprox[1] = ITC->zL_1_final.fval();
+    zprojapprox[2] = ITC->zL_2_final.fval();
+
+    phiprojdiskapprox[0] = ITC->phiD_0_final.fval();
+    phiprojdiskapprox[1] = ITC->phiD_1_final.fval();
+    phiprojdiskapprox[2] = ITC->phiD_2_final.fval();
+    phiprojdiskapprox[3] = ITC->phiD_3_final.fval();
+
+    rprojdiskapprox[0] = ITC->rD_0_final.fval();
+    rprojdiskapprox[1] = ITC->rD_1_final.fval();
+    rprojdiskapprox[2] = ITC->rD_2_final.fval();
+    rprojdiskapprox[3] = ITC->rD_3_final.fval();
+
+    //now binary
+
+    int irinv, iphi0, it, iz0;
+    int iphiproj[N_LAYER - 2], izproj[N_LAYER - 2];
+    int iphiprojdisk[N_DISK], irprojdisk[N_DISK];
+
+    int ir2 = innerFPGAStub->r().value();
+    int iphi2 = innerFPGAStub->phi().value();
+    int iz2 = innerFPGAStub->z().value();
+
+    int ir1 = outerFPGAStub->r().value();
+    int iphi1 = outerFPGAStub->phi().value();
+    int iz1 = outerFPGAStub->z().value();
+
+    //To get global precission
+    ir1 = l1t::bitShift(ir1, (8 - settings_.nrbitsstub(ll - 1)));
+    iphi1 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
+    iphi2 <<= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
+
+    ITC->r1.set_ival(ir1);
+    ITC->r2.set_ival(ir2);
+    ITC->z1.set_ival(iz1);
+    ITC->z2.set_ival(iz2);
+    ITC->phi1.set_ival(iphi1);
+    ITC->phi2.set_ival(iphi2);
+
+    ITC->rinv_final.calculate();
+    ITC->phi0_final.calculate();
+    ITC->t_final.calculate();
+    ITC->z0_final.calculate();
+
+    ITC->phiL_0_final.calculate();
+    ITC->phiL_1_final.calculate();
+    ITC->phiL_2_final.calculate();
+
+    ITC->zL_0_final.calculate();
+    ITC->zL_1_final.calculate();
+    ITC->zL_2_final.calculate();
+
+    ITC->phiD_0_final.calculate();
+    ITC->phiD_1_final.calculate();
+    ITC->phiD_2_final.calculate();
+    ITC->phiD_3_final.calculate();
+
+    ITC->rD_0_final.calculate();
+    ITC->rD_1_final.calculate();
+    ITC->rD_2_final.calculate();
+    ITC->rD_3_final.calculate();
+
+    ITC->der_phiL_final.calculate();
+    ITC->der_zL_final.calculate();
+    ITC->der_phiD_final.calculate();
+    ITC->der_rD_final.calculate();
+
+    //store the binary results
+    irinv = ITC->rinv_final.ival();
+    iphi0 = ITC->phi0_final.ival();
+    it = ITC->t_final.ival();
+    iz0 = ITC->z0_final.ival();
+
+    iphiproj[0] = ITC->phiL_0_final.ival();
+    iphiproj[1] = ITC->phiL_1_final.ival();
+    iphiproj[2] = ITC->phiL_2_final.ival();
+
+    izproj[0] = ITC->zL_0_final.ival();
+    izproj[1] = ITC->zL_1_final.ival();
+    izproj[2] = ITC->zL_2_final.ival();
+
+    iphiprojdisk[0] = ITC->phiD_0_final.ival();
+    iphiprojdisk[1] = ITC->phiD_1_final.ival();
+    iphiprojdisk[2] = ITC->phiD_2_final.ival();
+    iphiprojdisk[3] = ITC->phiD_3_final.ival();
+
+    irprojdisk[0] = ITC->rD_0_final.ival();
+    irprojdisk[1] = ITC->rD_1_final.ival();
+    irprojdisk[2] = ITC->rD_2_final.ival();
+    irprojdisk[3] = ITC->rD_3_final.ival();
+
+    if (!goodTrackPars(ITC->rinv_final.local_passes(), ITC->z0_final.local_passes()))
+      return false;
+
+    if (!inSector(iphi0, irinv, phi0approx, rinvapprox))
+      return false;
+
+    Projection projs[N_LAYER + N_DISK];
+
+    for (unsigned int i = 0; i < N_DISK - 2; ++i) {
+      //check that zproj is in range
+      if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
+        continue;
+      if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
+        continue;
+
+      //check that phiproj is in range
+      if (iphiproj[i] >= (1 << settings_.nphibitsstub(5)) - 1)
+        continue;
+      if (iphiproj[i] <= 0)
+        continue;
+
+      //adjust bits for PS modules (no 2S modules in overlap seeds)
+      iphiproj[i] >>= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
+
+      projs[i].init(settings_,
+                    i,
+                    iphiproj[i],
+                    izproj[i],
+                    ITC->der_phiL_final.ival(),
+                    ITC->der_zL_final.ival(),
+                    phiproj[i],
+                    zproj[i],
+                    phider[i],
+                    zder[i],
+                    phiprojapprox[i],
+                    zprojapprox[i],
+                    ITC->der_phiL_final.fval(),
+                    ITC->der_zL_final.fval(),
+                    true);
+    }
+
+    for (int i = 0; i < 4; ++i) {
+      //check that phi projection in range
+      if (iphiprojdisk[i] <= 0)
+        continue;
+      if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
+        continue;
+
+      //check that r projection in range
+      if (irprojdisk[i] <= 0 || irprojdisk[i] >= settings_.rmaxdisk() / ITC->rD_0_final.K())
+        continue;
+
+      projs[N_LAYER + i + 1].init(settings_,
+                                  N_LAYER + i + 1,
+                                  iphiprojdisk[i],
+                                  irprojdisk[i],
+                                  ITC->der_phiD_final.ival(),
+                                  ITC->der_rD_final.ival(),
+                                  phiprojdisk[i],
+                                  rprojdisk[i],
+                                  phiderdisk[i],
+                                  rderdisk[i],
+                                  phiprojdiskapprox[i],
+                                  rprojdiskapprox[i],
+                                  ITC->der_phiD_final.fval(),
+                                  ITC->der_rD_final.fval(),
+                                  true);
+    }
+
+    if (settings_.writeMonitorData("TPars")) {
+      globals_->ofstream("trackletparsoverlap.txt")
+          << "Trackpars " << layerdisk1_ - 5 << "   " << rinv << " " << irinv << " " << ITC->rinv_final.fval() << "   "
+          << phi0 << " " << iphi0 << " " << ITC->phi0_final.fval() << "   " << t << " " << it << " "
+          << ITC->t_final.fval() << "   " << z0 << " " << iz0 << " " << ITC->z0_final.fval() << endl;
+    }
+
+    Tracklet* tracklet = new Tracklet(settings_,
+                                      iSeed_,
+                                      innerFPGAStub,
+                                      nullptr,
+                                      outerFPGAStub,
+                                      rinv,
+                                      phi0,
+                                      0.0,
+                                      z0,
+                                      t,
+                                      rinvapprox,
+                                      phi0approx,
+                                      0.0,
+                                      z0approx,
+                                      tapprox,
+                                      irinv,
+                                      iphi0,
+                                      0,
+                                      iz0,
+                                      it,
+                                      projs,
+                                      false,
+                                      true);
+
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "Found tracklet in overlap seed = " << iSeed_ << " " << tracklet << " "
+                                   << iSector_;
+    }
+
+    tracklet->setTrackletIndex(trackletpars_->nTracklets());
+    tracklet->setTCIndex(TCIndex_);
+
+    if (settings_.writeMonitorData("Seeds")) {
+      ofstream fout("seeds.txt", ofstream::app);
+      fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
+      fout.close();
+    }
+    trackletpars_->addTracklet(tracklet);
+
+    int layer = outerFPGAStub->layer().value() + 1;
+
+    if (layer == 2) {
+      if (tracklet->validProj(0)) {
+        addLayerProj(tracklet, 1);
+      }
+    }
+
+    for (unsigned int disk = 2; disk < 6; disk++) {
+      if (layer == 2 && disk == 5)
+        continue;
+      if (tracklet->validProj(N_LAYER + disk - 1)) {
+        addDiskProj(tracklet, disk);
+      }
+    }
+
+    return true;
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
@@ -13,7 +13,8 @@
 #include "L1Trigger/L1TCommon/interface/BitShift.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletCalculatorBase::TrackletCalculatorBase(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global) {}
@@ -1466,4 +1467,6 @@ bool TrackletCalculatorBase::overlapSeeding(const Stub* innerFPGAStub,
   }
 
   return true;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -14,1936 +14,1938 @@ using namespace std;
 
 namespace trklet {
 
-TrackletCalculatorDisplaced::TrackletCalculatorDisplaced(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global) {
-  for (unsigned int ilayer = 0; ilayer < N_LAYER; ilayer++) {
-    vector<TrackletProjectionsMemory*> tmp(settings.nallstubs(ilayer), nullptr);
-    trackletprojlayers_.push_back(tmp);
-  }
-
-  for (unsigned int idisk = 0; idisk < N_DISK; idisk++) {
-    vector<TrackletProjectionsMemory*> tmp(settings.nallstubs(idisk + N_LAYER), nullptr);
-    trackletprojdisks_.push_back(tmp);
-  }
-
-  layer_ = 0;
-  disk_ = 0;
-
-  string name1 = name.substr(1);  //this is to correct for "TCD" having one more letter then "TC"
-  if (name1[3] == 'L')
-    layer_ = name1[4] - '0';
-  if (name1[3] == 'D')
-    disk_ = name1[4] - '0';
-
-  // set TC index
-  iSeed_ = 0;
-
-  int iTC = name1[9] - 'A';
-
-  if (name1.substr(3, 6) == "L3L4L2")
-    iSeed_ = 8;
-  else if (name1.substr(3, 6) == "L5L6L4")
-    iSeed_ = 9;
-  else if (name1.substr(3, 6) == "L2L3D1")
-    iSeed_ = 10;
-  else if (name1.substr(3, 6) == "D1D2L2")
-    iSeed_ = 11;
-
-  assert(iSeed_ != 0);
-
-  TCIndex_ = (iSeed_ << 4) + iTC;
-  assert(TCIndex_ >= 128 && TCIndex_ < 191);
-
-  assert((layer_ != 0) || (disk_ != 0));
-
-  toR_.clear();
-  toZ_.clear();
-
-  if (iSeed_ == 8 || iSeed_ == 9) {
-    if (layer_ == 3) {
-      rzmeanInv_[0] = 1.0 / settings_.rmean(2 - 1);
-      rzmeanInv_[1] = 1.0 / settings_.rmean(3 - 1);
-      rzmeanInv_[2] = 1.0 / settings_.rmean(4 - 1);
-
-      rproj_[0] = settings_.rmean(0);
-      rproj_[1] = settings_.rmean(4);
-      rproj_[2] = settings_.rmean(5);
-      lproj_[0] = 1;
-      lproj_[1] = 5;
-      lproj_[2] = 6;
-
-      dproj_[0] = 1;
-      dproj_[1] = 2;
-      dproj_[2] = 0;
-      toZ_.push_back(settings_.zmean(0));
-      toZ_.push_back(settings_.zmean(1));
+  TrackletCalculatorDisplaced::TrackletCalculatorDisplaced(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global) {
+    for (unsigned int ilayer = 0; ilayer < N_LAYER; ilayer++) {
+      vector<TrackletProjectionsMemory*> tmp(settings.nallstubs(ilayer), nullptr);
+      trackletprojlayers_.push_back(tmp);
     }
-    if (layer_ == 5) {
-      rzmeanInv_[0] = 1.0 / settings_.rmean(4 - 1);
-      rzmeanInv_[1] = 1.0 / settings_.rmean(5 - 1);
-      rzmeanInv_[2] = 1.0 / settings_.rmean(6 - 1);
 
-      rproj_[0] = settings_.rmean(0);
-      rproj_[1] = settings_.rmean(1);
-      rproj_[2] = settings_.rmean(2);
-      lproj_[0] = 1;
-      lproj_[1] = 2;
-      lproj_[2] = 3;
-
-      dproj_[0] = 0;
-      dproj_[1] = 0;
-      dproj_[2] = 0;
+    for (unsigned int idisk = 0; idisk < N_DISK; idisk++) {
+      vector<TrackletProjectionsMemory*> tmp(settings.nallstubs(idisk + N_LAYER), nullptr);
+      trackletprojdisks_.push_back(tmp);
     }
-    for (unsigned int i = 0; i < N_LAYER - 3; ++i)
-      toR_.push_back(rproj_[i]);
-  }
 
-  if (iSeed_ == 10 || iSeed_ == 11) {
-    if (layer_ == 2) {
-      rzmeanInv_[0] = 1.0 / settings_.rmean(2 - 1);
-      rzmeanInv_[1] = 1.0 / settings_.rmean(3 - 1);
-      rzmeanInv_[2] = 1.0 / settings_.zmean(1 - 1);
+    layer_ = 0;
+    disk_ = 0;
 
-      rproj_[0] = settings_.rmean(0);
-      lproj_[0] = 1;
-      lproj_[1] = -1;
-      lproj_[2] = -1;
+    string name1 = name.substr(1);  //this is to correct for "TCD" having one more letter then "TC"
+    if (name1[3] == 'L')
+      layer_ = name1[4] - '0';
+    if (name1[3] == 'D')
+      disk_ = name1[4] - '0';
 
-      zproj_[0] = settings_.zmean(1);
-      zproj_[1] = settings_.zmean(2);
-      zproj_[2] = settings_.zmean(3);
-      dproj_[0] = 2;
-      dproj_[1] = 3;
-      dproj_[2] = 4;
+    // set TC index
+    iSeed_ = 0;
+
+    int iTC = name1[9] - 'A';
+
+    if (name1.substr(3, 6) == "L3L4L2")
+      iSeed_ = 8;
+    else if (name1.substr(3, 6) == "L5L6L4")
+      iSeed_ = 9;
+    else if (name1.substr(3, 6) == "L2L3D1")
+      iSeed_ = 10;
+    else if (name1.substr(3, 6) == "D1D2L2")
+      iSeed_ = 11;
+
+    assert(iSeed_ != 0);
+
+    TCIndex_ = (iSeed_ << 4) + iTC;
+    assert(TCIndex_ >= 128 && TCIndex_ < 191);
+
+    assert((layer_ != 0) || (disk_ != 0));
+
+    toR_.clear();
+    toZ_.clear();
+
+    if (iSeed_ == 8 || iSeed_ == 9) {
+      if (layer_ == 3) {
+        rzmeanInv_[0] = 1.0 / settings_.rmean(2 - 1);
+        rzmeanInv_[1] = 1.0 / settings_.rmean(3 - 1);
+        rzmeanInv_[2] = 1.0 / settings_.rmean(4 - 1);
+
+        rproj_[0] = settings_.rmean(0);
+        rproj_[1] = settings_.rmean(4);
+        rproj_[2] = settings_.rmean(5);
+        lproj_[0] = 1;
+        lproj_[1] = 5;
+        lproj_[2] = 6;
+
+        dproj_[0] = 1;
+        dproj_[1] = 2;
+        dproj_[2] = 0;
+        toZ_.push_back(settings_.zmean(0));
+        toZ_.push_back(settings_.zmean(1));
+      }
+      if (layer_ == 5) {
+        rzmeanInv_[0] = 1.0 / settings_.rmean(4 - 1);
+        rzmeanInv_[1] = 1.0 / settings_.rmean(5 - 1);
+        rzmeanInv_[2] = 1.0 / settings_.rmean(6 - 1);
+
+        rproj_[0] = settings_.rmean(0);
+        rproj_[1] = settings_.rmean(1);
+        rproj_[2] = settings_.rmean(2);
+        lproj_[0] = 1;
+        lproj_[1] = 2;
+        lproj_[2] = 3;
+
+        dproj_[0] = 0;
+        dproj_[1] = 0;
+        dproj_[2] = 0;
+      }
+      for (unsigned int i = 0; i < N_LAYER - 3; ++i)
+        toR_.push_back(rproj_[i]);
     }
-    if (disk_ == 1) {
-      rzmeanInv_[0] = 1.0 / settings_.rmean(2 - 1);
-      rzmeanInv_[1] = 1.0 / settings_.zmean(1 - 1);
-      rzmeanInv_[2] = 1.0 / settings_.zmean(2 - 1);
 
-      rproj_[0] = settings_.rmean(0);
-      lproj_[0] = 1;
-      lproj_[1] = -1;
-      lproj_[2] = -1;
+    if (iSeed_ == 10 || iSeed_ == 11) {
+      if (layer_ == 2) {
+        rzmeanInv_[0] = 1.0 / settings_.rmean(2 - 1);
+        rzmeanInv_[1] = 1.0 / settings_.rmean(3 - 1);
+        rzmeanInv_[2] = 1.0 / settings_.zmean(1 - 1);
 
-      zproj_[0] = settings_.zmean(2);
-      zproj_[1] = settings_.zmean(3);
-      zproj_[2] = settings_.zmean(4);
-      dproj_[0] = 3;
-      dproj_[1] = 4;
-      dproj_[2] = 5;
+        rproj_[0] = settings_.rmean(0);
+        lproj_[0] = 1;
+        lproj_[1] = -1;
+        lproj_[2] = -1;
+
+        zproj_[0] = settings_.zmean(1);
+        zproj_[1] = settings_.zmean(2);
+        zproj_[2] = settings_.zmean(3);
+        dproj_[0] = 2;
+        dproj_[1] = 3;
+        dproj_[2] = 4;
+      }
+      if (disk_ == 1) {
+        rzmeanInv_[0] = 1.0 / settings_.rmean(2 - 1);
+        rzmeanInv_[1] = 1.0 / settings_.zmean(1 - 1);
+        rzmeanInv_[2] = 1.0 / settings_.zmean(2 - 1);
+
+        rproj_[0] = settings_.rmean(0);
+        lproj_[0] = 1;
+        lproj_[1] = -1;
+        lproj_[2] = -1;
+
+        zproj_[0] = settings_.zmean(2);
+        zproj_[1] = settings_.zmean(3);
+        zproj_[2] = settings_.zmean(4);
+        dproj_[0] = 3;
+        dproj_[1] = 4;
+        dproj_[2] = 5;
+      }
+      toR_.push_back(settings_.rmean(0));
+      for (unsigned int i = 0; i < N_DISK - 2; ++i)
+        toZ_.push_back(zproj_[i]);
     }
-    toR_.push_back(settings_.rmean(0));
-    for (unsigned int i = 0; i < N_DISK - 2; ++i)
-      toZ_.push_back(zproj_[i]);
-  }
-}
-
-void TrackletCalculatorDisplaced::addOutputProjection(TrackletProjectionsMemory*& outputProj, MemoryBase* memory) {
-  outputProj = dynamic_cast<TrackletProjectionsMemory*>(memory);
-  assert(outputProj != nullptr);
-}
-
-void TrackletCalculatorDisplaced::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
   }
 
-  if (output == "trackpar") {
-    auto* tmp = dynamic_cast<TrackletParametersMemory*>(memory);
-    assert(tmp != nullptr);
-    trackletpars_ = tmp;
-    return;
+  void TrackletCalculatorDisplaced::addOutputProjection(TrackletProjectionsMemory*& outputProj, MemoryBase* memory) {
+    outputProj = dynamic_cast<TrackletProjectionsMemory*>(memory);
+    assert(outputProj != nullptr);
   }
 
-  if (output.substr(0, 7) == "projout") {
-    //output is on the form 'projoutL2PHIC' or 'projoutD3PHIB'
-    auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
-    assert(tmp != nullptr);
+  void TrackletCalculatorDisplaced::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
 
-    unsigned int layerdisk = output[8] - '1';   //layer or disk counting from 0
-    unsigned int phiregion = output[12] - 'A';  //phiregion counting from 0
-
-    if (output[7] == 'L') {
-      assert(layerdisk < N_LAYER);
-      assert(phiregion < trackletprojlayers_[layerdisk].size());
-      //check that phiregion not already initialized
-      assert(trackletprojlayers_[layerdisk][phiregion] == nullptr);
-      trackletprojlayers_[layerdisk][phiregion] = tmp;
+    if (output == "trackpar") {
+      auto* tmp = dynamic_cast<TrackletParametersMemory*>(memory);
+      assert(tmp != nullptr);
+      trackletpars_ = tmp;
       return;
     }
 
-    if (output[7] == 'D') {
-      assert(layerdisk < N_DISK);
-      assert(phiregion < trackletprojdisks_[layerdisk].size());
-      //check that phiregion not already initialized
-      assert(trackletprojdisks_[layerdisk][phiregion] == nullptr);
-      trackletprojdisks_[layerdisk][phiregion] = tmp;
+    if (output.substr(0, 7) == "projout") {
+      //output is on the form 'projoutL2PHIC' or 'projoutD3PHIB'
+      auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
+      assert(tmp != nullptr);
+
+      unsigned int layerdisk = output[8] - '1';   //layer or disk counting from 0
+      unsigned int phiregion = output[12] - 'A';  //phiregion counting from 0
+
+      if (output[7] == 'L') {
+        assert(layerdisk < N_LAYER);
+        assert(phiregion < trackletprojlayers_[layerdisk].size());
+        //check that phiregion not already initialized
+        assert(trackletprojlayers_[layerdisk][phiregion] == nullptr);
+        trackletprojlayers_[layerdisk][phiregion] = tmp;
+        return;
+      }
+
+      if (output[7] == 'D') {
+        assert(layerdisk < N_DISK);
+        assert(phiregion < trackletprojdisks_[layerdisk].size());
+        //check that phiregion not already initialized
+        assert(trackletprojdisks_[layerdisk][phiregion] == nullptr);
+        trackletprojdisks_[layerdisk][phiregion] = tmp;
+        return;
+      }
+    }
+
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
+  }
+
+  void TrackletCalculatorDisplaced::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+
+    if (input == "thirdallstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      innerallstubs_.push_back(tmp);
       return;
     }
-  }
-
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
-}
-
-void TrackletCalculatorDisplaced::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-
-  if (input == "thirdallstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    innerallstubs_.push_back(tmp);
-    return;
-  }
-  if (input == "firstallstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    middleallstubs_.push_back(tmp);
-    return;
-  }
-  if (input == "secondallstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    outerallstubs_.push_back(tmp);
-    return;
-  }
-  if (input.find("stubtriplet") == 0) {
-    auto* tmp = dynamic_cast<StubTripletsMemory*>(memory);
-    assert(tmp != nullptr);
-    stubtriplets_.push_back(tmp);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
-}
-
-void TrackletCalculatorDisplaced::execute(unsigned int iSector, double phimin, double phimax) {
-  unsigned int countall = 0;
-  unsigned int countsel = 0;
-
-  phimin_ = phimin;
-  phimax_ = phimax;
-  iSector_ = iSector;
-
-  for (auto& stubtriplet : stubtriplets_) {
-    if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
-      edm::LogVerbatim("Tracklet") << "Will break on too many tracklets in " << getName();
-      break;
+    if (input == "firstallstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      middleallstubs_.push_back(tmp);
+      return;
     }
-    for (unsigned int i = 0; i < stubtriplet->nStubTriplets(); i++) {
-      countall++;
+    if (input == "secondallstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      outerallstubs_.push_back(tmp);
+      return;
+    }
+    if (input.find("stubtriplet") == 0) {
+      auto* tmp = dynamic_cast<StubTripletsMemory*>(memory);
+      assert(tmp != nullptr);
+      stubtriplets_.push_back(tmp);
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
+  }
 
-      const Stub* innerFPGAStub = stubtriplet->getFPGAStub1(i);
-      const L1TStub* innerStub = innerFPGAStub->l1tstub();
+  void TrackletCalculatorDisplaced::execute(unsigned int iSector, double phimin, double phimax) {
+    unsigned int countall = 0;
+    unsigned int countsel = 0;
 
-      const Stub* middleFPGAStub = stubtriplet->getFPGAStub2(i);
-      const L1TStub* middleStub = middleFPGAStub->l1tstub();
+    phimin_ = phimin;
+    phimax_ = phimax;
+    iSector_ = iSector;
 
-      const Stub* outerFPGAStub = stubtriplet->getFPGAStub3(i);
-      const L1TStub* outerStub = outerFPGAStub->l1tstub();
+    for (auto& stubtriplet : stubtriplets_) {
+      if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
+        edm::LogVerbatim("Tracklet") << "Will break on too many tracklets in " << getName();
+        break;
+      }
+      for (unsigned int i = 0; i < stubtriplet->nStubTriplets(); i++) {
+        countall++;
 
-      if (settings_.debugTracklet())
-        edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
+        const Stub* innerFPGAStub = stubtriplet->getFPGAStub1(i);
+        const L1TStub* innerStub = innerFPGAStub->l1tstub();
 
-      if (innerFPGAStub->layerdisk() < N_LAYER && middleFPGAStub->layerdisk() < N_LAYER &&
-          outerFPGAStub->layerdisk() < N_LAYER) {
-        //barrel+barrel seeding
-        bool accept = LLLSeeding(innerFPGAStub, innerStub, middleFPGAStub, middleStub, outerFPGAStub, outerStub);
-        if (accept)
-          countsel++;
-      } else if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
-                 outerFPGAStub->layerdisk() >= N_LAYER) {
-        throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
-      } else {
-        //layer+disk seeding
-        if (innerFPGAStub->layerdisk() < N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
-            outerFPGAStub->layerdisk() >= N_LAYER) {  //D1D2L2
-          bool accept = DDLSeeding(innerFPGAStub, innerStub, middleFPGAStub, middleStub, outerFPGAStub, outerStub);
+        const Stub* middleFPGAStub = stubtriplet->getFPGAStub2(i);
+        const L1TStub* middleStub = middleFPGAStub->l1tstub();
+
+        const Stub* outerFPGAStub = stubtriplet->getFPGAStub3(i);
+        const L1TStub* outerStub = outerFPGAStub->l1tstub();
+
+        if (settings_.debugTracklet())
+          edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
+
+        if (innerFPGAStub->layerdisk() < N_LAYER && middleFPGAStub->layerdisk() < N_LAYER &&
+            outerFPGAStub->layerdisk() < N_LAYER) {
+          //barrel+barrel seeding
+          bool accept = LLLSeeding(innerFPGAStub, innerStub, middleFPGAStub, middleStub, outerFPGAStub, outerStub);
           if (accept)
             countsel++;
-        } else if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() < N_LAYER &&
-                   outerFPGAStub->layerdisk() < N_LAYER) {  //L2L3D1
-          bool accept = LLDSeeding(innerFPGAStub, innerStub, middleFPGAStub, middleStub, outerFPGAStub, outerStub);
-          if (accept)
-            countsel++;
-        } else {
+        } else if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
+                   outerFPGAStub->layerdisk() >= N_LAYER) {
           throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
+        } else {
+          //layer+disk seeding
+          if (innerFPGAStub->layerdisk() < N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
+              outerFPGAStub->layerdisk() >= N_LAYER) {  //D1D2L2
+            bool accept = DDLSeeding(innerFPGAStub, innerStub, middleFPGAStub, middleStub, outerFPGAStub, outerStub);
+            if (accept)
+              countsel++;
+          } else if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() < N_LAYER &&
+                     outerFPGAStub->layerdisk() < N_LAYER) {  //L2L3D1
+            bool accept = LLDSeeding(innerFPGAStub, innerStub, middleFPGAStub, middleStub, outerFPGAStub, outerStub);
+            if (accept)
+              countsel++;
+          } else {
+            throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
+          }
+        }
+
+        if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
+          edm::LogVerbatim("Tracklet") << "Will break on number of tracklets in " << getName();
+          break;
+        }
+
+        if (countall >= settings_.maxStep("TC")) {
+          if (settings_.debugTracklet())
+            edm::LogVerbatim("Tracklet") << "Will break on MAXTC 1";
+          break;
+        }
+        if (settings_.debugTracklet())
+          edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
+      }
+      if (countall >= settings_.maxStep("TC")) {
+        if (settings_.debugTracklet())
+          edm::LogVerbatim("Tracklet") << "Will break on MAXTC 2";
+        break;
+      }
+    }
+
+    if (settings_.writeMonitorData("TPD")) {
+      globals_->ofstream("trackletcalculatordisplaced.txt") << getName() << " " << countall << " " << countsel << endl;
+    }
+  }
+
+  void TrackletCalculatorDisplaced::addDiskProj(Tracklet* tracklet, int disk) {
+    disk = std::abs(disk);
+    FPGAWord fpgar = tracklet->proj(N_LAYER + disk - 1).fpgarzproj();
+
+    if (fpgar.value() * settings_.krprojshiftdisk() < settings_.rmindiskvm())
+      return;
+    if (fpgar.value() * settings_.krprojshiftdisk() > settings_.rmaxdisk())
+      return;
+
+    FPGAWord fpgaphi = tracklet->proj(N_LAYER + disk - 1).fpgaphiproj();
+
+    int iphivmRaw = fpgaphi.value() >> (fpgaphi.nbits() - 5);
+    int iphi = iphivmRaw / (32 / settings_.nallstubs(disk + N_LAYER - 1));
+
+    addProjectionDisk(disk, iphi, trackletprojdisks_[disk - 1][iphi], tracklet);
+  }
+
+  bool TrackletCalculatorDisplaced::addLayerProj(Tracklet* tracklet, int layer) {
+    assert(layer > 0);
+
+    FPGAWord fpgaz = tracklet->proj(layer - 1).fpgarzproj();
+    FPGAWord fpgaphi = tracklet->proj(layer - 1).fpgaphiproj();
+
+    if (fpgaz.atExtreme())
+      return false;
+
+    if (std::abs(fpgaz.value() * settings_.kz()) > settings_.zlength())
+      return false;
+
+    int iphivmRaw = fpgaphi.value() >> (fpgaphi.nbits() - 5);
+    int iphi = iphivmRaw / (32 / settings_.nallstubs(layer - 1));
+
+    addProjection(layer, iphi, trackletprojlayers_[layer - 1][iphi], tracklet);
+
+    return true;
+  }
+
+  void TrackletCalculatorDisplaced::addProjection(int layer,
+                                                  int iphi,
+                                                  TrackletProjectionsMemory* trackletprojs,
+                                                  Tracklet* tracklet) {
+    if (trackletprojs == nullptr) {
+      if (settings_.warnNoMem()) {
+        edm::LogVerbatim("Tracklet") << "No projection memory exists in " << getName() << " for layer = " << layer
+                                     << " iphi = " << iphi + 1;
+      }
+      return;
+    }
+    assert(trackletprojs != nullptr);
+    trackletprojs->addProj(tracklet);
+  }
+
+  void TrackletCalculatorDisplaced::addProjectionDisk(int disk,
+                                                      int iphi,
+                                                      TrackletProjectionsMemory* trackletprojs,
+                                                      Tracklet* tracklet) {
+    if (trackletprojs == nullptr) {
+      if (layer_ == 3 && abs(disk) == 3)
+        return;  //L3L4 projections to D3 are not used.
+      if (settings_.warnNoMem()) {
+        edm::LogVerbatim("Tracklet") << "No projection memory exists in " << getName() << " for disk = " << abs(disk)
+                                     << " iphi = " << iphi + 1;
+      }
+      return;
+    }
+    assert(trackletprojs != nullptr);
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << getName() << " adding projection to " << trackletprojs->getName();
+    trackletprojs->addProj(tracklet);
+  }
+
+  bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
+                                               const L1TStub* innerStub,
+                                               const Stub* middleFPGAStub,
+                                               const L1TStub* middleStub,
+                                               const Stub* outerFPGAStub,
+                                               const L1TStub* outerStub) {
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName() << " " << layer_
+                                   << " trying stub triplet in layer (L L L): " << innerFPGAStub->layer().value() << " "
+                                   << middleFPGAStub->layer().value() << " " << outerFPGAStub->layer().value();
+
+    assert(outerFPGAStub->layerdisk() < N_LAYER);
+
+    double r1 = innerStub->r();
+    double z1 = innerStub->z();
+    double phi1 = innerStub->phi();
+
+    double r2 = middleStub->r();
+    double z2 = middleStub->z();
+    double phi2 = middleStub->phi();
+
+    double r3 = outerStub->r();
+    double z3 = outerStub->z();
+    double phi3 = outerStub->phi();
+
+    int take3 = 0;
+    if (layer_ == 5)
+      take3 = 1;
+    unsigned ndisks = 0;
+
+    double rinv, phi0, d0, t, z0;
+
+    Projection projs[N_LAYER + N_DISK];
+
+    double phiproj[N_LAYER - 2], zproj[N_LAYER - 2], phider[N_LAYER - 2], zder[N_LAYER - 2];
+    double phiprojdisk[N_DISK], rprojdisk[N_DISK], phiderdisk[N_DISK], rderdisk[N_DISK];
+
+    exacttracklet(r1,
+                  z1,
+                  phi1,
+                  r2,
+                  z2,
+                  phi2,
+                  r3,
+                  z3,
+                  phi3,
+                  take3,
+                  rinv,
+                  phi0,
+                  d0,
+                  t,
+                  z0,
+                  phiproj,
+                  zproj,
+                  phiprojdisk,
+                  rprojdisk,
+                  phider,
+                  zder,
+                  phiderdisk,
+                  rderdisk);
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << "LLL Exact values " << innerFPGAStub->isBarrel()
+                                   << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi1 << ", "
+                                   << z1 << ", " << r1 << ", " << phi2 << ", " << z2 << ", " << r2 << ", " << phi3
+                                   << ", " << z3 << ", " << r3 << endl;
+
+    if (settings_.useapprox()) {
+      phi1 = innerFPGAStub->phiapprox(phimin_, phimax_);
+      z1 = innerFPGAStub->zapprox();
+      r1 = innerFPGAStub->rapprox();
+
+      phi2 = middleFPGAStub->phiapprox(phimin_, phimax_);
+      z2 = middleFPGAStub->zapprox();
+      r2 = middleFPGAStub->rapprox();
+
+      phi3 = outerFPGAStub->phiapprox(phimin_, phimax_);
+      z3 = outerFPGAStub->zapprox();
+      r3 = outerFPGAStub->rapprox();
+    }
+
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << "LLL Approx values " << innerFPGAStub->isBarrel()
+                                   << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi1 << ", "
+                                   << z1 << ", " << r1 << ", " << phi2 << ", " << z2 << ", " << r2 << ", " << phi3
+                                   << ", " << z3 << ", " << r3 << endl;
+
+    double rinvapprox, phi0approx, d0approx, tapprox, z0approx;
+    double phiprojapprox[N_LAYER - 2], zprojapprox[N_LAYER - 2], phiderapprox[N_LAYER - 2], zderapprox[N_LAYER - 2];
+    double phiprojdiskapprox[N_DISK], rprojdiskapprox[N_DISK];
+    double phiderdiskapprox[N_DISK], rderdiskapprox[N_DISK];
+
+    //TODO: implement the actual integer calculation
+    if (settings_.useapprox()) {
+      approxtracklet(r1,
+                     z1,
+                     phi1,
+                     r2,
+                     z2,
+                     phi2,
+                     r3,
+                     z3,
+                     phi3,
+                     take3,
+                     ndisks,
+                     rinvapprox,
+                     phi0approx,
+                     d0approx,
+                     tapprox,
+                     z0approx,
+                     phiprojapprox,
+                     zprojapprox,
+                     phiderapprox,
+                     zderapprox,
+                     phiprojdiskapprox,
+                     rprojdiskapprox,
+                     phiderdiskapprox,
+                     rderdiskapprox);
+    } else {
+      rinvapprox = rinv;
+      phi0approx = phi0;
+      d0approx = d0;
+      tapprox = t;
+      z0approx = z0;
+
+      for (unsigned int i = 0; i < toR_.size(); ++i) {
+        phiprojapprox[i] = phiproj[i];
+        zprojapprox[i] = zproj[i];
+        phiderapprox[i] = phider[i];
+        zderapprox[i] = zder[i];
+      }
+
+      for (unsigned int i = 0; i < toZ_.size(); ++i) {
+        phiprojdiskapprox[i] = phiprojdisk[i];
+        rprojdiskapprox[i] = rprojdisk[i];
+        phiderdiskapprox[i] = phiderdisk[i];
+        rderdiskapprox[i] = rderdisk[i];
+      }
+    }
+
+    //store the approcximate results
+
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "rinvapprox: " << rinvapprox << " rinv: " << rinv << endl;
+      edm::LogVerbatim("Tracklet") << "phi0approx: " << phi0approx << " phi0: " << phi0 << endl;
+      edm::LogVerbatim("Tracklet") << "d0approx: " << d0approx << " d0: " << d0 << endl;
+      edm::LogVerbatim("Tracklet") << "tapprox: " << tapprox << " t: " << t << endl;
+      edm::LogVerbatim("Tracklet") << "z0approx: " << z0approx << " z0: " << z0 << endl;
+    }
+
+    for (unsigned int i = 0; i < toR_.size(); ++i) {
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << "phiprojapprox[" << i << "]: " << phiprojapprox[i] << " phiproj[" << i
+                                     << "]: " << phiproj[i] << endl;
+        edm::LogVerbatim("Tracklet") << "zprojapprox[" << i << "]: " << zprojapprox[i] << " zproj[" << i
+                                     << "]: " << zproj[i] << endl;
+        edm::LogVerbatim("Tracklet") << "phiderapprox[" << i << "]: " << phiderapprox[i] << " phider[" << i
+                                     << "]: " << phider[i] << endl;
+        edm::LogVerbatim("Tracklet") << "zderapprox[" << i << "]: " << zderapprox[i] << " zder[" << i
+                                     << "]: " << zder[i] << endl;
+      }
+    }
+
+    for (unsigned int i = 0; i < toZ_.size(); ++i) {
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << "phiprojdiskapprox[" << i << "]: " << phiprojdiskapprox[i] << " phiprojdisk["
+                                     << i << "]: " << phiprojdisk[i] << endl;
+        edm::LogVerbatim("Tracklet") << "rprojdiskapprox[" << i << "]: " << rprojdiskapprox[i] << " rprojdisk[" << i
+                                     << "]: " << rprojdisk[i] << endl;
+        edm::LogVerbatim("Tracklet") << "phiderdiskapprox[" << i << "]: " << phiderdiskapprox[i] << " phiderdisk[" << i
+                                     << "]: " << phiderdisk[i] << endl;
+        edm::LogVerbatim("Tracklet") << "rderdiskapprox[" << i << "]: " << rderdiskapprox[i] << " rderdisk[" << i
+                                     << "]: " << rderdisk[i] << endl;
+      }
+    }
+
+    //now binary
+    double krinv = settings_.kphi1() / settings_.kr() * pow(2, settings_.rinv_shift()),
+           kphi0 = settings_.kphi1() * pow(2, settings_.phi0_shift()),
+           kt = settings_.kz() / settings_.kr() * pow(2, settings_.t_shift()),
+           kz0 = settings_.kz() * pow(2, settings_.z0_shift()),
+           kphiproj = settings_.kphi1() * pow(2, settings_.SS_phiL_shift()),
+           kphider = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderL_shift()),
+           kzproj = settings_.kz() * pow(2, settings_.PS_zL_shift()),
+           kzder = settings_.kz() / settings_.kr() * pow(2, settings_.PS_zderL_shift()),
+           kphiprojdisk = settings_.kphi1() * pow(2, settings_.SS_phiD_shift()),
+           kphiderdisk = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderD_shift()),
+           krprojdisk = settings_.kr() * pow(2, settings_.PS_rD_shift()),
+           krderdisk = settings_.kr() / settings_.kz() * pow(2, settings_.PS_rderD_shift());
+
+    int irinv, iphi0, id0, it, iz0;
+    int iphiproj[N_LAYER - 2], izproj[N_LAYER - 2], iphider[N_LAYER - 2], izder[N_LAYER - 2];
+    int iphiprojdisk[N_DISK], irprojdisk[N_DISK], iphiderdisk[N_DISK], irderdisk[N_DISK];
+
+    //store the binary results
+    irinv = rinvapprox / krinv;
+    iphi0 = phi0approx / kphi0;
+    id0 = d0approx / settings_.kd0();
+    it = tapprox / kt;
+    iz0 = z0approx / kz0;
+
+    bool success = true;
+    if (std::abs(rinvapprox) > settings_.rinvcut()) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "TrackletCalculator::LLL Seeding irinv too large: " << rinvapprox << "("
+                                     << irinv << ")";
+      success = false;
+    }
+    if (std::abs(z0approx) > settings_.disp_z0cut()) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "Failed tracklet z0 cut " << z0approx << " in layer " << layer_;
+      success = false;
+    }
+    if (std::abs(d0approx) > settings_.maxd0()) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "Failed tracklet d0 cut " << d0approx;
+      success = false;
+    }
+
+    if (!success) {
+      return false;
+    }
+
+    double phicritapprox = phi0approx - asin((0.5 * settings_.rcrit() * rinvapprox) + (d0approx / settings_.rcrit()));
+    int phicrit = iphi0 - 2 * irinv - 2 * id0;
+
+    int iphicritmincut = settings_.phicritminmc() / globals_->ITC_L1L2()->phi0_final.K();
+    int iphicritmaxcut = settings_.phicritmaxmc() / globals_->ITC_L1L2()->phi0_final.K();
+
+    bool keepapprox = (phicritapprox > settings_.phicritminmc()) && (phicritapprox < settings_.phicritmaxmc()),
+         keep = (phicrit > iphicritmincut) && (phicrit < iphicritmaxcut);
+
+    if (settings_.debugTracklet())
+      if (keep && !keepapprox)
+        edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced::LLLSeeding tracklet kept with exact phicrit cut "
+                                        "but not approximate, phicritapprox: "
+                                     << phicritapprox;
+    if (settings_.usephicritapprox()) {
+      if (!keepapprox) {
+        return false;
+      }
+    } else {
+      if (!keep) {
+        return false;
+      }
+    }
+
+    for (unsigned int i = 0; i < toR_.size(); ++i) {
+      iphiproj[i] = phiprojapprox[i] / kphiproj;
+      izproj[i] = zprojapprox[i] / kzproj;
+
+      iphider[i] = phiderapprox[i] / kphider;
+      izder[i] = zderapprox[i] / kzder;
+
+      //check that z projection is in range
+      if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
+        continue;
+      if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
+        continue;
+
+      //check that phi projection is in range
+      if (iphiproj[i] >= (1 << settings_.nphibitsstub(N_LAYER - 1)) - 1)
+        continue;
+      if (iphiproj[i] <= 0)
+        continue;
+
+      //adjust number of bits for phi and z projection
+      if (rproj_[i] < settings_.rPS2S()) {
+        iphiproj[i] >>= (settings_.nphibitsstub(N_LAYER - 1) - settings_.nphibitsstub(0));
+        if (iphiproj[i] >= (1 << settings_.nphibitsstub(0)) - 1)
+          iphiproj[i] = (1 << settings_.nphibitsstub(0)) - 2;  //-2 not to hit atExtreme
+      } else {
+        izproj[i] >>= (settings_.nzbitsstub(0) - settings_.nzbitsstub(N_LAYER - 1));
+      }
+
+      if (rproj_[i] < settings_.rPS2S()) {
+        if (iphider[i] < -(1 << (settings_.nbitsphiprojderL123() - 1))) {
+          iphider[i] = -(1 << (settings_.nbitsphiprojderL123() - 1));
+        }
+        if (iphider[i] >= (1 << (settings_.nbitsphiprojderL123() - 1))) {
+          iphider[i] = (1 << (settings_.nbitsphiprojderL123() - 1)) - 1;
+        }
+      } else {
+        if (iphider[i] < -(1 << (settings_.nbitsphiprojderL456() - 1))) {
+          iphider[i] = -(1 << (settings_.nbitsphiprojderL456() - 1));
+        }
+        if (iphider[i] >= (1 << (settings_.nbitsphiprojderL456() - 1))) {
+          iphider[i] = (1 << (settings_.nbitsphiprojderL456() - 1)) - 1;
         }
       }
 
-      if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
-        edm::LogVerbatim("Tracklet") << "Will break on number of tracklets in " << getName();
-        break;
-      }
+      projs[lproj_[i] - 1].init(settings_,
+                                lproj_[i] - 1,
+                                iphiproj[i],
+                                izproj[i],
+                                iphider[i],
+                                izder[i],
+                                phiproj[i],
+                                zproj[i],
+                                phider[i],
+                                zder[i],
+                                phiprojapprox[i],
+                                zprojapprox[i],
+                                phiderapprox[i],
+                                zderapprox[i],
+                                false);
+    }
 
-      if (countall >= settings_.maxStep("TC")) {
-        if (settings_.debugTracklet())
-          edm::LogVerbatim("Tracklet") << "Will break on MAXTC 1";
-        break;
+    if (std::abs(it * kt) > 1.0) {
+      for (unsigned int i = 0; i < toZ_.size(); ++i) {
+        iphiprojdisk[i] = phiprojdiskapprox[i] / kphiprojdisk;
+        irprojdisk[i] = rprojdiskapprox[i] / krprojdisk;
+
+        iphiderdisk[i] = phiderdiskapprox[i] / kphiderdisk;
+        irderdisk[i] = rderdiskapprox[i] / krderdisk;
+
+        //check phi projection in range
+        if (iphiprojdisk[i] <= 0)
+          continue;
+        if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
+          continue;
+
+        //check r projection in range
+        if (rprojdiskapprox[i] < settings_.rmindisk() || rprojdiskapprox[i] >= settings_.rmaxdisk())
+          continue;
+
+        projs[N_LAYER + i].init(settings_,
+                                N_LAYER + i,
+                                iphiprojdisk[i],
+                                irprojdisk[i],
+                                iphiderdisk[i],
+                                irderdisk[i],
+                                phiprojdisk[i],
+                                rprojdisk[i],
+                                phiderdisk[i],
+                                rderdisk[i],
+                                phiprojdiskapprox[i],
+                                rprojdiskapprox[i],
+                                phiderdisk[i],
+                                rderdisk[i],
+                                false);
       }
+    }
+
+    if (settings_.writeMonitorData("TrackletPars")) {
+      globals_->ofstream("trackletpars.txt")
+          << layer_ << " , " << rinv << " , " << rinvapprox << " , " << phi0 << " , " << phi0approx << " , " << t
+          << " , " << tapprox << " , " << z0 << " , " << z0approx << " , " << d0 << " , " << d0approx << endl;
+    }
+
+    Tracklet* tracklet = new Tracklet(settings_,
+                                      iSeed_,
+                                      innerFPGAStub,
+                                      middleFPGAStub,
+                                      outerFPGAStub,
+                                      rinv,
+                                      phi0,
+                                      d0,
+                                      z0,
+                                      t,
+                                      rinvapprox,
+                                      phi0approx,
+                                      d0approx,
+                                      z0approx,
+                                      tapprox,
+                                      irinv,
+                                      iphi0,
+                                      id0,
+                                      iz0,
+                                      it,
+                                      projs,
+                                      false);
+
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName()
+                                   << " Found LLL tracklet in sector = " << iSector_ << " phi0 = " << phi0;
+
+    tracklet->setTrackletIndex(trackletpars_->nTracklets());
+    tracklet->setTCIndex(TCIndex_);
+
+    if (settings_.writeMonitorData("Seeds")) {
+      ofstream fout("seeds.txt", ofstream::app);
+      fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
+      fout.close();
+    }
+    trackletpars_->addTracklet(tracklet);
+
+    bool addL5 = false;
+    bool addL6 = false;
+    for (unsigned int j = 0; j < toR_.size(); j++) {
+      bool added = false;
+
       if (settings_.debugTracklet())
-        edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
+        edm::LogVerbatim("Tracklet") << "adding layer projection " << j << "/" << toR_.size() << " " << lproj_[j];
+      if (tracklet->validProj(lproj_[j] - 1)) {
+        added = addLayerProj(tracklet, lproj_[j]);
+        if (added && lproj_[j] == 5)
+          addL5 = true;
+        if (added && lproj_[j] == 6)
+          addL6 = true;
+      }
     }
-    if (countall >= settings_.maxStep("TC")) {
+
+    for (unsigned int j = 0; j < toZ_.size(); j++) {
+      int disk = dproj_[j];
+      if (disk == 0)
+        continue;
+      if (disk == 2 && addL5)
+        continue;
+      if (disk == 1 && addL6)
+        continue;
+      if (it < 0)
+        disk = -disk;
       if (settings_.debugTracklet())
-        edm::LogVerbatim("Tracklet") << "Will break on MAXTC 2";
-      break;
+        edm::LogVerbatim("Tracklet") << "adding disk projection " << j << "/" << toZ_.size() << " " << disk;
+      if (tracklet->validProj(N_LAYER + abs(disk) - 1)) {
+        addDiskProj(tracklet, disk);
+      }
     }
+
+    return true;
   }
 
-  if (settings_.writeMonitorData("TPD")) {
-    globals_->ofstream("trackletcalculatordisplaced.txt") << getName() << " " << countall << " " << countsel << endl;
-  }
-}
+  bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
+                                               const L1TStub* innerStub,
+                                               const Stub* middleFPGAStub,
+                                               const L1TStub* middleStub,
+                                               const Stub* outerFPGAStub,
+                                               const L1TStub* outerStub) {
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName() << " " << layer_
+                                   << " trying stub triplet in  (L2 D1 D2): " << innerFPGAStub->layer().value() << " "
+                                   << middleFPGAStub->disk().value() << " " << outerFPGAStub->disk().value();
 
-void TrackletCalculatorDisplaced::addDiskProj(Tracklet* tracklet, int disk) {
-  disk = std::abs(disk);
-  FPGAWord fpgar = tracklet->proj(N_LAYER + disk - 1).fpgarzproj();
+    int take3 = 1;  //D1D2L2
+    unsigned ndisks = 2;
 
-  if (fpgar.value() * settings_.krprojshiftdisk() < settings_.rmindiskvm())
-    return;
-  if (fpgar.value() * settings_.krprojshiftdisk() > settings_.rmaxdisk())
-    return;
+    double r1 = innerStub->r();
+    double z1 = innerStub->z();
+    double phi1 = innerStub->phi();
 
-  FPGAWord fpgaphi = tracklet->proj(N_LAYER + disk - 1).fpgaphiproj();
+    double r2 = middleStub->r();
+    double z2 = middleStub->z();
+    double phi2 = middleStub->phi();
 
-  int iphivmRaw = fpgaphi.value() >> (fpgaphi.nbits() - 5);
-  int iphi = iphivmRaw / (32 / settings_.nallstubs(disk + N_LAYER - 1));
+    double r3 = outerStub->r();
+    double z3 = outerStub->z();
+    double phi3 = outerStub->phi();
 
-  addProjectionDisk(disk, iphi, trackletprojdisks_[disk - 1][iphi], tracklet);
-}
+    double rinv, phi0, d0, t, z0;
 
-bool TrackletCalculatorDisplaced::addLayerProj(Tracklet* tracklet, int layer) {
-  assert(layer > 0);
+    double phiproj[N_LAYER - 2], zproj[N_LAYER - 2], phider[N_LAYER - 2], zder[N_LAYER - 2];
+    double phiprojdisk[N_DISK], rprojdisk[N_DISK], phiderdisk[N_DISK], rderdisk[N_DISK];
 
-  FPGAWord fpgaz = tracklet->proj(layer - 1).fpgarzproj();
-  FPGAWord fpgaphi = tracklet->proj(layer - 1).fpgaphiproj();
+    exacttracklet(r1,
+                  z1,
+                  phi1,
+                  r2,
+                  z2,
+                  phi2,
+                  r3,
+                  z3,
+                  phi3,
+                  take3,
+                  rinv,
+                  phi0,
+                  d0,
+                  t,
+                  z0,
+                  phiproj,
+                  zproj,
+                  phiprojdisk,
+                  rprojdisk,
+                  phider,
+                  zder,
+                  phiderdisk,
+                  rderdisk);
 
-  if (fpgaz.atExtreme())
-    return false;
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << " DLL Exact values " << innerFPGAStub->isBarrel()
+                                   << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi1 << ", "
+                                   << z1 << ", " << r1 << ", " << phi2 << ", " << z2 << ", " << r2 << ", " << phi3
+                                   << ", " << z3 << ", " << r3 << endl;
 
-  if (std::abs(fpgaz.value() * settings_.kz()) > settings_.zlength())
-    return false;
+    if (settings_.useapprox()) {
+      phi1 = innerFPGAStub->phiapprox(phimin_, phimax_);
+      z1 = innerFPGAStub->zapprox();
+      r1 = innerFPGAStub->rapprox();
 
-  int iphivmRaw = fpgaphi.value() >> (fpgaphi.nbits() - 5);
-  int iphi = iphivmRaw / (32 / settings_.nallstubs(layer - 1));
+      phi2 = middleFPGAStub->phiapprox(phimin_, phimax_);
+      z2 = middleFPGAStub->zapprox();
+      r2 = middleFPGAStub->rapprox();
 
-  addProjection(layer, iphi, trackletprojlayers_[layer - 1][iphi], tracklet);
-
-  return true;
-}
-
-void TrackletCalculatorDisplaced::addProjection(int layer,
-                                                int iphi,
-                                                TrackletProjectionsMemory* trackletprojs,
-                                                Tracklet* tracklet) {
-  if (trackletprojs == nullptr) {
-    if (settings_.warnNoMem()) {
-      edm::LogVerbatim("Tracklet") << "No projection memory exists in " << getName() << " for layer = " << layer
-                                   << " iphi = " << iphi + 1;
+      phi3 = outerFPGAStub->phiapprox(phimin_, phimax_);
+      z3 = outerFPGAStub->zapprox();
+      r3 = outerFPGAStub->rapprox();
     }
-    return;
-  }
-  assert(trackletprojs != nullptr);
-  trackletprojs->addProj(tracklet);
-}
 
-void TrackletCalculatorDisplaced::addProjectionDisk(int disk,
-                                                    int iphi,
-                                                    TrackletProjectionsMemory* trackletprojs,
-                                                    Tracklet* tracklet) {
-  if (trackletprojs == nullptr) {
-    if (layer_ == 3 && abs(disk) == 3)
-      return;  //L3L4 projections to D3 are not used.
-    if (settings_.warnNoMem()) {
-      edm::LogVerbatim("Tracklet") << "No projection memory exists in " << getName() << " for disk = " << abs(disk)
-                                   << " iphi = " << iphi + 1;
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << "DLL Approx values " << innerFPGAStub->isBarrel()
+                                   << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi1 << ", "
+                                   << z1 << ", " << r1 << ", " << phi2 << ", " << z2 << ", " << r2 << ", " << phi3
+                                   << ", " << z3 << ", " << r3 << endl;
+
+    double rinvapprox, phi0approx, d0approx, tapprox, z0approx;
+    double phiprojapprox[N_LAYER - 2], zprojapprox[N_LAYER - 2], phiderapprox[N_LAYER - 2], zderapprox[N_LAYER - 2];
+    double phiprojdiskapprox[N_DISK], rprojdiskapprox[N_DISK];
+    double phiderdiskapprox[N_DISK], rderdiskapprox[N_DISK];
+
+    //TODO: implement the actual integer calculation
+    if (settings_.useapprox()) {
+      approxtracklet(r1,
+                     z1,
+                     phi1,
+                     r2,
+                     z2,
+                     phi2,
+                     r3,
+                     z3,
+                     phi3,
+                     take3,
+                     ndisks,
+                     rinvapprox,
+                     phi0approx,
+                     d0approx,
+                     tapprox,
+                     z0approx,
+                     phiprojapprox,
+                     zprojapprox,
+                     phiderapprox,
+                     zderapprox,
+                     phiprojdiskapprox,
+                     rprojdiskapprox,
+                     phiderdiskapprox,
+                     rderdiskapprox);
+    } else {
+      rinvapprox = rinv;
+      phi0approx = phi0;
+      d0approx = d0;
+      tapprox = t;
+      z0approx = z0;
+
+      for (unsigned int i = 0; i < toR_.size(); ++i) {
+        phiprojapprox[i] = phiproj[i];
+        zprojapprox[i] = zproj[i];
+        phiderapprox[i] = phider[i];
+        zderapprox[i] = zder[i];
+      }
+
+      for (unsigned int i = 0; i < toZ_.size(); ++i) {
+        phiprojdiskapprox[i] = phiprojdisk[i];
+        rprojdiskapprox[i] = rprojdisk[i];
+        phiderdiskapprox[i] = phiderdisk[i];
+        rderdiskapprox[i] = rderdisk[i];
+      }
     }
-    return;
-  }
-  assert(trackletprojs != nullptr);
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << getName() << " adding projection to " << trackletprojs->getName();
-  trackletprojs->addProj(tracklet);
-}
 
-bool TrackletCalculatorDisplaced::LLLSeeding(const Stub* innerFPGAStub,
-                                             const L1TStub* innerStub,
-                                             const Stub* middleFPGAStub,
-                                             const L1TStub* middleStub,
-                                             const Stub* outerFPGAStub,
-                                             const L1TStub* outerStub) {
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName() << " " << layer_
-                                 << " trying stub triplet in layer (L L L): " << innerFPGAStub->layer().value() << " "
-                                 << middleFPGAStub->layer().value() << " " << outerFPGAStub->layer().value();
-
-  assert(outerFPGAStub->layerdisk() < N_LAYER);
-
-  double r1 = innerStub->r();
-  double z1 = innerStub->z();
-  double phi1 = innerStub->phi();
-
-  double r2 = middleStub->r();
-  double z2 = middleStub->z();
-  double phi2 = middleStub->phi();
-
-  double r3 = outerStub->r();
-  double z3 = outerStub->z();
-  double phi3 = outerStub->phi();
-
-  int take3 = 0;
-  if (layer_ == 5)
-    take3 = 1;
-  unsigned ndisks = 0;
-
-  double rinv, phi0, d0, t, z0;
-
-  Projection projs[N_LAYER + N_DISK];
-
-  double phiproj[N_LAYER - 2], zproj[N_LAYER - 2], phider[N_LAYER - 2], zder[N_LAYER - 2];
-  double phiprojdisk[N_DISK], rprojdisk[N_DISK], phiderdisk[N_DISK], rderdisk[N_DISK];
-
-  exacttracklet(r1,
-                z1,
-                phi1,
-                r2,
-                z2,
-                phi2,
-                r3,
-                z3,
-                phi3,
-                take3,
-                rinv,
-                phi0,
-                d0,
-                t,
-                z0,
-                phiproj,
-                zproj,
-                phiprojdisk,
-                rprojdisk,
-                phider,
-                zder,
-                phiderdisk,
-                rderdisk);
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << "LLL Exact values " << innerFPGAStub->isBarrel()
-                                 << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi1 << ", " << z1
-                                 << ", " << r1 << ", " << phi2 << ", " << z2 << ", " << r2 << ", " << phi3 << ", " << z3
-                                 << ", " << r3 << endl;
-
-  if (settings_.useapprox()) {
-    phi1 = innerFPGAStub->phiapprox(phimin_, phimax_);
-    z1 = innerFPGAStub->zapprox();
-    r1 = innerFPGAStub->rapprox();
-
-    phi2 = middleFPGAStub->phiapprox(phimin_, phimax_);
-    z2 = middleFPGAStub->zapprox();
-    r2 = middleFPGAStub->rapprox();
-
-    phi3 = outerFPGAStub->phiapprox(phimin_, phimax_);
-    z3 = outerFPGAStub->zapprox();
-    r3 = outerFPGAStub->rapprox();
-  }
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << "LLL Approx values " << innerFPGAStub->isBarrel()
-                                 << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi1 << ", " << z1
-                                 << ", " << r1 << ", " << phi2 << ", " << z2 << ", " << r2 << ", " << phi3 << ", " << z3
-                                 << ", " << r3 << endl;
-
-  double rinvapprox, phi0approx, d0approx, tapprox, z0approx;
-  double phiprojapprox[N_LAYER - 2], zprojapprox[N_LAYER - 2], phiderapprox[N_LAYER - 2], zderapprox[N_LAYER - 2];
-  double phiprojdiskapprox[N_DISK], rprojdiskapprox[N_DISK];
-  double phiderdiskapprox[N_DISK], rderdiskapprox[N_DISK];
-
-  //TODO: implement the actual integer calculation
-  if (settings_.useapprox()) {
-    approxtracklet(r1,
-                   z1,
-                   phi1,
-                   r2,
-                   z2,
-                   phi2,
-                   r3,
-                   z3,
-                   phi3,
-                   take3,
-                   ndisks,
-                   rinvapprox,
-                   phi0approx,
-                   d0approx,
-                   tapprox,
-                   z0approx,
-                   phiprojapprox,
-                   zprojapprox,
-                   phiderapprox,
-                   zderapprox,
-                   phiprojdiskapprox,
-                   rprojdiskapprox,
-                   phiderdiskapprox,
-                   rderdiskapprox);
-  } else {
-    rinvapprox = rinv;
-    phi0approx = phi0;
-    d0approx = d0;
-    tapprox = t;
-    z0approx = z0;
+    //store the approcximate results
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "rinvapprox: " << rinvapprox << " rinv: " << rinv << endl;
+      edm::LogVerbatim("Tracklet") << "phi0approx: " << phi0approx << " phi0: " << phi0 << endl;
+      edm::LogVerbatim("Tracklet") << "d0approx: " << d0approx << " d0: " << d0 << endl;
+      edm::LogVerbatim("Tracklet") << "tapprox: " << tapprox << " t: " << t << endl;
+      edm::LogVerbatim("Tracklet") << "z0approx: " << z0approx << " z0: " << z0 << endl;
+    }
 
     for (unsigned int i = 0; i < toR_.size(); ++i) {
-      phiprojapprox[i] = phiproj[i];
-      zprojapprox[i] = zproj[i];
-      phiderapprox[i] = phider[i];
-      zderapprox[i] = zder[i];
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << "phiprojapprox[" << i << "]: " << phiprojapprox[i] << " phiproj[" << i
+                                     << "]: " << phiproj[i] << endl;
+        edm::LogVerbatim("Tracklet") << "zprojapprox[" << i << "]: " << zprojapprox[i] << " zproj[" << i
+                                     << "]: " << zproj[i] << endl;
+        edm::LogVerbatim("Tracklet") << "phiderapprox[" << i << "]: " << phiderapprox[i] << " phider[" << i
+                                     << "]: " << phider[i] << endl;
+        edm::LogVerbatim("Tracklet") << "zderapprox[" << i << "]: " << zderapprox[i] << " zder[" << i
+                                     << "]: " << zder[i] << endl;
+      }
     }
 
     for (unsigned int i = 0; i < toZ_.size(); ++i) {
-      phiprojdiskapprox[i] = phiprojdisk[i];
-      rprojdiskapprox[i] = rprojdisk[i];
-      phiderdiskapprox[i] = phiderdisk[i];
-      rderdiskapprox[i] = rderdisk[i];
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << "phiprojdiskapprox[" << i << "]: " << phiprojdiskapprox[i] << " phiprojdisk["
+                                     << i << "]: " << phiprojdisk[i] << endl;
+        edm::LogVerbatim("Tracklet") << "rprojdiskapprox[" << i << "]: " << rprojdiskapprox[i] << " rprojdisk[" << i
+                                     << "]: " << rprojdisk[i] << endl;
+        edm::LogVerbatim("Tracklet") << "phiderdiskapprox[" << i << "]: " << phiderdiskapprox[i] << " phiderdisk[" << i
+                                     << "]: " << phiderdisk[i] << endl;
+        edm::LogVerbatim("Tracklet") << "rderdiskapprox[" << i << "]: " << rderdiskapprox[i] << " rderdisk[" << i
+                                     << "]: " << rderdisk[i] << endl;
+      }
     }
-  }
 
-  //store the approcximate results
+    //now binary
+    double krinv = settings_.kphi1() / settings_.kr() * pow(2, settings_.rinv_shift()),
+           kphi0 = settings_.kphi1() * pow(2, settings_.phi0_shift()),
+           kt = settings_.kz() / settings_.kr() * pow(2, settings_.t_shift()),
+           kz0 = settings_.kz() * pow(2, settings_.z0_shift()),
+           kphiproj = settings_.kphi1() * pow(2, settings_.SS_phiL_shift()),
+           kphider = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderL_shift()),
+           kzproj = settings_.kz() * pow(2, settings_.PS_zL_shift()),
+           kzder = settings_.kz() / settings_.kr() * pow(2, settings_.PS_zderL_shift()),
+           kphiprojdisk = settings_.kphi1() * pow(2, settings_.SS_phiD_shift()),
+           kphiderdisk = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderD_shift()),
+           krprojdisk = settings_.kr() * pow(2, settings_.PS_rD_shift()),
+           krderdisk = settings_.kr() / settings_.kz() * pow(2, settings_.PS_rderD_shift());
 
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "rinvapprox: " << rinvapprox << " rinv: " << rinv << endl;
-    edm::LogVerbatim("Tracklet") << "phi0approx: " << phi0approx << " phi0: " << phi0 << endl;
-    edm::LogVerbatim("Tracklet") << "d0approx: " << d0approx << " d0: " << d0 << endl;
-    edm::LogVerbatim("Tracklet") << "tapprox: " << tapprox << " t: " << t << endl;
-    edm::LogVerbatim("Tracklet") << "z0approx: " << z0approx << " z0: " << z0 << endl;
-  }
+    int irinv, iphi0, id0, it, iz0;
+    int iphiproj[N_LAYER - 2], izproj[N_LAYER - 2], iphider[N_LAYER - 2], izder[N_LAYER - 2];
+    int iphiprojdisk[N_DISK], irprojdisk[N_DISK], iphiderdisk[N_DISK], irderdisk[N_DISK];
 
-  for (unsigned int i = 0; i < toR_.size(); ++i) {
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << "phiprojapprox[" << i << "]: " << phiprojapprox[i] << " phiproj[" << i
-                                   << "]: " << phiproj[i] << endl;
-      edm::LogVerbatim("Tracklet") << "zprojapprox[" << i << "]: " << zprojapprox[i] << " zproj[" << i
-                                   << "]: " << zproj[i] << endl;
-      edm::LogVerbatim("Tracklet") << "phiderapprox[" << i << "]: " << phiderapprox[i] << " phider[" << i
-                                   << "]: " << phider[i] << endl;
-      edm::LogVerbatim("Tracklet") << "zderapprox[" << i << "]: " << zderapprox[i] << " zder[" << i << "]: " << zder[i]
-                                   << endl;
+    //store the binary results
+    irinv = rinvapprox / krinv;
+    iphi0 = phi0approx / kphi0;
+    id0 = d0approx / settings_.kd0();
+    it = tapprox / kt;
+    iz0 = z0approx / kz0;
+
+    bool success = true;
+    if (std::abs(rinvapprox) > settings_.rinvcut()) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "TrackletCalculator::DDL Seeding irinv too large: " << rinvapprox << "("
+                                     << irinv << ")";
+      success = false;
     }
-  }
-
-  for (unsigned int i = 0; i < toZ_.size(); ++i) {
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << "phiprojdiskapprox[" << i << "]: " << phiprojdiskapprox[i] << " phiprojdisk[" << i
-                                   << "]: " << phiprojdisk[i] << endl;
-      edm::LogVerbatim("Tracklet") << "rprojdiskapprox[" << i << "]: " << rprojdiskapprox[i] << " rprojdisk[" << i
-                                   << "]: " << rprojdisk[i] << endl;
-      edm::LogVerbatim("Tracklet") << "phiderdiskapprox[" << i << "]: " << phiderdiskapprox[i] << " phiderdisk[" << i
-                                   << "]: " << phiderdisk[i] << endl;
-      edm::LogVerbatim("Tracklet") << "rderdiskapprox[" << i << "]: " << rderdiskapprox[i] << " rderdisk[" << i
-                                   << "]: " << rderdisk[i] << endl;
+    if (std::abs(z0approx) > settings_.disp_z0cut()) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "Failed tracklet z0 cut " << z0approx;
+      success = false;
     }
-  }
+    if (std::abs(d0approx) > settings_.maxd0()) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "Failed tracklet d0 cut " << d0approx;
+      success = false;
+    }
 
-  //now binary
-  double krinv = settings_.kphi1() / settings_.kr() * pow(2, settings_.rinv_shift()),
-         kphi0 = settings_.kphi1() * pow(2, settings_.phi0_shift()),
-         kt = settings_.kz() / settings_.kr() * pow(2, settings_.t_shift()),
-         kz0 = settings_.kz() * pow(2, settings_.z0_shift()),
-         kphiproj = settings_.kphi1() * pow(2, settings_.SS_phiL_shift()),
-         kphider = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderL_shift()),
-         kzproj = settings_.kz() * pow(2, settings_.PS_zL_shift()),
-         kzder = settings_.kz() / settings_.kr() * pow(2, settings_.PS_zderL_shift()),
-         kphiprojdisk = settings_.kphi1() * pow(2, settings_.SS_phiD_shift()),
-         kphiderdisk = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderD_shift()),
-         krprojdisk = settings_.kr() * pow(2, settings_.PS_rD_shift()),
-         krderdisk = settings_.kr() / settings_.kz() * pow(2, settings_.PS_rderD_shift());
-
-  int irinv, iphi0, id0, it, iz0;
-  int iphiproj[N_LAYER - 2], izproj[N_LAYER - 2], iphider[N_LAYER - 2], izder[N_LAYER - 2];
-  int iphiprojdisk[N_DISK], irprojdisk[N_DISK], iphiderdisk[N_DISK], irderdisk[N_DISK];
-
-  //store the binary results
-  irinv = rinvapprox / krinv;
-  iphi0 = phi0approx / kphi0;
-  id0 = d0approx / settings_.kd0();
-  it = tapprox / kt;
-  iz0 = z0approx / kz0;
-
-  bool success = true;
-  if (std::abs(rinvapprox) > settings_.rinvcut()) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "TrackletCalculator::LLL Seeding irinv too large: " << rinvapprox << "(" << irinv
-                                   << ")";
-    success = false;
-  }
-  if (std::abs(z0approx) > settings_.disp_z0cut()) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "Failed tracklet z0 cut " << z0approx << " in layer " << layer_;
-    success = false;
-  }
-  if (std::abs(d0approx) > settings_.maxd0()) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "Failed tracklet d0 cut " << d0approx;
-    success = false;
-  }
-
-  if (!success) {
-    return false;
-  }
-
-  double phicritapprox = phi0approx - asin((0.5 * settings_.rcrit() * rinvapprox) + (d0approx / settings_.rcrit()));
-  int phicrit = iphi0 - 2 * irinv - 2 * id0;
-
-  int iphicritmincut = settings_.phicritminmc() / globals_->ITC_L1L2()->phi0_final.K();
-  int iphicritmaxcut = settings_.phicritmaxmc() / globals_->ITC_L1L2()->phi0_final.K();
-
-  bool keepapprox = (phicritapprox > settings_.phicritminmc()) && (phicritapprox < settings_.phicritmaxmc()),
-       keep = (phicrit > iphicritmincut) && (phicrit < iphicritmaxcut);
-
-  if (settings_.debugTracklet())
-    if (keep && !keepapprox)
-      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced::LLLSeeding tracklet kept with exact phicrit cut "
-                                      "but not approximate, phicritapprox: "
-                                   << phicritapprox;
-  if (settings_.usephicritapprox()) {
-    if (!keepapprox) {
+    if (!success)
       return false;
-    }
-  } else {
-    if (!keep) {
-      return false;
-    }
-  }
 
-  for (unsigned int i = 0; i < toR_.size(); ++i) {
-    iphiproj[i] = phiprojapprox[i] / kphiproj;
-    izproj[i] = zprojapprox[i] / kzproj;
+    double phicritapprox = phi0approx - asin((0.5 * settings_.rcrit() * rinvapprox) + (d0approx / settings_.rcrit()));
+    int phicrit = iphi0 - 2 * irinv - 2 * id0;
 
-    iphider[i] = phiderapprox[i] / kphider;
-    izder[i] = zderapprox[i] / kzder;
+    int iphicritmincut = settings_.phicritminmc() / globals_->ITC_L1L2()->phi0_final.K();
+    int iphicritmaxcut = settings_.phicritmaxmc() / globals_->ITC_L1L2()->phi0_final.K();
 
-    //check that z projection is in range
-    if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-    if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
+    bool keepapprox = (phicritapprox > settings_.phicritminmc()) && (phicritapprox < settings_.phicritmaxmc()),
+         keep = (phicrit > iphicritmincut) && (phicrit < iphicritmaxcut);
 
-    //check that phi projection is in range
-    if (iphiproj[i] >= (1 << settings_.nphibitsstub(N_LAYER - 1)) - 1)
-      continue;
-    if (iphiproj[i] <= 0)
-      continue;
-
-    //adjust number of bits for phi and z projection
-    if (rproj_[i] < settings_.rPS2S()) {
-      iphiproj[i] >>= (settings_.nphibitsstub(N_LAYER - 1) - settings_.nphibitsstub(0));
-      if (iphiproj[i] >= (1 << settings_.nphibitsstub(0)) - 1)
-        iphiproj[i] = (1 << settings_.nphibitsstub(0)) - 2;  //-2 not to hit atExtreme
+    if (settings_.debugTracklet())
+      if (keep && !keepapprox)
+        edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced::DDLSeeding tracklet kept with exact phicrit cut "
+                                        "but not approximate, phicritapprox: "
+                                     << phicritapprox;
+    if (settings_.usephicritapprox()) {
+      if (!keepapprox)
+        return false;
     } else {
-      izproj[i] >>= (settings_.nzbitsstub(0) - settings_.nzbitsstub(N_LAYER - 1));
+      if (!keep)
+        return false;
     }
 
-    if (rproj_[i] < settings_.rPS2S()) {
-      if (iphider[i] < -(1 << (settings_.nbitsphiprojderL123() - 1))) {
-        iphider[i] = -(1 << (settings_.nbitsphiprojderL123() - 1));
+    Projection projs[N_LAYER + N_DISK];
+
+    for (unsigned int i = 0; i < toR_.size(); ++i) {
+      iphiproj[i] = phiprojapprox[i] / kphiproj;
+      izproj[i] = zprojapprox[i] / kzproj;
+
+      iphider[i] = phiderapprox[i] / kphider;
+      izder[i] = zderapprox[i] / kzder;
+
+      //check that z projection in range
+      if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
+        continue;
+      if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
+        continue;
+
+      //check that phi projection in range
+      if (iphiproj[i] >= (1 << settings_.nphibitsstub(5)) - 1)
+        continue;
+      if (iphiproj[i] <= 0)
+        continue;
+
+      if (rproj_[i] < settings_.rPS2S()) {
+        iphiproj[i] >>= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
+      } else {
+        izproj[i] >>= (settings_.nzbitsstub(0) - settings_.nzbitsstub(5));
       }
-      if (iphider[i] >= (1 << (settings_.nbitsphiprojderL123() - 1))) {
-        iphider[i] = (1 << (settings_.nbitsphiprojderL123() - 1)) - 1;
+
+      if (rproj_[i] < settings_.rPS2S()) {
+        if (iphider[i] < -(1 << (settings_.nbitsphiprojderL123() - 1)))
+          iphider[i] = -(1 << (settings_.nbitsphiprojderL123() - 1));
+        if (iphider[i] >= (1 << (settings_.nbitsphiprojderL123() - 1)))
+          iphider[i] = (1 << (settings_.nbitsphiprojderL123() - 1)) - 1;
+      } else {
+        if (iphider[i] < -(1 << (settings_.nbitsphiprojderL456() - 1)))
+          iphider[i] = -(1 << (settings_.nbitsphiprojderL456() - 1));
+        if (iphider[i] >= (1 << (settings_.nbitsphiprojderL456() - 1)))
+          iphider[i] = (1 << (settings_.nbitsphiprojderL456() - 1)) - 1;
       }
-    } else {
-      if (iphider[i] < -(1 << (settings_.nbitsphiprojderL456() - 1))) {
-        iphider[i] = -(1 << (settings_.nbitsphiprojderL456() - 1));
-      }
-      if (iphider[i] >= (1 << (settings_.nbitsphiprojderL456() - 1))) {
-        iphider[i] = (1 << (settings_.nbitsphiprojderL456() - 1)) - 1;
-      }
+
+      projs[lproj_[i] - 1].init(settings_,
+                                lproj_[i] - 1,
+                                iphiproj[i],
+                                izproj[i],
+                                iphider[i],
+                                izder[i],
+                                phiproj[i],
+                                zproj[i],
+                                phider[i],
+                                zder[i],
+                                phiprojapprox[i],
+                                zprojapprox[i],
+                                phiderapprox[i],
+                                zderapprox[i],
+                                false);
     }
 
-    projs[lproj_[i] - 1].init(settings_,
-                              lproj_[i] - 1,
-                              iphiproj[i],
-                              izproj[i],
-                              iphider[i],
-                              izder[i],
-                              phiproj[i],
-                              zproj[i],
-                              phider[i],
-                              zder[i],
-                              phiprojapprox[i],
-                              zprojapprox[i],
-                              phiderapprox[i],
-                              zderapprox[i],
-                              false);
-  }
+    if (std::abs(it * kt) > 1.0) {
+      for (unsigned int i = 0; i < toZ_.size(); ++i) {
+        iphiprojdisk[i] = phiprojdiskapprox[i] / kphiprojdisk;
+        irprojdisk[i] = rprojdiskapprox[i] / krprojdisk;
 
-  if (std::abs(it * kt) > 1.0) {
-    for (unsigned int i = 0; i < toZ_.size(); ++i) {
-      iphiprojdisk[i] = phiprojdiskapprox[i] / kphiprojdisk;
-      irprojdisk[i] = rprojdiskapprox[i] / krprojdisk;
+        iphiderdisk[i] = phiderdiskapprox[i] / kphiderdisk;
+        irderdisk[i] = rderdiskapprox[i] / krderdisk;
 
-      iphiderdisk[i] = phiderdiskapprox[i] / kphiderdisk;
-      irderdisk[i] = rderdiskapprox[i] / krderdisk;
+        if (iphiprojdisk[i] <= 0)
+          continue;
+        if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
+          continue;
 
-      //check phi projection in range
-      if (iphiprojdisk[i] <= 0)
-        continue;
-      if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
-        continue;
+        if (irprojdisk[i] < settings_.rmindisk() / krprojdisk || irprojdisk[i] >= settings_.rmaxdisk() / krprojdisk)
+          continue;
 
-      //check r projection in range
-      if (rprojdiskapprox[i] < settings_.rmindisk() || rprojdiskapprox[i] >= settings_.rmaxdisk())
-        continue;
-
-      projs[N_LAYER + i].init(settings_,
-                              N_LAYER + i,
-                              iphiprojdisk[i],
-                              irprojdisk[i],
-                              iphiderdisk[i],
-                              irderdisk[i],
-                              phiprojdisk[i],
-                              rprojdisk[i],
-                              phiderdisk[i],
-                              rderdisk[i],
-                              phiprojdiskapprox[i],
-                              rprojdiskapprox[i],
-                              phiderdisk[i],
-                              rderdisk[i],
-                              false);
-    }
-  }
-
-  if (settings_.writeMonitorData("TrackletPars")) {
-    globals_->ofstream("trackletpars.txt")
-        << layer_ << " , " << rinv << " , " << rinvapprox << " , " << phi0 << " , " << phi0approx << " , " << t << " , "
-        << tapprox << " , " << z0 << " , " << z0approx << " , " << d0 << " , " << d0approx << endl;
-  }
-
-  Tracklet* tracklet = new Tracklet(settings_,
-                                    iSeed_,
-                                    innerFPGAStub,
-                                    middleFPGAStub,
-                                    outerFPGAStub,
-                                    rinv,
-                                    phi0,
-                                    d0,
-                                    z0,
-                                    t,
-                                    rinvapprox,
-                                    phi0approx,
-                                    d0approx,
-                                    z0approx,
-                                    tapprox,
-                                    irinv,
-                                    iphi0,
-                                    id0,
-                                    iz0,
-                                    it,
-                                    projs,
+        projs[N_LAYER + i + 2].init(settings_,
+                                    N_LAYER + i + 2,
+                                    iphiprojdisk[i],
+                                    irprojdisk[i],
+                                    iphiderdisk[i],
+                                    irderdisk[i],
+                                    phiprojdisk[i],
+                                    rprojdisk[i],
+                                    phiderdisk[i],
+                                    rderdisk[i],
+                                    phiprojdiskapprox[i],
+                                    rprojdiskapprox[i],
+                                    phiderdisk[i],
+                                    rderdisk[i],
                                     false);
+      }
+    }
 
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName()
-                                 << " Found LLL tracklet in sector = " << iSector_ << " phi0 = " << phi0;
+    if (settings_.writeMonitorData("TrackletPars")) {
+      globals_->ofstream("trackletpars.txt")
+          << layer_ << " , " << rinv << " , " << rinvapprox << " , " << phi0 << " , " << phi0approx << " , " << t
+          << " , " << tapprox << " , " << z0 << " , " << z0approx << " , " << d0 << " , " << d0approx << endl;
+    }
 
-  tracklet->setTrackletIndex(trackletpars_->nTracklets());
-  tracklet->setTCIndex(TCIndex_);
-
-  if (settings_.writeMonitorData("Seeds")) {
-    ofstream fout("seeds.txt", ofstream::app);
-    fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
-    fout.close();
-  }
-  trackletpars_->addTracklet(tracklet);
-
-  bool addL5 = false;
-  bool addL6 = false;
-  for (unsigned int j = 0; j < toR_.size(); j++) {
-    bool added = false;
+    Tracklet* tracklet = new Tracklet(settings_,
+                                      iSeed_,
+                                      innerFPGAStub,
+                                      middleFPGAStub,
+                                      outerFPGAStub,
+                                      rinv,
+                                      phi0,
+                                      d0,
+                                      z0,
+                                      t,
+                                      rinvapprox,
+                                      phi0approx,
+                                      d0approx,
+                                      z0approx,
+                                      tapprox,
+                                      irinv,
+                                      iphi0,
+                                      id0,
+                                      iz0,
+                                      it,
+                                      projs,
+                                      true);
 
     if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "adding layer projection " << j << "/" << toR_.size() << " " << lproj_[j];
-    if (tracklet->validProj(lproj_[j] - 1)) {
-      added = addLayerProj(tracklet, lproj_[j]);
-      if (added && lproj_[j] == 5)
-        addL5 = true;
-      if (added && lproj_[j] == 6)
-        addL6 = true;
+      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName()
+                                   << " Found DDL tracklet in sector = " << iSector_ << " phi0 = " << phi0;
+
+    tracklet->setTrackletIndex(trackletpars_->nTracklets());
+    tracklet->setTCIndex(TCIndex_);
+
+    if (settings_.writeMonitorData("Seeds")) {
+      ofstream fout("seeds.txt", ofstream::app);
+      fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
+      fout.close();
     }
+    trackletpars_->addTracklet(tracklet);
+
+    for (unsigned int j = 0; j < toR_.size(); j++) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "adding layer projection " << j << "/" << toR_.size() << " " << lproj_[j] << " "
+                                     << tracklet->validProj(lproj_[j] - 1);
+      if (tracklet->validProj(lproj_[j] - 1)) {
+        addLayerProj(tracklet, lproj_[j]);
+      }
+    }
+
+    for (unsigned int j = 0; j < toZ_.size(); j++) {
+      int disk = dproj_[j];
+      if (disk == 0)
+        continue;
+      if (it < 0)
+        disk = -disk;
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "adding disk projection " << j << "/" << toZ_.size() << " " << disk << " "
+                                     << tracklet->validProj(N_LAYER + abs(disk) - 1);
+      if (tracklet->validProj(N_LAYER + abs(disk) - 1)) {
+        addDiskProj(tracklet, disk);
+      }
+    }
+
+    return true;
   }
 
-  for (unsigned int j = 0; j < toZ_.size(); j++) {
-    int disk = dproj_[j];
-    if (disk == 0)
-      continue;
-    if (disk == 2 && addL5)
-      continue;
-    if (disk == 1 && addL6)
-      continue;
-    if (it < 0)
-      disk = -disk;
+  bool TrackletCalculatorDisplaced::LLDSeeding(const Stub* innerFPGAStub,
+                                               const L1TStub* innerStub,
+                                               const Stub* middleFPGAStub,
+                                               const L1TStub* middleStub,
+                                               const Stub* outerFPGAStub,
+                                               const L1TStub* outerStub) {
     if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "adding disk projection " << j << "/" << toZ_.size() << " " << disk;
-    if (tracklet->validProj(N_LAYER + abs(disk) - 1)) {
-      addDiskProj(tracklet, disk);
+      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName() << " " << layer_
+                                   << " trying stub triplet in  (L2L3D1): " << middleFPGAStub->layer().value() << " "
+                                   << outerFPGAStub->layer().value() << " " << innerFPGAStub->disk().value();
+
+    int take3 = 0;  //L2L3D1
+    unsigned ndisks = 1;
+
+    double r3 = innerStub->r();
+    double z3 = innerStub->z();
+    double phi3 = innerStub->phi();
+
+    double r1 = middleStub->r();
+    double z1 = middleStub->z();
+    double phi1 = middleStub->phi();
+
+    double r2 = outerStub->r();
+    double z2 = outerStub->z();
+    double phi2 = outerStub->phi();
+
+    double rinv, phi0, d0, t, z0;
+
+    double phiproj[N_LAYER - 2], zproj[N_LAYER - 2], phider[N_LAYER - 2], zder[N_LAYER - 2];
+    double phiprojdisk[N_DISK], rprojdisk[N_DISK], phiderdisk[N_DISK], rderdisk[N_DISK];
+
+    exacttracklet(r1,
+                  z1,
+                  phi1,
+                  r2,
+                  z2,
+                  phi2,
+                  r3,
+                  z3,
+                  phi3,
+                  take3,
+                  rinv,
+                  phi0,
+                  d0,
+                  t,
+                  z0,
+                  phiproj,
+                  zproj,
+                  phiprojdisk,
+                  rprojdisk,
+                  phider,
+                  zder,
+                  phiderdisk,
+                  rderdisk);
+
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << "LLD Exact values " << innerFPGAStub->isBarrel()
+                                   << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi3 << ", "
+                                   << z3 << ", " << r3 << ", " << phi1 << ", " << z1 << ", " << r1 << ", " << phi2
+                                   << ", " << z2 << ", " << r2 << endl;
+
+    if (settings_.useapprox()) {
+      phi3 = innerFPGAStub->phiapprox(phimin_, phimax_);
+      z3 = innerFPGAStub->zapprox();
+      r3 = innerFPGAStub->rapprox();
+
+      phi1 = middleFPGAStub->phiapprox(phimin_, phimax_);
+      z1 = middleFPGAStub->zapprox();
+      r1 = middleFPGAStub->rapprox();
+
+      phi2 = outerFPGAStub->phiapprox(phimin_, phimax_);
+      z2 = outerFPGAStub->zapprox();
+      r2 = outerFPGAStub->rapprox();
     }
-  }
 
-  return true;
-}
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << "LLD approx values " << innerFPGAStub->isBarrel()
+                                   << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi3 << ", "
+                                   << z3 << ", " << r3 << ", " << phi1 << ", " << z1 << ", " << r1 << ", " << phi2
+                                   << ", " << z2 << ", " << r2 << endl;
 
-bool TrackletCalculatorDisplaced::DDLSeeding(const Stub* innerFPGAStub,
-                                             const L1TStub* innerStub,
-                                             const Stub* middleFPGAStub,
-                                             const L1TStub* middleStub,
-                                             const Stub* outerFPGAStub,
-                                             const L1TStub* outerStub) {
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName() << " " << layer_
-                                 << " trying stub triplet in  (L2 D1 D2): " << innerFPGAStub->layer().value() << " "
-                                 << middleFPGAStub->disk().value() << " " << outerFPGAStub->disk().value();
+    double rinvapprox, phi0approx, d0approx, tapprox, z0approx;
+    double phiprojapprox[N_LAYER - 2], zprojapprox[N_LAYER - 2], phiderapprox[N_LAYER - 2], zderapprox[N_LAYER - 2];
+    double phiprojdiskapprox[N_DISK], rprojdiskapprox[N_DISK];
+    double phiderdiskapprox[N_DISK], rderdiskapprox[N_DISK];
 
-  int take3 = 1;  //D1D2L2
-  unsigned ndisks = 2;
+    //TODO: implement the actual integer calculation
+    if (settings_.useapprox()) {
+      approxtracklet(r1,
+                     z1,
+                     phi1,
+                     r2,
+                     z2,
+                     phi2,
+                     r3,
+                     z3,
+                     phi3,
+                     take3,
+                     ndisks,
+                     rinvapprox,
+                     phi0approx,
+                     d0approx,
+                     tapprox,
+                     z0approx,
+                     phiprojapprox,
+                     zprojapprox,
+                     phiderapprox,
+                     zderapprox,
+                     phiprojdiskapprox,
+                     rprojdiskapprox,
+                     phiderdiskapprox,
+                     rderdiskapprox);
+    } else {
+      rinvapprox = rinv;
+      phi0approx = phi0;
+      d0approx = d0;
+      tapprox = t;
+      z0approx = z0;
 
-  double r1 = innerStub->r();
-  double z1 = innerStub->z();
-  double phi1 = innerStub->phi();
+      for (unsigned int i = 0; i < toR_.size(); ++i) {
+        phiprojapprox[i] = phiproj[i];
+        zprojapprox[i] = zproj[i];
+        phiderapprox[i] = phider[i];
+        zderapprox[i] = zder[i];
+      }
 
-  double r2 = middleStub->r();
-  double z2 = middleStub->z();
-  double phi2 = middleStub->phi();
+      for (unsigned int i = 0; i < toZ_.size(); ++i) {
+        phiprojdiskapprox[i] = phiprojdisk[i];
+        rprojdiskapprox[i] = rprojdisk[i];
+        phiderdiskapprox[i] = phiderdisk[i];
+        rderdiskapprox[i] = rderdisk[i];
+      }
+    }
 
-  double r3 = outerStub->r();
-  double z3 = outerStub->z();
-  double phi3 = outerStub->phi();
-
-  double rinv, phi0, d0, t, z0;
-
-  double phiproj[N_LAYER - 2], zproj[N_LAYER - 2], phider[N_LAYER - 2], zder[N_LAYER - 2];
-  double phiprojdisk[N_DISK], rprojdisk[N_DISK], phiderdisk[N_DISK], rderdisk[N_DISK];
-
-  exacttracklet(r1,
-                z1,
-                phi1,
-                r2,
-                z2,
-                phi2,
-                r3,
-                z3,
-                phi3,
-                take3,
-                rinv,
-                phi0,
-                d0,
-                t,
-                z0,
-                phiproj,
-                zproj,
-                phiprojdisk,
-                rprojdisk,
-                phider,
-                zder,
-                phiderdisk,
-                rderdisk);
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << " DLL Exact values " << innerFPGAStub->isBarrel()
-                                 << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi1 << ", " << z1
-                                 << ", " << r1 << ", " << phi2 << ", " << z2 << ", " << r2 << ", " << phi3 << ", " << z3
-                                 << ", " << r3 << endl;
-
-  if (settings_.useapprox()) {
-    phi1 = innerFPGAStub->phiapprox(phimin_, phimax_);
-    z1 = innerFPGAStub->zapprox();
-    r1 = innerFPGAStub->rapprox();
-
-    phi2 = middleFPGAStub->phiapprox(phimin_, phimax_);
-    z2 = middleFPGAStub->zapprox();
-    r2 = middleFPGAStub->rapprox();
-
-    phi3 = outerFPGAStub->phiapprox(phimin_, phimax_);
-    z3 = outerFPGAStub->zapprox();
-    r3 = outerFPGAStub->rapprox();
-  }
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << "DLL Approx values " << innerFPGAStub->isBarrel()
-                                 << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi1 << ", " << z1
-                                 << ", " << r1 << ", " << phi2 << ", " << z2 << ", " << r2 << ", " << phi3 << ", " << z3
-                                 << ", " << r3 << endl;
-
-  double rinvapprox, phi0approx, d0approx, tapprox, z0approx;
-  double phiprojapprox[N_LAYER - 2], zprojapprox[N_LAYER - 2], phiderapprox[N_LAYER - 2], zderapprox[N_LAYER - 2];
-  double phiprojdiskapprox[N_DISK], rprojdiskapprox[N_DISK];
-  double phiderdiskapprox[N_DISK], rderdiskapprox[N_DISK];
-
-  //TODO: implement the actual integer calculation
-  if (settings_.useapprox()) {
-    approxtracklet(r1,
-                   z1,
-                   phi1,
-                   r2,
-                   z2,
-                   phi2,
-                   r3,
-                   z3,
-                   phi3,
-                   take3,
-                   ndisks,
-                   rinvapprox,
-                   phi0approx,
-                   d0approx,
-                   tapprox,
-                   z0approx,
-                   phiprojapprox,
-                   zprojapprox,
-                   phiderapprox,
-                   zderapprox,
-                   phiprojdiskapprox,
-                   rprojdiskapprox,
-                   phiderdiskapprox,
-                   rderdiskapprox);
-  } else {
-    rinvapprox = rinv;
-    phi0approx = phi0;
-    d0approx = d0;
-    tapprox = t;
-    z0approx = z0;
+    //store the approcximate results
+    if (settings_.debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "rinvapprox: " << rinvapprox << " rinv: " << rinv << endl;
+      edm::LogVerbatim("Tracklet") << "phi0approx: " << phi0approx << " phi0: " << phi0 << endl;
+      edm::LogVerbatim("Tracklet") << "d0approx: " << d0approx << " d0: " << d0 << endl;
+      edm::LogVerbatim("Tracklet") << "tapprox: " << tapprox << " t: " << t << endl;
+      edm::LogVerbatim("Tracklet") << "z0approx: " << z0approx << " z0: " << z0 << endl;
+    }
 
     for (unsigned int i = 0; i < toR_.size(); ++i) {
-      phiprojapprox[i] = phiproj[i];
-      zprojapprox[i] = zproj[i];
-      phiderapprox[i] = phider[i];
-      zderapprox[i] = zder[i];
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << "phiprojapprox[" << i << "]: " << phiprojapprox[i] << " phiproj[" << i
+                                     << "]: " << phiproj[i] << endl;
+        edm::LogVerbatim("Tracklet") << "zprojapprox[" << i << "]: " << zprojapprox[i] << " zproj[" << i
+                                     << "]: " << zproj[i] << endl;
+        edm::LogVerbatim("Tracklet") << "phiderapprox[" << i << "]: " << phiderapprox[i] << " phider[" << i
+                                     << "]: " << phider[i] << endl;
+        edm::LogVerbatim("Tracklet") << "zderapprox[" << i << "]: " << zderapprox[i] << " zder[" << i
+                                     << "]: " << zder[i] << endl;
+      }
     }
 
     for (unsigned int i = 0; i < toZ_.size(); ++i) {
-      phiprojdiskapprox[i] = phiprojdisk[i];
-      rprojdiskapprox[i] = rprojdisk[i];
-      phiderdiskapprox[i] = phiderdisk[i];
-      rderdiskapprox[i] = rderdisk[i];
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << "phiprojdiskapprox[" << i << "]: " << phiprojdiskapprox[i] << " phiprojdisk["
+                                     << i << "]: " << phiprojdisk[i] << endl;
+        edm::LogVerbatim("Tracklet") << "rprojdiskapprox[" << i << "]: " << rprojdiskapprox[i] << " rprojdisk[" << i
+                                     << "]: " << rprojdisk[i] << endl;
+        edm::LogVerbatim("Tracklet") << "phiderdiskapprox[" << i << "]: " << phiderdiskapprox[i] << " phiderdisk[" << i
+                                     << "]: " << phiderdisk[i] << endl;
+        edm::LogVerbatim("Tracklet") << "rderdiskapprox[" << i << "]: " << rderdiskapprox[i] << " rderdisk[" << i
+                                     << "]: " << rderdisk[i] << endl;
+      }
     }
-  }
 
-  //store the approcximate results
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "rinvapprox: " << rinvapprox << " rinv: " << rinv << endl;
-    edm::LogVerbatim("Tracklet") << "phi0approx: " << phi0approx << " phi0: " << phi0 << endl;
-    edm::LogVerbatim("Tracklet") << "d0approx: " << d0approx << " d0: " << d0 << endl;
-    edm::LogVerbatim("Tracklet") << "tapprox: " << tapprox << " t: " << t << endl;
-    edm::LogVerbatim("Tracklet") << "z0approx: " << z0approx << " z0: " << z0 << endl;
-  }
+    //now binary
+    double krinv = settings_.kphi1() / settings_.kr() * pow(2, settings_.rinv_shift()),
+           kphi0 = settings_.kphi1() * pow(2, settings_.phi0_shift()),
+           kt = settings_.kz() / settings_.kr() * pow(2, settings_.t_shift()),
+           kz0 = settings_.kz() * pow(2, settings_.z0_shift()),
+           kphiproj = settings_.kphi1() * pow(2, settings_.SS_phiL_shift()),
+           kphider = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderL_shift()),
+           kzproj = settings_.kz() * pow(2, settings_.PS_zL_shift()),
+           kzder = settings_.kz() / settings_.kr() * pow(2, settings_.PS_zderL_shift()),
+           kphiprojdisk = settings_.kphi1() * pow(2, settings_.SS_phiD_shift()),
+           kphiderdisk = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderD_shift()),
+           krprojdisk = settings_.kr() * pow(2, settings_.PS_rD_shift()),
+           krderdisk = settings_.kr() / settings_.kz() * pow(2, settings_.PS_rderD_shift());
 
-  for (unsigned int i = 0; i < toR_.size(); ++i) {
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << "phiprojapprox[" << i << "]: " << phiprojapprox[i] << " phiproj[" << i
-                                   << "]: " << phiproj[i] << endl;
-      edm::LogVerbatim("Tracklet") << "zprojapprox[" << i << "]: " << zprojapprox[i] << " zproj[" << i
-                                   << "]: " << zproj[i] << endl;
-      edm::LogVerbatim("Tracklet") << "phiderapprox[" << i << "]: " << phiderapprox[i] << " phider[" << i
-                                   << "]: " << phider[i] << endl;
-      edm::LogVerbatim("Tracklet") << "zderapprox[" << i << "]: " << zderapprox[i] << " zder[" << i << "]: " << zder[i]
-                                   << endl;
+    int irinv, iphi0, id0, it, iz0;
+    int iphiproj[N_LAYER - 2], izproj[N_LAYER - 2], iphider[N_LAYER - 2], izder[N_LAYER - 2];
+    int iphiprojdisk[N_DISK], irprojdisk[N_DISK], iphiderdisk[N_DISK], irderdisk[N_DISK];
+
+    //store the binary results
+    irinv = rinvapprox / krinv;
+    iphi0 = phi0approx / kphi0;
+    id0 = d0approx / settings_.kd0();
+    it = tapprox / kt;
+    iz0 = z0approx / kz0;
+
+    bool success = true;
+    if (std::abs(rinvapprox) > settings_.rinvcut()) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "TrackletCalculator:: LLD Seeding irinv too large: " << rinvapprox << "("
+                                     << irinv << ")";
+      success = false;
     }
-  }
-
-  for (unsigned int i = 0; i < toZ_.size(); ++i) {
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << "phiprojdiskapprox[" << i << "]: " << phiprojdiskapprox[i] << " phiprojdisk[" << i
-                                   << "]: " << phiprojdisk[i] << endl;
-      edm::LogVerbatim("Tracklet") << "rprojdiskapprox[" << i << "]: " << rprojdiskapprox[i] << " rprojdisk[" << i
-                                   << "]: " << rprojdisk[i] << endl;
-      edm::LogVerbatim("Tracklet") << "phiderdiskapprox[" << i << "]: " << phiderdiskapprox[i] << " phiderdisk[" << i
-                                   << "]: " << phiderdisk[i] << endl;
-      edm::LogVerbatim("Tracklet") << "rderdiskapprox[" << i << "]: " << rderdiskapprox[i] << " rderdisk[" << i
-                                   << "]: " << rderdisk[i] << endl;
+    if (std::abs(z0approx) > settings_.disp_z0cut()) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "Failed tracklet z0 cut " << z0approx;
+      success = false;
     }
-  }
+    if (std::abs(d0approx) > settings_.maxd0()) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "Failed tracklet d0 cut " << d0approx;
+      success = false;
+    }
 
-  //now binary
-  double krinv = settings_.kphi1() / settings_.kr() * pow(2, settings_.rinv_shift()),
-         kphi0 = settings_.kphi1() * pow(2, settings_.phi0_shift()),
-         kt = settings_.kz() / settings_.kr() * pow(2, settings_.t_shift()),
-         kz0 = settings_.kz() * pow(2, settings_.z0_shift()),
-         kphiproj = settings_.kphi1() * pow(2, settings_.SS_phiL_shift()),
-         kphider = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderL_shift()),
-         kzproj = settings_.kz() * pow(2, settings_.PS_zL_shift()),
-         kzder = settings_.kz() / settings_.kr() * pow(2, settings_.PS_zderL_shift()),
-         kphiprojdisk = settings_.kphi1() * pow(2, settings_.SS_phiD_shift()),
-         kphiderdisk = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderD_shift()),
-         krprojdisk = settings_.kr() * pow(2, settings_.PS_rD_shift()),
-         krderdisk = settings_.kr() / settings_.kz() * pow(2, settings_.PS_rderD_shift());
-
-  int irinv, iphi0, id0, it, iz0;
-  int iphiproj[N_LAYER - 2], izproj[N_LAYER - 2], iphider[N_LAYER - 2], izder[N_LAYER - 2];
-  int iphiprojdisk[N_DISK], irprojdisk[N_DISK], iphiderdisk[N_DISK], irderdisk[N_DISK];
-
-  //store the binary results
-  irinv = rinvapprox / krinv;
-  iphi0 = phi0approx / kphi0;
-  id0 = d0approx / settings_.kd0();
-  it = tapprox / kt;
-  iz0 = z0approx / kz0;
-
-  bool success = true;
-  if (std::abs(rinvapprox) > settings_.rinvcut()) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "TrackletCalculator::DDL Seeding irinv too large: " << rinvapprox << "(" << irinv
-                                   << ")";
-    success = false;
-  }
-  if (std::abs(z0approx) > settings_.disp_z0cut()) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "Failed tracklet z0 cut " << z0approx;
-    success = false;
-  }
-  if (std::abs(d0approx) > settings_.maxd0()) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "Failed tracklet d0 cut " << d0approx;
-    success = false;
-  }
-
-  if (!success)
-    return false;
-
-  double phicritapprox = phi0approx - asin((0.5 * settings_.rcrit() * rinvapprox) + (d0approx / settings_.rcrit()));
-  int phicrit = iphi0 - 2 * irinv - 2 * id0;
-
-  int iphicritmincut = settings_.phicritminmc() / globals_->ITC_L1L2()->phi0_final.K();
-  int iphicritmaxcut = settings_.phicritmaxmc() / globals_->ITC_L1L2()->phi0_final.K();
-
-  bool keepapprox = (phicritapprox > settings_.phicritminmc()) && (phicritapprox < settings_.phicritmaxmc()),
-       keep = (phicrit > iphicritmincut) && (phicrit < iphicritmaxcut);
-
-  if (settings_.debugTracklet())
-    if (keep && !keepapprox)
-      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced::DDLSeeding tracklet kept with exact phicrit cut "
-                                      "but not approximate, phicritapprox: "
-                                   << phicritapprox;
-  if (settings_.usephicritapprox()) {
-    if (!keepapprox)
+    if (!success)
       return false;
-  } else {
-    if (!keep)
-      return false;
-  }
 
-  Projection projs[N_LAYER + N_DISK];
+    double phicritapprox = phi0approx - asin((0.5 * settings_.rcrit() * rinvapprox) + (d0approx / settings_.rcrit()));
+    int phicrit = iphi0 - 2 * irinv - 2 * id0;
 
-  for (unsigned int i = 0; i < toR_.size(); ++i) {
-    iphiproj[i] = phiprojapprox[i] / kphiproj;
-    izproj[i] = zprojapprox[i] / kzproj;
+    int iphicritmincut = settings_.phicritminmc() / globals_->ITC_L1L2()->phi0_final.K();
+    int iphicritmaxcut = settings_.phicritmaxmc() / globals_->ITC_L1L2()->phi0_final.K();
 
-    iphider[i] = phiderapprox[i] / kphider;
-    izder[i] = zderapprox[i] / kzder;
+    bool keepapprox = (phicritapprox > settings_.phicritminmc()) && (phicritapprox < settings_.phicritmaxmc()),
+         keep = (phicrit > iphicritmincut) && (phicrit < iphicritmaxcut);
 
-    //check that z projection in range
-    if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-    if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-
-    //check that phi projection in range
-    if (iphiproj[i] >= (1 << settings_.nphibitsstub(5)) - 1)
-      continue;
-    if (iphiproj[i] <= 0)
-      continue;
-
-    if (rproj_[i] < settings_.rPS2S()) {
-      iphiproj[i] >>= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
-    } else {
-      izproj[i] >>= (settings_.nzbitsstub(0) - settings_.nzbitsstub(5));
-    }
-
-    if (rproj_[i] < settings_.rPS2S()) {
-      if (iphider[i] < -(1 << (settings_.nbitsphiprojderL123() - 1)))
-        iphider[i] = -(1 << (settings_.nbitsphiprojderL123() - 1));
-      if (iphider[i] >= (1 << (settings_.nbitsphiprojderL123() - 1)))
-        iphider[i] = (1 << (settings_.nbitsphiprojderL123() - 1)) - 1;
-    } else {
-      if (iphider[i] < -(1 << (settings_.nbitsphiprojderL456() - 1)))
-        iphider[i] = -(1 << (settings_.nbitsphiprojderL456() - 1));
-      if (iphider[i] >= (1 << (settings_.nbitsphiprojderL456() - 1)))
-        iphider[i] = (1 << (settings_.nbitsphiprojderL456() - 1)) - 1;
-    }
-
-    projs[lproj_[i] - 1].init(settings_,
-                              lproj_[i] - 1,
-                              iphiproj[i],
-                              izproj[i],
-                              iphider[i],
-                              izder[i],
-                              phiproj[i],
-                              zproj[i],
-                              phider[i],
-                              zder[i],
-                              phiprojapprox[i],
-                              zprojapprox[i],
-                              phiderapprox[i],
-                              zderapprox[i],
-                              false);
-  }
-
-  if (std::abs(it * kt) > 1.0) {
-    for (unsigned int i = 0; i < toZ_.size(); ++i) {
-      iphiprojdisk[i] = phiprojdiskapprox[i] / kphiprojdisk;
-      irprojdisk[i] = rprojdiskapprox[i] / krprojdisk;
-
-      iphiderdisk[i] = phiderdiskapprox[i] / kphiderdisk;
-      irderdisk[i] = rderdiskapprox[i] / krderdisk;
-
-      if (iphiprojdisk[i] <= 0)
-        continue;
-      if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
-        continue;
-
-      if (irprojdisk[i] < settings_.rmindisk() / krprojdisk || irprojdisk[i] >= settings_.rmaxdisk() / krprojdisk)
-        continue;
-
-      projs[N_LAYER + i + 2].init(settings_,
-                                  N_LAYER + i + 2,
-                                  iphiprojdisk[i],
-                                  irprojdisk[i],
-                                  iphiderdisk[i],
-                                  irderdisk[i],
-                                  phiprojdisk[i],
-                                  rprojdisk[i],
-                                  phiderdisk[i],
-                                  rderdisk[i],
-                                  phiprojdiskapprox[i],
-                                  rprojdiskapprox[i],
-                                  phiderdisk[i],
-                                  rderdisk[i],
-                                  false);
-    }
-  }
-
-  if (settings_.writeMonitorData("TrackletPars")) {
-    globals_->ofstream("trackletpars.txt")
-        << layer_ << " , " << rinv << " , " << rinvapprox << " , " << phi0 << " , " << phi0approx << " , " << t << " , "
-        << tapprox << " , " << z0 << " , " << z0approx << " , " << d0 << " , " << d0approx << endl;
-  }
-
-  Tracklet* tracklet = new Tracklet(settings_,
-                                    iSeed_,
-                                    innerFPGAStub,
-                                    middleFPGAStub,
-                                    outerFPGAStub,
-                                    rinv,
-                                    phi0,
-                                    d0,
-                                    z0,
-                                    t,
-                                    rinvapprox,
-                                    phi0approx,
-                                    d0approx,
-                                    z0approx,
-                                    tapprox,
-                                    irinv,
-                                    iphi0,
-                                    id0,
-                                    iz0,
-                                    it,
-                                    projs,
-                                    true);
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName()
-                                 << " Found DDL tracklet in sector = " << iSector_ << " phi0 = " << phi0;
-
-  tracklet->setTrackletIndex(trackletpars_->nTracklets());
-  tracklet->setTCIndex(TCIndex_);
-
-  if (settings_.writeMonitorData("Seeds")) {
-    ofstream fout("seeds.txt", ofstream::app);
-    fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
-    fout.close();
-  }
-  trackletpars_->addTracklet(tracklet);
-
-  for (unsigned int j = 0; j < toR_.size(); j++) {
     if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "adding layer projection " << j << "/" << toR_.size() << " " << lproj_[j] << " "
-                                   << tracklet->validProj(lproj_[j] - 1);
-    if (tracklet->validProj(lproj_[j] - 1)) {
-      addLayerProj(tracklet, lproj_[j]);
+      if (keep && !keepapprox)
+        edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced::LLDSeeding tracklet kept with exact phicrit cut "
+                                        "but not approximate, phicritapprox: "
+                                     << phicritapprox;
+    if (settings_.usephicritapprox()) {
+      if (!keepapprox)
+        return false;
+    } else {
+      if (!keep)
+        return false;
     }
-  }
 
-  for (unsigned int j = 0; j < toZ_.size(); j++) {
-    int disk = dproj_[j];
-    if (disk == 0)
-      continue;
-    if (it < 0)
-      disk = -disk;
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "adding disk projection " << j << "/" << toZ_.size() << " " << disk << " "
-                                   << tracklet->validProj(N_LAYER + abs(disk) - 1);
-    if (tracklet->validProj(N_LAYER + abs(disk) - 1)) {
-      addDiskProj(tracklet, disk);
-    }
-  }
-
-  return true;
-}
-
-bool TrackletCalculatorDisplaced::LLDSeeding(const Stub* innerFPGAStub,
-                                             const L1TStub* innerStub,
-                                             const Stub* middleFPGAStub,
-                                             const L1TStub* middleStub,
-                                             const Stub* outerFPGAStub,
-                                             const L1TStub* outerStub) {
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName() << " " << layer_
-                                 << " trying stub triplet in  (L2L3D1): " << middleFPGAStub->layer().value() << " "
-                                 << outerFPGAStub->layer().value() << " " << innerFPGAStub->disk().value();
-
-  int take3 = 0;  //L2L3D1
-  unsigned ndisks = 1;
-
-  double r3 = innerStub->r();
-  double z3 = innerStub->z();
-  double phi3 = innerStub->phi();
-
-  double r1 = middleStub->r();
-  double z1 = middleStub->z();
-  double phi1 = middleStub->phi();
-
-  double r2 = outerStub->r();
-  double z2 = outerStub->z();
-  double phi2 = outerStub->phi();
-
-  double rinv, phi0, d0, t, z0;
-
-  double phiproj[N_LAYER - 2], zproj[N_LAYER - 2], phider[N_LAYER - 2], zder[N_LAYER - 2];
-  double phiprojdisk[N_DISK], rprojdisk[N_DISK], phiderdisk[N_DISK], rderdisk[N_DISK];
-
-  exacttracklet(r1,
-                z1,
-                phi1,
-                r2,
-                z2,
-                phi2,
-                r3,
-                z3,
-                phi3,
-                take3,
-                rinv,
-                phi0,
-                d0,
-                t,
-                z0,
-                phiproj,
-                zproj,
-                phiprojdisk,
-                rprojdisk,
-                phider,
-                zder,
-                phiderdisk,
-                rderdisk);
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << "LLD Exact values " << innerFPGAStub->isBarrel()
-                                 << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi3 << ", " << z3
-                                 << ", " << r3 << ", " << phi1 << ", " << z1 << ", " << r1 << ", " << phi2 << ", " << z2
-                                 << ", " << r2 << endl;
-
-  if (settings_.useapprox()) {
-    phi3 = innerFPGAStub->phiapprox(phimin_, phimax_);
-    z3 = innerFPGAStub->zapprox();
-    r3 = innerFPGAStub->rapprox();
-
-    phi1 = middleFPGAStub->phiapprox(phimin_, phimax_);
-    z1 = middleFPGAStub->zapprox();
-    r1 = middleFPGAStub->rapprox();
-
-    phi2 = outerFPGAStub->phiapprox(phimin_, phimax_);
-    z2 = outerFPGAStub->zapprox();
-    r2 = outerFPGAStub->rapprox();
-  }
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << __LINE__ << ":" << __FILE__ << "LLD approx values " << innerFPGAStub->isBarrel()
-                                 << middleFPGAStub->isBarrel() << outerFPGAStub->isBarrel() << " " << phi3 << ", " << z3
-                                 << ", " << r3 << ", " << phi1 << ", " << z1 << ", " << r1 << ", " << phi2 << ", " << z2
-                                 << ", " << r2 << endl;
-
-  double rinvapprox, phi0approx, d0approx, tapprox, z0approx;
-  double phiprojapprox[N_LAYER - 2], zprojapprox[N_LAYER - 2], phiderapprox[N_LAYER - 2], zderapprox[N_LAYER - 2];
-  double phiprojdiskapprox[N_DISK], rprojdiskapprox[N_DISK];
-  double phiderdiskapprox[N_DISK], rderdiskapprox[N_DISK];
-
-  //TODO: implement the actual integer calculation
-  if (settings_.useapprox()) {
-    approxtracklet(r1,
-                   z1,
-                   phi1,
-                   r2,
-                   z2,
-                   phi2,
-                   r3,
-                   z3,
-                   phi3,
-                   take3,
-                   ndisks,
-                   rinvapprox,
-                   phi0approx,
-                   d0approx,
-                   tapprox,
-                   z0approx,
-                   phiprojapprox,
-                   zprojapprox,
-                   phiderapprox,
-                   zderapprox,
-                   phiprojdiskapprox,
-                   rprojdiskapprox,
-                   phiderdiskapprox,
-                   rderdiskapprox);
-  } else {
-    rinvapprox = rinv;
-    phi0approx = phi0;
-    d0approx = d0;
-    tapprox = t;
-    z0approx = z0;
+    Projection projs[N_LAYER + N_DISK];
 
     for (unsigned int i = 0; i < toR_.size(); ++i) {
-      phiprojapprox[i] = phiproj[i];
-      zprojapprox[i] = zproj[i];
-      phiderapprox[i] = phider[i];
-      zderapprox[i] = zder[i];
-    }
+      iphiproj[i] = phiprojapprox[i] / kphiproj;
+      izproj[i] = zprojapprox[i] / kzproj;
 
-    for (unsigned int i = 0; i < toZ_.size(); ++i) {
-      phiprojdiskapprox[i] = phiprojdisk[i];
-      rprojdiskapprox[i] = rprojdisk[i];
-      phiderdiskapprox[i] = phiderdisk[i];
-      rderdiskapprox[i] = rderdisk[i];
-    }
-  }
+      iphider[i] = phiderapprox[i] / kphider;
+      izder[i] = zderapprox[i] / kzder;
 
-  //store the approcximate results
-  if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "rinvapprox: " << rinvapprox << " rinv: " << rinv << endl;
-    edm::LogVerbatim("Tracklet") << "phi0approx: " << phi0approx << " phi0: " << phi0 << endl;
-    edm::LogVerbatim("Tracklet") << "d0approx: " << d0approx << " d0: " << d0 << endl;
-    edm::LogVerbatim("Tracklet") << "tapprox: " << tapprox << " t: " << t << endl;
-    edm::LogVerbatim("Tracklet") << "z0approx: " << z0approx << " z0: " << z0 << endl;
-  }
-
-  for (unsigned int i = 0; i < toR_.size(); ++i) {
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << "phiprojapprox[" << i << "]: " << phiprojapprox[i] << " phiproj[" << i
-                                   << "]: " << phiproj[i] << endl;
-      edm::LogVerbatim("Tracklet") << "zprojapprox[" << i << "]: " << zprojapprox[i] << " zproj[" << i
-                                   << "]: " << zproj[i] << endl;
-      edm::LogVerbatim("Tracklet") << "phiderapprox[" << i << "]: " << phiderapprox[i] << " phider[" << i
-                                   << "]: " << phider[i] << endl;
-      edm::LogVerbatim("Tracklet") << "zderapprox[" << i << "]: " << zderapprox[i] << " zder[" << i << "]: " << zder[i]
-                                   << endl;
-    }
-  }
-
-  for (unsigned int i = 0; i < toZ_.size(); ++i) {
-    if (settings_.debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << "phiprojdiskapprox[" << i << "]: " << phiprojdiskapprox[i] << " phiprojdisk[" << i
-                                   << "]: " << phiprojdisk[i] << endl;
-      edm::LogVerbatim("Tracklet") << "rprojdiskapprox[" << i << "]: " << rprojdiskapprox[i] << " rprojdisk[" << i
-                                   << "]: " << rprojdisk[i] << endl;
-      edm::LogVerbatim("Tracklet") << "phiderdiskapprox[" << i << "]: " << phiderdiskapprox[i] << " phiderdisk[" << i
-                                   << "]: " << phiderdisk[i] << endl;
-      edm::LogVerbatim("Tracklet") << "rderdiskapprox[" << i << "]: " << rderdiskapprox[i] << " rderdisk[" << i
-                                   << "]: " << rderdisk[i] << endl;
-    }
-  }
-
-  //now binary
-  double krinv = settings_.kphi1() / settings_.kr() * pow(2, settings_.rinv_shift()),
-         kphi0 = settings_.kphi1() * pow(2, settings_.phi0_shift()),
-         kt = settings_.kz() / settings_.kr() * pow(2, settings_.t_shift()),
-         kz0 = settings_.kz() * pow(2, settings_.z0_shift()),
-         kphiproj = settings_.kphi1() * pow(2, settings_.SS_phiL_shift()),
-         kphider = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderL_shift()),
-         kzproj = settings_.kz() * pow(2, settings_.PS_zL_shift()),
-         kzder = settings_.kz() / settings_.kr() * pow(2, settings_.PS_zderL_shift()),
-         kphiprojdisk = settings_.kphi1() * pow(2, settings_.SS_phiD_shift()),
-         kphiderdisk = settings_.kphi1() / settings_.kr() * pow(2, settings_.SS_phiderD_shift()),
-         krprojdisk = settings_.kr() * pow(2, settings_.PS_rD_shift()),
-         krderdisk = settings_.kr() / settings_.kz() * pow(2, settings_.PS_rderD_shift());
-
-  int irinv, iphi0, id0, it, iz0;
-  int iphiproj[N_LAYER - 2], izproj[N_LAYER - 2], iphider[N_LAYER - 2], izder[N_LAYER - 2];
-  int iphiprojdisk[N_DISK], irprojdisk[N_DISK], iphiderdisk[N_DISK], irderdisk[N_DISK];
-
-  //store the binary results
-  irinv = rinvapprox / krinv;
-  iphi0 = phi0approx / kphi0;
-  id0 = d0approx / settings_.kd0();
-  it = tapprox / kt;
-  iz0 = z0approx / kz0;
-
-  bool success = true;
-  if (std::abs(rinvapprox) > settings_.rinvcut()) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "TrackletCalculator:: LLD Seeding irinv too large: " << rinvapprox << "(" << irinv
-                                   << ")";
-    success = false;
-  }
-  if (std::abs(z0approx) > settings_.disp_z0cut()) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "Failed tracklet z0 cut " << z0approx;
-    success = false;
-  }
-  if (std::abs(d0approx) > settings_.maxd0()) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "Failed tracklet d0 cut " << d0approx;
-    success = false;
-  }
-
-  if (!success)
-    return false;
-
-  double phicritapprox = phi0approx - asin((0.5 * settings_.rcrit() * rinvapprox) + (d0approx / settings_.rcrit()));
-  int phicrit = iphi0 - 2 * irinv - 2 * id0;
-
-  int iphicritmincut = settings_.phicritminmc() / globals_->ITC_L1L2()->phi0_final.K();
-  int iphicritmaxcut = settings_.phicritmaxmc() / globals_->ITC_L1L2()->phi0_final.K();
-
-  bool keepapprox = (phicritapprox > settings_.phicritminmc()) && (phicritapprox < settings_.phicritmaxmc()),
-       keep = (phicrit > iphicritmincut) && (phicrit < iphicritmaxcut);
-
-  if (settings_.debugTracklet())
-    if (keep && !keepapprox)
-      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced::LLDSeeding tracklet kept with exact phicrit cut "
-                                      "but not approximate, phicritapprox: "
-                                   << phicritapprox;
-  if (settings_.usephicritapprox()) {
-    if (!keepapprox)
-      return false;
-  } else {
-    if (!keep)
-      return false;
-  }
-
-  Projection projs[N_LAYER + N_DISK];
-
-  for (unsigned int i = 0; i < toR_.size(); ++i) {
-    iphiproj[i] = phiprojapprox[i] / kphiproj;
-    izproj[i] = zprojapprox[i] / kzproj;
-
-    iphider[i] = phiderapprox[i] / kphider;
-    izder[i] = zderapprox[i] / kzder;
-
-    if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-    if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
-      continue;
-
-    //this is left from the original....
-    if (iphiproj[i] >= (1 << settings_.nphibitsstub(5)) - 1)
-      continue;
-    if (iphiproj[i] <= 0)
-      continue;
-
-    if (rproj_[i] < settings_.rPS2S()) {
-      iphiproj[i] >>= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
-    } else {
-      izproj[i] >>= (settings_.nzbitsstub(0) - settings_.nzbitsstub(5));
-    }
-
-    if (rproj_[i] < settings_.rPS2S()) {
-      if (iphider[i] < -(1 << (settings_.nbitsphiprojderL123() - 1)))
-        iphider[i] = -(1 << (settings_.nbitsphiprojderL123() - 1));
-      if (iphider[i] >= (1 << (settings_.nbitsphiprojderL123() - 1)))
-        iphider[i] = (1 << (settings_.nbitsphiprojderL123() - 1)) - 1;
-    } else {
-      if (iphider[i] < -(1 << (settings_.nbitsphiprojderL456() - 1)))
-        iphider[i] = -(1 << (settings_.nbitsphiprojderL456() - 1));
-      if (iphider[i] >= (1 << (settings_.nbitsphiprojderL456() - 1)))
-        iphider[i] = (1 << (settings_.nbitsphiprojderL456() - 1)) - 1;
-    }
-
-    projs[lproj_[i] - 1].init(settings_,
-                              lproj_[i] - 1,
-                              iphiproj[i],
-                              izproj[i],
-                              iphider[i],
-                              izder[i],
-                              phiproj[i],
-                              zproj[i],
-                              phider[i],
-                              zder[i],
-                              phiprojapprox[i],
-                              zprojapprox[i],
-                              phiderapprox[i],
-                              zderapprox[i],
-                              false);
-  }
-
-  if (std::abs(it * kt) > 1.0) {
-    for (unsigned int i = 0; i < toZ_.size(); ++i) {
-      iphiprojdisk[i] = phiprojdiskapprox[i] / kphiprojdisk;
-      irprojdisk[i] = rprojdiskapprox[i] / krprojdisk;
-
-      iphiderdisk[i] = phiderdiskapprox[i] / kphiderdisk;
-      irderdisk[i] = rderdiskapprox[i] / krderdisk;
-
-      //Check phi range of projection
-      if (iphiprojdisk[i] <= 0)
+      if (izproj[i] < -(1 << (settings_.nzbitsstub(0) - 1)))
         continue;
-      if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
+      if (izproj[i] >= (1 << (settings_.nzbitsstub(0) - 1)))
         continue;
 
-      //Check r range of projection
-      if (irprojdisk[i] < settings_.rmindisk() / krprojdisk || irprojdisk[i] >= settings_.rmaxdisk() / krprojdisk)
+      //this is left from the original....
+      if (iphiproj[i] >= (1 << settings_.nphibitsstub(5)) - 1)
+        continue;
+      if (iphiproj[i] <= 0)
         continue;
 
-      projs[N_LAYER + i + 1].init(settings_,
-                                  N_LAYER + i + 1,
-                                  iphiprojdisk[i],
-                                  irprojdisk[i],
-                                  iphiderdisk[i],
-                                  irderdisk[i],
-                                  phiprojdisk[i],
-                                  rprojdisk[i],
-                                  phiderdisk[i],
-                                  rderdisk[i],
-                                  phiprojdiskapprox[i],
-                                  rprojdiskapprox[i],
-                                  phiderdisk[i],
-                                  rderdisk[i],
-                                  false);
+      if (rproj_[i] < settings_.rPS2S()) {
+        iphiproj[i] >>= (settings_.nphibitsstub(5) - settings_.nphibitsstub(0));
+      } else {
+        izproj[i] >>= (settings_.nzbitsstub(0) - settings_.nzbitsstub(5));
+      }
+
+      if (rproj_[i] < settings_.rPS2S()) {
+        if (iphider[i] < -(1 << (settings_.nbitsphiprojderL123() - 1)))
+          iphider[i] = -(1 << (settings_.nbitsphiprojderL123() - 1));
+        if (iphider[i] >= (1 << (settings_.nbitsphiprojderL123() - 1)))
+          iphider[i] = (1 << (settings_.nbitsphiprojderL123() - 1)) - 1;
+      } else {
+        if (iphider[i] < -(1 << (settings_.nbitsphiprojderL456() - 1)))
+          iphider[i] = -(1 << (settings_.nbitsphiprojderL456() - 1));
+        if (iphider[i] >= (1 << (settings_.nbitsphiprojderL456() - 1)))
+          iphider[i] = (1 << (settings_.nbitsphiprojderL456() - 1)) - 1;
+      }
+
+      projs[lproj_[i] - 1].init(settings_,
+                                lproj_[i] - 1,
+                                iphiproj[i],
+                                izproj[i],
+                                iphider[i],
+                                izder[i],
+                                phiproj[i],
+                                zproj[i],
+                                phider[i],
+                                zder[i],
+                                phiprojapprox[i],
+                                zprojapprox[i],
+                                phiderapprox[i],
+                                zderapprox[i],
+                                false);
     }
-  }
 
-  if (settings_.writeMonitorData("TrackletPars")) {
-    globals_->ofstream("trackletpars.txt")
-        << layer_ << " , " << rinv << " , " << rinvapprox << " , " << phi0 << " , " << phi0approx << " , " << t << " , "
-        << tapprox << " , " << z0 << " , " << z0approx << " , " << d0 << " , " << d0approx << endl;
-  }
+    if (std::abs(it * kt) > 1.0) {
+      for (unsigned int i = 0; i < toZ_.size(); ++i) {
+        iphiprojdisk[i] = phiprojdiskapprox[i] / kphiprojdisk;
+        irprojdisk[i] = rprojdiskapprox[i] / krprojdisk;
 
-  Tracklet* tracklet = new Tracklet(settings_,
-                                    iSeed_,
-                                    innerFPGAStub,
-                                    middleFPGAStub,
-                                    outerFPGAStub,
-                                    rinv,
-                                    phi0,
-                                    d0,
-                                    z0,
-                                    t,
-                                    rinvapprox,
-                                    phi0approx,
-                                    d0approx,
-                                    z0approx,
-                                    tapprox,
-                                    irinv,
-                                    iphi0,
-                                    id0,
-                                    iz0,
-                                    it,
-                                    projs,
+        iphiderdisk[i] = phiderdiskapprox[i] / kphiderdisk;
+        irderdisk[i] = rderdiskapprox[i] / krderdisk;
+
+        //Check phi range of projection
+        if (iphiprojdisk[i] <= 0)
+          continue;
+        if (iphiprojdisk[i] >= (1 << settings_.nphibitsstub(0)) - 1)
+          continue;
+
+        //Check r range of projection
+        if (irprojdisk[i] < settings_.rmindisk() / krprojdisk || irprojdisk[i] >= settings_.rmaxdisk() / krprojdisk)
+          continue;
+
+        projs[N_LAYER + i + 1].init(settings_,
+                                    N_LAYER + i + 1,
+                                    iphiprojdisk[i],
+                                    irprojdisk[i],
+                                    iphiderdisk[i],
+                                    irderdisk[i],
+                                    phiprojdisk[i],
+                                    rprojdisk[i],
+                                    phiderdisk[i],
+                                    rderdisk[i],
+                                    phiprojdiskapprox[i],
+                                    rprojdiskapprox[i],
+                                    phiderdisk[i],
+                                    rderdisk[i],
                                     false);
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName()
-                                 << " Found LLD tracklet in sector = " << iSector_ << " phi0 = " << phi0;
-
-  tracklet->setTrackletIndex(trackletpars_->nTracklets());
-  tracklet->setTCIndex(TCIndex_);
-
-  if (settings_.writeMonitorData("Seeds")) {
-    ofstream fout("seeds.txt", ofstream::app);
-    fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
-    fout.close();
-  }
-  trackletpars_->addTracklet(tracklet);
-
-  for (unsigned int j = 0; j < toR_.size(); j++) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "adding layer projection " << j << "/" << toR_.size() << " " << lproj_[j];
-    if (tracklet->validProj(lproj_[j] - 1)) {
-      addLayerProj(tracklet, lproj_[j]);
+      }
     }
-  }
 
-  for (unsigned int j = 0; j < toZ_.size(); j++) {
-    int disk = dproj_[j];
-    if (disk == 0)
-      continue;
-    if (it < 0)
-      disk = -disk;
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << "adding disk projection " << j << "/" << toZ_.size() << " " << disk;
-    if (tracklet->validProj(N_LAYER + abs(disk) - 1)) {
-      addDiskProj(tracklet, disk);
+    if (settings_.writeMonitorData("TrackletPars")) {
+      globals_->ofstream("trackletpars.txt")
+          << layer_ << " , " << rinv << " , " << rinvapprox << " , " << phi0 << " , " << phi0approx << " , " << t
+          << " , " << tapprox << " , " << z0 << " , " << z0approx << " , " << d0 << " , " << d0approx << endl;
     }
+
+    Tracklet* tracklet = new Tracklet(settings_,
+                                      iSeed_,
+                                      innerFPGAStub,
+                                      middleFPGAStub,
+                                      outerFPGAStub,
+                                      rinv,
+                                      phi0,
+                                      d0,
+                                      z0,
+                                      t,
+                                      rinvapprox,
+                                      phi0approx,
+                                      d0approx,
+                                      z0approx,
+                                      tapprox,
+                                      irinv,
+                                      iphi0,
+                                      id0,
+                                      iz0,
+                                      it,
+                                      projs,
+                                      false);
+
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced " << getName()
+                                   << " Found LLD tracklet in sector = " << iSector_ << " phi0 = " << phi0;
+
+    tracklet->setTrackletIndex(trackletpars_->nTracklets());
+    tracklet->setTCIndex(TCIndex_);
+
+    if (settings_.writeMonitorData("Seeds")) {
+      ofstream fout("seeds.txt", ofstream::app);
+      fout << __FILE__ << ":" << __LINE__ << " " << name_ << "_" << iSector_ << " " << tracklet->getISeed() << endl;
+      fout.close();
+    }
+    trackletpars_->addTracklet(tracklet);
+
+    for (unsigned int j = 0; j < toR_.size(); j++) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "adding layer projection " << j << "/" << toR_.size() << " " << lproj_[j];
+      if (tracklet->validProj(lproj_[j] - 1)) {
+        addLayerProj(tracklet, lproj_[j]);
+      }
+    }
+
+    for (unsigned int j = 0; j < toZ_.size(); j++) {
+      int disk = dproj_[j];
+      if (disk == 0)
+        continue;
+      if (it < 0)
+        disk = -disk;
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << "adding disk projection " << j << "/" << toZ_.size() << " " << disk;
+      if (tracklet->validProj(N_LAYER + abs(disk) - 1)) {
+        addDiskProj(tracklet, disk);
+      }
+    }
+
+    return true;
   }
 
-  return true;
-}
+  void TrackletCalculatorDisplaced::exactproj(double rproj,
+                                              double rinv,
+                                              double phi0,
+                                              double d0,
+                                              double t,
+                                              double z0,
+                                              double r0,
+                                              double& phiproj,
+                                              double& zproj,
+                                              double& phider,
+                                              double& zder) {
+    double rho = 1 / rinv;
+    if (rho < 0) {
+      r0 = -r0;
+    }
+    phiproj = phi0 - asin((rproj * rproj + r0 * r0 - rho * rho) / (2 * rproj * r0));
+    double beta = acos((rho * rho + r0 * r0 - rproj * rproj) / (2 * r0 * rho));
+    zproj = z0 + t * std::abs(rho * beta);
 
-void TrackletCalculatorDisplaced::exactproj(double rproj,
-                                            double rinv,
-                                            double phi0,
-                                            double d0,
-                                            double t,
-                                            double z0,
-                                            double r0,
-                                            double& phiproj,
-                                            double& zproj,
-                                            double& phider,
-                                            double& zder) {
-  double rho = 1 / rinv;
-  if (rho < 0) {
-    r0 = -r0;
-  }
-  phiproj = phi0 - asin((rproj * rproj + r0 * r0 - rho * rho) / (2 * rproj * r0));
-  double beta = acos((rho * rho + r0 * r0 - rproj * rproj) / (2 * r0 * rho));
-  zproj = z0 + t * std::abs(rho * beta);
+    //not exact, but close
+    phider = -0.5 * rinv / sqrt(1 - pow(0.5 * rproj * rinv, 2)) + d0 / (rproj * rproj);
+    zder = t / sqrt(1 - pow(0.5 * rproj * rinv, 2));
 
-  //not exact, but close
-  phider = -0.5 * rinv / sqrt(1 - pow(0.5 * rproj * rinv, 2)) + d0 / (rproj * rproj);
-  zder = t / sqrt(1 - pow(0.5 * rproj * rinv, 2));
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "exact proj layer at " << rproj << " : " << phiproj << " " << zproj;
-}
-
-void TrackletCalculatorDisplaced::exactprojdisk(double zproj,
-                                                double rinv,
-                                                double,
-                                                double,  //phi0 and d0 are not used.
-                                                double t,
-                                                double z0,
-                                                double x0,
-                                                double y0,
-                                                double& phiproj,
-                                                double& rproj,
-                                                double& phider,
-                                                double& rder) {
-  //protect against t=0
-  if (std::abs(t) < 0.1)
-    t = 0.1;
-  if (t < 0)
-    zproj = -zproj;
-  double rho = std::abs(1 / rinv);
-  double beta = (zproj - z0) / (t * rho);
-  double phiV = atan2(-y0, -x0);
-  double c = rinv > 0 ? -1 : 1;
-
-  double x = x0 + rho * cos(phiV + c * beta);
-  double y = y0 + rho * sin(phiV + c * beta);
-
-  phiproj = atan2(y, x);
-
-  phiproj = reco::reduceRange(phiproj - phimin_);
-
-  rproj = sqrt(x * x + y * y);
-
-  phider = c / t / (x * x + y * y) * (rho + x0 * cos(phiV + c * beta) + y0 * sin(phiV + c * beta));
-  rder = c / t / rproj * (y0 * cos(phiV + c * beta) - x0 * sin(phiV + c * beta));
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "exact proj disk at" << zproj << " : " << phiproj << " " << rproj;
-}
-
-void TrackletCalculatorDisplaced::exacttracklet(double r1,
-                                                double z1,
-                                                double phi1,
-                                                double r2,
-                                                double z2,
-                                                double phi2,
-                                                double r3,
-                                                double z3,
-                                                double phi3,
-                                                int take3,
-                                                double& rinv,
-                                                double& phi0,
-                                                double& d0,
-                                                double& t,
-                                                double& z0,
-                                                double phiproj[N_DISK],
-                                                double zproj[N_DISK],
-                                                double phiprojdisk[N_DISK],
-                                                double rprojdisk[N_DISK],
-                                                double phider[N_DISK],
-                                                double zder[N_DISK],
-                                                double phiderdisk[N_DISK],
-                                                double rderdisk[N_DISK]) {
-  //two lines perpendicular to the 1->2 and 2->3
-  double x1 = r1 * cos(phi1);
-  double x2 = r2 * cos(phi2);
-  double x3 = r3 * cos(phi3);
-
-  double y1 = r1 * sin(phi1);
-  double y2 = r2 * sin(phi2);
-  double y3 = r3 * sin(phi3);
-
-  double dy21 = y2 - y1;
-  double dy32 = y3 - y2;
-
-  //Hack to protect against dividing by zero
-  //code should be rewritten to avoid this
-  if (dy21 == 0.0)
-    dy21 = 1e-9;
-  if (dy32 == 0.0)
-    dy32 = 1e-9;
-
-  double k1 = -(x2 - x1) / dy21;
-  double k2 = -(x3 - x2) / dy32;
-  double b1 = 0.5 * (y2 + y1) - 0.5 * (x1 + x2) * k1;
-  double b2 = 0.5 * (y3 + y2) - 0.5 * (x2 + x3) * k2;
-  //their intersection gives the center of the circle
-  double y0 = (b1 * k2 - b2 * k1) / (k2 - k1);
-  double x0 = (b1 - b2) / (k2 - k1);
-  //get the radius three ways:
-  double R1 = sqrt(pow(x1 - x0, 2) + pow(y1 - y0, 2));
-  double R2 = sqrt(pow(x2 - x0, 2) + pow(y2 - y0, 2));
-  double R3 = sqrt(pow(x3 - x0, 2) + pow(y3 - y0, 2));
-  //check if the same
-  double eps1 = std::abs(R1 / R2 - 1);
-  double eps2 = std::abs(R3 / R2 - 1);
-  if (eps1 > 1e-10 || eps2 > 1e-10)
-    edm::LogVerbatim("Tracklet") << "&&&&&&&&&&&& bad circle! " << R1 << "\t" << R2 << "\t" << R3;
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "phimin_: " << phimin_ << " phimax_: " << phimax_;
-  //results
-  rinv = 1. / R1;
-  phi0 = 0.5 * M_PI + atan2(y0, x0);
-
-  phi0 -= phimin_;
-
-  d0 = -R1 + sqrt(x0 * x0 + y0 * y0);
-  //sign of rinv:
-  double dphi = reco::reduceRange(phi3 - atan2(y0, x0));
-  if (dphi < 0) {
-    rinv = -rinv;
-    d0 = -d0;
-    phi0 = phi0 + M_PI;
-  }
-  phi0 = angle0to2pi::make0To2pi(phi0);
-
-  //now in RZ:
-  //turning angle
-  double beta1 = reco::reduceRange(atan2(y1 - y0, x1 - x0) - atan2(-y0, -x0));
-  double beta2 = reco::reduceRange(atan2(y2 - y0, x2 - x0) - atan2(-y0, -x0));
-  double beta3 = reco::reduceRange(atan2(y3 - y0, x3 - x0) - atan2(-y0, -x0));
-
-  double t12 = (z2 - z1) / std::abs(beta2 - beta1) / R1;
-  double z12 = (z1 * beta2 - z2 * beta1) / (beta2 - beta1);
-  double t13 = (z3 - z1) / std::abs(beta3 - beta1) / R1;
-  double z13 = (z1 * beta3 - z3 * beta1) / (beta3 - beta1);
-
-  if (take3 > 0) {
-    //take 13 (large lever arm)
-    t = t13;
-    z0 = z13;
-  } else {
-    //take 12 (pixel layers)
-    t = t12;
-    z0 = z12;
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "exact proj layer at " << rproj << " : " << phiproj << " " << zproj;
   }
 
-  for (unsigned int i = 0; i < toR_.size(); i++) {
-    exactproj(toR_[i], rinv, phi0, d0, t, z0, sqrt(x0 * x0 + y0 * y0), phiproj[i], zproj[i], phider[i], zder[i]);
+  void TrackletCalculatorDisplaced::exactprojdisk(double zproj,
+                                                  double rinv,
+                                                  double,
+                                                  double,  //phi0 and d0 are not used.
+                                                  double t,
+                                                  double z0,
+                                                  double x0,
+                                                  double y0,
+                                                  double& phiproj,
+                                                  double& rproj,
+                                                  double& phider,
+                                                  double& rder) {
+    //protect against t=0
+    if (std::abs(t) < 0.1)
+      t = 0.1;
+    if (t < 0)
+      zproj = -zproj;
+    double rho = std::abs(1 / rinv);
+    double beta = (zproj - z0) / (t * rho);
+    double phiV = atan2(-y0, -x0);
+    double c = rinv > 0 ? -1 : 1;
+
+    double x = x0 + rho * cos(phiV + c * beta);
+    double y = y0 + rho * sin(phiV + c * beta);
+
+    phiproj = atan2(y, x);
+
+    phiproj = reco::reduceRange(phiproj - phimin_);
+
+    rproj = sqrt(x * x + y * y);
+
+    phider = c / t / (x * x + y * y) * (rho + x0 * cos(phiV + c * beta) + y0 * sin(phiV + c * beta));
+    rder = c / t / rproj * (y0 * cos(phiV + c * beta) - x0 * sin(phiV + c * beta));
+
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "exact proj disk at" << zproj << " : " << phiproj << " " << rproj;
   }
 
-  for (unsigned int i = 0; i < toZ_.size(); i++) {
-    exactprojdisk(toZ_[i], rinv, phi0, d0, t, z0, x0, y0, phiprojdisk[i], rprojdisk[i], phiderdisk[i], rderdisk[i]);
+  void TrackletCalculatorDisplaced::exacttracklet(double r1,
+                                                  double z1,
+                                                  double phi1,
+                                                  double r2,
+                                                  double z2,
+                                                  double phi2,
+                                                  double r3,
+                                                  double z3,
+                                                  double phi3,
+                                                  int take3,
+                                                  double& rinv,
+                                                  double& phi0,
+                                                  double& d0,
+                                                  double& t,
+                                                  double& z0,
+                                                  double phiproj[N_DISK],
+                                                  double zproj[N_DISK],
+                                                  double phiprojdisk[N_DISK],
+                                                  double rprojdisk[N_DISK],
+                                                  double phider[N_DISK],
+                                                  double zder[N_DISK],
+                                                  double phiderdisk[N_DISK],
+                                                  double rderdisk[N_DISK]) {
+    //two lines perpendicular to the 1->2 and 2->3
+    double x1 = r1 * cos(phi1);
+    double x2 = r2 * cos(phi2);
+    double x3 = r3 * cos(phi3);
+
+    double y1 = r1 * sin(phi1);
+    double y2 = r2 * sin(phi2);
+    double y3 = r3 * sin(phi3);
+
+    double dy21 = y2 - y1;
+    double dy32 = y3 - y2;
+
+    //Hack to protect against dividing by zero
+    //code should be rewritten to avoid this
+    if (dy21 == 0.0)
+      dy21 = 1e-9;
+    if (dy32 == 0.0)
+      dy32 = 1e-9;
+
+    double k1 = -(x2 - x1) / dy21;
+    double k2 = -(x3 - x2) / dy32;
+    double b1 = 0.5 * (y2 + y1) - 0.5 * (x1 + x2) * k1;
+    double b2 = 0.5 * (y3 + y2) - 0.5 * (x2 + x3) * k2;
+    //their intersection gives the center of the circle
+    double y0 = (b1 * k2 - b2 * k1) / (k2 - k1);
+    double x0 = (b1 - b2) / (k2 - k1);
+    //get the radius three ways:
+    double R1 = sqrt(pow(x1 - x0, 2) + pow(y1 - y0, 2));
+    double R2 = sqrt(pow(x2 - x0, 2) + pow(y2 - y0, 2));
+    double R3 = sqrt(pow(x3 - x0, 2) + pow(y3 - y0, 2));
+    //check if the same
+    double eps1 = std::abs(R1 / R2 - 1);
+    double eps2 = std::abs(R3 / R2 - 1);
+    if (eps1 > 1e-10 || eps2 > 1e-10)
+      edm::LogVerbatim("Tracklet") << "&&&&&&&&&&&& bad circle! " << R1 << "\t" << R2 << "\t" << R3;
+
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "phimin_: " << phimin_ << " phimax_: " << phimax_;
+    //results
+    rinv = 1. / R1;
+    phi0 = 0.5 * M_PI + atan2(y0, x0);
+
+    phi0 -= phimin_;
+
+    d0 = -R1 + sqrt(x0 * x0 + y0 * y0);
+    //sign of rinv:
+    double dphi = reco::reduceRange(phi3 - atan2(y0, x0));
+    if (dphi < 0) {
+      rinv = -rinv;
+      d0 = -d0;
+      phi0 = phi0 + M_PI;
+    }
+    phi0 = angle0to2pi::make0To2pi(phi0);
+
+    //now in RZ:
+    //turning angle
+    double beta1 = reco::reduceRange(atan2(y1 - y0, x1 - x0) - atan2(-y0, -x0));
+    double beta2 = reco::reduceRange(atan2(y2 - y0, x2 - x0) - atan2(-y0, -x0));
+    double beta3 = reco::reduceRange(atan2(y3 - y0, x3 - x0) - atan2(-y0, -x0));
+
+    double t12 = (z2 - z1) / std::abs(beta2 - beta1) / R1;
+    double z12 = (z1 * beta2 - z2 * beta1) / (beta2 - beta1);
+    double t13 = (z3 - z1) / std::abs(beta3 - beta1) / R1;
+    double z13 = (z1 * beta3 - z3 * beta1) / (beta3 - beta1);
+
+    if (take3 > 0) {
+      //take 13 (large lever arm)
+      t = t13;
+      z0 = z13;
+    } else {
+      //take 12 (pixel layers)
+      t = t12;
+      z0 = z12;
+    }
+
+    for (unsigned int i = 0; i < toR_.size(); i++) {
+      exactproj(toR_[i], rinv, phi0, d0, t, z0, sqrt(x0 * x0 + y0 * y0), phiproj[i], zproj[i], phider[i], zder[i]);
+    }
+
+    for (unsigned int i = 0; i < toZ_.size(); i++) {
+      exactprojdisk(toZ_[i], rinv, phi0, d0, t, z0, x0, y0, phiprojdisk[i], rprojdisk[i], phiderdisk[i], rderdisk[i]);
+    }
+
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "exact tracklet: " << rinv << " " << phi0 << " " << t << " " << z0 << " " << d0;
   }
 
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "exact tracklet: " << rinv << " " << phi0 << " " << t << " " << z0 << " " << d0;
-}
+  void TrackletCalculatorDisplaced::approxproj(double halfRinv,
+                                               double phi0,
+                                               double d0,
+                                               double t,
+                                               double z0,
+                                               double halfRinv_0,
+                                               double d0_0,  // zeroeth order result for higher order terms calculation
+                                               double rmean,
+                                               double& phiproj,
+                                               double& phiprojder,
+                                               double& zproj,
+                                               double& zprojder) {
+    if (std::abs(2.0 * halfRinv) > settings_.rinvcut() || std::abs(z0) > settings_.disp_z0cut() ||
+        std::abs(d0) > settings_.maxd0()) {
+      phiproj = 0.0;
+      return;
+    }
+    double rmeanInv = 1.0 / rmean;
 
-void TrackletCalculatorDisplaced::approxproj(double halfRinv,
-                                             double phi0,
-                                             double d0,
-                                             double t,
-                                             double z0,
-                                             double halfRinv_0,
-                                             double d0_0,  // zeroeth order result for higher order terms calculation
-                                             double rmean,
-                                             double& phiproj,
-                                             double& phiprojder,
-                                             double& zproj,
-                                             double& zprojder) {
-  if (std::abs(2.0 * halfRinv) > settings_.rinvcut() || std::abs(z0) > settings_.disp_z0cut() ||
-      std::abs(d0) > settings_.maxd0()) {
-    phiproj = 0.0;
-    return;
-  }
-  double rmeanInv = 1.0 / rmean;
+    phiproj = phi0 + rmean * (-halfRinv + 2.0 * d0_0 * halfRinv_0 * halfRinv_0) +
+              rmeanInv * (-d0 + halfRinv_0 * d0_0 * d0_0) + sixth * pow(-rmean * halfRinv_0 - rmeanInv * d0_0, 3);
+    phiprojder = -halfRinv + d0 * rmeanInv * rmeanInv;  //removed all high terms
 
-  phiproj = phi0 + rmean * (-halfRinv + 2.0 * d0_0 * halfRinv_0 * halfRinv_0) +
-            rmeanInv * (-d0 + halfRinv_0 * d0_0 * d0_0) + sixth * pow(-rmean * halfRinv_0 - rmeanInv * d0_0, 3);
-  phiprojder = -halfRinv + d0 * rmeanInv * rmeanInv;  //removed all high terms
+    zproj = z0 + t * rmean - 0.5 * rmeanInv * t * d0_0 * d0_0 - t * rmean * halfRinv * d0 +
+            sixth * pow(rmean, 3) * t * halfRinv_0 * halfRinv_0;
+    zprojder = t;  // removed all high terms
 
-  zproj = z0 + t * rmean - 0.5 * rmeanInv * t * d0_0 * d0_0 - t * rmean * halfRinv * d0 +
-          sixth * pow(rmean, 3) * t * halfRinv_0 * halfRinv_0;
-  zprojder = t;  // removed all high terms
+    phiproj = angle0to2pi::make0To2pi(phiproj);
 
-  phiproj = angle0to2pi::make0To2pi(phiproj);
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "approx proj layer at " << rmean << " : " << phiproj << " " << zproj << endl;
-}
-
-void TrackletCalculatorDisplaced::approxprojdisk(double halfRinv,
-                                                 double phi0,
-                                                 double d0,
-                                                 double t,
-                                                 double z0,
-                                                 double halfRinv_0,
-                                                 double d0_0,  // zeroeth order result for higher order terms calculation
-                                                 double zmean,
-                                                 double& phiproj,
-                                                 double& phiprojder,
-                                                 double& rproj,
-                                                 double& rprojder) {
-  if (std::abs(2.0 * halfRinv) > settings_.rinvcut() || std::abs(z0) > settings_.disp_z0cut() ||
-      std::abs(d0) > settings_.maxd0()) {
-    phiproj = 0.0;
-    return;
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "approx proj layer at " << rmean << " : " << phiproj << " " << zproj << endl;
   }
 
-  if (t < 0)
-    zmean = -zmean;
+  void TrackletCalculatorDisplaced::approxprojdisk(
+      double halfRinv,
+      double phi0,
+      double d0,
+      double t,
+      double z0,
+      double halfRinv_0,
+      double d0_0,  // zeroeth order result for higher order terms calculation
+      double zmean,
+      double& phiproj,
+      double& phiprojder,
+      double& rproj,
+      double& rprojder) {
+    if (std::abs(2.0 * halfRinv) > settings_.rinvcut() || std::abs(z0) > settings_.disp_z0cut() ||
+        std::abs(d0) > settings_.maxd0()) {
+      phiproj = 0.0;
+      return;
+    }
 
-  double zmeanInv = 1.0 / zmean, rstar = (zmean - z0) / t,
-         epsilon = 0.5 * zmeanInv * zmeanInv * d0_0 * d0_0 * t * t + halfRinv * d0 -
-                   sixth * rstar * rstar * halfRinv_0 * halfRinv_0;
+    if (t < 0)
+      zmean = -zmean;
 
-  rproj = rstar * (1 + epsilon);
-  rprojder = 1 / t;
+    double zmeanInv = 1.0 / zmean, rstar = (zmean - z0) / t,
+           epsilon = 0.5 * zmeanInv * zmeanInv * d0_0 * d0_0 * t * t + halfRinv * d0 -
+                     sixth * rstar * rstar * halfRinv_0 * halfRinv_0;
 
-  double A = rproj * halfRinv;
-  double B = -d0 * t * zmeanInv * (1 + z0 * zmeanInv) * (1 - epsilon);
-  double C = -d0 * halfRinv;
-  double A_0 = rproj * halfRinv_0;
-  double B_0 = -d0_0 * t * zmeanInv * (1 + z0 * zmeanInv) * (1 - epsilon);
-  // double C_0 = -d0_0 * halfRinv_0;
+    rproj = rstar * (1 + epsilon);
+    rprojder = 1 / t;
 
-  phiproj = phi0 - A + B * (1 + C - 2 * A_0 * A_0) + sixth * pow(-A_0 + B_0, 3);
-  phiprojder = -halfRinv / t + d0 * t * zmeanInv * zmeanInv;
+    double A = rproj * halfRinv;
+    double B = -d0 * t * zmeanInv * (1 + z0 * zmeanInv) * (1 - epsilon);
+    double C = -d0 * halfRinv;
+    double A_0 = rproj * halfRinv_0;
+    double B_0 = -d0_0 * t * zmeanInv * (1 + z0 * zmeanInv) * (1 - epsilon);
+    // double C_0 = -d0_0 * halfRinv_0;
 
-  phiproj = angle0to2pi::make0To2pi(phiproj);
+    phiproj = phi0 - A + B * (1 + C - 2 * A_0 * A_0) + sixth * pow(-A_0 + B_0, 3);
+    phiprojder = -halfRinv / t + d0 * t * zmeanInv * zmeanInv;
 
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "approx proj disk at" << zmean << " : " << phiproj << " " << rproj << endl;
-}
+    phiproj = angle0to2pi::make0To2pi(phiproj);
 
-void TrackletCalculatorDisplaced::approxtracklet(double r1,
-                                                 double z1,
-                                                 double phi1,
-                                                 double r2,
-                                                 double z2,
-                                                 double phi2,
-                                                 double r3,
-                                                 double z3,
-                                                 double phi3,
-                                                 bool take3,
-                                                 unsigned ndisks,
-                                                 double& rinv,
-                                                 double& phi0,
-                                                 double& d0,
-                                                 double& t,
-                                                 double& z0,
-                                                 double phiproj[4],
-                                                 double zproj[4],
-                                                 double phider[4],
-                                                 double zder[4],
-                                                 double phiprojdisk[5],
-                                                 double rprojdisk[5],
-                                                 double phiderdisk[5],
-                                                 double rderdisk[5]) {
-  double a = 1.0 / ((r1 - r2) * (r1 - r3));
-  double b = 1.0 / ((r1 - r2) * (r2 - r3));
-  double c = 1.0 / ((r1 - r3) * (r2 - r3));
-
-  // first iteration in r-phi plane
-  double halfRinv_0 = -phi1 * r1 * a + phi2 * r2 * b - phi3 * r3 * c;
-  double d0_0 = r1 * r2 * r3 * (-phi1 * a + phi2 * b - phi3 * c);
-
-  // corrections to phi1, phi2, and phi3
-  double r = r2, z = z2;
-  if (take3)
-    r = r3, z = z3;
-
-  double d0OverR1 = d0_0 * rzmeanInv_[0] * (ndisks > 2 ? std::abs((z - z1) / (r - r1)) : 1.0);
-  double d0OverR2 = d0_0 * rzmeanInv_[1] * (ndisks > 1 ? std::abs((z - z1) / (r - r1)) : 1.0);
-  double d0OverR3 = d0_0 * rzmeanInv_[2] * (ndisks > 0 ? std::abs((z - z1) / (r - r1)) : 1.0);
-
-  double d0OverR = d0OverR2;
-  if (take3)
-    d0OverR = d0OverR3;
-
-  double c1 = d0_0 * halfRinv_0 * d0OverR1 + 2.0 * d0_0 * halfRinv_0 * r1 * halfRinv_0 +
-              sixth * pow(-r1 * halfRinv_0 - d0OverR1, 3);
-  double c2 = d0_0 * halfRinv_0 * d0OverR2 + 2.0 * d0_0 * halfRinv_0 * r2 * halfRinv_0 +
-              sixth * pow(-r2 * halfRinv_0 - d0OverR2, 3);
-  double c3 = d0_0 * halfRinv_0 * d0OverR3 + 2.0 * d0_0 * halfRinv_0 * r3 * halfRinv_0 +
-              sixth * pow(-r3 * halfRinv_0 - d0OverR3, 3);
-
-  double phi1c = phi1 - c1;
-  double phi2c = phi2 - c2;
-  double phi3c = phi3 - c3;
-
-  // second iteration in r-phi plane
-  double halfRinv = -phi1c * r1 * a + phi2c * r2 * b - phi3c * r3 * c;
-  phi0 = -phi1c * r1 * (r2 + r3) * a + phi2c * r2 * (r1 + r3) * b - phi3c * r3 * (r1 + r2) * c;
-  d0 = r1 * r2 * r3 * (-phi1c * a + phi2c * b - phi3c * c);
-
-  t = ((z - z1) / (r - r1)) *
-      (1. + d0 * halfRinv - 0.5 * d0OverR1 * d0OverR - sixth * (r1 * r1 + r2 * r2 + r1 * r2) * halfRinv_0 * halfRinv_0);
-  z0 = z1 - t * r1 * (1.0 - d0_0 * halfRinv_0 - 0.5 * d0OverR1 * d0OverR1 + sixth * r1 * r1 * halfRinv_0 * halfRinv_0);
-
-  rinv = 2.0 * halfRinv;
-  phi0 += -phimin_;
-
-  phi0 = angle0to2pi::make0To2pi(phi0);
-
-  for (unsigned int i = 0; i < toR_.size(); i++) {
-    approxproj(halfRinv,
-               phi0,
-               d0,
-               t,
-               z0,
-               halfRinv_0,
-               d0_0,  // added _0 version for high term calculations
-               toR_.at(i),
-               phiproj[i],
-               phider[i],
-               zproj[i],
-               zder[i]);
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "approx proj disk at" << zmean << " : " << phiproj << " " << rproj << endl;
   }
 
-  for (unsigned int i = 0; i < toZ_.size(); i++) {
-    approxprojdisk(halfRinv,
-                   phi0,
-                   d0,
-                   t,
-                   z0,
-                   halfRinv_0,
-                   d0_0,  // added _0 version for high term calculations
-                   toZ_.at(i),
-                   phiprojdisk[i],
-                   phiderdisk[i],
-                   rprojdisk[i],
-                   rderdisk[i]);
+  void TrackletCalculatorDisplaced::approxtracklet(double r1,
+                                                   double z1,
+                                                   double phi1,
+                                                   double r2,
+                                                   double z2,
+                                                   double phi2,
+                                                   double r3,
+                                                   double z3,
+                                                   double phi3,
+                                                   bool take3,
+                                                   unsigned ndisks,
+                                                   double& rinv,
+                                                   double& phi0,
+                                                   double& d0,
+                                                   double& t,
+                                                   double& z0,
+                                                   double phiproj[4],
+                                                   double zproj[4],
+                                                   double phider[4],
+                                                   double zder[4],
+                                                   double phiprojdisk[5],
+                                                   double rprojdisk[5],
+                                                   double phiderdisk[5],
+                                                   double rderdisk[5]) {
+    double a = 1.0 / ((r1 - r2) * (r1 - r3));
+    double b = 1.0 / ((r1 - r2) * (r2 - r3));
+    double c = 1.0 / ((r1 - r3) * (r2 - r3));
+
+    // first iteration in r-phi plane
+    double halfRinv_0 = -phi1 * r1 * a + phi2 * r2 * b - phi3 * r3 * c;
+    double d0_0 = r1 * r2 * r3 * (-phi1 * a + phi2 * b - phi3 * c);
+
+    // corrections to phi1, phi2, and phi3
+    double r = r2, z = z2;
+    if (take3)
+      r = r3, z = z3;
+
+    double d0OverR1 = d0_0 * rzmeanInv_[0] * (ndisks > 2 ? std::abs((z - z1) / (r - r1)) : 1.0);
+    double d0OverR2 = d0_0 * rzmeanInv_[1] * (ndisks > 1 ? std::abs((z - z1) / (r - r1)) : 1.0);
+    double d0OverR3 = d0_0 * rzmeanInv_[2] * (ndisks > 0 ? std::abs((z - z1) / (r - r1)) : 1.0);
+
+    double d0OverR = d0OverR2;
+    if (take3)
+      d0OverR = d0OverR3;
+
+    double c1 = d0_0 * halfRinv_0 * d0OverR1 + 2.0 * d0_0 * halfRinv_0 * r1 * halfRinv_0 +
+                sixth * pow(-r1 * halfRinv_0 - d0OverR1, 3);
+    double c2 = d0_0 * halfRinv_0 * d0OverR2 + 2.0 * d0_0 * halfRinv_0 * r2 * halfRinv_0 +
+                sixth * pow(-r2 * halfRinv_0 - d0OverR2, 3);
+    double c3 = d0_0 * halfRinv_0 * d0OverR3 + 2.0 * d0_0 * halfRinv_0 * r3 * halfRinv_0 +
+                sixth * pow(-r3 * halfRinv_0 - d0OverR3, 3);
+
+    double phi1c = phi1 - c1;
+    double phi2c = phi2 - c2;
+    double phi3c = phi3 - c3;
+
+    // second iteration in r-phi plane
+    double halfRinv = -phi1c * r1 * a + phi2c * r2 * b - phi3c * r3 * c;
+    phi0 = -phi1c * r1 * (r2 + r3) * a + phi2c * r2 * (r1 + r3) * b - phi3c * r3 * (r1 + r2) * c;
+    d0 = r1 * r2 * r3 * (-phi1c * a + phi2c * b - phi3c * c);
+
+    t = ((z - z1) / (r - r1)) * (1. + d0 * halfRinv - 0.5 * d0OverR1 * d0OverR -
+                                 sixth * (r1 * r1 + r2 * r2 + r1 * r2) * halfRinv_0 * halfRinv_0);
+    z0 =
+        z1 - t * r1 * (1.0 - d0_0 * halfRinv_0 - 0.5 * d0OverR1 * d0OverR1 + sixth * r1 * r1 * halfRinv_0 * halfRinv_0);
+
+    rinv = 2.0 * halfRinv;
+    phi0 += -phimin_;
+
+    phi0 = angle0to2pi::make0To2pi(phi0);
+
+    for (unsigned int i = 0; i < toR_.size(); i++) {
+      approxproj(halfRinv,
+                 phi0,
+                 d0,
+                 t,
+                 z0,
+                 halfRinv_0,
+                 d0_0,  // added _0 version for high term calculations
+                 toR_.at(i),
+                 phiproj[i],
+                 phider[i],
+                 zproj[i],
+                 zder[i]);
+    }
+
+    for (unsigned int i = 0; i < toZ_.size(); i++) {
+      approxprojdisk(halfRinv,
+                     phi0,
+                     d0,
+                     t,
+                     z0,
+                     halfRinv_0,
+                     d0_0,  // added _0 version for high term calculations
+                     toZ_.at(i),
+                     phiprojdisk[i],
+                     phiderdisk[i],
+                     rprojdisk[i],
+                     rderdisk[i]);
+    }
+
+    if (std::abs(rinv) > settings_.rinvcut() || std::abs(z0) > settings_.disp_z0cut() ||
+        std::abs(d0) > settings_.maxd0()) {
+      phi0 = 0.0;
+      return;
+    }
+
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "TCD approx tracklet: " << rinv << " " << phi0 << " " << t << " " << z0 << " "
+                                   << d0 << endl;
   }
 
-  if (std::abs(rinv) > settings_.rinvcut() || std::abs(z0) > settings_.disp_z0cut() ||
-      std::abs(d0) > settings_.maxd0()) {
-    phi0 = 0.0;
-    return;
-  }
-
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "TCD approx tracklet: " << rinv << " " << phi0 << " " << t << " " << z0 << " " << d0
-                                 << endl;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -11,7 +11,8 @@
 #include "DataFormats/Math/interface/deltaPhi.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletCalculatorDisplaced::TrackletCalculatorDisplaced(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global) {
@@ -1943,4 +1944,6 @@ void TrackletCalculatorDisplaced::approxtracklet(double r1,
   if (settings_.debugTracklet())
     edm::LogVerbatim("Tracklet") << "TCD approx tracklet: " << rinv << " " << phi0 << " " << t << " " << z0 << " " << d0
                                  << endl;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -20,397 +20,398 @@ using namespace std;
 
 namespace trklet {
 
-TrackletConfigBuilder::TrackletConfigBuilder(const Settings& settings, const tt::Setup* setup) : settings_(settings) {
-  NSector_ = N_SECTOR;
-  rcrit_ = settings.rcrit();
+  TrackletConfigBuilder::TrackletConfigBuilder(const Settings& settings, const tt::Setup* setup) : settings_(settings) {
+    NSector_ = N_SECTOR;
+    rcrit_ = settings.rcrit();
 
-  combinedmodules_ = settings.combined();
+    combinedmodules_ = settings.combined();
 
-  extended_ = settings.extended();
+    extended_ = settings.extended();
 
-  rinvmax_ = settings.rinvmax();
+    rinvmax_ = settings.rinvmax();
 
-  rmaxdisk_ = settings.rmaxdisk();
-  zlength_ = settings.zlength();
+    rmaxdisk_ = settings.rmaxdisk();
+    zlength_ = settings.zlength();
 
-  for (int i = 0; i < N_LAYER; i++) {
-    rmean_[i] = settings.rmean(i);
+    for (int i = 0; i < N_LAYER; i++) {
+      rmean_[i] = settings.rmean(i);
+    }
+
+    for (int i = 0; i < N_DISK; i++) {
+      zmean_[i] = settings.zmean(i);
+    }
+
+    dphisectorHG_ = settings.dphisectorHG();
+
+    for (int layerdisk = 0; layerdisk < N_LAYER + N_DISK; layerdisk++) {
+      NRegions_[layerdisk] = settings.nallstubs(layerdisk);
+      NVMME_[layerdisk] = settings.nvmme(layerdisk);
+    }
+
+    for (unsigned int iseed = 0; iseed < N_SEED_PROMPT; iseed++) {
+      NVMTE_[iseed] = std::pair<unsigned int, unsigned int>(settings.nvmte(0, iseed), settings.nvmte(1, iseed));
+      NTC_[iseed] = settings.NTC(iseed);
+    }
+
+    initGeom();
+
+    buildTE();
+
+    buildTC();
+
+    buildProjections();
+
+    setDTCphirange(setup);
+
+    if (settings_.writeConfig()) {
+      static std::once_flag runOnce;  // Only one thread should call this.
+      std::call_once(runOnce, &TrackletConfigBuilder::writeDTCphirange, this);
+    }
   }
 
-  for (int i = 0; i < N_DISK; i++) {
-    zmean_[i] = settings.zmean(i);
-  }
-
-  dphisectorHG_ = settings.dphisectorHG();
-
-  for (int layerdisk = 0; layerdisk < N_LAYER + N_DISK; layerdisk++) {
-    NRegions_[layerdisk] = settings.nallstubs(layerdisk);
-    NVMME_[layerdisk] = settings.nvmme(layerdisk);
-  }
-
-  for (unsigned int iseed = 0; iseed < N_SEED_PROMPT; iseed++) {
-    NVMTE_[iseed] = std::pair<unsigned int, unsigned int>(settings.nvmte(0, iseed), settings.nvmte(1, iseed));
-    NTC_[iseed] = settings.NTC(iseed);
-  }
-
-  initGeom();
-
-  buildTE();
-
-  buildTC();
-
-  buildProjections();
-
-  setDTCphirange(setup);
-
-  if (settings_.writeConfig()) {
-    static std::once_flag runOnce;  // Only one thread should call this.
-    std::call_once(runOnce, &TrackletConfigBuilder::writeDTCphirange, this);
-  }
-}
-
-//--- Calculate phi range of modules read by each DTC.
+  //--- Calculate phi range of modules read by each DTC.
 
 #ifdef CMSSW_GIT_HASH
 
-void TrackletConfigBuilder::setDTCphirange(const tt::Setup* setup) {
-  list<DTCinfo> vecDTCinfo_unsorted;
+  void TrackletConfigBuilder::setDTCphirange(const tt::Setup* setup) {
+    list<DTCinfo> vecDTCinfo_unsorted;
 
-  // Loop over DTCs in this tracker nonant.
-  unsigned int numDTCsPerSector = setup->numDTCsPerRegion();
-  for (unsigned int dtcId = 0; dtcId < numDTCsPerSector; dtcId++) {
-    typedef std::pair<float, float> PhiRange;
-    std::map<int, PhiRange> dtcPhiRange;
+    // Loop over DTCs in this tracker nonant.
+    unsigned int numDTCsPerSector = setup->numDTCsPerRegion();
+    for (unsigned int dtcId = 0; dtcId < numDTCsPerSector; dtcId++) {
+      typedef std::pair<float, float> PhiRange;
+      std::map<int, PhiRange> dtcPhiRange;
 
-    // Loop over all tracker nonants, taking worst case not all identical.
-    for (unsigned int iSector = 0; iSector < N_SECTOR; iSector++) {
-      unsigned int dtcId_regI = iSector * numDTCsPerSector + dtcId;
-      const std::vector<tt::SensorModule*>& dtcModules = setup->dtcModules(dtcId_regI);
-      for (const tt::SensorModule* sm : dtcModules) {
-        // Convert layer number to Hybrid convention.
-        int layer = sm->layerId();  // Barrel = 1-6, Endcap = 11-15;
-        if (sm->barrel()) {
-          layer--;  // Barrel 0-5
-        } else {
-          const int endcapOffsetHybrid = 5;
-          layer -= endcapOffsetHybrid;  // Layer 6-19
-        }
-        // Inner radius of module.
-        float r = sm->r() - 0.5 * sm->numColumns() * sm->pitchCol() * fabs(sm->sinTilt());
-        // phi with respect to tracker nonant centre.
-        float phiMin = sm->phi() - 0.5 * sm->numRows() * sm->pitchRow() / r;
-        float phiMax = sm->phi() + 0.5 * sm->numRows() * sm->pitchRow() / r;
-        // Hybrid measures phi w.r.t. lower edge of tracker nonant.
-        const float phiOffsetHybrid = 0.5 * dphisectorHG_;
-        phiMin += phiOffsetHybrid;
-        phiMax += phiOffsetHybrid;
-        if (dtcPhiRange.find(layer) == dtcPhiRange.end()) {
-          dtcPhiRange[layer] = {phiMin, phiMax};
-        } else {
-          dtcPhiRange.at(layer).first = std::min(phiMin, dtcPhiRange.at(layer).first);
-          dtcPhiRange.at(layer).second = std::max(phiMax, dtcPhiRange.at(layer).second);
+      // Loop over all tracker nonants, taking worst case not all identical.
+      for (unsigned int iSector = 0; iSector < N_SECTOR; iSector++) {
+        unsigned int dtcId_regI = iSector * numDTCsPerSector + dtcId;
+        const std::vector<tt::SensorModule*>& dtcModules = setup->dtcModules(dtcId_regI);
+        for (const tt::SensorModule* sm : dtcModules) {
+          // Convert layer number to Hybrid convention.
+          int layer = sm->layerId();  // Barrel = 1-6, Endcap = 11-15;
+          if (sm->barrel()) {
+            layer--;  // Barrel 0-5
+          } else {
+            const int endcapOffsetHybrid = 5;
+            layer -= endcapOffsetHybrid;  // Layer 6-19
+          }
+          // Inner radius of module.
+          float r = sm->r() - 0.5 * sm->numColumns() * sm->pitchCol() * fabs(sm->sinTilt());
+          // phi with respect to tracker nonant centre.
+          float phiMin = sm->phi() - 0.5 * sm->numRows() * sm->pitchRow() / r;
+          float phiMax = sm->phi() + 0.5 * sm->numRows() * sm->pitchRow() / r;
+          // Hybrid measures phi w.r.t. lower edge of tracker nonant.
+          const float phiOffsetHybrid = 0.5 * dphisectorHG_;
+          phiMin += phiOffsetHybrid;
+          phiMax += phiOffsetHybrid;
+          if (dtcPhiRange.find(layer) == dtcPhiRange.end()) {
+            dtcPhiRange[layer] = {phiMin, phiMax};
+          } else {
+            dtcPhiRange.at(layer).first = std::min(phiMin, dtcPhiRange.at(layer).first);
+            dtcPhiRange.at(layer).second = std::max(phiMax, dtcPhiRange.at(layer).second);
+          }
         }
       }
+      for (const auto& p : dtcPhiRange) {
+        const unsigned int numSlots = setup->numATCASlots();
+        std::string dtcName = settings_.slotToDTCname(dtcId % numSlots);
+        if (dtcId >= numSlots)
+          dtcName = "neg" + dtcName;
+        DTCinfo info;
+        info.name = dtcName;
+        info.layer = p.first;
+        info.phimin = p.second.first;
+        info.phimax = p.second.second;
+        vecDTCinfo_unsorted.push_back(info);
+      }
     }
-    for (const auto& p : dtcPhiRange) {
-      const unsigned int numSlots = setup->numATCASlots();
-      std::string dtcName = settings_.slotToDTCname(dtcId % numSlots);
-      if (dtcId >= numSlots)
-        dtcName = "neg" + dtcName;
-      DTCinfo info;
-      info.name = dtcName;
-      info.layer = p.first;
-      info.phimin = p.second.first;
-      info.phimax = p.second.second;
-      vecDTCinfo_unsorted.push_back(info);
+
+    // Put DTCinfo vector in traditional order (PS first). (Needed?)
+    for (const DTCinfo& info : vecDTCinfo_unsorted) {
+      string dtcname = info.name;
+      if (dtcname.find("PS") != std::string::npos) {
+        vecDTCinfo_.push_back(info);
+      }
+    }
+    for (const DTCinfo& info : vecDTCinfo_unsorted) {
+      string dtcname = info.name;
+      if (dtcname.find("PS") == std::string::npos) {
+        vecDTCinfo_.push_back(info);
+      }
     }
   }
 
-  // Put DTCinfo vector in traditional order (PS first). (Needed?)
-  for (const DTCinfo& info : vecDTCinfo_unsorted) {
-    string dtcname = info.name;
-    if (dtcname.find("PS") != std::string::npos) {
-      vecDTCinfo_.push_back(info);
-    }
-  }
-  for (const DTCinfo& info : vecDTCinfo_unsorted) {
-    string dtcname = info.name;
-    if (dtcname.find("PS") == std::string::npos) {
-      vecDTCinfo_.push_back(info);
-    }
-  }
-}
+  //--- Write DTC phi ranges to file to support stand-alone emulation.
+  //--- (Only needed to support stand-alone emulation)
 
-//--- Write DTC phi ranges to file to support stand-alone emulation.
-//--- (Only needed to support stand-alone emulation)
-
-void TrackletConfigBuilder::writeDTCphirange() const {
-  bool first = true;
-  for (const DTCinfo& info : vecDTCinfo_) {
-    string dirName = settings_.tablePath();
-    string fileName = dirName + "../dtcphirange.dat";
-    std::ofstream out;
-    openfile(out, first, dirName, fileName, __FILE__, __LINE__);
-    if (first) {
-      out << "// layer & phi ranges of modules read by each DTC" << endl;
-      out << "// (Used by stand-alone emulation)" << endl;
+  void TrackletConfigBuilder::writeDTCphirange() const {
+    bool first = true;
+    for (const DTCinfo& info : vecDTCinfo_) {
+      string dirName = settings_.tablePath();
+      string fileName = dirName + "../dtcphirange.dat";
+      std::ofstream out;
+      openfile(out, first, dirName, fileName, __FILE__, __LINE__);
+      if (first) {
+        out << "// layer & phi ranges of modules read by each DTC" << endl;
+        out << "// (Used by stand-alone emulation)" << endl;
+      }
+      out << info.name << " " << info.layer << " " << info.phimin << " " << info.phimax << endl;
+      out.close();
+      first = false;
     }
-    out << info.name << " " << info.layer << " " << info.phimin << " " << info.phimax << endl;
-    out.close();
-    first = false;
   }
-}
 
 #else
 
-//--- Set DTC phi ranges from .txt file (stand-alone operation only)
+  //--- Set DTC phi ranges from .txt file (stand-alone operation only)
 
-void TrackletConfigBuilder::setDTCphirange(const tt::Setup* setup) {
-  // This file previously written by writeDTCphirange().
-  const string fname = "../data/dtcphirange.txt";
-  if (vecDTCinfo_.empty()) {  // Only run once per thread.
-    std::ifstream str_dtc;
-    str_dtc.open(fname);
-    assert(str_dtc.good());
-    string line;
-    while (ifstream, getline(line)) {
-      std::istringstream iss(line);
-      DTCinfo info;
-      iss >> info.name >> info.layer >> info.phimin >> info.phimax;
-      vecDTCinfo_.push_back(info);
+  void TrackletConfigBuilder::setDTCphirange(const tt::Setup* setup) {
+    // This file previously written by writeDTCphirange().
+    const string fname = "../data/dtcphirange.txt";
+    if (vecDTCinfo_.empty()) {  // Only run once per thread.
+      std::ifstream str_dtc;
+      str_dtc.open(fname);
+      assert(str_dtc.good());
+      string line;
+      while (ifstream, getline(line)) {
+        std::istringstream iss(line);
+        DTCinfo info;
+        iss >> info.name >> info.layer >> info.phimin >> info.phimax;
+        vecDTCinfo_.push_back(info);
+      }
+      str_dtc.close();
     }
-    str_dtc.close();
   }
-}
 
 #endif
 
-//--- Helper fcn. to get the layers/disks for a seed
+  //--- Helper fcn. to get the layers/disks for a seed
 
-std::pair<unsigned int, unsigned int> TrackletConfigBuilder::seedLayers(unsigned int iSeed) {
-  return std::pair<unsigned int, unsigned int>(settings_.seedlayers(0, iSeed), settings_.seedlayers(1, iSeed));
-}
+  std::pair<unsigned int, unsigned int> TrackletConfigBuilder::seedLayers(unsigned int iSeed) {
+    return std::pair<unsigned int, unsigned int>(settings_.seedlayers(0, iSeed), settings_.seedlayers(1, iSeed));
+  }
 
-//--- Method to initialize the regions and VM in each layer
+  //--- Method to initialize the regions and VM in each layer
 
-void TrackletConfigBuilder::initGeom() {
-  for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-    double dphi = dphisectorHG_ / NRegions_[ilayer];
-    for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-      std::vector<std::pair<unsigned int, unsigned int> > emptyVec;
-      projections_[ilayer].push_back(emptyVec);
-      // FIX: sector doesn't have hourglass shape
-      double phimin = dphi * iReg;
-      double phimax = phimin + dphi;
-      std::pair<double, double> tmp(phimin, phimax);
-      allStubs_[ilayer].push_back(tmp);
-      double dphiVM = dphi / NVMME_[ilayer];
-      for (unsigned int iVM = 0; iVM < NVMME_[ilayer]; iVM++) {
-        double phivmmin = phimin + iVM * dphiVM;
+  void TrackletConfigBuilder::initGeom() {
+    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+      double dphi = dphisectorHG_ / NRegions_[ilayer];
+      for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
+        std::vector<std::pair<unsigned int, unsigned int> > emptyVec;
+        projections_[ilayer].push_back(emptyVec);
+        // FIX: sector doesn't have hourglass shape
+        double phimin = dphi * iReg;
+        double phimax = phimin + dphi;
+        std::pair<double, double> tmp(phimin, phimax);
+        allStubs_[ilayer].push_back(tmp);
+        double dphiVM = dphi / NVMME_[ilayer];
+        for (unsigned int iVM = 0; iVM < NVMME_[ilayer]; iVM++) {
+          double phivmmin = phimin + iVM * dphiVM;
+          double phivmmax = phivmmin + dphiVM;
+          std::pair<double, double> tmp(phivmmin, phivmmax);
+          VMStubsME_[ilayer].push_back(tmp);
+        }
+      }
+    }
+    for (unsigned int iseed = 0; iseed < N_SEED_PROMPT; iseed++) {
+      unsigned int l1 = seedLayers(iseed).first;
+      unsigned int l2 = seedLayers(iseed).second;
+      unsigned int nVM1 = NVMTE_[iseed].first;
+      unsigned int nVM2 = NVMTE_[iseed].second;
+      double dphiVM = dphisectorHG_ / (nVM1 * NRegions_[l1]);
+      for (unsigned int iVM = 0; iVM < nVM1 * NRegions_[l1]; iVM++) {
+        double phivmmin = iVM * dphiVM;
         double phivmmax = phivmmin + dphiVM;
         std::pair<double, double> tmp(phivmmin, phivmmax);
-        VMStubsME_[ilayer].push_back(tmp);
+        VMStubsTE_[iseed].first.push_back(tmp);
+      }
+      dphiVM = dphisectorHG_ / (nVM2 * NRegions_[l2]);
+      for (unsigned int iVM = 0; iVM < nVM2 * NRegions_[l2]; iVM++) {
+        double phivmmin = iVM * dphiVM;
+        double phivmmax = phivmmin + dphiVM;
+        std::pair<double, double> tmp(phivmmin, phivmmax);
+        VMStubsTE_[iseed].second.push_back(tmp);
       }
     }
   }
-  for (unsigned int iseed = 0; iseed < N_SEED_PROMPT; iseed++) {
-    unsigned int l1 = seedLayers(iseed).first;
-    unsigned int l2 = seedLayers(iseed).second;
-    unsigned int nVM1 = NVMTE_[iseed].first;
-    unsigned int nVM2 = NVMTE_[iseed].second;
-    double dphiVM = dphisectorHG_ / (nVM1 * NRegions_[l1]);
-    for (unsigned int iVM = 0; iVM < nVM1 * NRegions_[l1]; iVM++) {
-      double phivmmin = iVM * dphiVM;
-      double phivmmax = phivmmin + dphiVM;
-      std::pair<double, double> tmp(phivmmin, phivmmax);
-      VMStubsTE_[iseed].first.push_back(tmp);
+
+  //--- Helper fcn to get the radii of the two layers in a seed
+
+  std::pair<double, double> TrackletConfigBuilder::seedRadii(unsigned int iseed) {
+    std::pair<unsigned int, unsigned int> seedlayers = seedLayers(iseed);
+
+    unsigned int l1 = seedlayers.first;
+    unsigned int l2 = seedlayers.second;
+
+    double r1, r2;
+
+    if (iseed < 4) {  //barrel seeding
+      r1 = rmean_[l1];
+      r2 = rmean_[l2];
+    } else if (iseed < 6) {   //disk seeding
+      r1 = rmean_[0] + 40.0;  //FIX: Somewhat of a hack - but allows finding all the regions
+      //when projecting to L1
+      r2 = r1 * zmean_[l2 - 6] / zmean_[l1 - 6];
+    } else {  //overlap seeding
+      r1 = rmean_[l1];
+      r2 = r1 * zmean_[l2 - 6] / zlength_;
     }
-    dphiVM = dphisectorHG_ / (nVM2 * NRegions_[l2]);
-    for (unsigned int iVM = 0; iVM < nVM2 * NRegions_[l2]; iVM++) {
-      double phivmmin = iVM * dphiVM;
-      double phivmmax = phivmmin + dphiVM;
-      std::pair<double, double> tmp(phivmmin, phivmmax);
-      VMStubsTE_[iseed].second.push_back(tmp);
-    }
-  }
-}
 
-//--- Helper fcn to get the radii of the two layers in a seed
-
-std::pair<double, double> TrackletConfigBuilder::seedRadii(unsigned int iseed) {
-  std::pair<unsigned int, unsigned int> seedlayers = seedLayers(iseed);
-
-  unsigned int l1 = seedlayers.first;
-  unsigned int l2 = seedlayers.second;
-
-  double r1, r2;
-
-  if (iseed < 4) {  //barrel seeding
-    r1 = rmean_[l1];
-    r2 = rmean_[l2];
-  } else if (iseed < 6) {   //disk seeding
-    r1 = rmean_[0] + 40.0;  //FIX: Somewhat of a hack - but allows finding all the regions
-    //when projecting to L1
-    r2 = r1 * zmean_[l2 - 6] / zmean_[l1 - 6];
-  } else {  //overlap seeding
-    r1 = rmean_[l1];
-    r2 = r1 * zmean_[l2 - 6] / zlength_;
+    return std::pair<double, double>(r1, r2);
   }
 
-  return std::pair<double, double>(r1, r2);
-}
+  //--- Helper function to determine if a pair of VM memories form valid TE
 
-//--- Helper function to determine if a pair of VM memories form valid TE
+  bool TrackletConfigBuilder::validTEPair(unsigned int iseed, unsigned int iTE1, unsigned int iTE2) {
+    double rinvmin = 999.9;
+    double rinvmax = -999.9;
 
-bool TrackletConfigBuilder::validTEPair(unsigned int iseed, unsigned int iTE1, unsigned int iTE2) {
-  double rinvmin = 999.9;
-  double rinvmax = -999.9;
+    double phi1[2] = {VMStubsTE_[iseed].first[iTE1].first, VMStubsTE_[iseed].first[iTE1].second};
+    double phi2[2] = {VMStubsTE_[iseed].second[iTE2].first, VMStubsTE_[iseed].second[iTE2].second};
 
-  double phi1[2] = {VMStubsTE_[iseed].first[iTE1].first, VMStubsTE_[iseed].first[iTE1].second};
-  double phi2[2] = {VMStubsTE_[iseed].second[iTE2].first, VMStubsTE_[iseed].second[iTE2].second};
+    std::pair<double, double> seedradii = seedRadii(iseed);
 
-  std::pair<double, double> seedradii = seedRadii(iseed);
-
-  for (unsigned int i1 = 0; i1 < 2; i1++) {
-    for (unsigned int i2 = 0; i2 < 2; i2++) {
-      double arinv = rinv(seedradii.first, phi1[i1], seedradii.second, phi2[i2]);
-      if (arinv < rinvmin)
-        rinvmin = arinv;
-      if (arinv > rinvmax)
-        rinvmax = arinv;
+    for (unsigned int i1 = 0; i1 < 2; i1++) {
+      for (unsigned int i2 = 0; i2 < 2; i2++) {
+        double arinv = rinv(seedradii.first, phi1[i1], seedradii.second, phi2[i2]);
+        if (arinv < rinvmin)
+          rinvmin = arinv;
+        if (arinv > rinvmax)
+          rinvmax = arinv;
+      }
     }
+
+    if (rinvmin > rinvmax_)
+      return false;
+    if (rinvmax < -rinvmax_)
+      return false;
+
+    return true;
   }
 
-  if (rinvmin > rinvmax_)
-    return false;
-  if (rinvmax < -rinvmax_)
-    return false;
+  //--- Builds the list of TE for each seeding combination
 
-  return true;
-}
-
-//--- Builds the list of TE for each seeding combination
-
-void TrackletConfigBuilder::buildTE() {
-  for (unsigned int iseed = 0; iseed < N_SEED_PROMPT; iseed++) {
-    for (unsigned int i1 = 0; i1 < VMStubsTE_[iseed].first.size(); i1++) {
-      for (unsigned int i2 = 0; i2 < VMStubsTE_[iseed].second.size(); i2++) {
-        if (validTEPair(iseed, i1, i2)) {
-          std::pair<unsigned int, unsigned int> tmp(i1, i2);
-          // Contains pairs of indices of all valid VM pairs in seeding layers
-          TE_[iseed].push_back(tmp);
+  void TrackletConfigBuilder::buildTE() {
+    for (unsigned int iseed = 0; iseed < N_SEED_PROMPT; iseed++) {
+      for (unsigned int i1 = 0; i1 < VMStubsTE_[iseed].first.size(); i1++) {
+        for (unsigned int i2 = 0; i2 < VMStubsTE_[iseed].second.size(); i2++) {
+          if (validTEPair(iseed, i1, i2)) {
+            std::pair<unsigned int, unsigned int> tmp(i1, i2);
+            // Contains pairs of indices of all valid VM pairs in seeding layers
+            TE_[iseed].push_back(tmp);
+          }
         }
       }
     }
   }
-}
 
-//--- Builds the lists of TC for each seeding combination
+  //--- Builds the lists of TC for each seeding combination
 
-void TrackletConfigBuilder::buildTC() {
-  for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-    unsigned int nTC = NTC_[iSeed];
-    std::vector<std::pair<unsigned int, unsigned int> >& TEs = TE_[iSeed];
+  void TrackletConfigBuilder::buildTC() {
+    for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+      unsigned int nTC = NTC_[iSeed];
+      std::vector<std::pair<unsigned int, unsigned int> >& TEs = TE_[iSeed];
+      std::vector<std::vector<unsigned int> >& TCs = TC_[iSeed];
+
+      //Very naive method to group TEs in TC
+
+      double invnTC = nTC * (1.0 / TEs.size());
+
+      for (unsigned int iTE = 0; iTE < TEs.size(); iTE++) {
+        int iTC = invnTC * iTE;
+        assert(iTC < (int)nTC);
+        if (iTC >= (int)TCs.size()) {
+          std::vector<unsigned int> tmp;
+          tmp.push_back(iTE);
+          TCs.push_back(tmp);
+        } else {
+          TCs[iTC].push_back(iTE);
+        }
+      }
+    }
+  }
+
+  //--- Helper fcn to return the phi range of a projection of a tracklet from a TC
+
+  std::pair<double, double> TrackletConfigBuilder::seedPhiRange(double rproj, unsigned int iSeed, unsigned int iTC) {
     std::vector<std::vector<unsigned int> >& TCs = TC_[iSeed];
 
-    //Very naive method to group TEs in TC
+    std::pair<double, double> seedradii = seedRadii(iSeed);
 
-    double invnTC = nTC * (1.0 / TEs.size());
-
-    for (unsigned int iTE = 0; iTE < TEs.size(); iTE++) {
-      int iTC = invnTC * iTE;
-      assert(iTC < (int)nTC);
-      if (iTC >= (int)TCs.size()) {
-        std::vector<unsigned int> tmp;
-        tmp.push_back(iTE);
-        TCs.push_back(tmp);
-      } else {
-        TCs[iTC].push_back(iTE);
+    double phimin = 999.0;
+    double phimax = -999.0;
+    for (unsigned int iTE = 0; iTE < TCs[iTC].size(); iTE++) {
+      unsigned int theTE = TCs[iTC][iTE];
+      unsigned int l1TE = TE_[iSeed][theTE].first;
+      unsigned int l2TE = TE_[iSeed][theTE].second;
+      double phi1[2] = {VMStubsTE_[iSeed].first[l1TE].first, VMStubsTE_[iSeed].first[l1TE].second};
+      double phi2[2] = {VMStubsTE_[iSeed].second[l2TE].first, VMStubsTE_[iSeed].second[l2TE].second};
+      for (unsigned int i1 = 0; i1 < 2; i1++) {
+        for (unsigned int i2 = 0; i2 < 2; i2++) {
+          double aphi = phi(seedradii.first, phi1[i1], seedradii.second, phi2[i2], rproj);
+          if (aphi < phimin)
+            phimin = aphi;
+          if (aphi > phimax)
+            phimax = aphi;
+        }
       }
     }
+    return std::pair<double, double>(phimin, phimax);
   }
-}
 
-//--- Helper fcn to return the phi range of a projection of a tracklet from a TC
+  //--- Finds the projections needed for each seeding combination
 
-std::pair<double, double> TrackletConfigBuilder::seedPhiRange(double rproj, unsigned int iSeed, unsigned int iTC) {
-  std::vector<std::vector<unsigned int> >& TCs = TC_[iSeed];
+  void TrackletConfigBuilder::buildProjections() {
+    set<string> emptyProjStandard = {
+        "TPROJ_L1L2H_L3PHIB", "TPROJ_L1L2E_L3PHIC", "TPROJ_L1L2K_L3PHIC", "TPROJ_L1L2H_L3PHID", "TPROJ_L1L2F_L5PHIA",
+        "TPROJ_L1L2G_L5PHID", "TPROJ_L1L2A_L6PHIA", "TPROJ_L1L2J_L6PHIB", "TPROJ_L1L2C_L6PHIC", "TPROJ_L1L2L_L6PHID",
+        "TPROJ_L3L4D_D1PHIB", "TPROJ_L2L3A_D1PHIC", "TPROJ_L3L4A_D1PHIC", "TPROJ_L1L2G_D2PHIA", "TPROJ_L1D1D_D2PHIA",
+        "TPROJ_L1D1E_D2PHIA", "TPROJ_L1L2J_D2PHIB", "TPROJ_L3L4D_D2PHIB", "TPROJ_L1D1A_D2PHIB", "TPROJ_L1D1F_D2PHIB",
+        "TPROJ_L1D1G_D2PHIB", "TPROJ_L1L2C_D2PHIC", "TPROJ_L2L3A_D2PHIC", "TPROJ_L3L4A_D2PHIC", "TPROJ_L1D1B_D2PHIC",
+        "TPROJ_L1D1C_D2PHIC", "TPROJ_L1D1H_D2PHIC", "TPROJ_L2D1A_D2PHIC", "TPROJ_L1L2F_D2PHID", "TPROJ_L1D1D_D2PHID",
+        "TPROJ_L1D1E_D2PHID", "TPROJ_L1L2G_D3PHIA", "TPROJ_L1D1D_D3PHIA", "TPROJ_L1D1E_D3PHIA", "TPROJ_L1L2J_D3PHIB",
+        "TPROJ_L1D1A_D3PHIB", "TPROJ_L1D1F_D3PHIB", "TPROJ_L1D1G_D3PHIB", "TPROJ_L1L2C_D3PHIC", "TPROJ_L2L3A_D3PHIC",
+        "TPROJ_L1D1B_D3PHIC", "TPROJ_L1D1C_D3PHIC", "TPROJ_L1D1H_D3PHIC", "TPROJ_L2D1A_D3PHIC", "TPROJ_L1L2F_D3PHID",
+        "TPROJ_L1D1D_D3PHID", "TPROJ_L1D1E_D3PHID", "TPROJ_L1L2G_D4PHIA", "TPROJ_L1D1D_D4PHIA", "TPROJ_L1D1E_D4PHIA",
+        "TPROJ_L1L2J_D4PHIB", "TPROJ_L1D1G_D4PHIB", "TPROJ_L1L2C_D4PHIC", "TPROJ_L2L3A_D4PHIC", "TPROJ_L1D1B_D4PHIC",
+        "TPROJ_L2D1A_D4PHIC", "TPROJ_L1L2F_D4PHID", "TPROJ_L1D1D_D4PHID", "TPROJ_L1D1E_D5PHIA", "TPROJ_L1D1G_D5PHIB",
+        "TPROJ_L1D1B_D5PHIC", "TPROJ_L1D1D_D5PHID"};
 
-  std::pair<double, double> seedradii = seedRadii(iSeed);
+    set<string> emptyProjCombined = {
+        "TPROJ_L1L2J_L6PHIB", "TPROJ_L1L2C_L6PHIC", "TPROJ_L1L2G_D1PHIA", "TPROJ_L1L2J_D1PHIB", "TPROJ_L2L3D_D1PHIB",
+        "TPROJ_L3L4D_D1PHIB", "TPROJ_L1L2C_D1PHIC", "TPROJ_L2L3A_D1PHIC", "TPROJ_L3L4A_D1PHIC", "TPROJ_L1L2F_D1PHID",
+        "TPROJ_L1L2G_D2PHIA", "TPROJ_L1D1E_D2PHIA", "TPROJ_L1L2J_D2PHIB", "TPROJ_L2L3D_D2PHIB", "TPROJ_L3L4D_D2PHIB",
+        "TPROJ_L1D1G_D2PHIB", "TPROJ_L1L2C_D2PHIC", "TPROJ_L2L3A_D2PHIC", "TPROJ_L3L4A_D2PHIC", "TPROJ_L1D1B_D2PHIC",
+        "TPROJ_L2D1A_D2PHIC", "TPROJ_L1L2F_D2PHID", "TPROJ_L1D1D_D2PHID", "TPROJ_L1L2G_D3PHIA", "TPROJ_L1D1E_D3PHIA",
+        "TPROJ_L1L2J_D3PHIB", "TPROJ_L2L3D_D3PHIB", "TPROJ_L1D1G_D3PHIB", "TPROJ_L1L2C_D3PHIC", "TPROJ_L2L3A_D3PHIC",
+        "TPROJ_L1D1B_D3PHIC", "TPROJ_L2D1A_D3PHIC", "TPROJ_L1L2F_D3PHID", "TPROJ_L1D1D_D3PHID", "TPROJ_L1L2G_D4PHIA",
+        "TPROJ_L1D1E_D4PHIA", "TPROJ_L1L2J_D4PHIB", "TPROJ_L2L3D_D4PHIB", "TPROJ_L1D1G_D4PHIB", "TPROJ_L1L2C_D4PHIC",
+        "TPROJ_L2L3A_D4PHIC", "TPROJ_L1D1B_D4PHIC", "TPROJ_L2D1A_D4PHIC", "TPROJ_L1L2F_D4PHID", "TPROJ_L1D1D_D4PHID",
+        "TPROJ_L1D1E_D5PHIA", "TPROJ_L1D1G_D5PHIB", "TPROJ_L1D1B_D5PHIC", "TPROJ_L1D1D_D5PHID"};
 
-  double phimin = 999.0;
-  double phimax = -999.0;
-  for (unsigned int iTE = 0; iTE < TCs[iTC].size(); iTE++) {
-    unsigned int theTE = TCs[iTC][iTE];
-    unsigned int l1TE = TE_[iSeed][theTE].first;
-    unsigned int l2TE = TE_[iSeed][theTE].second;
-    double phi1[2] = {VMStubsTE_[iSeed].first[l1TE].first, VMStubsTE_[iSeed].first[l1TE].second};
-    double phi2[2] = {VMStubsTE_[iSeed].second[l2TE].first, VMStubsTE_[iSeed].second[l2TE].second};
-    for (unsigned int i1 = 0; i1 < 2; i1++) {
-      for (unsigned int i2 = 0; i2 < 2; i2++) {
-        double aphi = phi(seedradii.first, phi1[i1], seedradii.second, phi2[i2], rproj);
-        if (aphi < phimin)
-          phimin = aphi;
-        if (aphi > phimax)
-          phimax = aphi;
-      }
-    }
-  }
-  return std::pair<double, double>(phimin, phimax);
-}
+    for (unsigned int iseed = 0; iseed < N_SEED_PROMPT; iseed++) {
+      std::vector<std::vector<unsigned int> >& TCs = TC_[iseed];
 
-//--- Finds the projections needed for each seeding combination
-
-void TrackletConfigBuilder::buildProjections() {
-  set<string> emptyProjStandard = {
-      "TPROJ_L1L2H_L3PHIB", "TPROJ_L1L2E_L3PHIC", "TPROJ_L1L2K_L3PHIC", "TPROJ_L1L2H_L3PHID", "TPROJ_L1L2F_L5PHIA",
-      "TPROJ_L1L2G_L5PHID", "TPROJ_L1L2A_L6PHIA", "TPROJ_L1L2J_L6PHIB", "TPROJ_L1L2C_L6PHIC", "TPROJ_L1L2L_L6PHID",
-      "TPROJ_L3L4D_D1PHIB", "TPROJ_L2L3A_D1PHIC", "TPROJ_L3L4A_D1PHIC", "TPROJ_L1L2G_D2PHIA", "TPROJ_L1D1D_D2PHIA",
-      "TPROJ_L1D1E_D2PHIA", "TPROJ_L1L2J_D2PHIB", "TPROJ_L3L4D_D2PHIB", "TPROJ_L1D1A_D2PHIB", "TPROJ_L1D1F_D2PHIB",
-      "TPROJ_L1D1G_D2PHIB", "TPROJ_L1L2C_D2PHIC", "TPROJ_L2L3A_D2PHIC", "TPROJ_L3L4A_D2PHIC", "TPROJ_L1D1B_D2PHIC",
-      "TPROJ_L1D1C_D2PHIC", "TPROJ_L1D1H_D2PHIC", "TPROJ_L2D1A_D2PHIC", "TPROJ_L1L2F_D2PHID", "TPROJ_L1D1D_D2PHID",
-      "TPROJ_L1D1E_D2PHID", "TPROJ_L1L2G_D3PHIA", "TPROJ_L1D1D_D3PHIA", "TPROJ_L1D1E_D3PHIA", "TPROJ_L1L2J_D3PHIB",
-      "TPROJ_L1D1A_D3PHIB", "TPROJ_L1D1F_D3PHIB", "TPROJ_L1D1G_D3PHIB", "TPROJ_L1L2C_D3PHIC", "TPROJ_L2L3A_D3PHIC",
-      "TPROJ_L1D1B_D3PHIC", "TPROJ_L1D1C_D3PHIC", "TPROJ_L1D1H_D3PHIC", "TPROJ_L2D1A_D3PHIC", "TPROJ_L1L2F_D3PHID",
-      "TPROJ_L1D1D_D3PHID", "TPROJ_L1D1E_D3PHID", "TPROJ_L1L2G_D4PHIA", "TPROJ_L1D1D_D4PHIA", "TPROJ_L1D1E_D4PHIA",
-      "TPROJ_L1L2J_D4PHIB", "TPROJ_L1D1G_D4PHIB", "TPROJ_L1L2C_D4PHIC", "TPROJ_L2L3A_D4PHIC", "TPROJ_L1D1B_D4PHIC",
-      "TPROJ_L2D1A_D4PHIC", "TPROJ_L1L2F_D4PHID", "TPROJ_L1D1D_D4PHID", "TPROJ_L1D1E_D5PHIA", "TPROJ_L1D1G_D5PHIB",
-      "TPROJ_L1D1B_D5PHIC", "TPROJ_L1D1D_D5PHID"};
-
-  set<string> emptyProjCombined = {
-      "TPROJ_L1L2J_L6PHIB", "TPROJ_L1L2C_L6PHIC", "TPROJ_L1L2G_D1PHIA", "TPROJ_L1L2J_D1PHIB", "TPROJ_L2L3D_D1PHIB",
-      "TPROJ_L3L4D_D1PHIB", "TPROJ_L1L2C_D1PHIC", "TPROJ_L2L3A_D1PHIC", "TPROJ_L3L4A_D1PHIC", "TPROJ_L1L2F_D1PHID",
-      "TPROJ_L1L2G_D2PHIA", "TPROJ_L1D1E_D2PHIA", "TPROJ_L1L2J_D2PHIB", "TPROJ_L2L3D_D2PHIB", "TPROJ_L3L4D_D2PHIB",
-      "TPROJ_L1D1G_D2PHIB", "TPROJ_L1L2C_D2PHIC", "TPROJ_L2L3A_D2PHIC", "TPROJ_L3L4A_D2PHIC", "TPROJ_L1D1B_D2PHIC",
-      "TPROJ_L2D1A_D2PHIC", "TPROJ_L1L2F_D2PHID", "TPROJ_L1D1D_D2PHID", "TPROJ_L1L2G_D3PHIA", "TPROJ_L1D1E_D3PHIA",
-      "TPROJ_L1L2J_D3PHIB", "TPROJ_L2L3D_D3PHIB", "TPROJ_L1D1G_D3PHIB", "TPROJ_L1L2C_D3PHIC", "TPROJ_L2L3A_D3PHIC",
-      "TPROJ_L1D1B_D3PHIC", "TPROJ_L2D1A_D3PHIC", "TPROJ_L1L2F_D3PHID", "TPROJ_L1D1D_D3PHID", "TPROJ_L1L2G_D4PHIA",
-      "TPROJ_L1D1E_D4PHIA", "TPROJ_L1L2J_D4PHIB", "TPROJ_L2L3D_D4PHIB", "TPROJ_L1D1G_D4PHIB", "TPROJ_L1L2C_D4PHIC",
-      "TPROJ_L2L3A_D4PHIC", "TPROJ_L1D1B_D4PHIC", "TPROJ_L2D1A_D4PHIC", "TPROJ_L1L2F_D4PHID", "TPROJ_L1D1D_D4PHID",
-      "TPROJ_L1D1E_D5PHIA", "TPROJ_L1D1G_D5PHIB", "TPROJ_L1D1B_D5PHIC", "TPROJ_L1D1D_D5PHID"};
-
-  for (unsigned int iseed = 0; iseed < N_SEED_PROMPT; iseed++) {
-    std::vector<std::vector<unsigned int> >& TCs = TC_[iseed];
-
-    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-      if (matchport_[iseed][ilayer] == -1)
-        continue;
-      for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        for (unsigned int iTC = 0; iTC < TCs.size(); iTC++) {
-          double rproj = rmaxdisk_;
-          if (ilayer < 6)
-            rproj = rmean_[ilayer];
-          std::pair<double, double> phiRange = seedPhiRange(rproj, iseed, iTC);
-          if (phiRange.first < allStubs_[ilayer][iReg].second && phiRange.second > allStubs_[ilayer][iReg].first) {
-            std::pair<unsigned int, unsigned int> tmp(iseed, iTC);  //seedindex and TC
-            string projName = TPROJName(iseed, iTC, ilayer, iReg);
-            if (combinedmodules_) {
-              if (emptyProjCombined.find(projName) == emptyProjCombined.end()) {
-                projections_[ilayer][iReg].push_back(tmp);
-              }
-            } else {
-              if (emptyProjStandard.find(projName) == emptyProjStandard.end()) {
-                projections_[ilayer][iReg].push_back(tmp);
+      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+        if (matchport_[iseed][ilayer] == -1)
+          continue;
+        for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
+          for (unsigned int iTC = 0; iTC < TCs.size(); iTC++) {
+            double rproj = rmaxdisk_;
+            if (ilayer < 6)
+              rproj = rmean_[ilayer];
+            std::pair<double, double> phiRange = seedPhiRange(rproj, iseed, iTC);
+            if (phiRange.first < allStubs_[ilayer][iReg].second && phiRange.second > allStubs_[ilayer][iReg].first) {
+              std::pair<unsigned int, unsigned int> tmp(iseed, iTC);  //seedindex and TC
+              string projName = TPROJName(iseed, iTC, ilayer, iReg);
+              if (combinedmodules_) {
+                if (emptyProjCombined.find(projName) == emptyProjCombined.end()) {
+                  projections_[ilayer][iReg].push_back(tmp);
+                }
+              } else {
+                if (emptyProjStandard.find(projName) == emptyProjStandard.end()) {
+                  projections_[ilayer][iReg].push_back(tmp);
+                }
               }
             }
           }
@@ -418,679 +419,624 @@ void TrackletConfigBuilder::buildProjections() {
       }
     }
   }
-}
 
-//--- Helper function to calculate the phi position of a seed at radius r that is formed
-//--- by two stubs at (r1,phi1) and (r2, phi2)
+  //--- Helper function to calculate the phi position of a seed at radius r that is formed
+  //--- by two stubs at (r1,phi1) and (r2, phi2)
 
-double TrackletConfigBuilder::phi(double r1, double phi1, double r2, double phi2, double r) {
-  double rhoinv = rinv(r1, phi1, r2, phi2);
-  if (std::abs(rhoinv) > rinvmax_) {
-    rhoinv = rinvmax_ * rhoinv / std::abs(rhoinv);
+  double TrackletConfigBuilder::phi(double r1, double phi1, double r2, double phi2, double r) {
+    double rhoinv = rinv(r1, phi1, r2, phi2);
+    if (std::abs(rhoinv) > rinvmax_) {
+      rhoinv = rinvmax_ * rhoinv / std::abs(rhoinv);
+    }
+    return phi1 + asin(0.5 * r * rhoinv) - asin(0.5 * r1 * rhoinv);
   }
-  return phi1 + asin(0.5 * r * rhoinv) - asin(0.5 * r1 * rhoinv);
-}
 
-//--- Helper function to calculate rinv for two stubs at (r1,phi1) and (r2,phi2)
+  //--- Helper function to calculate rinv for two stubs at (r1,phi1) and (r2,phi2)
 
-double TrackletConfigBuilder::rinv(double r1, double phi1, double r2, double phi2) {
-  double deltaphi = phi1 - phi2;
-  return 2 * sin(deltaphi) / sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
-}
-
-std::string TrackletConfigBuilder::iSeedStr(unsigned int iSeed) const {
-  static std::string name[8] = {"L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1"};
-
-  assert(iSeed < 8);
-  return name[iSeed];
-}
-
-std::string TrackletConfigBuilder::numStr(unsigned int i) {
-  static std::string num[32] = {"1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9",  "10", "11",
-                                "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22",
-                                "23", "24", "25", "26", "27", "28", "29", "30", "31", "32"};
-  assert(i < 32);
-  return num[i];
-}
-
-std::string TrackletConfigBuilder::iTCStr(unsigned int iTC) const {
-  static std::string name[12] = {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"};
-
-  assert(iTC < 12);
-  return name[iTC];
-}
-
-std::string TrackletConfigBuilder::iRegStr(unsigned int iReg, unsigned int iSeed) const {
-  static std::string name[8] = {"A", "B", "C", "D", "E", "F", "G", "H"};
-
-  static std::string nameOverlap[8] = {"X", "Y", "Z", "W", "Q", "R", "S", "T"};
-
-  static std::string nameL2L3[4] = {"I", "J", "K", "L"};
-
-  if (iSeed == Seed::L2L3) {
-    assert(iReg < 4);
-    return nameL2L3[iReg];
+  double TrackletConfigBuilder::rinv(double r1, double phi1, double r2, double phi2) {
+    double deltaphi = phi1 - phi2;
+    return 2 * sin(deltaphi) / sqrt(r2 * r2 + r1 * r1 - 2 * r1 * r2 * cos(deltaphi));
   }
-  if (iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
+
+  std::string TrackletConfigBuilder::iSeedStr(unsigned int iSeed) const {
+    static std::string name[8] = {"L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1"};
+
+    assert(iSeed < 8);
+    return name[iSeed];
+  }
+
+  std::string TrackletConfigBuilder::numStr(unsigned int i) {
+    static std::string num[32] = {"1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9",  "10", "11",
+                                  "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22",
+                                  "23", "24", "25", "26", "27", "28", "29", "30", "31", "32"};
+    assert(i < 32);
+    return num[i];
+  }
+
+  std::string TrackletConfigBuilder::iTCStr(unsigned int iTC) const {
+    static std::string name[12] = {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"};
+
+    assert(iTC < 12);
+    return name[iTC];
+  }
+
+  std::string TrackletConfigBuilder::iRegStr(unsigned int iReg, unsigned int iSeed) const {
+    static std::string name[8] = {"A", "B", "C", "D", "E", "F", "G", "H"};
+
+    static std::string nameOverlap[8] = {"X", "Y", "Z", "W", "Q", "R", "S", "T"};
+
+    static std::string nameL2L3[4] = {"I", "J", "K", "L"};
+
+    if (iSeed == Seed::L2L3) {
+      assert(iReg < 4);
+      return nameL2L3[iReg];
+    }
+    if (iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
+      assert(iReg < 8);
+      return nameOverlap[iReg];
+    }
     assert(iReg < 8);
-    return nameOverlap[iReg];
+    return name[iReg];
   }
-  assert(iReg < 8);
-  return name[iReg];
-}
 
-std::string TrackletConfigBuilder::TCName(unsigned int iSeed, unsigned int iTC) const {
-  if (combinedmodules_) {
-    return "TP_" + iSeedStr(iSeed) + iTCStr(iTC);
-  } else {
-    return "TC_" + iSeedStr(iSeed) + iTCStr(iTC);
+  std::string TrackletConfigBuilder::TCName(unsigned int iSeed, unsigned int iTC) const {
+    if (combinedmodules_) {
+      return "TP_" + iSeedStr(iSeed) + iTCStr(iTC);
+    } else {
+      return "TC_" + iSeedStr(iSeed) + iTCStr(iTC);
+    }
   }
-}
 
-std::string TrackletConfigBuilder::LayerName(unsigned int ilayer) {
-  return ilayer < 6 ? ("L" + numStr(ilayer)) : ("D" + numStr(ilayer - 6));
-}
-
-std::string TrackletConfigBuilder::TPROJName(unsigned int iSeed,
-                                             unsigned int iTC,
-                                             unsigned int ilayer,
-                                             unsigned int ireg) const {
-  return "TPROJ_" + iSeedStr(iSeed) + iTCStr(iTC) + "_" + LayerName(ilayer) + "PHI" + iTCStr(ireg);
-}
-
-std::string TrackletConfigBuilder::PRName(unsigned int ilayer, unsigned int ireg) const {
-  if (combinedmodules_) {
-    return "MP_" + LayerName(ilayer) + "PHI" + iTCStr(ireg);
-  } else {
-    return "PR_" + LayerName(ilayer) + "PHI" + iTCStr(ireg);
+  std::string TrackletConfigBuilder::LayerName(unsigned int ilayer) {
+    return ilayer < 6 ? ("L" + numStr(ilayer)) : ("D" + numStr(ilayer - 6));
   }
-}
 
-void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostream& memories, std::ostream&) {
-  // Each TC (e.g. TC_L1L2D) writes a projection memory (TPROJ) for each layer the seed projects to,
-  // with name indicating the TC and which layer & phi region it projects to (e.g. TPROJ_L1L2D_L3PHIA).
-  //
-  // Each PR (e.g. PR_L3PHIA) reads all TPROJ memories for the given layer & phi region.
+  std::string TrackletConfigBuilder::TPROJName(unsigned int iSeed,
+                                               unsigned int iTC,
+                                               unsigned int ilayer,
+                                               unsigned int ireg) const {
+    return "TPROJ_" + iSeedStr(iSeed) + iTCStr(iTC) + "_" + LayerName(ilayer) + "PHI" + iTCStr(ireg);
+  }
 
-  for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-    for (unsigned int ireg = 0; ireg < projections_[ilayer].size(); ireg++) {
-      for (unsigned int imem = 0; imem < projections_[ilayer][ireg].size(); imem++) {
-        unsigned int iSeed = projections_[ilayer][ireg][imem].first;
-        unsigned int iTC = projections_[ilayer][ireg][imem].second;
+  std::string TrackletConfigBuilder::PRName(unsigned int ilayer, unsigned int ireg) const {
+    if (combinedmodules_) {
+      return "MP_" + LayerName(ilayer) + "PHI" + iTCStr(ireg);
+    } else {
+      return "PR_" + LayerName(ilayer) + "PHI" + iTCStr(ireg);
+    }
+  }
 
-        memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
+  void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostream& memories, std::ostream&) {
+    // Each TC (e.g. TC_L1L2D) writes a projection memory (TPROJ) for each layer the seed projects to,
+    // with name indicating the TC and which layer & phi region it projects to (e.g. TPROJ_L1L2D_L3PHIA).
+    //
+    // Each PR (e.g. PR_L3PHIA) reads all TPROJ memories for the given layer & phi region.
 
-        os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-           << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
+    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+      for (unsigned int ireg = 0; ireg < projections_[ilayer].size(); ireg++) {
+        for (unsigned int imem = 0; imem < projections_[ilayer][ireg].size(); imem++) {
+          unsigned int iSeed = projections_[ilayer][ireg][imem].first;
+          unsigned int iTC = projections_[ilayer][ireg][imem].second;
+
+          memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
+
+          os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+             << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
+             << std::endl;
+        }
+      }
+    }
+  }
+
+  std::string TrackletConfigBuilder::SPName(unsigned int l1,
+                                            unsigned int ireg1,
+                                            unsigned int ivm1,
+                                            unsigned int l2,
+                                            unsigned int ireg2,
+                                            unsigned int ivm2,
+                                            unsigned int iseed) const {
+    return "SP_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
+           iRegStr(ireg2, iseed) + numStr(ivm2);
+  }
+
+  std::string TrackletConfigBuilder::SPDName(unsigned int l1,
+                                             unsigned int ireg1,
+                                             unsigned int ivm1,
+                                             unsigned int l2,
+                                             unsigned int ireg2,
+                                             unsigned int ivm2,
+                                             unsigned int l3,
+                                             unsigned int ireg3,
+                                             unsigned int ivm3,
+                                             unsigned int iseed) const {
+    return "SPD_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
+           iRegStr(ireg2, iseed) + numStr(ivm2) + "_" + LayerName(l3) + "PHI" + iRegStr(ireg3, iseed) + numStr(ivm3);
+  }
+
+  std::string TrackletConfigBuilder::TEName(unsigned int l1,
+                                            unsigned int ireg1,
+                                            unsigned int ivm1,
+                                            unsigned int l2,
+                                            unsigned int ireg2,
+                                            unsigned int ivm2,
+                                            unsigned int iseed) const {
+    return "TE_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
+           iRegStr(ireg2, iseed) + numStr(ivm2);
+  }
+
+  std::string TrackletConfigBuilder::TEDName(unsigned int l1,
+                                             unsigned int ireg1,
+                                             unsigned int ivm1,
+                                             unsigned int l2,
+                                             unsigned int ireg2,
+                                             unsigned int ivm2,
+                                             unsigned int iseed) const {
+    return "TED_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
+           iRegStr(ireg2, iseed) + numStr(ivm2);
+  }
+
+  std::string TrackletConfigBuilder::TParName(unsigned int l1,
+                                              unsigned int l2,
+                                              unsigned int l3,
+                                              unsigned int itc) const {
+    return "TPAR_" + LayerName(l1) + LayerName(l2) + LayerName(l3) + iTCStr(itc);
+  }
+
+  std::string TrackletConfigBuilder::TCDName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc) const {
+    return "TCD_" + LayerName(l1) + LayerName(l2) + LayerName(l3) + iTCStr(itc);
+  }
+
+  std::string TrackletConfigBuilder::TPROJName(unsigned int l1,
+                                               unsigned int l2,
+                                               unsigned int l3,
+                                               unsigned int itc,
+                                               unsigned int projlayer,
+                                               unsigned int projreg) const {
+    return "TPROJ_" + LayerName(l1) + LayerName(l2) + LayerName(l3) + iTCStr(itc) + "_" + LayerName(projlayer) + "PHI" +
+           iTCStr(projreg);
+  }
+
+  std::string TrackletConfigBuilder::FTName(unsigned int l1, unsigned int l2, unsigned int l3) const {
+    return "FT_" + LayerName(l1) + LayerName(l2) + LayerName(l3);
+  }
+
+  std::string TrackletConfigBuilder::TREName(unsigned int l1,
+                                             unsigned int ireg1,
+                                             unsigned int l2,
+                                             unsigned int ireg2,
+                                             unsigned int iseed,
+                                             unsigned int count) const {
+    return "TRE_" + LayerName(l1) + iRegStr(ireg1, iseed) + LayerName(l2) + iRegStr(ireg2, iseed) + "_" + numStr(count);
+  }
+
+  std::string TrackletConfigBuilder::STName(unsigned int l1,
+                                            unsigned int ireg1,
+                                            unsigned int l2,
+                                            unsigned int ireg2,
+                                            unsigned int l3,
+                                            unsigned int ireg3,
+                                            unsigned int iseed,
+                                            unsigned int count) const {
+    return "ST_" + LayerName(l1) + iRegStr(ireg1, iseed) + LayerName(l2) + iRegStr(ireg2, iseed) + "_" + LayerName(l3) +
+           iRegStr(ireg3, iseed) + "_" + numStr(count);
+  }
+
+  void TrackletConfigBuilder::writeSPMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
+    // Each TE reads one VM in two seed layers, finds stub pairs & writes to a StubPair ("SP") memory.
+    //
+    // Each TC reads several StubPair (SP) memories, each containing a pair of VMs of two seeding layers.
+    // Several TC are created for each layer pair, and the SP distributed between them.
+    // If TC name is TC_L1L2C, "C" indicates this is the 3rd TC in L1L2.
+
+    if (combinedmodules_)
+      return;
+
+    for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+      for (unsigned int iTC = 0; iTC < TC_[iSeed].size(); iTC++) {
+        for (unsigned int iTE = 0; iTE < TC_[iSeed][iTC].size(); iTE++) {
+          unsigned int theTE = TC_[iSeed][iTC][iTE];
+
+          unsigned int TE1 = TE_[iSeed][theTE].first;
+          unsigned int TE2 = TE_[iSeed][theTE].second;
+
+          unsigned int l1 = seedLayers(iSeed).first;
+          unsigned int l2 = seedLayers(iSeed).second;
+
+          memories << "StubPairs: "
+                   << SPName(l1, TE1 / NVMTE_[iSeed].first, TE1, l2, TE2 / NVMTE_[iSeed].second, TE2, iSeed) << " [12]"
+                   << std::endl;
+          modules << "TrackletEngine: "
+                  << TEName(l1, TE1 / NVMTE_[iSeed].first, TE1, l2, TE2 / NVMTE_[iSeed].second, TE2, iSeed)
+                  << std::endl;
+
+          os << SPName(l1, TE1 / NVMTE_[iSeed].first, TE1, l2, TE2 / NVMTE_[iSeed].second, TE2, iSeed) << " input=> "
+             << TEName(l1, TE1 / NVMTE_[iSeed].first, TE1, l2, TE2 / NVMTE_[iSeed].second, TE2, iSeed)
+             << ".stubpairout output=> " << TCName(iSeed, iTC) << ".stubpairin" << std::endl;
+        }
+      }
+    }
+  }
+
+  void TrackletConfigBuilder::writeSPDMemories(std::ostream& wires, std::ostream& memories, std::ostream& modules) {
+    // Similar to writeSPMemories, but for displaced (=extended) tracking,
+    // with seeds based on triplets of layers.
+
+    if (!extended_)
+      return;
+
+    vector<string> stubTriplets[N_SEED];
+
+    for (unsigned int iSeed = N_SEED_PROMPT; iSeed < N_SEED; iSeed++) {
+      int layerdisk1 = settings_.seedlayers(0, iSeed);
+      int layerdisk2 = settings_.seedlayers(1, iSeed);
+      int layerdisk3 = settings_.seedlayers(2, iSeed);
+
+      unsigned int nallstub1 = settings_.nallstubs(layerdisk1);
+      unsigned int nallstub2 = settings_.nallstubs(layerdisk2);
+      unsigned int nallstub3 = settings_.nallstubs(layerdisk3);
+
+      unsigned int nvm1 = settings_.nvmte(0, iSeed);
+      unsigned int nvm2 = settings_.nvmte(1, iSeed);
+      unsigned int nvm3 = settings_.nvmte(2, iSeed);
+
+      int count = 0;
+      for (unsigned int ireg1 = 0; ireg1 < nallstub1; ireg1++) {
+        for (unsigned int ireg2 = 0; ireg2 < nallstub2; ireg2++) {
+          for (unsigned int ireg3 = 0; ireg3 < nallstub3; ireg3++) {
+            count++;
+            memories << "StubTriplets: "
+                     << STName(layerdisk1, ireg1, layerdisk2, ireg2, layerdisk3, ireg3, iSeed, count) << " [18]"
+                     << std::endl;
+            stubTriplets[iSeed].push_back(
+                STName(layerdisk1, ireg1, layerdisk2, ireg2, layerdisk3, ireg3, iSeed, count));
+          }
+        }
+      }
+
+      for (unsigned int ireg1 = 0; ireg1 < nallstub1; ireg1++) {
+        for (unsigned int ivm1 = 0; ivm1 < nvm1; ivm1++) {
+          for (unsigned int ireg2 = 0; ireg2 < nallstub2; ireg2++) {
+            for (unsigned int ivm2 = 0; ivm2 < nvm2; ivm2++) {
+              int count = 0;
+
+              modules << "TrackletEngineDisplaced: "
+                      << TEDName(layerdisk1, ireg1, ireg1 * nvm1 + ivm1, layerdisk2, ireg2, ireg2 * nvm2 + ivm2, iSeed)
+                      << std::endl;
+
+              for (unsigned int ireg3 = 0; ireg3 < nallstub3; ireg3++) {
+                for (unsigned int ivm3 = 0; ivm3 < nvm3; ivm3++) {
+                  count++;
+
+                  memories << "StubPairsDisplaced: "
+                           << SPDName(layerdisk1,
+                                      ireg1,
+                                      ireg1 * nvm1 + ivm1,
+                                      layerdisk2,
+                                      ireg2,
+                                      ireg2 * nvm2 + ivm2,
+                                      layerdisk3,
+                                      ireg3,
+                                      ireg3 * nvm3 + ivm3,
+                                      iSeed)
+                           << " [12]" << std::endl;
+
+                  modules << "TripletEngine: " << TREName(layerdisk1, ireg1, layerdisk2, ireg2, iSeed, count)
+                          << std::endl;
+
+                  wires << SPDName(layerdisk1,
+                                   ireg1,
+                                   ireg1 * nvm1 + ivm1,
+                                   layerdisk2,
+                                   ireg2,
+                                   ireg2 * nvm2 + ivm2,
+                                   layerdisk3,
+                                   ireg3,
+                                   ireg3 * nvm3 + ivm3,
+                                   iSeed)
+                        << " input=> "
+                        << TEDName(
+                               layerdisk1, ireg1, ireg1 * nvm1 + ivm1, layerdisk2, ireg2, ireg2 * nvm2 + ivm2, iSeed)
+                        << ".stubpairout output=> " << TREName(layerdisk1, ireg1, layerdisk2, ireg2, iSeed, count)
+                        << ".stubpair"
+                        << "1"
+                        << "in" << std::endl;
+                }
+              }
+            }
+          }
+        }
+      }
+
+      unsigned int nTC = 10;
+      for (unsigned int itc = 0; itc < nTC; itc++) {
+        for (int iproj = 0; iproj < 4; iproj++) {
+          int ilay = settings_.projlayers(iSeed, iproj);
+          if (ilay > 0) {
+            unsigned int nallstub = settings_.nallstubs(ilay - 1);
+            for (unsigned int ireg = 0; ireg < nallstub; ireg++) {
+              memories << "TrackletProjections: " << TPROJName(layerdisk1, layerdisk2, layerdisk3, itc, ilay - 1, ireg)
+                       << " [54]" << std::endl;
+            }
+          }
+
+          int idisk = settings_.projdisks(iSeed, iproj);
+          if (idisk > 0) {
+            unsigned int nallstub = settings_.nallstubs(idisk + 5);
+            for (unsigned int ireg = 0; ireg < nallstub; ireg++) {
+              memories << "TrackletProjections: " << TPROJName(layerdisk1, layerdisk2, layerdisk3, itc, idisk + 5, ireg)
+                       << " [54]" << std::endl;
+
+              wires << TPROJName(layerdisk1, layerdisk2, layerdisk3, itc, idisk + 5, ireg) << " input=> "
+                    << TCDName(layerdisk1, layerdisk2, layerdisk3, itc) << ".projout" << LayerName(idisk + 1) << "PHI"
+                    << iTCStr(ireg) << " output=> "
+                    << "PR_" << LayerName(idisk + 1) << "PHI" << iTCStr(ireg) << ".projin" << std::endl;
+            }
+          }
+        }
+
+        memories << "TrackletParameters: " << TParName(layerdisk1, layerdisk2, layerdisk3, itc) << " [56]" << std::endl;
+
+        modules << "TrackletCalculatorDisplaced: " << TCDName(layerdisk1, layerdisk2, layerdisk3, itc) << std::endl;
+      }
+
+      unsigned int nST = stubTriplets[iSeed].size();
+      for (unsigned int iST = 0; iST < nST; iST++) {
+        unsigned int iTC = (iST * nTC) / nST;
+        assert(iTC < nTC);
+        string stname = stubTriplets[iSeed][iST];
+        string trename = "TRE_" + stname.substr(3, 6) + "_";
+        unsigned int stlen = stname.size();
+        if (stname[stlen - 2] == '_')
+          trename += stname.substr(stlen - 1, 1);
+        if (stname[stlen - 3] == '_')
+          trename += stname.substr(stlen - 2, 2);
+        wires << stname << " input=> " << trename << ".stubtripout output=> "
+              << TCDName(layerdisk1, layerdisk2, layerdisk3, iTC) << ".stubtriplet" << ((iST * nTC) % nST) << "in"
+              << std::endl;
+      }
+
+      modules << "FitTrack: " << FTName(layerdisk1, layerdisk2, layerdisk3) << std::endl;
+    }
+  }
+
+  void TrackletConfigBuilder::writeAPMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
+    // The AllProjection memories (e.g. AP_L2PHIA) contain the intercept point of the projection to
+    // a layer. Each is written by one PR module of similar name (e.g. PR_L2PHIA), and read by
+    // a MC (e.g. MC_L2PHIA).
+
+    if (combinedmodules_)
+      return;
+
+    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+      for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
+        memories << "AllProj: AP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " [56]" << std::endl;
+        modules << "ProjectionRouter: PR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+
+        os << "AP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> PR_" << LayerName(ilayer) << "PHI"
+           << iTCStr(iReg) << ".allprojout output=> MC_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allprojin"
            << std::endl;
       }
     }
   }
-}
 
-std::string TrackletConfigBuilder::SPName(unsigned int l1,
-                                          unsigned int ireg1,
-                                          unsigned int ivm1,
-                                          unsigned int l2,
-                                          unsigned int ireg2,
-                                          unsigned int ivm2,
-                                          unsigned int iseed) const {
-  return "SP_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
-         iRegStr(ireg2, iseed) + numStr(ivm2);
-}
+  void TrackletConfigBuilder::writeCMMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
+    // The CandidateMatch memory (e.g. CM_L1PHIA1) are each written by ME module of similar name
+    // (e.g. ME_L1PHIA1) and contain indices of matching (tracklet projections,stubs) in the specified
+    // VM region.
+    // All CM memories in a given phi region (e.g. L1PHIA) are read by a MC module (e.g. MC_L1PHIA) that
+    // does more precise matching.
 
-std::string TrackletConfigBuilder::SPDName(unsigned int l1,
-                                           unsigned int ireg1,
-                                           unsigned int ivm1,
-                                           unsigned int l2,
-                                           unsigned int ireg2,
-                                           unsigned int ivm2,
-                                           unsigned int l3,
-                                           unsigned int ireg3,
-                                           unsigned int ivm3,
-                                           unsigned int iseed) const {
-  return "SPD_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
-         iRegStr(ireg2, iseed) + numStr(ivm2) + "_" + LayerName(l3) + "PHI" + iRegStr(ireg3, iseed) + numStr(ivm3);
-}
+    if (combinedmodules_)
+      return;
 
-std::string TrackletConfigBuilder::TEName(unsigned int l1,
-                                          unsigned int ireg1,
-                                          unsigned int ivm1,
-                                          unsigned int l2,
-                                          unsigned int ireg2,
-                                          unsigned int ivm2,
-                                          unsigned int iseed) const {
-  return "TE_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
-         iRegStr(ireg2, iseed) + numStr(ivm2);
-}
+    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+      for (unsigned int iME = 0; iME < NVMME_[ilayer] * NRegions_[ilayer]; iME++) {
+        memories << "CandidateMatch: CM_" << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1
+                 << " [12]" << std::endl;
+        modules << "MatchEngine: ME_" << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1
+                << std::endl;
 
-std::string TrackletConfigBuilder::TEDName(unsigned int l1,
-                                           unsigned int ireg1,
-                                           unsigned int ivm1,
-                                           unsigned int l2,
-                                           unsigned int ireg2,
-                                           unsigned int ivm2,
-                                           unsigned int iseed) const {
-  return "TED_" + LayerName(l1) + "PHI" + iRegStr(ireg1, iseed) + numStr(ivm1) + "_" + LayerName(l2) + "PHI" +
-         iRegStr(ireg2, iseed) + numStr(ivm2);
-}
-
-std::string TrackletConfigBuilder::TParName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc) const {
-  return "TPAR_" + LayerName(l1) + LayerName(l2) + LayerName(l3) + iTCStr(itc);
-}
-
-std::string TrackletConfigBuilder::TCDName(unsigned int l1, unsigned int l2, unsigned int l3, unsigned int itc) const {
-  return "TCD_" + LayerName(l1) + LayerName(l2) + LayerName(l3) + iTCStr(itc);
-}
-
-std::string TrackletConfigBuilder::TPROJName(unsigned int l1,
-                                             unsigned int l2,
-                                             unsigned int l3,
-                                             unsigned int itc,
-                                             unsigned int projlayer,
-                                             unsigned int projreg) const {
-  return "TPROJ_" + LayerName(l1) + LayerName(l2) + LayerName(l3) + iTCStr(itc) + "_" + LayerName(projlayer) + "PHI" +
-         iTCStr(projreg);
-}
-
-std::string TrackletConfigBuilder::FTName(unsigned int l1, unsigned int l2, unsigned int l3) const {
-  return "FT_" + LayerName(l1) + LayerName(l2) + LayerName(l3);
-}
-
-std::string TrackletConfigBuilder::TREName(unsigned int l1,
-                                           unsigned int ireg1,
-                                           unsigned int l2,
-                                           unsigned int ireg2,
-                                           unsigned int iseed,
-                                           unsigned int count) const {
-  return "TRE_" + LayerName(l1) + iRegStr(ireg1, iseed) + LayerName(l2) + iRegStr(ireg2, iseed) + "_" + numStr(count);
-}
-
-std::string TrackletConfigBuilder::STName(unsigned int l1,
-                                          unsigned int ireg1,
-                                          unsigned int l2,
-                                          unsigned int ireg2,
-                                          unsigned int l3,
-                                          unsigned int ireg3,
-                                          unsigned int iseed,
-                                          unsigned int count) const {
-  return "ST_" + LayerName(l1) + iRegStr(ireg1, iseed) + LayerName(l2) + iRegStr(ireg2, iseed) + "_" + LayerName(l3) +
-         iRegStr(ireg3, iseed) + "_" + numStr(count);
-}
-
-void TrackletConfigBuilder::writeSPMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
-  // Each TE reads one VM in two seed layers, finds stub pairs & writes to a StubPair ("SP") memory.
-  //
-  // Each TC reads several StubPair (SP) memories, each containing a pair of VMs of two seeding layers.
-  // Several TC are created for each layer pair, and the SP distributed between them.
-  // If TC name is TC_L1L2C, "C" indicates this is the 3rd TC in L1L2.
-
-  if (combinedmodules_)
-    return;
-
-  for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-    for (unsigned int iTC = 0; iTC < TC_[iSeed].size(); iTC++) {
-      for (unsigned int iTE = 0; iTE < TC_[iSeed][iTC].size(); iTE++) {
-        unsigned int theTE = TC_[iSeed][iTC][iTE];
-
-        unsigned int TE1 = TE_[iSeed][theTE].first;
-        unsigned int TE2 = TE_[iSeed][theTE].second;
-
-        unsigned int l1 = seedLayers(iSeed).first;
-        unsigned int l2 = seedLayers(iSeed).second;
-
-        memories << "StubPairs: "
-                 << SPName(l1, TE1 / NVMTE_[iSeed].first, TE1, l2, TE2 / NVMTE_[iSeed].second, TE2, iSeed) << " [12]"
-                 << std::endl;
-        modules << "TrackletEngine: "
-                << TEName(l1, TE1 / NVMTE_[iSeed].first, TE1, l2, TE2 / NVMTE_[iSeed].second, TE2, iSeed) << std::endl;
-
-        os << SPName(l1, TE1 / NVMTE_[iSeed].first, TE1, l2, TE2 / NVMTE_[iSeed].second, TE2, iSeed) << " input=> "
-           << TEName(l1, TE1 / NVMTE_[iSeed].first, TE1, l2, TE2 / NVMTE_[iSeed].second, TE2, iSeed)
-           << ".stubpairout output=> " << TCName(iSeed, iTC) << ".stubpairin" << std::endl;
+        os << "CM_" << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1 << " input=> ME_"
+           << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1 << ".matchout output=> MC_"
+           << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << ".matchin" << std::endl;
       }
     }
   }
-}
 
-void TrackletConfigBuilder::writeSPDMemories(std::ostream& wires, std::ostream& memories, std::ostream& modules) {
-  // Similar to writeSPMemories, but for displaced (=extended) tracking,
-  // with seeds based on triplets of layers.
+  void TrackletConfigBuilder::writeVMPROJMemories(std::ostream& os, std::ostream& memories, std::ostream&) {
+    // The VMPROJ memories (e.g. VMPROJ_L2PHIA1) written by a PR module each correspond to projections to
+    // a single VM region in a layer. Each is filled by the PR using all projections (TPROJ) to this VM
+    // from different seeding layers.
+    //
+    // Each VMPROJ memory is read by a ME module, which matches the projection to stubs.
 
-  if (!extended_)
-    return;
+    if (combinedmodules_)
+      return;
 
-  vector<string> stubTriplets[N_SEED];
+    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+      for (unsigned int iME = 0; iME < NVMME_[ilayer] * NRegions_[ilayer]; iME++) {
+        memories << "VMProjections: VMPROJ_" << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1
+                 << " [13]" << std::endl;
 
-  for (unsigned int iSeed = N_SEED_PROMPT; iSeed < N_SEED; iSeed++) {
-    int layerdisk1 = settings_.seedlayers(0, iSeed);
-    int layerdisk2 = settings_.seedlayers(1, iSeed);
-    int layerdisk3 = settings_.seedlayers(2, iSeed);
-
-    unsigned int nallstub1 = settings_.nallstubs(layerdisk1);
-    unsigned int nallstub2 = settings_.nallstubs(layerdisk2);
-    unsigned int nallstub3 = settings_.nallstubs(layerdisk3);
-
-    unsigned int nvm1 = settings_.nvmte(0, iSeed);
-    unsigned int nvm2 = settings_.nvmte(1, iSeed);
-    unsigned int nvm3 = settings_.nvmte(2, iSeed);
-
-    int count = 0;
-    for (unsigned int ireg1 = 0; ireg1 < nallstub1; ireg1++) {
-      for (unsigned int ireg2 = 0; ireg2 < nallstub2; ireg2++) {
-        for (unsigned int ireg3 = 0; ireg3 < nallstub3; ireg3++) {
-          count++;
-          memories << "StubTriplets: " << STName(layerdisk1, ireg1, layerdisk2, ireg2, layerdisk3, ireg3, iSeed, count)
-                   << " [18]" << std::endl;
-          stubTriplets[iSeed].push_back(STName(layerdisk1, ireg1, layerdisk2, ireg2, layerdisk3, ireg3, iSeed, count));
-        }
+        os << "VMPROJ_" << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1 << " input=> PR_"
+           << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << ".vmprojout"
+           << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1 << " output=> ME_" << LayerName(ilayer) << "PHI"
+           << iTCStr(iME / NVMME_[ilayer]) << iME + 1 << ".vmprojin" << std::endl;
       }
     }
+  }
 
-    for (unsigned int ireg1 = 0; ireg1 < nallstub1; ireg1++) {
-      for (unsigned int ivm1 = 0; ivm1 < nvm1; ivm1++) {
-        for (unsigned int ireg2 = 0; ireg2 < nallstub2; ireg2++) {
-          for (unsigned int ivm2 = 0; ivm2 < nvm2; ivm2++) {
-            int count = 0;
+  void TrackletConfigBuilder::writeFMMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
+    // All FullMatch (e.g. FM_L2L3_L1PHIA) memories corresponding to a matches between stubs & tracklets
+    // in a given region (e.g. L1PHIA) from all seeding layers, are written by a MC module (e.g. MC_L1PHIA).
+    //
+    // All FullMatch memories corresponding to a given seed pair are read by the TrackBuilder (e.g. FT_L1L2),
+    // which checks if the track has stubs in enough layers.
 
-            modules << "TrackletEngineDisplaced: "
-                    << TEDName(layerdisk1, ireg1, ireg1 * nvm1 + ivm1, layerdisk2, ireg2, ireg2 * nvm2 + ivm2, iSeed)
-                    << std::endl;
-
-            for (unsigned int ireg3 = 0; ireg3 < nallstub3; ireg3++) {
-              for (unsigned int ivm3 = 0; ivm3 < nvm3; ivm3++) {
-                count++;
-
-                memories << "StubPairsDisplaced: "
-                         << SPDName(layerdisk1,
-                                    ireg1,
-                                    ireg1 * nvm1 + ivm1,
-                                    layerdisk2,
-                                    ireg2,
-                                    ireg2 * nvm2 + ivm2,
-                                    layerdisk3,
-                                    ireg3,
-                                    ireg3 * nvm3 + ivm3,
-                                    iSeed)
-                         << " [12]" << std::endl;
-
-                modules << "TripletEngine: " << TREName(layerdisk1, ireg1, layerdisk2, ireg2, iSeed, count)
-                        << std::endl;
-
-                wires << SPDName(layerdisk1,
-                                 ireg1,
-                                 ireg1 * nvm1 + ivm1,
-                                 layerdisk2,
-                                 ireg2,
-                                 ireg2 * nvm2 + ivm2,
-                                 layerdisk3,
-                                 ireg3,
-                                 ireg3 * nvm3 + ivm3,
-                                 iSeed)
-                      << " input=> "
-                      << TEDName(layerdisk1, ireg1, ireg1 * nvm1 + ivm1, layerdisk2, ireg2, ireg2 * nvm2 + ivm2, iSeed)
-                      << ".stubpairout output=> " << TREName(layerdisk1, ireg1, layerdisk2, ireg2, iSeed, count)
-                      << ".stubpair"
-                      << "1"
-                      << "in" << std::endl;
-              }
-            }
+    if (combinedmodules_) {
+      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+        for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
+          modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+            if (matchport_[iSeed][ilayer] == -1)
+              continue;
+            memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
+                     << " [36]" << std::endl;
+            os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
+               << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
+               << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
+          }
+        }
+      }
+    } else {
+      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+        for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
+          modules << "MatchCalculator: MC_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+            if (matchport_[iSeed][ilayer] == -1)
+              continue;
+            memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
+                     << " [36]" << std::endl;
+            os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MC_"
+               << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
+               << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
           }
         }
       }
     }
+  }
 
-    unsigned int nTC = 10;
-    for (unsigned int itc = 0; itc < nTC; itc++) {
-      for (int iproj = 0; iproj < 4; iproj++) {
-        int ilay = settings_.projlayers(iSeed, iproj);
-        if (ilay > 0) {
-          unsigned int nallstub = settings_.nallstubs(ilay - 1);
-          for (unsigned int ireg = 0; ireg < nallstub; ireg++) {
-            memories << "TrackletProjections: " << TPROJName(layerdisk1, layerdisk2, layerdisk3, itc, ilay - 1, ireg)
-                     << " [54]" << std::endl;
+  void TrackletConfigBuilder::writeASMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
+    // Each VMR writes AllStub memories (AS) for a single phi region (e.g. PHIC),
+    // merging data from all DTCs related to this phi region. It does so by merging data from
+    // the IL memories written by all IRs for this phi region. The wiring map lists all
+    // IL memories that feed (">") into a single VMR ("VMR_L1PHIC") that writes to the
+    // an AS memory ("AS_L1PHIC").
+    // Multiple copies of each AS memory exist where several modules in chain want to read it.
+
+    if (combinedmodules_) {
+      //First write AS memories used by MatchProcessor
+      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+        for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
+          memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+                   << " [42]" << std::endl;
+          if (combinedmodules_) {
+            modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          } else {
+            modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
           }
-        }
-
-        int idisk = settings_.projdisks(iSeed, iproj);
-        if (idisk > 0) {
-          unsigned int nallstub = settings_.nallstubs(idisk + 5);
-          for (unsigned int ireg = 0; ireg < nallstub; ireg++) {
-            memories << "TrackletProjections: " << TPROJName(layerdisk1, layerdisk2, layerdisk3, itc, idisk + 5, ireg)
-                     << " [54]" << std::endl;
-
-            wires << TPROJName(layerdisk1, layerdisk2, layerdisk3, itc, idisk + 5, ireg) << " input=> "
-                  << TCDName(layerdisk1, layerdisk2, layerdisk3, itc) << ".projout" << LayerName(idisk + 1) << "PHI"
-                  << iTCStr(ireg) << " output=> "
-                  << "PR_" << LayerName(idisk + 1) << "PHI" << iTCStr(ireg) << ".projin" << std::endl;
-          }
+          os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
+             << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
         }
       }
 
-      memories << "TrackletParameters: " << TParName(layerdisk1, layerdisk2, layerdisk3, itc) << " [56]" << std::endl;
+      //Next write AS memories used by TrackletProcessor
+      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+        for (int iReg = 0; iReg < (int)NRegions_[ilayer]; iReg++) {
+          unsigned int nmem = 1;
 
-      modules << "TrackletCalculatorDisplaced: " << TCDName(layerdisk1, layerdisk2, layerdisk3, itc) << std::endl;
-    }
+          for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+            unsigned int l1 = seedLayers(iSeed).first;
+            unsigned int l2 = seedLayers(iSeed).second;
 
-    unsigned int nST = stubTriplets[iSeed].size();
-    for (unsigned int iST = 0; iST < nST; iST++) {
-      unsigned int iTC = (iST * nTC) / nST;
-      assert(iTC < nTC);
-      string stname = stubTriplets[iSeed][iST];
-      string trename = "TRE_" + stname.substr(3, 6) + "_";
-      unsigned int stlen = stname.size();
-      if (stname[stlen - 2] == '_')
-        trename += stname.substr(stlen - 1, 1);
-      if (stname[stlen - 3] == '_')
-        trename += stname.substr(stlen - 2, 2);
-      wires << stname << " input=> " << trename << ".stubtripout output=> "
-            << TCDName(layerdisk1, layerdisk2, layerdisk3, iTC) << ".stubtriplet" << ((iST * nTC) % nST) << "in"
-            << std::endl;
-    }
+            if (ilayer != l1 && ilayer != l2)
+              continue;
 
-    modules << "FitTrack: " << FTName(layerdisk1, layerdisk2, layerdisk3) << std::endl;
-  }
-}
+            bool inner = ilayer == l1;
 
-void TrackletConfigBuilder::writeAPMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
-  // The AllProjection memories (e.g. AP_L2PHIA) contain the intercept point of the projection to
-  // a layer. Each is written by one PR module of similar name (e.g. PR_L2PHIA), and read by
-  // a MC (e.g. MC_L2PHIA).
+            for (unsigned int iTC = 0; iTC < TC_[iSeed].size(); iTC++) {
+              int nTCReg = TC_[iSeed].size() / NRegions_[l2];
 
-  if (combinedmodules_)
-    return;
+              int iTCReg = iTC / nTCReg;
 
-  for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-    for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-      memories << "AllProj: AP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " [56]" << std::endl;
-      modules << "ProjectionRouter: PR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+              int jTCReg = iTC % nTCReg;
 
-      os << "AP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> PR_" << LayerName(ilayer) << "PHI"
-         << iTCStr(iReg) << ".allprojout output=> MC_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allprojin"
-         << std::endl;
-    }
-  }
-}
-
-void TrackletConfigBuilder::writeCMMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
-  // The CandidateMatch memory (e.g. CM_L1PHIA1) are each written by ME module of similar name
-  // (e.g. ME_L1PHIA1) and contain indices of matching (tracklet projections,stubs) in the specified
-  // VM region.
-  // All CM memories in a given phi region (e.g. L1PHIA) are read by a MC module (e.g. MC_L1PHIA) that
-  // does more precise matching.
-
-  if (combinedmodules_)
-    return;
-
-  for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-    for (unsigned int iME = 0; iME < NVMME_[ilayer] * NRegions_[ilayer]; iME++) {
-      memories << "CandidateMatch: CM_" << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1
-               << " [12]" << std::endl;
-      modules << "MatchEngine: ME_" << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1
-              << std::endl;
-
-      os << "CM_" << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1 << " input=> ME_"
-         << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1 << ".matchout output=> MC_"
-         << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << ".matchin" << std::endl;
-    }
-  }
-}
-
-void TrackletConfigBuilder::writeVMPROJMemories(std::ostream& os, std::ostream& memories, std::ostream&) {
-  // The VMPROJ memories (e.g. VMPROJ_L2PHIA1) written by a PR module each correspond to projections to
-  // a single VM region in a layer. Each is filled by the PR using all projections (TPROJ) to this VM
-  // from different seeding layers.
-  //
-  // Each VMPROJ memory is read by a ME module, which matches the projection to stubs.
-
-  if (combinedmodules_)
-    return;
-
-  for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-    for (unsigned int iME = 0; iME < NVMME_[ilayer] * NRegions_[ilayer]; iME++) {
-      memories << "VMProjections: VMPROJ_" << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1
-               << " [13]" << std::endl;
-
-      os << "VMPROJ_" << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1 << " input=> PR_"
-         << LayerName(ilayer) << "PHI" << iTCStr(iME / NVMME_[ilayer]) << ".vmprojout"
-         << "PHI" << iTCStr(iME / NVMME_[ilayer]) << iME + 1 << " output=> ME_" << LayerName(ilayer) << "PHI"
-         << iTCStr(iME / NVMME_[ilayer]) << iME + 1 << ".vmprojin" << std::endl;
-    }
-  }
-}
-
-void TrackletConfigBuilder::writeFMMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
-  // All FullMatch (e.g. FM_L2L3_L1PHIA) memories corresponding to a matches between stubs & tracklets
-  // in a given region (e.g. L1PHIA) from all seeding layers, are written by a MC module (e.g. MC_L1PHIA).
-  //
-  // All FullMatch memories corresponding to a given seed pair are read by the TrackBuilder (e.g. FT_L1L2),
-  // which checks if the track has stubs in enough layers.
-
-  if (combinedmodules_) {
-    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-      for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-        for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-          if (matchport_[iSeed][ilayer] == -1)
-            continue;
-          memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
-                   << " [36]" << std::endl;
-          os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
-             << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
-             << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
-        }
-      }
-    }
-  } else {
-    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-      for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        modules << "MatchCalculator: MC_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-        for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-          if (matchport_[iSeed][ilayer] == -1)
-            continue;
-          memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
-                   << " [36]" << std::endl;
-          os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MC_"
-             << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
-             << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
-        }
-      }
-    }
-  }
-}
-
-void TrackletConfigBuilder::writeASMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
-  // Each VMR writes AllStub memories (AS) for a single phi region (e.g. PHIC),
-  // merging data from all DTCs related to this phi region. It does so by merging data from
-  // the IL memories written by all IRs for this phi region. The wiring map lists all
-  // IL memories that feed (">") into a single VMR ("VMR_L1PHIC") that writes to the
-  // an AS memory ("AS_L1PHIC").
-  // Multiple copies of each AS memory exist where several modules in chain want to read it.
-
-  if (combinedmodules_) {
-    //First write AS memories used by MatchProcessor
-    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-      for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-                 << " [42]" << std::endl;
-        if (combinedmodules_) {
-          modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-        } else {
-          modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-        }
-        os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-           << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
-           << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
-      }
-    }
-
-    //Next write AS memories used by TrackletProcessor
-    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-      for (int iReg = 0; iReg < (int)NRegions_[ilayer]; iReg++) {
-        unsigned int nmem = 1;
-
-        for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-          unsigned int l1 = seedLayers(iSeed).first;
-          unsigned int l2 = seedLayers(iSeed).second;
-
-          if (ilayer != l1 && ilayer != l2)
-            continue;
-
-          bool inner = ilayer == l1;
-
-          for (unsigned int iTC = 0; iTC < TC_[iSeed].size(); iTC++) {
-            int nTCReg = TC_[iSeed].size() / NRegions_[l2];
-
-            int iTCReg = iTC / nTCReg;
-
-            int jTCReg = iTC % nTCReg;
-
-            if (ilayer == l2) {
-              if (iTCReg != iReg)
-                continue;
-            }
-
-            string ext = "";
-
-            if (ilayer == l1) {
-              int ratio = NRegions_[l1] / NRegions_[l2];
-              int min = iTCReg * ratio - 1 + jTCReg;
-              int max = (iTCReg + 1) * ratio - (nTCReg - jTCReg - 1);
-              if ((int)iReg < min || (int)iReg > max)
-                continue;
-
-              if (max - min >= 2) {
-                ext = "M";
-                if (iReg == min)
-                  ext = "R";
-                if (iReg == max)
-                  ext = "L";
+              if (ilayer == l2) {
+                if (iTCReg != iReg)
+                  continue;
               }
 
-              if (max - min == 1) {
-                if (nTCReg == 2) {
-                  assert(0);
-                  if (jTCReg == 0) {
-                    if (iReg == min)
-                      ext = "R";
-                    if (iReg == max)
-                      ext = "B";
-                  }
-                  if (jTCReg == 1) {
-                    if (iReg == min)
-                      ext = "A";
-                    if (iReg == max)
-                      ext = "L";
-                  }
-                }
-                if (nTCReg == 3) {
-                  if (jTCReg == 0) {
-                    if (iReg == min)
-                      ext = "A";
-                    if (iReg == max)
-                      ext = "F";
-                  }
-                  if (jTCReg == 1) {
-                    if (iReg == min)
-                      ext = "E";
-                    if (iReg == max)
-                      ext = "D";
-                  }
-                  if (jTCReg == 2) {
-                    if (iReg == min)
-                      ext = "C";
-                    if (iReg == max)
-                      ext = "B";
-                  }
-                }
-              }
-              assert(!ext.empty());
-            }
+              string ext = "";
 
-            if (ext.empty()) {
-              ext = "_" + LayerName(l1) + iTCStr(iTC);
-            }
-
-            if (iSeed < 4) {  //Barrel seeding
-              ext = "_B" + ext;
-            } else if (iSeed > 5) {
-              ext = "_O" + ext;
-            } else {
-              ext = "_D" + ext;
-            }
-
-            nmem++;
-            if (inner) {
-              memories << "AllInnerStubs: ";
-            } else {
-              memories << "AllStubs: ";
-            }
-            memories << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ext << " [42]" << std::endl;
-            os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ext << " input=> VMR_" << LayerName(ilayer)
-               << "PHI" << iTCStr(iReg) << ".all" << (inner ? "inner" : "") << "stubout output=> TP_" << iSeedStr(iSeed)
-               << iTCStr(iTC);
-            if (inner) {
-              os << ".innerallstubin" << std::endl;
-            } else {
-              os << ".outerallstubin" << std::endl;
-            }
-          }
-        }
-      }
-    }
-
-  } else {
-    //First write AS memories used by MatchCalculator
-    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-      for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-                 << " [42]" << std::endl;
-        if (combinedmodules_) {
-          modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-        } else {
-          modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-        }
-        os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-           << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MC_"
-           << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
-      }
-    }
-
-    //Next write AS memories used by TrackletCalculator
-    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-      for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        unsigned int nmem = 1;
-
-        for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-          unsigned int l1 = seedLayers(iSeed).first;
-          unsigned int l2 = seedLayers(iSeed).second;
-
-          if (ilayer != l1 && ilayer != l2)
-            continue;
-
-          for (unsigned int iTC = 0; iTC < TC_[iSeed].size(); iTC++) {
-            bool used = false;
-            // Each TC processes data from several TEs.
-            for (unsigned int iTE = 0; iTE < TC_[iSeed][iTC].size(); iTE++) {
-              unsigned int theTE = TC_[iSeed][iTC][iTE];
-
-              unsigned int TE1 = TE_[iSeed][theTE].first;  // VM in inner/outer layer of this TE.
-              unsigned int TE2 = TE_[iSeed][theTE].second;
-
-              if (l1 == ilayer && iReg == TE1 / NVMTE_[iSeed].first)
-                used = true;
-              if (l2 == ilayer && iReg == TE2 / NVMTE_[iSeed].second)
-                used = true;
-            }
-
-            if (used) {
-              nmem++;  // Another copy of memory
-              memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n" << nmem << " [42]"
-                       << std::endl;
-              os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n" << nmem << " input=> VMR_"
-                 << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> TC_" << iSeedStr(iSeed)
-                 << iTCStr(iTC);
               if (ilayer == l1) {
+                int ratio = NRegions_[l1] / NRegions_[l2];
+                int min = iTCReg * ratio - 1 + jTCReg;
+                int max = (iTCReg + 1) * ratio - (nTCReg - jTCReg - 1);
+                if ((int)iReg < min || (int)iReg > max)
+                  continue;
+
+                if (max - min >= 2) {
+                  ext = "M";
+                  if (iReg == min)
+                    ext = "R";
+                  if (iReg == max)
+                    ext = "L";
+                }
+
+                if (max - min == 1) {
+                  if (nTCReg == 2) {
+                    assert(0);
+                    if (jTCReg == 0) {
+                      if (iReg == min)
+                        ext = "R";
+                      if (iReg == max)
+                        ext = "B";
+                    }
+                    if (jTCReg == 1) {
+                      if (iReg == min)
+                        ext = "A";
+                      if (iReg == max)
+                        ext = "L";
+                    }
+                  }
+                  if (nTCReg == 3) {
+                    if (jTCReg == 0) {
+                      if (iReg == min)
+                        ext = "A";
+                      if (iReg == max)
+                        ext = "F";
+                    }
+                    if (jTCReg == 1) {
+                      if (iReg == min)
+                        ext = "E";
+                      if (iReg == max)
+                        ext = "D";
+                    }
+                    if (jTCReg == 2) {
+                      if (iReg == min)
+                        ext = "C";
+                      if (iReg == max)
+                        ext = "B";
+                    }
+                  }
+                }
+                assert(!ext.empty());
+              }
+
+              if (ext.empty()) {
+                ext = "_" + LayerName(l1) + iTCStr(iTC);
+              }
+
+              if (iSeed < 4) {  //Barrel seeding
+                ext = "_B" + ext;
+              } else if (iSeed > 5) {
+                ext = "_O" + ext;
+              } else {
+                ext = "_D" + ext;
+              }
+
+              nmem++;
+              if (inner) {
+                memories << "AllInnerStubs: ";
+              } else {
+                memories << "AllStubs: ";
+              }
+              memories << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ext << " [42]" << std::endl;
+              os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ext << " input=> VMR_" << LayerName(ilayer)
+                 << "PHI" << iTCStr(iReg) << ".all" << (inner ? "inner" : "") << "stubout output=> TP_"
+                 << iSeedStr(iSeed) << iTCStr(iTC);
+              if (inner) {
                 os << ".innerallstubin" << std::endl;
               } else {
                 os << ".outerallstubin" << std::endl;
@@ -1099,228 +1045,290 @@ void TrackletConfigBuilder::writeASMemories(std::ostream& os, std::ostream& memo
           }
         }
       }
-    }
-  }
-}
 
-void TrackletConfigBuilder::writeVMSMemories(std::ostream& os, std::ostream& memories, std::ostream&) {
-  // Each VMR writes to Virtual Module memories ("VMS") to be used later by the ME or TE etc.
-  // Memory VMSTE_L1PHIC9-12 is the memory for small phi region C in L1 for the TE module.
-  // Numbers 9-12 correspond to the 4 VMs in this phi region.
-  //
-  // Each TE reads one VMS memory in each seeding layer.
-
-  if (combinedmodules_) {
-    //First write VMS memories used by MatchProcessor
-    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-      for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
-        os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-           << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
-           << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
-      }
-    }
-
-    //Next write VMS memories used by TrackletProcessor
-    for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-      //FIXME - code could be cleaner
-      unsigned int l1 = seedLayers(iSeed).first;
-      unsigned int l2 = seedLayers(iSeed).second;
-
-      unsigned int ilayer = seedLayers(iSeed).second;
-
-      //for(unsigned int iReg=0;iReg<NRegions_[ilayer];iReg++){
-
-      unsigned int nTCReg = TC_[iSeed].size() / NRegions_[l2];
-
-      for (unsigned int iReg = 0; iReg < NRegions_[l2]; iReg++) {
-        unsigned int nmem = 0;
-        //Hack since we use same module twice
-        if (iSeed == Seed::L2D1) {
-          nmem = 2;
-        }
-
-        for (unsigned iTC = 0; iTC < nTCReg; iTC++) {
-          nmem++;
-          memories << "VMStubsTE: VMSTE_" << LayerName(ilayer) << "PHI" << iRegStr(iReg, iSeed) << "n" << nmem
-                   << " [18]" << std::endl;
-          os << "VMSTE_" << LayerName(ilayer) << "PHI" << iRegStr(iReg, iSeed) << "n" << nmem << " input=> VMR_"
-             << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubout_seed_" << iSeed << " output=> TP_"
-             << LayerName(l1) << LayerName(l2) << iTCStr(iReg * nTCReg + iTC) << ".outervmstubin" << std::endl;
-        }
-      }
-    }
-
-  } else {
-    //First write VMS memories used by MatchEngine
-    for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
-      for (unsigned int iVMME = 0; iVMME < NVMME_[ilayer] * NRegions_[ilayer]; iVMME++) {
-        unsigned int iReg = iVMME / NVMME_[ilayer];
-        memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << iVMME + 1 << "n1 [18]"
-                 << std::endl;
-        os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << iVMME + 1 << "n1"
-           << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutMEPHI" << iTCStr(iReg)
-           << iVMME + 1 << " output=> ME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << iVMME + 1 << ".vmstubin"
-           << std::endl;
-      }
-    }
-
-    // Next write VMS memories used by TrackletEngine
-    // Each TE processes one VM region in inner + outer seeding layers, and needs its own copy of input memories.
-    for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-      for (unsigned int innerouterseed = 0; innerouterseed < 2; innerouterseed++) {
-        //FIXME - code could be cleaner
-        unsigned int l1 = seedLayers(iSeed).first;
-        unsigned int l2 = seedLayers(iSeed).second;
-
-        unsigned int NVMTE1 = NVMTE_[iSeed].first;
-        unsigned int NVMTE2 = NVMTE_[iSeed].second;
-
-        unsigned int ilayer = l1;
-        unsigned int NVMTE = NVMTE1;
-        if (innerouterseed == 1) {
-          ilayer = l2;
-          NVMTE = NVMTE2;
-        }
-
-        for (unsigned int iVMTE = 0; iVMTE < NVMTE * NRegions_[ilayer]; iVMTE++) {
-          unsigned int iReg = iVMTE / NVMTE;
-
-          unsigned int nmem = 0;
-
-          if (iSeed == Seed::L2D1) {
-            nmem = 4;
+    } else {
+      //First write AS memories used by MatchCalculator
+      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+        for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
+          memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+                   << " [42]" << std::endl;
+          if (combinedmodules_) {
+            modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          } else {
+            modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
           }
+          os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MC_"
+             << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
+        }
+      }
 
-          for (unsigned int iTE = 0; iTE < TE_[iSeed].size(); iTE++) {
-            unsigned int TE1 = TE_[iSeed][iTE].first;  // VM region in inner/outer layer of this TE
-            unsigned int TE2 = TE_[iSeed][iTE].second;
+      //Next write AS memories used by TrackletCalculator
+      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+        for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
+          unsigned int nmem = 1;
 
-            bool used = false;
+          for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+            unsigned int l1 = seedLayers(iSeed).first;
+            unsigned int l2 = seedLayers(iSeed).second;
 
-            if (innerouterseed == 0 && iVMTE == TE1)
-              used = true;
-            if (innerouterseed == 1 && iVMTE == TE2)
-              used = true;
-
-            if (!used)
+            if (ilayer != l1 && ilayer != l2)
               continue;
 
-            string inorout = "I";
-            if (innerouterseed == 1)
-              inorout = "O";
+            for (unsigned int iTC = 0; iTC < TC_[iSeed].size(); iTC++) {
+              bool used = false;
+              // Each TC processes data from several TEs.
+              for (unsigned int iTE = 0; iTE < TC_[iSeed][iTC].size(); iTE++) {
+                unsigned int theTE = TC_[iSeed][iTC][iTE];
 
-            nmem++;  // Add another copy of memory.
-            memories << "VMStubsTE: VMSTE_" << LayerName(ilayer) << "PHI" << iRegStr(iReg, iSeed) << iVMTE + 1 << "n"
-                     << nmem << " [18]" << std::endl;
-            os << "VMSTE_" << LayerName(ilayer) << "PHI" << iRegStr(iReg, iSeed) << iVMTE + 1 << "n" << nmem
-               << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutTE" << inorout << "PHI"
-               << iRegStr(iReg, iSeed) << iVMTE + 1 << " output=> TE_" << LayerName(l1) << "PHI"
-               << iRegStr(TE1 / NVMTE1, iSeed) << TE1 + 1 << "_" << LayerName(l2) << "PHI"
-               << iRegStr(TE2 / NVMTE2, iSeed) << TE2 + 1;
-            if (innerouterseed == 0) {
-              os << ".innervmstubin" << std::endl;
-            } else {
-              os << ".outervmstubin" << std::endl;
+                unsigned int TE1 = TE_[iSeed][theTE].first;  // VM in inner/outer layer of this TE.
+                unsigned int TE2 = TE_[iSeed][theTE].second;
+
+                if (l1 == ilayer && iReg == TE1 / NVMTE_[iSeed].first)
+                  used = true;
+                if (l2 == ilayer && iReg == TE2 / NVMTE_[iSeed].second)
+                  used = true;
+              }
+
+              if (used) {
+                nmem++;  // Another copy of memory
+                memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n" << nmem << " [42]"
+                         << std::endl;
+                os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n" << nmem << " input=> VMR_"
+                   << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> TC_" << iSeedStr(iSeed)
+                   << iTCStr(iTC);
+                if (ilayer == l1) {
+                  os << ".innerallstubin" << std::endl;
+                } else {
+                  os << ".outerallstubin" << std::endl;
+                }
+              }
             }
           }
         }
       }
     }
   }
-}
 
-void TrackletConfigBuilder::writeTPARMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
-  // Each TC module (e.g. TC_L1L2A) stores helix params in a single TPAR memory of similar name
-  // (e.g. TPAR_L1L2A). The TPAR is subsequently read by the TrackBuilder (FT).
+  void TrackletConfigBuilder::writeVMSMemories(std::ostream& os, std::ostream& memories, std::ostream&) {
+    // Each VMR writes to Virtual Module memories ("VMS") to be used later by the ME or TE etc.
+    // Memory VMSTE_L1PHIC9-12 is the memory for small phi region C in L1 for the TE module.
+    // Numbers 9-12 correspond to the 4 VMs in this phi region.
+    //
+    // Each TE reads one VMS memory in each seeding layer.
 
-  if (combinedmodules_) {
+    if (combinedmodules_) {
+      //First write VMS memories used by MatchProcessor
+      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+        for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
+          memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
+          os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
+             << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
+        }
+      }
+
+      //Next write VMS memories used by TrackletProcessor
+      for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+        //FIXME - code could be cleaner
+        unsigned int l1 = seedLayers(iSeed).first;
+        unsigned int l2 = seedLayers(iSeed).second;
+
+        unsigned int ilayer = seedLayers(iSeed).second;
+
+        //for(unsigned int iReg=0;iReg<NRegions_[ilayer];iReg++){
+
+        unsigned int nTCReg = TC_[iSeed].size() / NRegions_[l2];
+
+        for (unsigned int iReg = 0; iReg < NRegions_[l2]; iReg++) {
+          unsigned int nmem = 0;
+          //Hack since we use same module twice
+          if (iSeed == Seed::L2D1) {
+            nmem = 2;
+          }
+
+          for (unsigned iTC = 0; iTC < nTCReg; iTC++) {
+            nmem++;
+            memories << "VMStubsTE: VMSTE_" << LayerName(ilayer) << "PHI" << iRegStr(iReg, iSeed) << "n" << nmem
+                     << " [18]" << std::endl;
+            os << "VMSTE_" << LayerName(ilayer) << "PHI" << iRegStr(iReg, iSeed) << "n" << nmem << " input=> VMR_"
+               << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubout_seed_" << iSeed << " output=> TP_"
+               << LayerName(l1) << LayerName(l2) << iTCStr(iReg * nTCReg + iTC) << ".outervmstubin" << std::endl;
+          }
+        }
+      }
+
+    } else {
+      //First write VMS memories used by MatchEngine
+      for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
+        for (unsigned int iVMME = 0; iVMME < NVMME_[ilayer] * NRegions_[ilayer]; iVMME++) {
+          unsigned int iReg = iVMME / NVMME_[ilayer];
+          memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << iVMME + 1 << "n1 [18]"
+                   << std::endl;
+          os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << iVMME + 1 << "n1"
+             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutMEPHI" << iTCStr(iReg)
+             << iVMME + 1 << " output=> ME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << iVMME + 1 << ".vmstubin"
+             << std::endl;
+        }
+      }
+
+      // Next write VMS memories used by TrackletEngine
+      // Each TE processes one VM region in inner + outer seeding layers, and needs its own copy of input memories.
+      for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+        for (unsigned int innerouterseed = 0; innerouterseed < 2; innerouterseed++) {
+          //FIXME - code could be cleaner
+          unsigned int l1 = seedLayers(iSeed).first;
+          unsigned int l2 = seedLayers(iSeed).second;
+
+          unsigned int NVMTE1 = NVMTE_[iSeed].first;
+          unsigned int NVMTE2 = NVMTE_[iSeed].second;
+
+          unsigned int ilayer = l1;
+          unsigned int NVMTE = NVMTE1;
+          if (innerouterseed == 1) {
+            ilayer = l2;
+            NVMTE = NVMTE2;
+          }
+
+          for (unsigned int iVMTE = 0; iVMTE < NVMTE * NRegions_[ilayer]; iVMTE++) {
+            unsigned int iReg = iVMTE / NVMTE;
+
+            unsigned int nmem = 0;
+
+            if (iSeed == Seed::L2D1) {
+              nmem = 4;
+            }
+
+            for (unsigned int iTE = 0; iTE < TE_[iSeed].size(); iTE++) {
+              unsigned int TE1 = TE_[iSeed][iTE].first;  // VM region in inner/outer layer of this TE
+              unsigned int TE2 = TE_[iSeed][iTE].second;
+
+              bool used = false;
+
+              if (innerouterseed == 0 && iVMTE == TE1)
+                used = true;
+              if (innerouterseed == 1 && iVMTE == TE2)
+                used = true;
+
+              if (!used)
+                continue;
+
+              string inorout = "I";
+              if (innerouterseed == 1)
+                inorout = "O";
+
+              nmem++;  // Add another copy of memory.
+              memories << "VMStubsTE: VMSTE_" << LayerName(ilayer) << "PHI" << iRegStr(iReg, iSeed) << iVMTE + 1 << "n"
+                       << nmem << " [18]" << std::endl;
+              os << "VMSTE_" << LayerName(ilayer) << "PHI" << iRegStr(iReg, iSeed) << iVMTE + 1 << "n" << nmem
+                 << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutTE" << inorout << "PHI"
+                 << iRegStr(iReg, iSeed) << iVMTE + 1 << " output=> TE_" << LayerName(l1) << "PHI"
+                 << iRegStr(TE1 / NVMTE1, iSeed) << TE1 + 1 << "_" << LayerName(l2) << "PHI"
+                 << iRegStr(TE2 / NVMTE2, iSeed) << TE2 + 1;
+              if (innerouterseed == 0) {
+                os << ".innervmstubin" << std::endl;
+              } else {
+                os << ".outervmstubin" << std::endl;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void TrackletConfigBuilder::writeTPARMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
+    // Each TC module (e.g. TC_L1L2A) stores helix params in a single TPAR memory of similar name
+    // (e.g. TPAR_L1L2A). The TPAR is subsequently read by the TrackBuilder (FT).
+
+    if (combinedmodules_) {
+      for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+        for (unsigned int iTP = 0; iTP < TC_[iSeed].size(); iTP++) {
+          memories << "TrackletParameters: TPAR_" << iSeedStr(iSeed) << iTCStr(iTP) << " [56]" << std::endl;
+          modules << "TrackletProcessor: TP_" << iSeedStr(iSeed) << iTCStr(iTP) << std::endl;
+          os << "TPAR_" << iSeedStr(iSeed) << iTCStr(iTP) << " input=> TP_" << iSeedStr(iSeed) << iTCStr(iTP)
+             << ".trackpar output=> FT_" << iSeedStr(iSeed) << ".tparin" << std::endl;
+        }
+      }
+    } else {
+      for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+        for (unsigned int iTC = 0; iTC < TC_[iSeed].size(); iTC++) {
+          memories << "TrackletParameters: TPAR_" << iSeedStr(iSeed) << iTCStr(iTC) << " [56]" << std::endl;
+          modules << "TrackletCalculator: TC_" << iSeedStr(iSeed) << iTCStr(iTC) << std::endl;
+          os << "TPAR_" << iSeedStr(iSeed) << iTCStr(iTC) << " input=> TC_" << iSeedStr(iSeed) << iTCStr(iTC)
+             << ".trackpar output=> FT_" << iSeedStr(iSeed) << ".tparin" << std::endl;
+        }
+      }
+    }
+  }
+
+  void TrackletConfigBuilder::writeTFMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
     for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-      for (unsigned int iTP = 0; iTP < TC_[iSeed].size(); iTP++) {
-        memories << "TrackletParameters: TPAR_" << iSeedStr(iSeed) << iTCStr(iTP) << " [56]" << std::endl;
-        modules << "TrackletProcessor: TP_" << iSeedStr(iSeed) << iTCStr(iTP) << std::endl;
-        os << "TPAR_" << iSeedStr(iSeed) << iTCStr(iTP) << " input=> TP_" << iSeedStr(iSeed) << iTCStr(iTP)
-           << ".trackpar output=> FT_" << iSeedStr(iSeed) << ".tparin" << std::endl;
-      }
+      memories << "TrackFit: TF_" << iSeedStr(iSeed) << " [126]" << std::endl;
+      modules << "FitTrack: FT_" << iSeedStr(iSeed) << std::endl;
+      os << "TF_" << iSeedStr(iSeed) << " input=> FT_" << iSeedStr(iSeed) << ".trackout output=> PD.trackin"
+         << std::endl;
     }
-  } else {
+  }
+
+  void TrackletConfigBuilder::writeCTMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
+    modules << "PurgeDuplicate: PD" << std::endl;
+
     for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-      for (unsigned int iTC = 0; iTC < TC_[iSeed].size(); iTC++) {
-        memories << "TrackletParameters: TPAR_" << iSeedStr(iSeed) << iTCStr(iTC) << " [56]" << std::endl;
-        modules << "TrackletCalculator: TC_" << iSeedStr(iSeed) << iTCStr(iTC) << std::endl;
-        os << "TPAR_" << iSeedStr(iSeed) << iTCStr(iTC) << " input=> TC_" << iSeedStr(iSeed) << iTCStr(iTC)
-           << ".trackpar output=> FT_" << iSeedStr(iSeed) << ".tparin" << std::endl;
-      }
+      memories << "CleanTrack: CT_" << iSeedStr(iSeed) << " [126]" << std::endl;
+      os << "CT_" << iSeedStr(iSeed) << " input=> PD.trackout output=>" << std::endl;
     }
   }
-}
 
-void TrackletConfigBuilder::writeTFMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
-  for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-    memories << "TrackFit: TF_" << iSeedStr(iSeed) << " [126]" << std::endl;
-    modules << "FitTrack: FT_" << iSeedStr(iSeed) << std::endl;
-    os << "TF_" << iSeedStr(iSeed) << " input=> FT_" << iSeedStr(iSeed) << ".trackout output=> PD.trackin" << std::endl;
-  }
-}
+  void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
+    // Each Input Router (IR) reads stubs from one DTC (e.g. PS10G_1) & sends them
+    // to 4-8 InputLink (IL) memories (labelled PHIA-PHIH), each corresponding to a small
+    // phi region of a nonant, for each tracklet layer (L1-L6 or D1-D5) that the DTC
+    // reads. The InputLink memories have names such as IL_L1PHIC_PS10G_1 to reflect this.
 
-void TrackletConfigBuilder::writeCTMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
-  modules << "PurgeDuplicate: PD" << std::endl;
-
-  for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-    memories << "CleanTrack: CT_" << iSeedStr(iSeed) << " [126]" << std::endl;
-    os << "CT_" << iSeedStr(iSeed) << " input=> PD.trackout output=>" << std::endl;
-  }
-}
-
-void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memories, std::ostream& modules) {
-  // Each Input Router (IR) reads stubs from one DTC (e.g. PS10G_1) & sends them
-  // to 4-8 InputLink (IL) memories (labelled PHIA-PHIH), each corresponding to a small
-  // phi region of a nonant, for each tracklet layer (L1-L6 or D1-D5) that the DTC
-  // reads. The InputLink memories have names such as IL_L1PHIC_PS10G_1 to reflect this.
-
-  string olddtc = "";
-  for (const DTCinfo& info : vecDTCinfo_) {
-    string dtcname = info.name;
-    if (olddtc != dtcname) {
-      // Write one entry per DTC, with each DTC connected to one IR.
-      modules << "InputRouter: IR_" << dtcname << "_A" << std::endl;
-      modules << "InputRouter: IR_" << dtcname << "_B" << std::endl;
-      memories << "DTCLink: DL_" << dtcname << "_A [36]" << std::endl;
-      memories << "DTCLink: DL_" << dtcname << "_B [36]" << std::endl;
-      os << "DL_" << dtcname << "_A"
-         << " input=> output=> IR_" << dtcname << "_A.stubin" << std::endl;
-      os << "DL_" << dtcname << "_B"
-         << " input=> output=> IR_" << dtcname << "_B.stubin" << std::endl;
+    string olddtc = "";
+    for (const DTCinfo& info : vecDTCinfo_) {
+      string dtcname = info.name;
+      if (olddtc != dtcname) {
+        // Write one entry per DTC, with each DTC connected to one IR.
+        modules << "InputRouter: IR_" << dtcname << "_A" << std::endl;
+        modules << "InputRouter: IR_" << dtcname << "_B" << std::endl;
+        memories << "DTCLink: DL_" << dtcname << "_A [36]" << std::endl;
+        memories << "DTCLink: DL_" << dtcname << "_B [36]" << std::endl;
+        os << "DL_" << dtcname << "_A"
+           << " input=> output=> IR_" << dtcname << "_A.stubin" << std::endl;
+        os << "DL_" << dtcname << "_B"
+           << " input=> output=> IR_" << dtcname << "_B.stubin" << std::endl;
+      }
+      olddtc = dtcname;
     }
-    olddtc = dtcname;
-  }
 
-  for (const DTCinfo& info : vecDTCinfo_) {
-    string dtcname = info.name;
-    int layerdisk = info.layer;
+    for (const DTCinfo& info : vecDTCinfo_) {
+      string dtcname = info.name;
+      int layerdisk = info.layer;
 
-    for (unsigned int iReg = 0; iReg < NRegions_[layerdisk]; iReg++) {
-      //--- Ian Tomalin's proposed bug fix
-      double phiminDTC_A = info.phimin - M_PI / N_SECTOR;  // Phi range of each DTC.
-      double phimaxDTC_A = info.phimax - M_PI / N_SECTOR;
-      double phiminDTC_B = info.phimin + M_PI / N_SECTOR;  // Phi range of each DTC.
-      double phimaxDTC_B = info.phimax + M_PI / N_SECTOR;
-      if (allStubs_[layerdisk][iReg].second > phiminDTC_A && allStubs_[layerdisk][iReg].first < phimaxDTC_A) {
-        memories << "InputLink: IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_A"
-                 << " [36]" << std::endl;
-        os << "IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_A"
-           << " input=> IR_" << dtcname << "_A.stubout output=> VMR_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg)
-           << ".stubin" << std::endl;
-      }
-      if (allStubs_[layerdisk][iReg].second > phiminDTC_B && allStubs_[layerdisk][iReg].first < phimaxDTC_B) {
-        memories << "InputLink: IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_B"
-                 << " [36]" << std::endl;
-        os << "IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_B"
-           << " input=> IR_" << dtcname << "_B.stubout output=> VMR_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg)
-           << ".stubin" << std::endl;
-      }
-      //--- Original (buggy) code
-      /*
+      for (unsigned int iReg = 0; iReg < NRegions_[layerdisk]; iReg++) {
+        //--- Ian Tomalin's proposed bug fix
+        double phiminDTC_A = info.phimin - M_PI / N_SECTOR;  // Phi range of each DTC.
+        double phimaxDTC_A = info.phimax - M_PI / N_SECTOR;
+        double phiminDTC_B = info.phimin + M_PI / N_SECTOR;  // Phi range of each DTC.
+        double phimaxDTC_B = info.phimax + M_PI / N_SECTOR;
+        if (allStubs_[layerdisk][iReg].second > phiminDTC_A && allStubs_[layerdisk][iReg].first < phimaxDTC_A) {
+          memories << "InputLink: IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_A"
+                   << " [36]" << std::endl;
+          os << "IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_A"
+             << " input=> IR_" << dtcname << "_A.stubout output=> VMR_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg)
+             << ".stubin" << std::endl;
+        }
+        if (allStubs_[layerdisk][iReg].second > phiminDTC_B && allStubs_[layerdisk][iReg].first < phimaxDTC_B) {
+          memories << "InputLink: IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_B"
+                   << " [36]" << std::endl;
+          os << "IL_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg) << "_" << dtcname << "_B"
+             << " input=> IR_" << dtcname << "_B.stubout output=> VMR_" << LayerName(layerdisk) << "PHI" << iTCStr(iReg)
+             << ".stubin" << std::endl;
+        }
+        //--- Original (buggy) code
+        /*
       double phiminDTC = info.phimin; // Phi range of each DTC.
       double phimaxDTC = info.phimax;
 
@@ -1344,26 +1352,26 @@ void TrackletConfigBuilder::writeILMemories(std::ostream& os, std::ostream& memo
            << iTCStr(iReg) << ".stubin" << std::endl;
       }
 */
+      }
     }
   }
-}
 
-//--- Fill streams used to write wiring map to file
+  //--- Fill streams used to write wiring map to file
 
-void TrackletConfigBuilder::writeAll(std::ostream& wires, std::ostream& memories, std::ostream& modules) {
-  writeILMemories(wires, memories, modules);
-  writeASMemories(wires, memories, modules);
-  writeVMSMemories(wires, memories, modules);
-  writeSPMemories(wires, memories, modules);
-  writeSPDMemories(wires, memories, modules);
-  writeProjectionMemories(wires, memories, modules);
-  writeTPARMemories(wires, memories, modules);
-  writeVMPROJMemories(wires, memories, modules);
-  writeAPMemories(wires, memories, modules);
-  writeCMMemories(wires, memories, modules);
-  writeFMMemories(wires, memories, modules);
-  writeTFMemories(wires, memories, modules);
-  writeCTMemories(wires, memories, modules);
-}
+  void TrackletConfigBuilder::writeAll(std::ostream& wires, std::ostream& memories, std::ostream& modules) {
+    writeILMemories(wires, memories, modules);
+    writeASMemories(wires, memories, modules);
+    writeVMSMemories(wires, memories, modules);
+    writeSPMemories(wires, memories, modules);
+    writeSPDMemories(wires, memories, modules);
+    writeProjectionMemories(wires, memories, modules);
+    writeTPARMemories(wires, memories, modules);
+    writeVMPROJMemories(wires, memories, modules);
+    writeAPMemories(wires, memories, modules);
+    writeCMMemories(wires, memories, modules);
+    writeFMMemories(wires, memories, modules);
+    writeTFMemories(wires, memories, modules);
+    writeCTMemories(wires, memories, modules);
+  }
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -17,7 +17,8 @@
 #endif
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletConfigBuilder::TrackletConfigBuilder(const Settings& settings, const tt::Setup* setup) : settings_(settings) {
   NSector_ = N_SECTOR;
@@ -1363,4 +1364,6 @@ void TrackletConfigBuilder::writeAll(std::ostream& wires, std::ostream& memories
   writeFMMemories(wires, memories, modules);
   writeTFMemories(wires, memories, modules);
   writeCTMemories(wires, memories, modules);
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngine.cc
@@ -14,192 +14,160 @@ using namespace std;
 
 namespace trklet {
 
-TrackletEngine::TrackletEngine(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global), innerptlut_(settings), outerptlut_(settings) {
-  stubpairs_ = nullptr;
-  innervmstubs_ = nullptr;
-  outervmstubs_ = nullptr;
+  TrackletEngine::TrackletEngine(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global), innerptlut_(settings), outerptlut_(settings) {
+    stubpairs_ = nullptr;
+    innervmstubs_ = nullptr;
+    outervmstubs_ = nullptr;
 
-  initLayerDisksandISeed(layerdisk1_, layerdisk2_, iSeed_);
+    initLayerDisksandISeed(layerdisk1_, layerdisk2_, iSeed_);
 
-  innerphibits_ = settings.nfinephi(0, iSeed_);
-  outerphibits_ = settings.nfinephi(1, iSeed_);
-}
-
-void TrackletEngine::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
+    innerphibits_ = settings.nfinephi(0, iSeed_);
+    outerphibits_ = settings.nfinephi(1, iSeed_);
   }
-  if (output == "stubpairout") {
-    StubPairsMemory* tmp = dynamic_cast<StubPairsMemory*>(memory);
-    assert(tmp != nullptr);
-    stubpairs_ = tmp;
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
-}
 
-void TrackletEngine::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input == "innervmstubin") {
-    VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
-    assert(tmp != nullptr);
-    innervmstubs_ = tmp;
-    setVMPhiBin();
-    return;
-  }
-  if (input == "outervmstubin") {
-    VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
-    assert(tmp != nullptr);
-    outervmstubs_ = tmp;
-    setVMPhiBin();
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
-}
-
-void TrackletEngine::execute() {
-  if (!settings_.useSeed(iSeed_))
-    return;
-
-  unsigned int countall = 0;
-  unsigned int countpass = 0;
-
-  assert(innervmstubs_ != nullptr);
-  assert(outervmstubs_ != nullptr);
-
-  for (unsigned int i = 0; i < innervmstubs_->nVMStubs(); i++) {
-    const VMStubTE& innervmstub = innervmstubs_->getVMStubTE(i);
-    FPGAWord lookupbits = innervmstub.vmbits();
-
-    unsigned int nbits = 7;
-    if (iSeed_ == 4 || iSeed_ == 5)
-      nbits = 6;
-    int rzdiffmax = lookupbits.bits(nbits, lookupbits.nbits() - nbits);
-    int rzbinfirst = lookupbits.bits(0, 3);
-    int start = lookupbits.bits(4, nbits - 4);
-    int next = lookupbits.bits(3, 1);
-
-    if ((iSeed_ == 4 || iSeed_ == 5) && innervmstub.stub()->disk().value() < 0) {  //TODO - need to store negative disk
-      start += 4;
+  void TrackletEngine::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
     }
-    int last = start + next;
+    if (output == "stubpairout") {
+      StubPairsMemory* tmp = dynamic_cast<StubPairsMemory*>(memory);
+      assert(tmp != nullptr);
+      stubpairs_ = tmp;
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
+  }
 
-    for (int ibin = start; ibin <= last; ibin++) {
-      for (unsigned int j = 0; j < outervmstubs_->nVMStubsBinned(ibin); j++) {
-        if (countall >= settings_.maxStep("TE"))
-          break;
-        countall++;
-        const VMStubTE& outervmstub = outervmstubs_->getVMStubTEBinned(ibin, j);
+  void TrackletEngine::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input == "innervmstubin") {
+      VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
+      assert(tmp != nullptr);
+      innervmstubs_ = tmp;
+      setVMPhiBin();
+      return;
+    }
+    if (input == "outervmstubin") {
+      VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
+      assert(tmp != nullptr);
+      outervmstubs_ = tmp;
+      setVMPhiBin();
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
+  }
 
-        int rzbin = outervmstub.vmbits().bits(0, N_RZBITS);
+  void TrackletEngine::execute() {
+    if (!settings_.useSeed(iSeed_))
+      return;
 
-        FPGAWord iphiinnerbin = innervmstub.finephi();
-        FPGAWord iphiouterbin = outervmstub.finephi();
+    unsigned int countall = 0;
+    unsigned int countpass = 0;
 
-        unsigned int index = (iphiinnerbin.value() << outerphibits_) + iphiouterbin.value();
+    assert(innervmstubs_ != nullptr);
+    assert(outervmstubs_ != nullptr);
 
-        if (iSeed_ >= 4) {  //Also use r-position
+    for (unsigned int i = 0; i < innervmstubs_->nVMStubs(); i++) {
+      const VMStubTE& innervmstub = innervmstubs_->getVMStubTE(i);
+      FPGAWord lookupbits = innervmstub.vmbits();
 
-          int nrbits = 3;                          // Number of bits used for r position in disk LUT
-          int ibinmask = (1 << (nrbits - 1)) - 1;  // Mask of two least significant bits
+      unsigned int nbits = 7;
+      if (iSeed_ == 4 || iSeed_ == 5)
+        nbits = 6;
+      int rzdiffmax = lookupbits.bits(nbits, lookupbits.nbits() - nbits);
+      int rzbinfirst = lookupbits.bits(0, 3);
+      int start = lookupbits.bits(4, nbits - 4);
+      int next = lookupbits.bits(3, 1);
 
-          int ir = ((ibin & ibinmask) << 1) + (rzbin >> (N_RZBITS - 1));
-          index += (ir << (outerphibits_ + innerphibits_));
-        }
+      if ((iSeed_ == 4 || iSeed_ == 5) &&
+          innervmstub.stub()->disk().value() < 0) {  //TODO - need to store negative disk
+        start += 4;
+      }
+      int last = start + next;
 
-        if (start != ibin)
-          rzbin += (1 << N_RZBITS);
-        if ((rzbin < rzbinfirst) || (rzbin - rzbinfirst > rzdiffmax)) {
-          continue;
-        }
+      for (int ibin = start; ibin <= last; ibin++) {
+        for (unsigned int j = 0; j < outervmstubs_->nVMStubsBinned(ibin); j++) {
+          if (countall >= settings_.maxStep("TE"))
+            break;
+          countall++;
+          const VMStubTE& outervmstub = outervmstubs_->getVMStubTEBinned(ibin, j);
 
-        FPGAWord innerbend = innervmstub.bend();
-        FPGAWord outerbend = outervmstub.bend();
+          int rzbin = outervmstub.vmbits().bits(0, N_RZBITS);
 
-        int ptinnerindex = (index << innerbend.nbits()) + innerbend.value();
-        int ptouterindex = (index << outerbend.nbits()) + outerbend.value();
+          FPGAWord iphiinnerbin = innervmstub.finephi();
+          FPGAWord iphiouterbin = outervmstub.finephi();
 
-        if (!(innerptlut_.lookup(ptinnerindex) && outerptlut_.lookup(ptouterindex))) {
-          if (settings_.debugTracklet()) {
-            edm::LogVerbatim("Tracklet") << "Stub pair rejected because of stub pt cut bends : "
-                                         << settings_.benddecode(
-                                                innervmstub.bend().value(), layerdisk1_, innervmstub.isPSmodule())
-                                         << " "
-                                         << settings_.benddecode(
-                                                outervmstub.bend().value(), layerdisk2_, outervmstub.isPSmodule());
+          unsigned int index = (iphiinnerbin.value() << outerphibits_) + iphiouterbin.value();
+
+          if (iSeed_ >= 4) {  //Also use r-position
+
+            int nrbits = 3;                          // Number of bits used for r position in disk LUT
+            int ibinmask = (1 << (nrbits - 1)) - 1;  // Mask of two least significant bits
+
+            int ir = ((ibin & ibinmask) << 1) + (rzbin >> (N_RZBITS - 1));
+            index += (ir << (outerphibits_ + innerphibits_));
           }
-          continue;
+
+          if (start != ibin)
+            rzbin += (1 << N_RZBITS);
+          if ((rzbin < rzbinfirst) || (rzbin - rzbinfirst > rzdiffmax)) {
+            continue;
+          }
+
+          FPGAWord innerbend = innervmstub.bend();
+          FPGAWord outerbend = outervmstub.bend();
+
+          int ptinnerindex = (index << innerbend.nbits()) + innerbend.value();
+          int ptouterindex = (index << outerbend.nbits()) + outerbend.value();
+
+          if (!(innerptlut_.lookup(ptinnerindex) && outerptlut_.lookup(ptouterindex))) {
+            if (settings_.debugTracklet()) {
+              edm::LogVerbatim("Tracklet")
+                  << "Stub pair rejected because of stub pt cut bends : "
+                  << settings_.benddecode(innervmstub.bend().value(), layerdisk1_, innervmstub.isPSmodule()) << " "
+                  << settings_.benddecode(outervmstub.bend().value(), layerdisk2_, outervmstub.isPSmodule());
+            }
+            continue;
+          }
+
+          if (settings_.debugTracklet())
+            edm::LogVerbatim("Tracklet") << "Adding stub pair in " << getName();
+
+          assert(stubpairs_ != nullptr);
+          stubpairs_->addStubPair(innervmstub, outervmstub);
+          countpass++;
         }
-
-        if (settings_.debugTracklet())
-          edm::LogVerbatim("Tracklet") << "Adding stub pair in " << getName();
-
-        assert(stubpairs_ != nullptr);
-        stubpairs_->addStubPair(innervmstub, outervmstub);
-        countpass++;
       }
     }
+
+    if (settings_.writeMonitorData("TE")) {
+      globals_->ofstream("trackletengine.txt") << getName() << " " << countall << " " << countpass << endl;
+    }
   }
 
-  if (settings_.writeMonitorData("TE")) {
-    globals_->ofstream("trackletengine.txt") << getName() << " " << countall << " " << countpass << endl;
-  }
-}
+  void TrackletEngine::setVMPhiBin() {
+    if (innervmstubs_ == nullptr || outervmstubs_ == nullptr)
+      return;
 
-void TrackletEngine::setVMPhiBin() {
-  if (innervmstubs_ == nullptr || outervmstubs_ == nullptr)
-    return;
+    innervmstubs_->setother(outervmstubs_);
+    outervmstubs_->setother(innervmstubs_);
 
-  innervmstubs_->setother(outervmstubs_);
-  outervmstubs_->setother(innervmstubs_);
+    double innerphimin, innerphimax;
+    innervmstubs_->getPhiRange(innerphimin, innerphimax, iSeed_, 0);
 
-  double innerphimin, innerphimax;
-  innervmstubs_->getPhiRange(innerphimin, innerphimax, iSeed_, 0);
+    double outerphimin, outerphimax;
+    outervmstubs_->getPhiRange(outerphimin, outerphimax, iSeed_, 1);
 
-  double outerphimin, outerphimax;
-  outervmstubs_->getPhiRange(outerphimin, outerphimax, iSeed_, 1);
+    string innermem = innervmstubs_->getName().substr(6);
+    string outermem = outervmstubs_->getName().substr(6);
 
-  string innermem = innervmstubs_->getName().substr(6);
-  string outermem = outervmstubs_->getName().substr(6);
-
-  innerptlut_.initteptlut(true,
-                          false,
-                          iSeed_,
-                          layerdisk1_,
-                          layerdisk2_,
-                          innerphibits_,
-                          outerphibits_,
-                          innerphimin,
-                          innerphimax,
-                          outerphimin,
-                          outerphimax,
-                          innermem,
-                          outermem);
-
-  outerptlut_.initteptlut(false,
-                          false,
-                          iSeed_,
-                          layerdisk1_,
-                          layerdisk2_,
-                          innerphibits_,
-                          outerphibits_,
-                          innerphimin,
-                          innerphimax,
-                          outerphimin,
-                          outerphimax,
-                          innermem,
-                          outermem);
-
-  TrackletLUT innertememlut(settings_);
-  TrackletLUT outertememlut(settings_);
-
-  innertememlut.initteptlut(true,
-                            true,
+    innerptlut_.initteptlut(true,
+                            false,
                             iSeed_,
                             layerdisk1_,
                             layerdisk2_,
@@ -212,8 +180,8 @@ void TrackletEngine::setVMPhiBin() {
                             innermem,
                             outermem);
 
-  outertememlut.initteptlut(false,
-                            true,
+    outerptlut_.initteptlut(false,
+                            false,
                             iSeed_,
                             layerdisk1_,
                             layerdisk2_,
@@ -226,8 +194,39 @@ void TrackletEngine::setVMPhiBin() {
                             innermem,
                             outermem);
 
-  innervmstubs_->setbendtable(innertememlut);
-  outervmstubs_->setbendtable(outertememlut);
-}
+    TrackletLUT innertememlut(settings_);
+    TrackletLUT outertememlut(settings_);
 
-}
+    innertememlut.initteptlut(true,
+                              true,
+                              iSeed_,
+                              layerdisk1_,
+                              layerdisk2_,
+                              innerphibits_,
+                              outerphibits_,
+                              innerphimin,
+                              innerphimax,
+                              outerphimin,
+                              outerphimax,
+                              innermem,
+                              outermem);
+
+    outertememlut.initteptlut(false,
+                              true,
+                              iSeed_,
+                              layerdisk1_,
+                              layerdisk2_,
+                              innerphibits_,
+                              outerphibits_,
+                              innerphimin,
+                              innerphimax,
+                              outerphimin,
+                              outerphimax,
+                              innermem,
+                              outermem);
+
+    innervmstubs_->setbendtable(innertememlut);
+    outervmstubs_->setbendtable(outertememlut);
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngine.cc
@@ -10,8 +10,9 @@
 
 #include <filesystem>
 
-using namespace trklet;
 using namespace std;
+
+namespace trklet {
 
 TrackletEngine::TrackletEngine(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global), innerptlut_(settings), outerptlut_(settings) {
@@ -227,4 +228,6 @@ void TrackletEngine::setVMPhiBin() {
 
   innervmstubs_->setbendtable(innertememlut);
   outervmstubs_->setbendtable(outertememlut);
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
@@ -13,413 +13,413 @@ using namespace std;
 
 namespace trklet {
 
-TrackletEngineDisplaced::TrackletEngineDisplaced(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global) {
-  stubpairs_.clear();
-  firstvmstubs_.clear();
-  secondvmstubs_ = nullptr;
-  layer1_ = 0;
-  layer2_ = 0;
-  disk1_ = 0;
-  disk2_ = 0;
-  string name1 = name.substr(1);  //this is to correct for "TED" having one more letter then "TE"
-  if (name1[3] == 'L') {
-    layer1_ = name1[4] - '0';
-  }
-  if (name1[3] == 'D') {
-    disk1_ = name1[4] - '0';
-  }
-  if (name1[11] == 'L') {
-    layer2_ = name1[12] - '0';
-  }
-  if (name1[11] == 'D') {
-    disk2_ = name1[12] - '0';
-  }
-  if (name1[12] == 'L') {
-    layer2_ = name1[13] - '0';
-  }
-  if (name1[12] == 'D') {
-    disk2_ = name1[13] - '0';
-  }
-
-  iSeed_ = -1;
-  if (layer1_ == 3 && layer2_ == 4)
-    iSeed_ = 8;
-  if (layer1_ == 5 && layer2_ == 6)
-    iSeed_ = 9;
-  if (layer1_ == 2 && layer2_ == 3)
-    iSeed_ = 10;
-  if (disk1_ == 1 && disk2_ == 2)
-    iSeed_ = 11;
-
-  firstphibits_ = settings_.nfinephi(0, iSeed_);
-  secondphibits_ = settings_.nfinephi(1, iSeed_);
-}
-
-TrackletEngineDisplaced::~TrackletEngineDisplaced() { table_.clear(); }
-
-void TrackletEngineDisplaced::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-  if (output == "stubpairout") {
-    StubPairsMemory* tmp = dynamic_cast<StubPairsMemory*>(memory);
-    assert(tmp != nullptr);
-    stubpairs_.push_back(tmp);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
-}
-
-void TrackletEngineDisplaced::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input == "firstvmstubin") {
-    VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
-    assert(tmp != nullptr);
-    firstvmstubs_.push_back(tmp);
-    return;
-  }
-  if (input == "secondvmstubin") {
-    VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
-    assert(tmp != nullptr);
-    secondvmstubs_ = tmp;
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
-}
-
-void TrackletEngineDisplaced::execute() {
-  if (!settings_.useSeed(iSeed_))
-    return;
-
-  if (table_.empty() && (settings_.enableTripletTables() && !settings_.writeTripletTables()))
-    readTables();
-
-  unsigned int countall = 0;
-  unsigned int countpass = 0;
-  unsigned int nInnerStubs = 0;
-
-  for (unsigned int iInnerMem = 0; iInnerMem < firstvmstubs_.size();
-       nInnerStubs += firstvmstubs_.at(iInnerMem)->nVMStubs(), iInnerMem++)
-    ;
-
-  assert(!firstvmstubs_.empty());
-  assert(secondvmstubs_ != nullptr);
-
-  for (auto& iInnerMem : firstvmstubs_) {
-    assert(iInnerMem->nVMStubs() == iInnerMem->nVMStubs());
-    for (unsigned int i = 0; i < iInnerMem->nVMStubs(); i++) {
-      const VMStubTE& firstvmstub = iInnerMem->getVMStubTE(i);
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "In " << getName() << " have first stub";
-      }
-
-      if ((layer1_ == 3 && layer2_ == 4) || (layer1_ == 5 && layer2_ == 6)) {
-        int lookupbits = firstvmstub.vmbits().value() & 1023;
-        int zdiffmax = (lookupbits >> 7);
-        int newbin = (lookupbits & 127);
-        int bin = newbin / 8;
-
-        int zbinfirst = newbin & 7;
-
-        int start = (bin >> 1);
-        int last = start + (bin & 1);
-
-        assert(last < 8);
-
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last;
-        }
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int j = 0; j < secondvmstubs_->nVMStubsBinned(ibin); j++) {
-            if (settings_.debugTracklet()) {
-              edm::LogVerbatim("Tracklet") << "In " << getName() << " have second stub(1) " << ibin << " " << j;
-            }
-
-            if (countall >= settings_.maxStep("TE"))
-              break;
-            countall++;
-            const VMStubTE& secondvmstub = secondvmstubs_->getVMStubTEBinned(ibin, j);
-
-            int zbin = (secondvmstub.vmbits().value() & 7);
-            if (start != ibin)
-              zbin += 8;
-            if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
-              if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
-              }
-              continue;
-            }
-
-            assert(firstphibits_ != -1);
-            assert(secondphibits_ != -1);
-
-            FPGAWord iphifirstbin = firstvmstub.finephi();
-            FPGAWord iphisecondbin = secondvmstub.finephi();
-
-            unsigned int index = (iphifirstbin.value() << secondphibits_) + iphisecondbin.value();
-
-            FPGAWord firstbend = firstvmstub.bend();
-            FPGAWord secondbend = secondvmstub.bend();
-
-            index = (index << firstbend.nbits()) + firstbend.value();
-            index = (index << secondbend.nbits()) + secondbend.value();
-
-            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
-                (index >= table_.size() || table_.at(index).empty())) {
-              if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet")
-                    << "Stub pair rejected because of stub pt cut bends : "
-                    << settings_.benddecode(firstvmstub.bend().value(), layer1_ - 1, firstvmstub.isPSmodule()) << " "
-                    << settings_.benddecode(secondvmstub.bend().value(), layer2_ - 1, secondvmstub.isPSmodule());
-              }
-
-              //FIXME temporarily commented out until stub bend table fixed
-              //if (!settings_.writeTripletTables())
-              //  continue;
-            }
-
-            if (settings_.debugTracklet())
-              edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
-            for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if (!settings_.enableTripletTables() || settings_.writeTripletTables() || table_.at(index).count(isp)) {
-                if (settings_.writeMonitorData("Seeds")) {
-                  ofstream fout("seeds.txt", ofstream::app);
-                  fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
-                  fout.close();
-                }
-                stubpairs_.at(isp)->addStubPair(firstvmstub, secondvmstub, index, getName());
-              }
-            }
-
-            countpass++;
-          }
-        }
-
-      } else if (layer1_ == 2 && layer2_ == 3) {
-        int lookupbits = firstvmstub.vmbits().value() & 1023;
-        int zdiffmax = (lookupbits >> 7);
-        int newbin = (lookupbits & 127);
-        int bin = newbin / 8;
-
-        int zbinfirst = newbin & 7;
-
-        int start = (bin >> 1);
-        int last = start + (bin & 1);
-
-        assert(last < 8);
-
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last;
-        }
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int j = 0; j < secondvmstubs_->nVMStubsBinned(ibin); j++) {
-            if (settings_.debugTracklet()) {
-              edm::LogVerbatim("Tracklet") << "In " << getName() << " have second stub(2) ";
-            }
-
-            if (countall >= settings_.maxStep("TE"))
-              break;
-            countall++;
-
-            const VMStubTE& secondvmstub = secondvmstubs_->getVMStubTEBinned(ibin, j);
-
-            int zbin = (secondvmstub.vmbits().value() & 7);
-            if (start != ibin)
-              zbin += 8;
-            if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
-              if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
-              }
-              continue;
-            }
-
-            assert(firstphibits_ != -1);
-            assert(secondphibits_ != -1);
-
-            FPGAWord iphifirstbin = firstvmstub.finephi();
-            FPGAWord iphisecondbin = secondvmstub.finephi();
-
-            unsigned int index = (iphifirstbin.value() << secondphibits_) + iphisecondbin.value();
-
-            FPGAWord firstbend = firstvmstub.bend();
-            FPGAWord secondbend = secondvmstub.bend();
-
-            index = (index << firstbend.nbits()) + firstbend.value();
-            index = (index << secondbend.nbits()) + secondbend.value();
-
-            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
-                (index >= table_.size() || table_.at(index).empty())) {
-              if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet")
-                    << "Stub pair rejected because of stub pt cut bends : "
-                    << settings_.benddecode(firstvmstub.bend().value(), layer1_ - 1, firstvmstub.isPSmodule()) << " "
-                    << settings_.benddecode(secondvmstub.bend().value(), layer2_ - 1, secondvmstub.isPSmodule());
-              }
-              continue;
-            }
-
-            if (settings_.debugTracklet())
-              edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
-            for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) ||
-                  (index < table_.size() && table_.at(index).count(isp))) {
-                if (settings_.writeMonitorData("Seeds")) {
-                  ofstream fout("seeds.txt", ofstream::app);
-                  fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
-                  fout.close();
-                }
-                stubpairs_.at(isp)->addStubPair(firstvmstub, secondvmstub, index, getName());
-              }
-            }
-
-            countpass++;
-          }
-        }
-
-      } else if (disk1_ == 1 && disk2_ == 2) {
-        if (settings_.debugTracklet())
-          edm::LogVerbatim("Tracklet") << getName() << " Disk-disk pair";
-
-        int lookupbits = firstvmstub.vmbits().value() & 511;
-        bool negdisk = firstvmstub.stub()->disk().value() < 0;
-        int rdiffmax = (lookupbits >> 6);
-        int newbin = (lookupbits & 63);
-        int bin = newbin / 8;
-
-        int rbinfirst = newbin & 7;
-
-        int start = (bin >> 1);
-        if (negdisk)
-          start += 4;
-        int last = start + (bin & 1);
-        assert(last < 8);
-        for (int ibin = start; ibin <= last; ibin++) {
-          if (settings_.debugTracklet()) {
-            edm::LogVerbatim("Tracklet") << getName() << " looking for matching stub in " << secondvmstubs_->getName()
-                                         << " in bin = " << ibin << " with " << secondvmstubs_->nVMStubsBinned(ibin)
-                                         << " stubs";
-          }
-          for (unsigned int j = 0; j < secondvmstubs_->nVMStubsBinned(ibin); j++) {
-            if (countall >= settings_.maxStep("TE"))
-              break;
-            countall++;
-
-            const VMStubTE& secondvmstub = secondvmstubs_->getVMStubTEBinned(ibin, j);
-
-            int rbin = (secondvmstub.vmbits().value() & 7);
-            if (start != ibin)
-              rbin += 8;
-            if (rbin < rbinfirst)
-              continue;
-            if (rbin - rbinfirst > rdiffmax)
-              continue;
-
-            unsigned int irsecondbin = secondvmstub.vmbits().value() >> 2;
-
-            FPGAWord iphifirstbin = firstvmstub.finephi();
-            FPGAWord iphisecondbin = secondvmstub.finephi();
-
-            unsigned int index = (irsecondbin << (secondphibits_ + firstphibits_)) +
-                                 (iphifirstbin.value() << secondphibits_) + iphisecondbin.value();
-
-            FPGAWord firstbend = firstvmstub.bend();
-            FPGAWord secondbend = secondvmstub.bend();
-
-            index = (index << firstbend.nbits()) + firstbend.value();
-            index = (index << secondbend.nbits()) + secondbend.value();
-
-            if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
-                (index >= table_.size() || table_.at(index).empty())) {
-              if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet")
-                    << "Stub pair rejected because of stub pt cut bends : "
-                    << settings_.benddecode(firstvmstub.bend().value(), disk1_ + 5, firstvmstub.isPSmodule()) << " "
-                    << settings_.benddecode(secondvmstub.bend().value(), disk2_ + 5, secondvmstub.isPSmodule());
-              }
-              continue;
-            }
-
-            if (settings_.debugTracklet())
-              edm::LogVerbatim("Tracklet") << "Adding disk-disk pair in " << getName();
-
-            for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
-              if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) ||
-                  (index < table_.size() && table_.at(index).count(isp))) {
-                if (settings_.writeMonitorData("Seeds")) {
-                  ofstream fout("seeds.txt", ofstream::app);
-                  fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
-                  fout.close();
-                }
-                stubpairs_.at(isp)->addStubPair(firstvmstub, secondvmstub, index, getName());
-              }
-            }
-            countpass++;
-          }
-        }
-      }
+  TrackletEngineDisplaced::TrackletEngineDisplaced(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global) {
+    stubpairs_.clear();
+    firstvmstubs_.clear();
+    secondvmstubs_ = nullptr;
+    layer1_ = 0;
+    layer2_ = 0;
+    disk1_ = 0;
+    disk2_ = 0;
+    string name1 = name.substr(1);  //this is to correct for "TED" having one more letter then "TE"
+    if (name1[3] == 'L') {
+      layer1_ = name1[4] - '0';
     }
+    if (name1[3] == 'D') {
+      disk1_ = name1[4] - '0';
+    }
+    if (name1[11] == 'L') {
+      layer2_ = name1[12] - '0';
+    }
+    if (name1[11] == 'D') {
+      disk2_ = name1[12] - '0';
+    }
+    if (name1[12] == 'L') {
+      layer2_ = name1[13] - '0';
+    }
+    if (name1[12] == 'D') {
+      disk2_ = name1[13] - '0';
+    }
+
+    iSeed_ = -1;
+    if (layer1_ == 3 && layer2_ == 4)
+      iSeed_ = 8;
+    if (layer1_ == 5 && layer2_ == 6)
+      iSeed_ = 9;
+    if (layer1_ == 2 && layer2_ == 3)
+      iSeed_ = 10;
+    if (disk1_ == 1 && disk2_ == 2)
+      iSeed_ = 11;
+
+    firstphibits_ = settings_.nfinephi(0, iSeed_);
+    secondphibits_ = settings_.nfinephi(1, iSeed_);
   }
-  if (countall > 5000) {
-    edm::LogVerbatim("Tracklet") << "In TrackletEngineDisplaced::execute : " << getName() << " " << nInnerStubs << " "
-                                 << secondvmstubs_->nVMStubs() << " " << countall << " " << countpass;
+
+  TrackletEngineDisplaced::~TrackletEngineDisplaced() { table_.clear(); }
+
+  void TrackletEngineDisplaced::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
+    if (output == "stubpairout") {
+      StubPairsMemory* tmp = dynamic_cast<StubPairsMemory*>(memory);
+      assert(tmp != nullptr);
+      stubpairs_.push_back(tmp);
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
+  }
+
+  void TrackletEngineDisplaced::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input == "firstvmstubin") {
+      VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
+      assert(tmp != nullptr);
+      firstvmstubs_.push_back(tmp);
+      return;
+    }
+    if (input == "secondvmstubin") {
+      VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
+      assert(tmp != nullptr);
+      secondvmstubs_ = tmp;
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
+  }
+
+  void TrackletEngineDisplaced::execute() {
+    if (!settings_.useSeed(iSeed_))
+      return;
+
+    if (table_.empty() && (settings_.enableTripletTables() && !settings_.writeTripletTables()))
+      readTables();
+
+    unsigned int countall = 0;
+    unsigned int countpass = 0;
+    unsigned int nInnerStubs = 0;
+
+    for (unsigned int iInnerMem = 0; iInnerMem < firstvmstubs_.size();
+         nInnerStubs += firstvmstubs_.at(iInnerMem)->nVMStubs(), iInnerMem++)
+      ;
+
+    assert(!firstvmstubs_.empty());
+    assert(secondvmstubs_ != nullptr);
+
     for (auto& iInnerMem : firstvmstubs_) {
+      assert(iInnerMem->nVMStubs() == iInnerMem->nVMStubs());
       for (unsigned int i = 0; i < iInnerMem->nVMStubs(); i++) {
         const VMStubTE& firstvmstub = iInnerMem->getVMStubTE(i);
-        edm::LogVerbatim("Tracklet") << "In TrackletEngineDisplaced::execute first stub : "
-                                     << firstvmstub.stub()->l1tstub()->r() << " "
-                                     << firstvmstub.stub()->l1tstub()->phi() << " "
-                                     << firstvmstub.stub()->l1tstub()->r() * firstvmstub.stub()->l1tstub()->phi() << " "
-                                     << firstvmstub.stub()->l1tstub()->z();
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << "In " << getName() << " have first stub";
+        }
+
+        if ((layer1_ == 3 && layer2_ == 4) || (layer1_ == 5 && layer2_ == 6)) {
+          int lookupbits = firstvmstub.vmbits().value() & 1023;
+          int zdiffmax = (lookupbits >> 7);
+          int newbin = (lookupbits & 127);
+          int bin = newbin / 8;
+
+          int zbinfirst = newbin & 7;
+
+          int start = (bin >> 1);
+          int last = start + (bin & 1);
+
+          assert(last < 8);
+
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last;
+          }
+          for (int ibin = start; ibin <= last; ibin++) {
+            for (unsigned int j = 0; j < secondvmstubs_->nVMStubsBinned(ibin); j++) {
+              if (settings_.debugTracklet()) {
+                edm::LogVerbatim("Tracklet") << "In " << getName() << " have second stub(1) " << ibin << " " << j;
+              }
+
+              if (countall >= settings_.maxStep("TE"))
+                break;
+              countall++;
+              const VMStubTE& secondvmstub = secondvmstubs_->getVMStubTEBinned(ibin, j);
+
+              int zbin = (secondvmstub.vmbits().value() & 7);
+              if (start != ibin)
+                zbin += 8;
+              if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
+                if (settings_.debugTracklet()) {
+                  edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
+                }
+                continue;
+              }
+
+              assert(firstphibits_ != -1);
+              assert(secondphibits_ != -1);
+
+              FPGAWord iphifirstbin = firstvmstub.finephi();
+              FPGAWord iphisecondbin = secondvmstub.finephi();
+
+              unsigned int index = (iphifirstbin.value() << secondphibits_) + iphisecondbin.value();
+
+              FPGAWord firstbend = firstvmstub.bend();
+              FPGAWord secondbend = secondvmstub.bend();
+
+              index = (index << firstbend.nbits()) + firstbend.value();
+              index = (index << secondbend.nbits()) + secondbend.value();
+
+              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                  (index >= table_.size() || table_.at(index).empty())) {
+                if (settings_.debugTracklet()) {
+                  edm::LogVerbatim("Tracklet")
+                      << "Stub pair rejected because of stub pt cut bends : "
+                      << settings_.benddecode(firstvmstub.bend().value(), layer1_ - 1, firstvmstub.isPSmodule()) << " "
+                      << settings_.benddecode(secondvmstub.bend().value(), layer2_ - 1, secondvmstub.isPSmodule());
+                }
+
+                //FIXME temporarily commented out until stub bend table fixed
+                //if (!settings_.writeTripletTables())
+                //  continue;
+              }
+
+              if (settings_.debugTracklet())
+                edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
+              for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
+                if (!settings_.enableTripletTables() || settings_.writeTripletTables() || table_.at(index).count(isp)) {
+                  if (settings_.writeMonitorData("Seeds")) {
+                    ofstream fout("seeds.txt", ofstream::app);
+                    fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
+                    fout.close();
+                  }
+                  stubpairs_.at(isp)->addStubPair(firstvmstub, secondvmstub, index, getName());
+                }
+              }
+
+              countpass++;
+            }
+          }
+
+        } else if (layer1_ == 2 && layer2_ == 3) {
+          int lookupbits = firstvmstub.vmbits().value() & 1023;
+          int zdiffmax = (lookupbits >> 7);
+          int newbin = (lookupbits & 127);
+          int bin = newbin / 8;
+
+          int zbinfirst = newbin & 7;
+
+          int start = (bin >> 1);
+          int last = start + (bin & 1);
+
+          assert(last < 8);
+
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last;
+          }
+          for (int ibin = start; ibin <= last; ibin++) {
+            for (unsigned int j = 0; j < secondvmstubs_->nVMStubsBinned(ibin); j++) {
+              if (settings_.debugTracklet()) {
+                edm::LogVerbatim("Tracklet") << "In " << getName() << " have second stub(2) ";
+              }
+
+              if (countall >= settings_.maxStep("TE"))
+                break;
+              countall++;
+
+              const VMStubTE& secondvmstub = secondvmstubs_->getVMStubTEBinned(ibin, j);
+
+              int zbin = (secondvmstub.vmbits().value() & 7);
+              if (start != ibin)
+                zbin += 8;
+              if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
+                if (settings_.debugTracklet()) {
+                  edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
+                }
+                continue;
+              }
+
+              assert(firstphibits_ != -1);
+              assert(secondphibits_ != -1);
+
+              FPGAWord iphifirstbin = firstvmstub.finephi();
+              FPGAWord iphisecondbin = secondvmstub.finephi();
+
+              unsigned int index = (iphifirstbin.value() << secondphibits_) + iphisecondbin.value();
+
+              FPGAWord firstbend = firstvmstub.bend();
+              FPGAWord secondbend = secondvmstub.bend();
+
+              index = (index << firstbend.nbits()) + firstbend.value();
+              index = (index << secondbend.nbits()) + secondbend.value();
+
+              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                  (index >= table_.size() || table_.at(index).empty())) {
+                if (settings_.debugTracklet()) {
+                  edm::LogVerbatim("Tracklet")
+                      << "Stub pair rejected because of stub pt cut bends : "
+                      << settings_.benddecode(firstvmstub.bend().value(), layer1_ - 1, firstvmstub.isPSmodule()) << " "
+                      << settings_.benddecode(secondvmstub.bend().value(), layer2_ - 1, secondvmstub.isPSmodule());
+                }
+                continue;
+              }
+
+              if (settings_.debugTracklet())
+                edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
+              for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
+                if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) ||
+                    (index < table_.size() && table_.at(index).count(isp))) {
+                  if (settings_.writeMonitorData("Seeds")) {
+                    ofstream fout("seeds.txt", ofstream::app);
+                    fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
+                    fout.close();
+                  }
+                  stubpairs_.at(isp)->addStubPair(firstvmstub, secondvmstub, index, getName());
+                }
+              }
+
+              countpass++;
+            }
+          }
+
+        } else if (disk1_ == 1 && disk2_ == 2) {
+          if (settings_.debugTracklet())
+            edm::LogVerbatim("Tracklet") << getName() << " Disk-disk pair";
+
+          int lookupbits = firstvmstub.vmbits().value() & 511;
+          bool negdisk = firstvmstub.stub()->disk().value() < 0;
+          int rdiffmax = (lookupbits >> 6);
+          int newbin = (lookupbits & 63);
+          int bin = newbin / 8;
+
+          int rbinfirst = newbin & 7;
+
+          int start = (bin >> 1);
+          if (negdisk)
+            start += 4;
+          int last = start + (bin & 1);
+          assert(last < 8);
+          for (int ibin = start; ibin <= last; ibin++) {
+            if (settings_.debugTracklet()) {
+              edm::LogVerbatim("Tracklet")
+                  << getName() << " looking for matching stub in " << secondvmstubs_->getName() << " in bin = " << ibin
+                  << " with " << secondvmstubs_->nVMStubsBinned(ibin) << " stubs";
+            }
+            for (unsigned int j = 0; j < secondvmstubs_->nVMStubsBinned(ibin); j++) {
+              if (countall >= settings_.maxStep("TE"))
+                break;
+              countall++;
+
+              const VMStubTE& secondvmstub = secondvmstubs_->getVMStubTEBinned(ibin, j);
+
+              int rbin = (secondvmstub.vmbits().value() & 7);
+              if (start != ibin)
+                rbin += 8;
+              if (rbin < rbinfirst)
+                continue;
+              if (rbin - rbinfirst > rdiffmax)
+                continue;
+
+              unsigned int irsecondbin = secondvmstub.vmbits().value() >> 2;
+
+              FPGAWord iphifirstbin = firstvmstub.finephi();
+              FPGAWord iphisecondbin = secondvmstub.finephi();
+
+              unsigned int index = (irsecondbin << (secondphibits_ + firstphibits_)) +
+                                   (iphifirstbin.value() << secondphibits_) + iphisecondbin.value();
+
+              FPGAWord firstbend = firstvmstub.bend();
+              FPGAWord secondbend = secondvmstub.bend();
+
+              index = (index << firstbend.nbits()) + firstbend.value();
+              index = (index << secondbend.nbits()) + secondbend.value();
+
+              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                  (index >= table_.size() || table_.at(index).empty())) {
+                if (settings_.debugTracklet()) {
+                  edm::LogVerbatim("Tracklet")
+                      << "Stub pair rejected because of stub pt cut bends : "
+                      << settings_.benddecode(firstvmstub.bend().value(), disk1_ + 5, firstvmstub.isPSmodule()) << " "
+                      << settings_.benddecode(secondvmstub.bend().value(), disk2_ + 5, secondvmstub.isPSmodule());
+                }
+                continue;
+              }
+
+              if (settings_.debugTracklet())
+                edm::LogVerbatim("Tracklet") << "Adding disk-disk pair in " << getName();
+
+              for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp) {
+                if ((!settings_.enableTripletTables() || settings_.writeTripletTables()) ||
+                    (index < table_.size() && table_.at(index).count(isp))) {
+                  if (settings_.writeMonitorData("Seeds")) {
+                    ofstream fout("seeds.txt", ofstream::app);
+                    fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
+                    fout.close();
+                  }
+                  stubpairs_.at(isp)->addStubPair(firstvmstub, secondvmstub, index, getName());
+                }
+              }
+              countpass++;
+            }
+          }
+        }
       }
     }
-    for (unsigned int i = 0; i < secondvmstubs_->nVMStubs(); i++) {
-      const VMStubTE& secondvmstub = secondvmstubs_->getVMStubTE(i);
-      edm::LogVerbatim("Tracklet") << "In TrackletEngineDisplaced::execute second stub : "
-                                   << secondvmstub.stub()->l1tstub()->r() << " "
-                                   << secondvmstub.stub()->l1tstub()->phi() << " "
-                                   << secondvmstub.stub()->l1tstub()->r() * secondvmstub.stub()->l1tstub()->phi() << " "
-                                   << secondvmstub.stub()->l1tstub()->z();
+    if (countall > 5000) {
+      edm::LogVerbatim("Tracklet") << "In TrackletEngineDisplaced::execute : " << getName() << " " << nInnerStubs << " "
+                                   << secondvmstubs_->nVMStubs() << " " << countall << " " << countpass;
+      for (auto& iInnerMem : firstvmstubs_) {
+        for (unsigned int i = 0; i < iInnerMem->nVMStubs(); i++) {
+          const VMStubTE& firstvmstub = iInnerMem->getVMStubTE(i);
+          edm::LogVerbatim("Tracklet") << "In TrackletEngineDisplaced::execute first stub : "
+                                       << firstvmstub.stub()->l1tstub()->r() << " "
+                                       << firstvmstub.stub()->l1tstub()->phi() << " "
+                                       << firstvmstub.stub()->l1tstub()->r() * firstvmstub.stub()->l1tstub()->phi()
+                                       << " " << firstvmstub.stub()->l1tstub()->z();
+        }
+      }
+      for (unsigned int i = 0; i < secondvmstubs_->nVMStubs(); i++) {
+        const VMStubTE& secondvmstub = secondvmstubs_->getVMStubTE(i);
+        edm::LogVerbatim("Tracklet") << "In TrackletEngineDisplaced::execute second stub : "
+                                     << secondvmstub.stub()->l1tstub()->r() << " "
+                                     << secondvmstub.stub()->l1tstub()->phi() << " "
+                                     << secondvmstub.stub()->l1tstub()->r() * secondvmstub.stub()->l1tstub()->phi()
+                                     << " " << secondvmstub.stub()->l1tstub()->z();
+      }
+    }
+
+    if (settings_.writeMonitorData("TED")) {
+      globals_->ofstream("trackletenginedisplaces.txt") << getName() << " " << countall << " " << countpass << endl;
     }
   }
 
-  if (settings_.writeMonitorData("TED")) {
-    globals_->ofstream("trackletenginedisplaces.txt") << getName() << " " << countall << " " << countpass << endl;
+  void TrackletEngineDisplaced::readTables() {
+    ifstream fin;
+    string tableName, line, word;
+
+    string tablePath = settings_.tableTEDFile();
+    unsigned int finddir = tablePath.find("table_TED_");
+    tableName = tablePath.substr(0, finddir) + "table_" + name_ + ".txt";
+
+    fin.open(tableName, ifstream::in);
+    if (!fin) {
+      throw cms::Exception("BadConfig") << "TripletEngine::readTables, file " << tableName << " not known";
+    }
+
+    while (getline(fin, line)) {
+      istringstream iss(line);
+      table_.resize(table_.size() + 1);
+
+      while (iss >> word)
+        table_[table_.size() - 1].insert(memNameToIndex(word));
+    }
+    fin.close();
   }
-}
 
-void TrackletEngineDisplaced::readTables() {
-  ifstream fin;
-  string tableName, line, word;
-
-  string tablePath = settings_.tableTEDFile();
-  unsigned int finddir = tablePath.find("table_TED_");
-  tableName = tablePath.substr(0, finddir) + "table_" + name_ + ".txt";
-
-  fin.open(tableName, ifstream::in);
-  if (!fin) {
-    throw cms::Exception("BadConfig") << "TripletEngine::readTables, file " << tableName << " not known";
+  short TrackletEngineDisplaced::memNameToIndex(const string& name) {
+    for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp)
+      if (stubpairs_.at(isp)->getName() == name)
+        return isp;
+    return -1;
   }
 
-  while (getline(fin, line)) {
-    istringstream iss(line);
-    table_.resize(table_.size() + 1);
-
-    while (iss >> word)
-      table_[table_.size() - 1].insert(memNameToIndex(word));
-  }
-  fin.close();
-}
-
-short TrackletEngineDisplaced::memNameToIndex(const string& name) {
-  for (unsigned int isp = 0; isp < stubpairs_.size(); ++isp)
-    if (stubpairs_.at(isp)->getName() == name)
-      return isp;
-  return -1;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngineDisplaced.cc
@@ -10,7 +10,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletEngineDisplaced::TrackletEngineDisplaced(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global) {
@@ -419,4 +420,6 @@ short TrackletEngineDisplaced::memNameToIndex(const string& name) {
     if (stubpairs_.at(isp)->getName() == name)
       return isp;
   return -1;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngineUnit.cc
@@ -3,7 +3,8 @@
 #include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletEngineUnit::TrackletEngineUnit(const Settings* const settings,
                                        unsigned int nbitsfinephi,
@@ -126,4 +127,6 @@ void TrackletEngineUnit::step(bool, int, int) {
       std::tie(next_, ireg_, nstub_) = tedata_.regions_[nreg_];
     }
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEngineUnit.cc
@@ -6,127 +6,128 @@ using namespace std;
 
 namespace trklet {
 
-TrackletEngineUnit::TrackletEngineUnit(const Settings* const settings,
-                                       unsigned int nbitsfinephi,
-                                       unsigned int layerdisk1,
-                                       unsigned int layerdisk2,
-                                       unsigned int iSeed,
-                                       unsigned int nbitsfinephidiff,
-                                       unsigned int iAllStub,
-                                       const TrackletLUT* pttableinnernew,
-                                       const TrackletLUT* pttableouternew,
-                                       VMStubsTEMemory* outervmstubs)
-    : settings_(settings), pttableinnernew_(pttableinnernew), pttableouternew_(pttableouternew), candpairs_(3) {
-  idle_ = true;
-  nbitsfinephi_ = nbitsfinephi;
-  layerdisk2_ = layerdisk2;
-  layerdisk1_ = layerdisk1;
-  iSeed_ = iSeed;
-  nbitsfinephidiff_ = nbitsfinephidiff;
-  iAllStub_ = iAllStub;
-  outervmstubs_ = outervmstubs;
-}
-
-void TrackletEngineUnit::init(const TEData& tedata) {
-  tedata_ = tedata;
-  nreg_ = 0;
-  istub_ = 0;
-  idle_ = false;
-  assert(!tedata_.regions_.empty());
-  std::tie(next_, ireg_, nstub_) = tedata_.regions_[0];
-}
-
-void TrackletEngineUnit::reset() {
-  idle_ = true;
-  goodpair_ = false;
-  goodpair__ = false;
-  candpairs_.reset();
-}
-
-void TrackletEngineUnit::step(bool, int, int) {
-  if (goodpair__) {
-    candpairs_.store(candpair__);
+  TrackletEngineUnit::TrackletEngineUnit(const Settings* const settings,
+                                         unsigned int nbitsfinephi,
+                                         unsigned int layerdisk1,
+                                         unsigned int layerdisk2,
+                                         unsigned int iSeed,
+                                         unsigned int nbitsfinephidiff,
+                                         unsigned int iAllStub,
+                                         const TrackletLUT* pttableinnernew,
+                                         const TrackletLUT* pttableouternew,
+                                         VMStubsTEMemory* outervmstubs)
+      : settings_(settings), pttableinnernew_(pttableinnernew), pttableouternew_(pttableouternew), candpairs_(3) {
+    idle_ = true;
+    nbitsfinephi_ = nbitsfinephi;
+    layerdisk2_ = layerdisk2;
+    layerdisk1_ = layerdisk1;
+    iSeed_ = iSeed;
+    nbitsfinephidiff_ = nbitsfinephidiff;
+    iAllStub_ = iAllStub;
+    outervmstubs_ = outervmstubs;
   }
 
-  goodpair__ = goodpair_;
-  candpair__ = candpair_;
-
-  goodpair_ = false;
-
-  if (idle_ || nearfull_) {
-    return;
+  void TrackletEngineUnit::init(const TEData& tedata) {
+    tedata_ = tedata;
+    nreg_ = 0;
+    istub_ = 0;
+    idle_ = false;
+    assert(!tedata_.regions_.empty());
+    std::tie(next_, ireg_, nstub_) = tedata_.regions_[0];
   }
 
-  int ibin = tedata_.start_ + next_;
-
-  int nbins = (1 << NFINERZBITS);
-
-  assert(istub_ < outervmstubs_->nVMStubsBinned(ireg_ * nbins + ibin));
-
-  const VMStubTE& outervmstub = outervmstubs_->getVMStubTEBinned(ireg_ * nbins + ibin, istub_);
-  int rzbin = (outervmstub.vmbits().value() & (nbins - 1));
-
-  FPGAWord iphiouterbin = outervmstub.finephi();
-
-  assert(iphiouterbin == outervmstub.finephi());
-
-  //New code to calculate lut value
-  int outerfinephi = iAllStub_ * (1 << (nbitsfinephi_ - settings_->nbitsallstubs(layerdisk2_))) +
-                     ireg_ * (1 << settings_->nfinephi(1, iSeed_)) + iphiouterbin.value();
-  int idphi = outerfinephi - tedata_.innerfinephi_;
-
-  bool inrange = (idphi < (1 << (nbitsfinephidiff_ - 1))) && (idphi >= -(1 << (nbitsfinephidiff_ - 1)));
-
-  idphi = idphi & ((1 << nbitsfinephidiff_) - 1);
-
-  unsigned int firstDiskSeed = 4;
-  if (iSeed_ >= firstDiskSeed) {  //Also use r-position
-    int ibinMask = 3;             //Get two least sign. bits
-    int ir = ((ibin & ibinMask) << 1) + (rzbin >> (NFINERZBITS - 1));
-    int nrbits = 3;
-    idphi = (idphi << nrbits) + ir;
+  void TrackletEngineUnit::reset() {
+    idle_ = true;
+    goodpair_ = false;
+    goodpair__ = false;
+    candpairs_.reset();
   }
 
-  if (next_ != 0)
-    rzbin += (1 << NFINERZBITS);
-
-  if ((rzbin < tedata_.rzbinfirst_) || (rzbin - tedata_.rzbinfirst_ > tedata_.rzdiffmax_)) {
-    if (settings_->debugTracklet()) {
-      edm::LogVerbatim("Tracklet") << " layer-disk stub pair rejected because rbin cut : " << rzbin << " "
-                                   << tedata_.rzbinfirst_ << " " << tedata_.rzdiffmax_;
+  void TrackletEngineUnit::step(bool, int, int) {
+    if (goodpair__) {
+      candpairs_.store(candpair__);
     }
-  } else {
-    FPGAWord outerbend = outervmstub.bend();
 
-    int ptinnerindex = (idphi << tedata_.innerbend_.nbits()) + tedata_.innerbend_.value();
-    int ptouterindex = (idphi << outerbend.nbits()) + outerbend.value();
+    goodpair__ = goodpair_;
+    candpair__ = candpair_;
 
-    if (!(inrange && pttableinnernew_->lookup(ptinnerindex) && pttableouternew_->lookup(ptouterindex))) {
+    goodpair_ = false;
+
+    if (idle_ || nearfull_) {
+      return;
+    }
+
+    int ibin = tedata_.start_ + next_;
+
+    int nbins = (1 << NFINERZBITS);
+
+    assert(istub_ < outervmstubs_->nVMStubsBinned(ireg_ * nbins + ibin));
+
+    const VMStubTE& outervmstub = outervmstubs_->getVMStubTEBinned(ireg_ * nbins + ibin, istub_);
+    int rzbin = (outervmstub.vmbits().value() & (nbins - 1));
+
+    FPGAWord iphiouterbin = outervmstub.finephi();
+
+    assert(iphiouterbin == outervmstub.finephi());
+
+    //New code to calculate lut value
+    int outerfinephi = iAllStub_ * (1 << (nbitsfinephi_ - settings_->nbitsallstubs(layerdisk2_))) +
+                       ireg_ * (1 << settings_->nfinephi(1, iSeed_)) + iphiouterbin.value();
+    int idphi = outerfinephi - tedata_.innerfinephi_;
+
+    bool inrange = (idphi < (1 << (nbitsfinephidiff_ - 1))) && (idphi >= -(1 << (nbitsfinephidiff_ - 1)));
+
+    idphi = idphi & ((1 << nbitsfinephidiff_) - 1);
+
+    unsigned int firstDiskSeed = 4;
+    if (iSeed_ >= firstDiskSeed) {  //Also use r-position
+      int ibinMask = 3;             //Get two least sign. bits
+      int ir = ((ibin & ibinMask) << 1) + (rzbin >> (NFINERZBITS - 1));
+      int nrbits = 3;
+      idphi = (idphi << nrbits) + ir;
+    }
+
+    if (next_ != 0)
+      rzbin += (1 << NFINERZBITS);
+
+    if ((rzbin < tedata_.rzbinfirst_) || (rzbin - tedata_.rzbinfirst_ > tedata_.rzdiffmax_)) {
       if (settings_->debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << " Stub pair rejected because of stub pt cut bends : "
-                                     << settings_->benddecode(
-                                            tedata_.innerbend_.value(), layerdisk1_, tedata_.stub_->isPSmodule())
-                                     << " "
-                                     << settings_->benddecode(outerbend.value(), layerdisk2_, outervmstub.isPSmodule());
+        edm::LogVerbatim("Tracklet") << " layer-disk stub pair rejected because rbin cut : " << rzbin << " "
+                                     << tedata_.rzbinfirst_ << " " << tedata_.rzdiffmax_;
       }
     } else {
-      candpair_ = pair<const Stub*, const Stub*>(tedata_.stub_, outervmstub.stub());
-      goodpair_ = true;
+      FPGAWord outerbend = outervmstub.bend();
+
+      int ptinnerindex = (idphi << tedata_.innerbend_.nbits()) + tedata_.innerbend_.value();
+      int ptouterindex = (idphi << outerbend.nbits()) + outerbend.value();
+
+      if (!(inrange && pttableinnernew_->lookup(ptinnerindex) && pttableouternew_->lookup(ptouterindex))) {
+        if (settings_->debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << " Stub pair rejected because of stub pt cut bends : "
+                                       << settings_->benddecode(
+                                              tedata_.innerbend_.value(), layerdisk1_, tedata_.stub_->isPSmodule())
+                                       << " "
+                                       << settings_->benddecode(
+                                              outerbend.value(), layerdisk2_, outervmstub.isPSmodule());
+        }
+      } else {
+        candpair_ = pair<const Stub*, const Stub*>(tedata_.stub_, outervmstub.stub());
+        goodpair_ = true;
+      }
+    }
+
+    istub_++;
+    assert(nstub_ <= N_VMSTUBSMAX);
+    if (istub_ >= nstub_) {
+      istub_ = 0;
+      nreg_++;
+      if (nreg_ >= tedata_.regions_.size()) {
+        nreg_ = 0;
+        idle_ = true;
+      } else {
+        std::tie(next_, ireg_, nstub_) = tedata_.regions_[nreg_];
+      }
     }
   }
 
-  istub_++;
-  assert(nstub_ <= N_VMSTUBSMAX);
-  if (istub_ >= nstub_) {
-    istub_ = 0;
-    nreg_++;
-    if (nreg_ >= tedata_.regions_.size()) {
-      nreg_ = 0;
-      idle_ = true;
-    } else {
-      std::tie(next_, ireg_, nstub_) = tedata_.regions_[nreg_];
-    }
-  }
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -14,8 +14,9 @@
 #include <iomanip>
 #include <filesystem>
 
-using namespace trklet;
 using namespace std;
+
+namespace trklet {
 
 TrackletEventProcessor::TrackletEventProcessor() : settings_(nullptr) {}
 
@@ -455,4 +456,6 @@ void TrackletEventProcessor::printSummary() {
                                << "PurgeDuplicate        " << setw(10) << PDTimer_.ntimes() << setw(20)
                                << setprecision(3) << PDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
                                << PDTimer_.tottime();
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -18,444 +18,444 @@ using namespace std;
 
 namespace trklet {
 
-TrackletEventProcessor::TrackletEventProcessor() : settings_(nullptr) {}
+  TrackletEventProcessor::TrackletEventProcessor() : settings_(nullptr) {}
 
-TrackletEventProcessor::~TrackletEventProcessor() {
-  if (settings_ && settings_->bookHistos()) {
-    histbase_->close();
-  }
-}
-
-void TrackletEventProcessor::init(Settings const& theSettings, const tt::Setup* setup) {
-  settings_ = &theSettings;
-  globals_ = make_unique<Globals>(*settings_);
-
-  //Verify consistency
-  if (settings_->kphi0pars() != globals_->ITC_L1L2()->phi0_final.K()) {
-    throw cms::Exception("Inconsistency") << "phi0 conversion parameter inconsistency\n";
+  TrackletEventProcessor::~TrackletEventProcessor() {
+    if (settings_ && settings_->bookHistos()) {
+      histbase_->close();
+    }
   }
 
-  if (settings_->krinvpars() != globals_->ITC_L1L2()->rinv_final.K()) {
-    throw cms::Exception("Inconsistency") << "ring conversion parameter inconsistency\n";
-  }
+  void TrackletEventProcessor::init(Settings const& theSettings, const tt::Setup* setup) {
+    settings_ = &theSettings;
+    globals_ = make_unique<Globals>(*settings_);
 
-  if (settings_->ktpars() != globals_->ITC_L1L2()->t_final.K()) {
-    throw cms::Exception("Inconsistency") << "t conversion parameter inconsistency\n";
-  }
+    //Verify consistency
+    if (settings_->kphi0pars() != globals_->ITC_L1L2()->phi0_final.K()) {
+      throw cms::Exception("Inconsistency") << "phi0 conversion parameter inconsistency\n";
+    }
 
-  if (settings_->kphider() != globals_->ITC_L1L2()->der_phiL_final.K()) {
-    throw cms::Exception("Inconsistency")
-        << "t conversion parameter inconsistency:" << settings_->kphider() / globals_->ITC_L1L2()->der_phiL_final.K()
-        << "\n";
-  }
+    if (settings_->krinvpars() != globals_->ITC_L1L2()->rinv_final.K()) {
+      throw cms::Exception("Inconsistency") << "ring conversion parameter inconsistency\n";
+    }
 
-  if (settings_->debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "========================================================= \n"
-                                 << "Conversion factors for global coordinates: \n"
-                                 << "z    kz            = " << settings_->kz() << "\n"
-                                 << "r    kr            = " << settings_->kr() << "\n"
-                                 << "phi  kphi1         = " << settings_->kphi1() << "\n"
-                                 << "========================================================= \n"
-                                 << "Conversion factors for track(let) parameters: \n"
-                                 << "rinv krinvpars     = " << settings_->krinvpars() << "\n"
-                                 << "phi0 kphi0pars     = " << settings_->kphi0pars() << "\n"
-                                 << "d0   kd0pars       = " << settings_->kd0pars() << "\n"
-                                 << "t    ktpars        = " << settings_->ktpars() << "\n"
-                                 << "z0   kz0pars       = " << settings_->kz0pars() << "\n"
-                                 << "========================================================= \n"
-                                 << "phi0bitshift = " << settings_->phi0bitshift() << "\n"
-                                 << "d0bitshift   = ??? \n"
-                                 << "=========================================================";
-  }
+    if (settings_->ktpars() != globals_->ITC_L1L2()->t_final.K()) {
+      throw cms::Exception("Inconsistency") << "t conversion parameter inconsistency\n";
+    }
 
-  if (settings_->bookHistos()) {
-    histbase_ = new HistBase;
-    histbase_->open();
-    histbase_->bookLayerResidual();
-    histbase_->bookDiskResidual();
-    histbase_->bookTrackletParams();
-    histbase_->bookSeedEff();
+    if (settings_->kphider() != globals_->ITC_L1L2()->der_phiL_final.K()) {
+      throw cms::Exception("Inconsistency")
+          << "t conversion parameter inconsistency:" << settings_->kphider() / globals_->ITC_L1L2()->der_phiL_final.K()
+          << "\n";
+    }
 
-    globals_->histograms() = histbase_;
-  }
+    if (settings_->debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "========================================================= \n"
+                                   << "Conversion factors for global coordinates: \n"
+                                   << "z    kz            = " << settings_->kz() << "\n"
+                                   << "r    kr            = " << settings_->kr() << "\n"
+                                   << "phi  kphi1         = " << settings_->kphi1() << "\n"
+                                   << "========================================================= \n"
+                                   << "Conversion factors for track(let) parameters: \n"
+                                   << "rinv krinvpars     = " << settings_->krinvpars() << "\n"
+                                   << "phi0 kphi0pars     = " << settings_->kphi0pars() << "\n"
+                                   << "d0   kd0pars       = " << settings_->kd0pars() << "\n"
+                                   << "t    ktpars        = " << settings_->ktpars() << "\n"
+                                   << "z0   kz0pars       = " << settings_->kz0pars() << "\n"
+                                   << "========================================================= \n"
+                                   << "phi0bitshift = " << settings_->phi0bitshift() << "\n"
+                                   << "d0bitshift   = ??? \n"
+                                   << "=========================================================";
+    }
 
-  sector_ = make_unique<Sector>(*settings_, globals_.get());
+    if (settings_->bookHistos()) {
+      histbase_ = new HistBase;
+      histbase_->open();
+      histbase_->bookLayerResidual();
+      histbase_->bookDiskResidual();
+      histbase_->bookTrackletParams();
+      histbase_->bookSeedEff();
 
-  if (settings_->extended() || settings_->reduced()) {
-    ifstream inmem(settings_->memoryModulesFile().c_str());
-    assert(inmem.good());
+      globals_->histograms() = histbase_;
+    }
 
-    ifstream inproc(settings_->processingModulesFile().c_str());
-    assert(inproc.good());
+    sector_ = make_unique<Sector>(*settings_, globals_.get());
 
-    ifstream inwire(settings_->wiresFile().c_str());
-    assert(inwire.good());
+    if (settings_->extended() || settings_->reduced()) {
+      ifstream inmem(settings_->memoryModulesFile().c_str());
+      assert(inmem.good());
 
-    configure(inwire, inmem, inproc);
+      ifstream inproc(settings_->processingModulesFile().c_str());
+      assert(inproc.good());
 
-  } else {
-    TrackletConfigBuilder config(*settings_, setup);
+      ifstream inwire(settings_->wiresFile().c_str());
+      assert(inwire.good());
 
-    //Write configurations to file.
-    if (settings_->writeConfig()) {
-      std::ofstream wires = openfile(settings_->tablePath(), "wires.dat", __FILE__, __LINE__);
-      std::ofstream memorymodules = openfile(settings_->tablePath(), "memorymodules.dat", __FILE__, __LINE__);
-      std::ofstream processingmodules = openfile(settings_->tablePath(), "processingmodules.dat", __FILE__, __LINE__);
+      configure(inwire, inmem, inproc);
+
+    } else {
+      TrackletConfigBuilder config(*settings_, setup);
+
+      //Write configurations to file.
+      if (settings_->writeConfig()) {
+        std::ofstream wires = openfile(settings_->tablePath(), "wires.dat", __FILE__, __LINE__);
+        std::ofstream memorymodules = openfile(settings_->tablePath(), "memorymodules.dat", __FILE__, __LINE__);
+        std::ofstream processingmodules = openfile(settings_->tablePath(), "processingmodules.dat", __FILE__, __LINE__);
+
+        config.writeAll(wires, memorymodules, processingmodules);
+      }
+
+      std::stringstream wires;
+      std::stringstream memorymodules;
+      std::stringstream processingmodules;
 
       config.writeAll(wires, memorymodules, processingmodules);
+      configure(wires, memorymodules, processingmodules);
+    }
+  }
+
+  void TrackletEventProcessor::configure(istream& inwire, istream& inmem, istream& inproc) {
+    // get the memory modules
+    if (settings_->debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "Will read memory modules";
     }
 
-    std::stringstream wires;
-    std::stringstream memorymodules;
-    std::stringstream processingmodules;
-
-    config.writeAll(wires, memorymodules, processingmodules);
-    configure(wires, memorymodules, processingmodules);
-  }
-}
-
-void TrackletEventProcessor::configure(istream& inwire, istream& inmem, istream& inproc) {
-  // get the memory modules
-  if (settings_->debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "Will read memory modules";
-  }
-
-  while (inmem.good()) {
-    string memType, memName, size;
-    inmem >> memType >> memName >> size;
-    if (!inmem.good())
-      continue;
-    if (settings_->writetrace()) {
-      edm::LogVerbatim("Tracklet") << "Read memory: " << memType << " " << memName;
-    }
-    sector_->addMem(memType, memName);
-  }
-
-  // get the processing modules
-  if (settings_->debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "Will read processing modules";
-  }
-
-  while (inproc.good()) {
-    string procType, procName;
-    inproc >> procType >> procName;
-    if (!inproc.good())
-      continue;
-    if (settings_->writetrace()) {
-      edm::LogVerbatim("Tracklet") << "Read process: " << procType << " " << procName;
-    }
-    sector_->addProc(procType, procName);
-  }
-
-  // get the wiring information
-  if (settings_->debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "Will read wiring information";
-  }
-
-  while (inwire.good()) {
-    string line;
-    getline(inwire, line);
-    if (!inwire.good())
-      continue;
-    if (settings_->writetrace()) {
-      edm::LogVerbatim("Tracklet") << "Line : " << line;
-    }
-    stringstream ss(line);
-    string mem, tmp1, procin, tmp2, procout;
-    ss >> mem >> tmp1 >> procin;
-    if (procin == "output=>") {
-      procin = "";
-      ss >> procout;
-    } else {
-      ss >> tmp2 >> procout;
-    }
-
-    sector_->addWire(mem, procin, procout);
-  }
-}
-
-void TrackletEventProcessor::event(SLHCEvent& ev,
-                                   vector<vector<string>>& streamsTrackRaw,
-                                   vector<vector<StubStreamData>>& streamsStubRaw) {
-  globals_->event() = &ev;
-
-  tracks_.clear();
-
-  eventnum_++;
-  bool first = (eventnum_ == 1);
-
-  for (unsigned int k = 0; k < N_SECTOR; k++) {
-    sector_->setSector(k);
-
-    cleanTimer_.start();
-    sector_->clean();
-    cleanTimer_.stop();
-
-    addStubTimer_.start();
-
-    vector<int> layerstubs(N_LAYER + N_DISK, 0);
-    vector<int> layerstubssector(N_SECTOR * (N_LAYER + N_DISK), 0);
-
-    for (int j = 0; j < ev.nstubs(); j++) {
-      const L1TStub& stub = ev.stub(j);
-      unsigned int isector = stub.region();
-      if (isector != k) {
+    while (inmem.good()) {
+      string memType, memName, size;
+      inmem >> memType >> memName >> size;
+      if (!inmem.good())
         continue;
+      if (settings_->writetrace()) {
+        edm::LogVerbatim("Tracklet") << "Read memory: " << memType << " " << memName;
+      }
+      sector_->addMem(memType, memName);
+    }
+
+    // get the processing modules
+    if (settings_->debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "Will read processing modules";
+    }
+
+    while (inproc.good()) {
+      string procType, procName;
+      inproc >> procType >> procName;
+      if (!inproc.good())
+        continue;
+      if (settings_->writetrace()) {
+        edm::LogVerbatim("Tracklet") << "Read process: " << procType << " " << procName;
+      }
+      sector_->addProc(procType, procName);
+    }
+
+    // get the wiring information
+    if (settings_->debugTracklet()) {
+      edm::LogVerbatim("Tracklet") << "Will read wiring information";
+    }
+
+    while (inwire.good()) {
+      string line;
+      getline(inwire, line);
+      if (!inwire.good())
+        continue;
+      if (settings_->writetrace()) {
+        edm::LogVerbatim("Tracklet") << "Line : " << line;
+      }
+      stringstream ss(line);
+      string mem, tmp1, procin, tmp2, procout;
+      ss >> mem >> tmp1 >> procin;
+      if (procin == "output=>") {
+        procin = "";
+        ss >> procout;
+      } else {
+        ss >> tmp2 >> procout;
       }
 
-      const string& dtc = stub.DTClink();
-
-      layerstubs[stub.layerdisk()]++;
-      layerstubssector[isector * (N_LAYER + N_DISK) + stub.layerdisk()]++;
-
-      sector_->addStub(stub, dtc);
+      sector_->addWire(mem, procin, procout);
     }
+  }
 
-    if (settings_->writeMonitorData("StubsLayerSector")) {
-      for (unsigned int index = 0; index < layerstubssector.size(); index++) {
-        int layerdisk = index % (N_LAYER + N_DISK);
-        int sector = index / (N_LAYER + N_DISK);
-        globals_->ofstream("stubslayersector.txt")
-            << layerdisk << " " << sector << " " << layerstubssector[index] << endl;
-      }
-    }
+  void TrackletEventProcessor::event(SLHCEvent& ev,
+                                     vector<vector<string>>& streamsTrackRaw,
+                                     vector<vector<StubStreamData>>& streamsStubRaw) {
+    globals_->event() = &ev;
 
-    if (settings_->writeMonitorData("StubsLayer")) {
-      for (unsigned int layerdisk = 0; layerdisk < layerstubs.size(); layerdisk++) {
-        globals_->ofstream("stubslayer.txt") << layerdisk << " " << layerstubs[layerdisk] << endl;
-      }
-    }
+    tracks_.clear();
 
-    addStubTimer_.stop();
+    eventnum_++;
+    bool first = (eventnum_ == 1);
 
-    // ----------------------------------------------------------------------------------------
-    // Now start the tracklet processing
+    for (unsigned int k = 0; k < N_SECTOR; k++) {
+      sector_->setSector(k);
 
-    // VM router
-    InputRouterTimer_.start();
-    sector_->executeIR();
-    if (settings_->writeMem() && k == settings_->writememsect()) {
-      sector_->writeDTCStubs(first);
-      sector_->writeIRStubs(first);
-    }
-    InputRouterTimer_.stop();
+      cleanTimer_.start();
+      sector_->clean();
+      cleanTimer_.stop();
 
-    VMRouterTimer_.start();
-    sector_->executeVMR();
-    if (settings_->writeMem() && k == settings_->writememsect()) {
-      sector_->writeVMSTE(first);
-      sector_->writeVMSME(first);
-      sector_->writeAS(first);
-      sector_->writeAIS(first);
-    }
-    VMRouterTimer_.stop();
+      addStubTimer_.start();
 
-    // tracklet engine
-    TETimer_.start();
-    sector_->executeTE();
-    TETimer_.stop();
+      vector<int> layerstubs(N_LAYER + N_DISK, 0);
+      vector<int> layerstubssector(N_SECTOR * (N_LAYER + N_DISK), 0);
 
-    // tracklet engine displaced
-    TEDTimer_.start();
-    sector_->executeTED();
-    TEDTimer_.stop();
-
-    // triplet engine
-    TRETimer_.start();
-    sector_->executeTRE();
-    if (settings_->writeMem() && k == settings_->writememsect()) {
-      sector_->writeST(first);
-    }
-    TRETimer_.stop();
-
-    // tracklet processor (alternative implementation to TE+TC)
-    TPTimer_.start();
-    sector_->executeTP();
-    TPTimer_.stop();
-
-    if (settings_->writeMem() && k == settings_->writememsect()) {
-      sector_->writeSP(first);
-    }
-
-    // tracklet calculator
-    TCTimer_.start();
-    sector_->executeTC();
-    TCTimer_.stop();
-
-    if (settings_->writeMonitorData("HitEff") || settings_->bookHistos()) {
-      int nTP = globals_->event()->nsimtracks();
-      for (int iTP = 0; iTP < nTP; iTP++) {
-        L1SimTrack simtrk = globals_->event()->simtrack(iTP);
-        if (simtrk.pt() < 2.0)
+      for (int j = 0; j < ev.nstubs(); j++) {
+        const L1TStub& stub = ev.stub(j);
+        unsigned int isector = stub.region();
+        if (isector != k) {
           continue;
-        if (std::abs(simtrk.vz()) > 15.0)
-          continue;
-        if (hypot(simtrk.vx(), simtrk.vy()) > 0.1)
-          continue;
-        bool electron = (abs(simtrk.type()) == 11);
-        bool muon = (abs(simtrk.type()) == 13);
-        bool pion = (abs(simtrk.type()) == 211);
-        bool kaon = (abs(simtrk.type()) == 321);
-        bool proton = (abs(simtrk.type()) == 2212);
-        if (!(electron || muon || pion || kaon || proton))
-          continue;
-        int nlayers = 0;
-        int ndisks = 0;
-        int simtrackid = simtrk.trackid();
-        unsigned int hitmask = 0;
-        hitmask = ev.layersHit(simtrackid, nlayers, ndisks);  // FIX CPU use.
-        if (nlayers + ndisks < 4)
-          continue;
-
-        if (settings_->writeMonitorData("HitEff")) {
-          static ofstream outhit("hiteff.txt");
-          outhit << simtrk.eta() << " " << (hitmask & 1) << " " << (hitmask & 2) << " " << (hitmask & 4) << " "
-                 << (hitmask & 8) << " " << (hitmask & 16) << " " << (hitmask & 32) << " " << (hitmask & 64) << " "
-                 << (hitmask & 128) << " " << (hitmask & 256) << " " << (hitmask & 512) << " " << (hitmask & 1024)
-                 << endl;
         }
 
-        std::unordered_set<int> matchseed;
-        std::unordered_set<int> matchseedtmp = sector_->seedMatch(iTP);
-        matchseed.insert(matchseedtmp.begin(), matchseedtmp.end());
-        if (settings_->bookHistos()) {
-          for (int iseed = 0; iseed < 8; iseed++) {
-            bool eff = matchseed.find(iseed) != matchseed.end();
-            globals_->histograms()->fillSeedEff(iseed, simtrk.eta(), eff);
+        const string& dtc = stub.DTClink();
+
+        layerstubs[stub.layerdisk()]++;
+        layerstubssector[isector * (N_LAYER + N_DISK) + stub.layerdisk()]++;
+
+        sector_->addStub(stub, dtc);
+      }
+
+      if (settings_->writeMonitorData("StubsLayerSector")) {
+        for (unsigned int index = 0; index < layerstubssector.size(); index++) {
+          int layerdisk = index % (N_LAYER + N_DISK);
+          int sector = index / (N_LAYER + N_DISK);
+          globals_->ofstream("stubslayersector.txt")
+              << layerdisk << " " << sector << " " << layerstubssector[index] << endl;
+        }
+      }
+
+      if (settings_->writeMonitorData("StubsLayer")) {
+        for (unsigned int layerdisk = 0; layerdisk < layerstubs.size(); layerdisk++) {
+          globals_->ofstream("stubslayer.txt") << layerdisk << " " << layerstubs[layerdisk] << endl;
+        }
+      }
+
+      addStubTimer_.stop();
+
+      // ----------------------------------------------------------------------------------------
+      // Now start the tracklet processing
+
+      // VM router
+      InputRouterTimer_.start();
+      sector_->executeIR();
+      if (settings_->writeMem() && k == settings_->writememsect()) {
+        sector_->writeDTCStubs(first);
+        sector_->writeIRStubs(first);
+      }
+      InputRouterTimer_.stop();
+
+      VMRouterTimer_.start();
+      sector_->executeVMR();
+      if (settings_->writeMem() && k == settings_->writememsect()) {
+        sector_->writeVMSTE(first);
+        sector_->writeVMSME(first);
+        sector_->writeAS(first);
+        sector_->writeAIS(first);
+      }
+      VMRouterTimer_.stop();
+
+      // tracklet engine
+      TETimer_.start();
+      sector_->executeTE();
+      TETimer_.stop();
+
+      // tracklet engine displaced
+      TEDTimer_.start();
+      sector_->executeTED();
+      TEDTimer_.stop();
+
+      // triplet engine
+      TRETimer_.start();
+      sector_->executeTRE();
+      if (settings_->writeMem() && k == settings_->writememsect()) {
+        sector_->writeST(first);
+      }
+      TRETimer_.stop();
+
+      // tracklet processor (alternative implementation to TE+TC)
+      TPTimer_.start();
+      sector_->executeTP();
+      TPTimer_.stop();
+
+      if (settings_->writeMem() && k == settings_->writememsect()) {
+        sector_->writeSP(first);
+      }
+
+      // tracklet calculator
+      TCTimer_.start();
+      sector_->executeTC();
+      TCTimer_.stop();
+
+      if (settings_->writeMonitorData("HitEff") || settings_->bookHistos()) {
+        int nTP = globals_->event()->nsimtracks();
+        for (int iTP = 0; iTP < nTP; iTP++) {
+          L1SimTrack simtrk = globals_->event()->simtrack(iTP);
+          if (simtrk.pt() < 2.0)
+            continue;
+          if (std::abs(simtrk.vz()) > 15.0)
+            continue;
+          if (hypot(simtrk.vx(), simtrk.vy()) > 0.1)
+            continue;
+          bool electron = (abs(simtrk.type()) == 11);
+          bool muon = (abs(simtrk.type()) == 13);
+          bool pion = (abs(simtrk.type()) == 211);
+          bool kaon = (abs(simtrk.type()) == 321);
+          bool proton = (abs(simtrk.type()) == 2212);
+          if (!(electron || muon || pion || kaon || proton))
+            continue;
+          int nlayers = 0;
+          int ndisks = 0;
+          int simtrackid = simtrk.trackid();
+          unsigned int hitmask = 0;
+          hitmask = ev.layersHit(simtrackid, nlayers, ndisks);  // FIX CPU use.
+          if (nlayers + ndisks < 4)
+            continue;
+
+          if (settings_->writeMonitorData("HitEff")) {
+            static ofstream outhit("hiteff.txt");
+            outhit << simtrk.eta() << " " << (hitmask & 1) << " " << (hitmask & 2) << " " << (hitmask & 4) << " "
+                   << (hitmask & 8) << " " << (hitmask & 16) << " " << (hitmask & 32) << " " << (hitmask & 64) << " "
+                   << (hitmask & 128) << " " << (hitmask & 256) << " " << (hitmask & 512) << " " << (hitmask & 1024)
+                   << endl;
+          }
+
+          std::unordered_set<int> matchseed;
+          std::unordered_set<int> matchseedtmp = sector_->seedMatch(iTP);
+          matchseed.insert(matchseedtmp.begin(), matchseedtmp.end());
+          if (settings_->bookHistos()) {
+            for (int iseed = 0; iseed < 8; iseed++) {
+              bool eff = matchseed.find(iseed) != matchseed.end();
+              globals_->histograms()->fillSeedEff(iseed, simtrk.eta(), eff);
+            }
           }
         }
       }
+
+      // tracklet calculator displaced
+      TCDTimer_.start();
+      sector_->executeTCD();
+      TCDTimer_.stop();
+
+      // tracklet processor displaced
+      TPDTimer_.start();
+      sector_->executeTPD();
+      TPDTimer_.stop();
+
+      if (settings_->writeMem() && k == settings_->writememsect()) {
+        sector_->writeTPAR(first);
+        sector_->writeTPROJ(first);
+      }
+
+      // projection router
+      PRTimer_.start();
+      sector_->executePR();
+      if (settings_->writeMem() && k == settings_->writememsect()) {
+        sector_->writeVMPROJ(first);
+        sector_->writeAP(first);
+      }
+      PRTimer_.stop();
+
+      // match engine
+      METimer_.start();
+      sector_->executeME();
+      if (settings_->writeMem() && k == settings_->writememsect()) {
+        sector_->writeCM(first);
+      }
+      METimer_.stop();
+
+      // match calculator
+      MCTimer_.start();
+      sector_->executeMC();
+      MCTimer_.stop();
+
+      // match processor (alternative to ME+MC)
+      MPTimer_.start();
+      sector_->executeMP();
+      MPTimer_.stop();
+
+      if (settings_->writeMem() && k == settings_->writememsect()) {
+        sector_->writeMC(first);
+      }
+
+      // fit track
+      FTTimer_.start();
+      sector_->executeFT(streamsTrackRaw, streamsStubRaw);
+      if ((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) {
+        sector_->writeTF(first);
+      }
+      FTTimer_.stop();
+
+      // purge duplicate
+      PDTimer_.start();
+      sector_->executePD(tracks_);
+      if (((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) ||
+          settings_->writeMonitorData("CT")) {
+        sector_->writeCT(first);
+      }
+      PDTimer_.stop();
     }
-
-    // tracklet calculator displaced
-    TCDTimer_.start();
-    sector_->executeTCD();
-    TCDTimer_.stop();
-
-    // tracklet processor displaced
-    TPDTimer_.start();
-    sector_->executeTPD();
-    TPDTimer_.stop();
-
-    if (settings_->writeMem() && k == settings_->writememsect()) {
-      sector_->writeTPAR(first);
-      sector_->writeTPROJ(first);
-    }
-
-    // projection router
-    PRTimer_.start();
-    sector_->executePR();
-    if (settings_->writeMem() && k == settings_->writememsect()) {
-      sector_->writeVMPROJ(first);
-      sector_->writeAP(first);
-    }
-    PRTimer_.stop();
-
-    // match engine
-    METimer_.start();
-    sector_->executeME();
-    if (settings_->writeMem() && k == settings_->writememsect()) {
-      sector_->writeCM(first);
-    }
-    METimer_.stop();
-
-    // match calculator
-    MCTimer_.start();
-    sector_->executeMC();
-    MCTimer_.stop();
-
-    // match processor (alternative to ME+MC)
-    MPTimer_.start();
-    sector_->executeMP();
-    MPTimer_.stop();
-
-    if (settings_->writeMem() && k == settings_->writememsect()) {
-      sector_->writeMC(first);
-    }
-
-    // fit track
-    FTTimer_.start();
-    sector_->executeFT(streamsTrackRaw, streamsStubRaw);
-    if ((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) {
-      sector_->writeTF(first);
-    }
-    FTTimer_.stop();
-
-    // purge duplicate
-    PDTimer_.start();
-    sector_->executePD(tracks_);
-    if (((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) ||
-        settings_->writeMonitorData("CT")) {
-      sector_->writeCT(first);
-    }
-    PDTimer_.stop();
-  }
-}
-
-void TrackletEventProcessor::printSummary() {
-  if (settings_->bookHistos()) {
-    globals_->histograms()->close();
   }
 
-  edm::LogVerbatim("Tracklet") << "Process             Times called   Average time (ms)      Total time (s)"
-                               << "\n"
-                               << "Cleaning              " << setw(10) << cleanTimer_.ntimes() << setw(20)
-                               << setprecision(3) << cleanTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                               << cleanTimer_.tottime() << "\n"
-                               << "Add Stubs             " << setw(10) << addStubTimer_.ntimes() << setw(20)
-                               << setprecision(3) << addStubTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                               << addStubTimer_.tottime() << "\n"
-                               << "InputRouter           " << setw(10) << InputRouterTimer_.ntimes() << setw(20)
-                               << setprecision(3) << InputRouterTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                               << InputRouterTimer_.tottime() << "\n"
-                               << "VMRouter              " << setw(10) << VMRouterTimer_.ntimes() << setw(20)
-                               << setprecision(3) << VMRouterTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                               << VMRouterTimer_.tottime();
-  if (settings_->combined()) {
-    edm::LogVerbatim("Tracklet") << "TrackletProcessor     " << setw(10) << TPTimer_.ntimes() << setw(20)
-                                 << setprecision(3) << TPTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                 << TPTimer_.tottime() << "\n"
-                                 << "MatchProcessor        " << setw(10) << MPTimer_.ntimes() << setw(20)
-                                 << setprecision(3) << MPTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                 << MPTimer_.tottime();
-  } else {
-    edm::LogVerbatim("Tracklet") << "TrackletEngine        " << setw(10) << TETimer_.ntimes() << setw(20)
-                                 << setprecision(3) << TETimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                 << TETimer_.tottime();
-    if (settings_->extended()) {
-      edm::LogVerbatim("Tracklet") << "TrackletEngineDisplaced" << setw(10) << TEDTimer_.ntimes() << setw(20)
-                                   << setprecision(3) << TEDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                   << TEDTimer_.tottime() << "\n"
-                                   << "TripletEngine         " << setw(10) << TRETimer_.ntimes() << setw(20)
-                                   << setprecision(3) << TRETimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                   << TRETimer_.tottime() << "\n"
-                                   << "TrackletCalculatorDisplaced" << setw(10) << TCDTimer_.ntimes() << setw(20)
-                                   << setprecision(3) << TCDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                   << TCDTimer_.tottime() << "\n"
-                                   << TCDTimer_.tottime() << "\n"
-                                   << "TrackletProcessorDisplaced" << setw(10) << TPDTimer_.ntimes() << setw(20)
-                                   << setprecision(3) << TPDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                   << TPDTimer_.tottime();
+  void TrackletEventProcessor::printSummary() {
+    if (settings_->bookHistos()) {
+      globals_->histograms()->close();
     }
-    edm::LogVerbatim("Tracklet") << "TrackletCalculator    " << setw(10) << TCTimer_.ntimes() << setw(20)
-                                 << setprecision(3) << TCTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                 << TCTimer_.tottime() << "\n"
-                                 << "ProjectionRouter      " << setw(10) << PRTimer_.ntimes() << setw(20)
-                                 << setprecision(3) << PRTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                 << PRTimer_.tottime() << "\n"
-                                 << "MatchEngine           " << setw(10) << METimer_.ntimes() << setw(20)
-                                 << setprecision(3) << METimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                 << METimer_.tottime() << "\n"
-                                 << "MatchCalculator       " << setw(10) << MCTimer_.ntimes() << setw(20)
-                                 << setprecision(3) << MCTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                                 << MCTimer_.tottime();
-  }
-  edm::LogVerbatim("Tracklet") << "FitTrack              " << setw(10) << FTTimer_.ntimes() << setw(20)
-                               << setprecision(3) << FTTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                               << FTTimer_.tottime() << "\n"
-                               << "PurgeDuplicate        " << setw(10) << PDTimer_.ntimes() << setw(20)
-                               << setprecision(3) << PDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
-                               << PDTimer_.tottime();
-}
 
-}
+    edm::LogVerbatim("Tracklet") << "Process             Times called   Average time (ms)      Total time (s)"
+                                 << "\n"
+                                 << "Cleaning              " << setw(10) << cleanTimer_.ntimes() << setw(20)
+                                 << setprecision(3) << cleanTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                 << cleanTimer_.tottime() << "\n"
+                                 << "Add Stubs             " << setw(10) << addStubTimer_.ntimes() << setw(20)
+                                 << setprecision(3) << addStubTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                 << addStubTimer_.tottime() << "\n"
+                                 << "InputRouter           " << setw(10) << InputRouterTimer_.ntimes() << setw(20)
+                                 << setprecision(3) << InputRouterTimer_.avgtime() * 1000.0 << setw(20)
+                                 << setprecision(3) << InputRouterTimer_.tottime() << "\n"
+                                 << "VMRouter              " << setw(10) << VMRouterTimer_.ntimes() << setw(20)
+                                 << setprecision(3) << VMRouterTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                 << VMRouterTimer_.tottime();
+    if (settings_->combined()) {
+      edm::LogVerbatim("Tracklet") << "TrackletProcessor     " << setw(10) << TPTimer_.ntimes() << setw(20)
+                                   << setprecision(3) << TPTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                   << TPTimer_.tottime() << "\n"
+                                   << "MatchProcessor        " << setw(10) << MPTimer_.ntimes() << setw(20)
+                                   << setprecision(3) << MPTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                   << MPTimer_.tottime();
+    } else {
+      edm::LogVerbatim("Tracklet") << "TrackletEngine        " << setw(10) << TETimer_.ntimes() << setw(20)
+                                   << setprecision(3) << TETimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                   << TETimer_.tottime();
+      if (settings_->extended()) {
+        edm::LogVerbatim("Tracklet") << "TrackletEngineDisplaced" << setw(10) << TEDTimer_.ntimes() << setw(20)
+                                     << setprecision(3) << TEDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                     << TEDTimer_.tottime() << "\n"
+                                     << "TripletEngine         " << setw(10) << TRETimer_.ntimes() << setw(20)
+                                     << setprecision(3) << TRETimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                     << TRETimer_.tottime() << "\n"
+                                     << "TrackletCalculatorDisplaced" << setw(10) << TCDTimer_.ntimes() << setw(20)
+                                     << setprecision(3) << TCDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                     << TCDTimer_.tottime() << "\n"
+                                     << TCDTimer_.tottime() << "\n"
+                                     << "TrackletProcessorDisplaced" << setw(10) << TPDTimer_.ntimes() << setw(20)
+                                     << setprecision(3) << TPDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                     << TPDTimer_.tottime();
+      }
+      edm::LogVerbatim("Tracklet") << "TrackletCalculator    " << setw(10) << TCTimer_.ntimes() << setw(20)
+                                   << setprecision(3) << TCTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                   << TCTimer_.tottime() << "\n"
+                                   << "ProjectionRouter      " << setw(10) << PRTimer_.ntimes() << setw(20)
+                                   << setprecision(3) << PRTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                   << PRTimer_.tottime() << "\n"
+                                   << "MatchEngine           " << setw(10) << METimer_.ntimes() << setw(20)
+                                   << setprecision(3) << METimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                   << METimer_.tottime() << "\n"
+                                   << "MatchCalculator       " << setw(10) << MCTimer_.ntimes() << setw(20)
+                                   << setprecision(3) << MCTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                   << MCTimer_.tottime();
+    }
+    edm::LogVerbatim("Tracklet") << "FitTrack              " << setw(10) << FTTimer_.ntimes() << setw(20)
+                                 << setprecision(3) << FTTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                 << FTTimer_.tottime() << "\n"
+                                 << "PurgeDuplicate        " << setw(10) << PDTimer_.ntimes() << setw(20)
+                                 << setprecision(3) << PDTimer_.avgtime() * 1000.0 << setw(20) << setprecision(3)
+                                 << PDTimer_.tottime();
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -7,7 +7,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletLUT::TrackletLUT(const Settings& settings) : settings_(settings), setup_(settings.setup()) {}
 
@@ -1431,4 +1432,6 @@ void TrackletLUT::writeTable() const {
 int TrackletLUT::lookup(unsigned int index) const {
   assert(index < table_.size());
   return table_[index];
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -10,319 +10,594 @@ using namespace std;
 
 namespace trklet {
 
-TrackletLUT::TrackletLUT(const Settings& settings) : settings_(settings), setup_(settings.setup()) {}
+  TrackletLUT::TrackletLUT(const Settings& settings) : settings_(settings), setup_(settings.setup()) {}
 
-std::vector<const tt::SensorModule*> TrackletLUT::getSensorModules(
-    unsigned int layerdisk, bool isPS, std::array<double, 2> tan_range, unsigned int nzbins, unsigned int zbin) {
-  //Returns a vector of SensorModules using T. Schuh's Setup and SensorModule classes.
-  //Can be used 3 ways:
-  //Default: No specified tan_range or nzbins, returns all SensorModules in specified layerdisk (unique in |z|)
-  //tan_range: Returns modules in given tan range, where the min and max tan(theta) are measured from 0 -/+ z0 to account for displaced tracks
-  //zbins: Returns modules in specified z bin (2 zbins = (Flat, Tilted), 13 zbins = (Flat, TR1, ..., TR12). Only for tilted barrel
+  std::vector<const tt::SensorModule*> TrackletLUT::getSensorModules(
+      unsigned int layerdisk, bool isPS, std::array<double, 2> tan_range, unsigned int nzbins, unsigned int zbin) {
+    //Returns a vector of SensorModules using T. Schuh's Setup and SensorModule classes.
+    //Can be used 3 ways:
+    //Default: No specified tan_range or nzbins, returns all SensorModules in specified layerdisk (unique in |z|)
+    //tan_range: Returns modules in given tan range, where the min and max tan(theta) are measured from 0 -/+ z0 to account for displaced tracks
+    //zbins: Returns modules in specified z bin (2 zbins = (Flat, Tilted), 13 zbins = (Flat, TR1, ..., TR12). Only for tilted barrel
 
-  bool use_tan_range = !(tan_range[0] == -1 and tan_range[1] == -1);
-  bool use_zbins = (nzbins > 1);
+    bool use_tan_range = !(tan_range[0] == -1 and tan_range[1] == -1);
+    bool use_zbins = (nzbins > 1);
 
-  bool barrel = layerdisk < N_LAYER;
+    bool barrel = layerdisk < N_LAYER;
 
-  int layerId = barrel ? layerdisk + 1 : layerdisk + N_LAYER - 1;
+    int layerId = barrel ? layerdisk + 1 : layerdisk + N_LAYER - 1;
 
-  std::vector<const tt::SensorModule*> sensorModules;
+    std::vector<const tt::SensorModule*> sensorModules;
 
-  double z0 = settings_.z0cut();
+    double z0 = settings_.z0cut();
 
-  for (auto& sm : setup_->sensorModules()) {
-    if (sm.layerId() != layerId || sm.z() < 0 || sm.psModule() != isPS) {
-      continue;
-    }
+    for (auto& sm : setup_->sensorModules()) {
+      if (sm.layerId() != layerId || sm.z() < 0 || sm.psModule() != isPS) {
+        continue;
+      }
 
-    if (use_tan_range) {
-      double rmin = sm.r() - (sm.numColumns() / 2 - 0.5) * sm.pitchCol() * std::abs(sm.sinTilt());
-      double rmax = sm.r() + (sm.numColumns() / 2 - 0.5) * sm.pitchCol() * std::abs(sm.sinTilt());
+      if (use_tan_range) {
+        double rmin = sm.r() - (sm.numColumns() / 2 - 0.5) * sm.pitchCol() * std::abs(sm.sinTilt());
+        double rmax = sm.r() + (sm.numColumns() / 2 - 0.5) * sm.pitchCol() * std::abs(sm.sinTilt());
 
-      double zmin = std::abs(sm.z()) - (sm.numColumns() / 2 - 0.5) * sm.pitchCol() * std::abs(sm.cosTilt());
-      double zmax = std::abs(sm.z()) + (sm.numColumns() / 2 - 0.5) * sm.pitchCol() * std::abs(sm.cosTilt());
+        double zmin = std::abs(sm.z()) - (sm.numColumns() / 2 - 0.5) * sm.pitchCol() * std::abs(sm.cosTilt());
+        double zmax = std::abs(sm.z()) + (sm.numColumns() / 2 - 0.5) * sm.pitchCol() * std::abs(sm.cosTilt());
 
-      //z0_max is swapped here so that the comparison down 5 lines is from same origin (+/- z0)
-      double mod_tan_max = tan_theta(rmin, zmax, z0, false);
-      double mod_tan_min = tan_theta(rmax, zmin, z0, true);
+        //z0_max is swapped here so that the comparison down 5 lines is from same origin (+/- z0)
+        double mod_tan_max = tan_theta(rmin, zmax, z0, false);
+        double mod_tan_min = tan_theta(rmax, zmin, z0, true);
 
-      if (mod_tan_max >= tan_range[0] && mod_tan_min <= tan_range[1]) {
+        if (mod_tan_max >= tan_range[0] && mod_tan_min <= tan_range[1]) {
+          sensorModules.push_back(&sm);
+        }
+      } else if (use_zbins) {
+        assert(layerdisk < 3);
+
+        if (nzbins == 2) {
+          bool useFlat = (zbin == 0);
+          bool isFlat = (sm.tilt() == 0);
+
+          if (useFlat and isFlat)
+            sensorModules.push_back(&sm);
+          else if (!useFlat and !isFlat)
+            sensorModules.push_back(&sm);
+        } else if (nzbins == 13) {
+          if (sm.ringId(setup_) == zbin)
+            sensorModules.push_back(&sm);
+        } else {
+          throw cms::Exception("Unspecified number of z bins");
+        }
+      } else {
         sensorModules.push_back(&sm);
       }
-    } else if (use_zbins) {
-      assert(layerdisk < 3);
-
-      if (nzbins == 2) {
-        bool useFlat = (zbin == 0);
-        bool isFlat = (sm.tilt() == 0);
-
-        if (useFlat and isFlat)
-          sensorModules.push_back(&sm);
-        else if (!useFlat and !isFlat)
-          sensorModules.push_back(&sm);
-      } else if (nzbins == 13) {
-        if (sm.ringId(setup_) == zbin)
-          sensorModules.push_back(&sm);
-      } else {
-        throw cms::Exception("Unspecified number of z bins");
-      }
-    } else {
-      sensorModules.push_back(&sm);
     }
+
+    //Remove Duplicate Modules
+    static constexpr double delta = 1.e-3;
+    auto smallerR = [](const tt::SensorModule* lhs, const tt::SensorModule* rhs) { return lhs->r() < rhs->r(); };
+    auto smallerZ = [](const tt::SensorModule* lhs, const tt::SensorModule* rhs) { return lhs->z() < rhs->z(); };
+    auto equalRZ = [](const tt::SensorModule* lhs, const tt::SensorModule* rhs) {
+      return abs(lhs->r() - rhs->r()) < delta && abs(lhs->z() - rhs->z()) < delta;
+    };
+    stable_sort(sensorModules.begin(), sensorModules.end(), smallerR);
+    stable_sort(sensorModules.begin(), sensorModules.end(), smallerZ);
+    sensorModules.erase(unique(sensorModules.begin(), sensorModules.end(), equalRZ), sensorModules.end());
+
+    return sensorModules;
   }
 
-  //Remove Duplicate Modules
-  static constexpr double delta = 1.e-3;
-  auto smallerR = [](const tt::SensorModule* lhs, const tt::SensorModule* rhs) { return lhs->r() < rhs->r(); };
-  auto smallerZ = [](const tt::SensorModule* lhs, const tt::SensorModule* rhs) { return lhs->z() < rhs->z(); };
-  auto equalRZ = [](const tt::SensorModule* lhs, const tt::SensorModule* rhs) {
-    return abs(lhs->r() - rhs->r()) < delta && abs(lhs->z() - rhs->z()) < delta;
-  };
-  stable_sort(sensorModules.begin(), sensorModules.end(), smallerR);
-  stable_sort(sensorModules.begin(), sensorModules.end(), smallerZ);
-  sensorModules.erase(unique(sensorModules.begin(), sensorModules.end(), equalRZ), sensorModules.end());
+  std::array<double, 2> TrackletLUT::getTanRange(const std::vector<const tt::SensorModule*>& sensorModules) {
+    //Given a set of modules returns a range in tan(theta), the angle is measured in the r-z(+/-z0) plane from the r-axis
 
-  return sensorModules;
-}
+    std::array<double, 2> tan_range = {{2147483647, 0}};  //(tan_min, tan_max)
 
-std::array<double, 2> TrackletLUT::getTanRange(const std::vector<const tt::SensorModule*>& sensorModules) {
-  //Given a set of modules returns a range in tan(theta), the angle is measured in the r-z(+/-z0) plane from the r-axis
+    double z0 = settings_.z0cut();
 
-  std::array<double, 2> tan_range = {{2147483647, 0}};  //(tan_min, tan_max)
+    for (auto sm : sensorModules) {
+      double rmin = sm->r() - (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * std::abs(sm->sinTilt());
+      double rmax = sm->r() + (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * std::abs(sm->sinTilt());
 
-  double z0 = settings_.z0cut();
+      double zmin = std::abs(sm->z()) - (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * sm->cosTilt();
+      double zmax = std::abs(sm->z()) + (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * sm->cosTilt();
 
-  for (auto sm : sensorModules) {
-    double rmin = sm->r() - (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * std::abs(sm->sinTilt());
-    double rmax = sm->r() + (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * std::abs(sm->sinTilt());
+      double mod_tan_max = tan_theta(rmin, zmax, z0, true);  //(r, z, z0, bool z0_max), z0_max measures from +/- z0
+      double mod_tan_min = tan_theta(rmax, zmin, z0, false);
 
-    double zmin = std::abs(sm->z()) - (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * sm->cosTilt();
-    double zmax = std::abs(sm->z()) + (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * sm->cosTilt();
-
-    double mod_tan_max = tan_theta(rmin, zmax, z0, true);  //(r, z, z0, bool z0_max), z0_max measures from +/- z0
-    double mod_tan_min = tan_theta(rmax, zmin, z0, false);
-
-    if (mod_tan_min < tan_range[0])
-      tan_range[0] = mod_tan_min;
-    if (mod_tan_max > tan_range[1])
-      tan_range[1] = mod_tan_max;
-  }
-  return tan_range;
-}
-
-std::vector<std::array<double, 2>> TrackletLUT::getBendCut(unsigned int layerdisk,
-                                                           const std::vector<const tt::SensorModule*>& sensorModules,
-                                                           bool isPS,
-                                                           double FEbendcut) {
-  //Finds range of bendstrip for given SensorModules as a function of the encoded bend. Returns in format (mid, half_range).
-  //This uses the stub windows provided by T. Schuh's SensorModule class to determine the bend encoding. TODO test changes in stub windows
-  //Any other change to the bend encoding requires changes here, perhaps a function that given (FEbend, isPS, stub window) and outputs an encoded bend
-  //would be useful for consistency.
-
-  unsigned int bendbits = isPS ? 3 : 4;
-
-  std::vector<std::array<double, 2>> bendpars;    // mid, cut
-  std::vector<std::array<double, 2>> bendminmax;  // min, max
-
-  //Initialize array
-  for (int i = 0; i < 1 << bendbits; i++) {
-    bendpars.push_back({{99, 0}});
-    bendminmax.push_back({{99, -99}});
+      if (mod_tan_min < tan_range[0])
+        tan_range[0] = mod_tan_min;
+      if (mod_tan_max > tan_range[1])
+        tan_range[1] = mod_tan_max;
+    }
+    return tan_range;
   }
 
-  //Loop over modules
-  for (auto sm : sensorModules) {
-    int window = sm->windowSize();  //Half-strip units
-    const vector<double>& encodingBend = setup_->encodingBend(window, isPS);
+  std::vector<std::array<double, 2>> TrackletLUT::getBendCut(unsigned int layerdisk,
+                                                             const std::vector<const tt::SensorModule*>& sensorModules,
+                                                             bool isPS,
+                                                             double FEbendcut) {
+    //Finds range of bendstrip for given SensorModules as a function of the encoded bend. Returns in format (mid, half_range).
+    //This uses the stub windows provided by T. Schuh's SensorModule class to determine the bend encoding. TODO test changes in stub windows
+    //Any other change to the bend encoding requires changes here, perhaps a function that given (FEbend, isPS, stub window) and outputs an encoded bend
+    //would be useful for consistency.
 
-    //Loop over FEbends
-    for (int ibend = 0; ibend <= 2 * window; ibend++) {
-      int FEbend = ibend - window;                                                 //Half-strip units
-      double BEbend = setup_->stubAlgorithm()->degradeBend(isPS, window, FEbend);  //Full strip units
+    unsigned int bendbits = isPS ? 3 : 4;
 
-      const auto pos = std::find(encodingBend.begin(), encodingBend.end(), std::abs(BEbend));
-      int bend = std::signbit(BEbend) ? (1 << bendbits) - distance(encodingBend.begin(), pos)
-                                      : distance(encodingBend.begin(), pos);  //Encoded bend
+    std::vector<std::array<double, 2>> bendpars;    // mid, cut
+    std::vector<std::array<double, 2>> bendminmax;  // min, max
 
-      double bendmin = FEbend / 2.0 - FEbendcut;  //Full Strip units
-      double bendmax = FEbend / 2.0 + FEbendcut;
+    //Initialize array
+    for (int i = 0; i < 1 << bendbits; i++) {
+      bendpars.push_back({{99, 0}});
+      bendminmax.push_back({{99, -99}});
+    }
 
-      //Convert to bendstrip, calculate at module edges (z min, r max) and  (z max, r min)
-      double z_mod[2];
-      double r_mod[2];
+    //Loop over modules
+    for (auto sm : sensorModules) {
+      int window = sm->windowSize();  //Half-strip units
+      const vector<double>& encodingBend = setup_->encodingBend(window, isPS);
 
-      z_mod[0] = std::abs(sm->z()) + (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * sm->cosTilt();  //z max
-      z_mod[1] = std::abs(sm->z()) - (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * sm->cosTilt();  //z min
+      //Loop over FEbends
+      for (int ibend = 0; ibend <= 2 * window; ibend++) {
+        int FEbend = ibend - window;                                                 //Half-strip units
+        double BEbend = setup_->stubAlgorithm()->degradeBend(isPS, window, FEbend);  //Full strip units
 
-      r_mod[0] = sm->r() - (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * std::abs(sm->sinTilt());  //r min
-      r_mod[1] = sm->r() + (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * std::abs(sm->sinTilt());  //r max
+        const auto pos = std::find(encodingBend.begin(), encodingBend.end(), std::abs(BEbend));
+        int bend = std::signbit(BEbend) ? (1 << bendbits) - distance(encodingBend.begin(), pos)
+                                        : distance(encodingBend.begin(), pos);  //Encoded bend
 
-      for (int i = 0; i < 2; i++) {  // 2 points to cover range in tan(theta) = z/r
-        double CF = std::abs(sm->sinTilt()) * (z_mod[i] / r_mod[i]) + sm->cosTilt();
+        double bendmin = FEbend / 2.0 - FEbendcut;  //Full Strip units
+        double bendmax = FEbend / 2.0 + FEbendcut;
 
-        double cbendmin =
-            convertFEBend(bendmin, sm->sep(), settings_.sensorSpacing2S(), CF, (layerdisk < N_LAYER), r_mod[i]);
-        double cbendmax =
-            convertFEBend(bendmax, sm->sep(), settings_.sensorSpacing2S(), CF, (layerdisk < N_LAYER), r_mod[i]);
+        //Convert to bendstrip, calculate at module edges (z min, r max) and  (z max, r min)
+        double z_mod[2];
+        double r_mod[2];
 
-        if (cbendmin < bendminmax[bend][0])
-          bendminmax.at(bend)[0] = cbendmin;
-        if (cbendmax > bendminmax[bend][1])
-          bendminmax.at(bend)[1] = cbendmax;
+        z_mod[0] = std::abs(sm->z()) + (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * sm->cosTilt();  //z max
+        z_mod[1] = std::abs(sm->z()) - (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * sm->cosTilt();  //z min
+
+        r_mod[0] = sm->r() - (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * std::abs(sm->sinTilt());  //r min
+        r_mod[1] = sm->r() + (sm->numColumns() / 2 - 0.5) * sm->pitchCol() * std::abs(sm->sinTilt());  //r max
+
+        for (int i = 0; i < 2; i++) {  // 2 points to cover range in tan(theta) = z/r
+          double CF = std::abs(sm->sinTilt()) * (z_mod[i] / r_mod[i]) + sm->cosTilt();
+
+          double cbendmin =
+              convertFEBend(bendmin, sm->sep(), settings_.sensorSpacing2S(), CF, (layerdisk < N_LAYER), r_mod[i]);
+          double cbendmax =
+              convertFEBend(bendmax, sm->sep(), settings_.sensorSpacing2S(), CF, (layerdisk < N_LAYER), r_mod[i]);
+
+          if (cbendmin < bendminmax[bend][0])
+            bendminmax.at(bend)[0] = cbendmin;
+          if (cbendmax > bendminmax[bend][1])
+            bendminmax.at(bend)[1] = cbendmax;
+        }
       }
     }
+    //Convert min, max to mid, cut for ease of use
+    for (int i = 0; i < 1 << bendbits; i++) {
+      double mid = (bendminmax[i][1] + bendminmax[i][0]) / 2;
+      double cut = (bendminmax[i][1] - bendminmax[i][0]) / 2;
+
+      bendpars[i][0] = mid;
+      bendpars[i][1] = cut;
+    }
+
+    return bendpars;
   }
-  //Convert min, max to mid, cut for ease of use
-  for (int i = 0; i < 1 << bendbits; i++) {
-    double mid = (bendminmax[i][1] + bendminmax[i][0]) / 2;
-    double cut = (bendminmax[i][1] - bendminmax[i][0]) / 2;
 
-    bendpars[i][0] = mid;
-    bendpars[i][1] = cut;
-  }
+  void TrackletLUT::initmatchcut(unsigned int layerdisk, MatchType type, unsigned int region) {
+    char cregion = 'A' + region;
 
-  return bendpars;
-}
+    for (unsigned int iSeed = 0; iSeed < N_SEED; iSeed++) {
+      if (type == barrelphi) {
+        table_.push_back(settings_.rphimatchcut(iSeed, layerdisk) / (settings_.kphi1() * settings_.rmean(layerdisk)));
+      }
+      if (type == barrelz) {
+        table_.push_back(settings_.zmatchcut(iSeed, layerdisk) / settings_.kz());
+      }
+      if (type == diskPSphi) {
+        table_.push_back(settings_.rphicutPS(iSeed, layerdisk - N_LAYER) / (settings_.kphi() * settings_.kr()));
+      }
+      if (type == disk2Sphi) {
+        table_.push_back(settings_.rphicut2S(iSeed, layerdisk - N_LAYER) / (settings_.kphi() * settings_.kr()));
+      }
+      if (type == disk2Sr) {
+        table_.push_back(settings_.rcut2S(iSeed, layerdisk - N_LAYER) / settings_.krprojshiftdisk());
+      }
+      if (type == diskPSr) {
+        table_.push_back(settings_.rcutPS(iSeed, layerdisk - N_LAYER) / settings_.krprojshiftdisk());
+      }
+    }
+    if (type == alphainner) {
+      for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
+        table_.push_back((1 << settings_.alphashift()) * settings_.krprojshiftdisk() * settings_.half2SmoduleWidth() /
+                         (1 << (settings_.nbitsalpha() - 1)) / (settings_.rDSSinner(i) * settings_.rDSSinner(i)) /
+                         settings_.kphi());
+      }
+    }
+    if (type == alphaouter) {
+      for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
+        table_.push_back((1 << settings_.alphashift()) * settings_.krprojshiftdisk() * settings_.half2SmoduleWidth() /
+                         (1 << (settings_.nbitsalpha() - 1)) / (settings_.rDSSouter(i) * settings_.rDSSouter(i)) /
+                         settings_.kphi());
+      }
+    }
+    if (type == rSSinner) {
+      for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
+        table_.push_back(settings_.rDSSinner(i) / settings_.kr());
+      }
+    }
+    if (type == rSSouter) {
+      for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
+        table_.push_back(settings_.rDSSouter(i) / settings_.kr());
+      }
+    }
 
-void TrackletLUT::initmatchcut(unsigned int layerdisk, MatchType type, unsigned int region) {
-  char cregion = 'A' + region;
+    name_ = settings_.combined() ? "MP_" : "MC_";
 
-  for (unsigned int iSeed = 0; iSeed < N_SEED; iSeed++) {
     if (type == barrelphi) {
-      table_.push_back(settings_.rphimatchcut(iSeed, layerdisk) / (settings_.kphi1() * settings_.rmean(layerdisk)));
+      name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_phicut.tab";
     }
     if (type == barrelz) {
-      table_.push_back(settings_.zmatchcut(iSeed, layerdisk) / settings_.kz());
+      name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_zcut.tab";
     }
     if (type == diskPSphi) {
-      table_.push_back(settings_.rphicutPS(iSeed, layerdisk - N_LAYER) / (settings_.kphi() * settings_.kr()));
+      name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_PSphicut.tab";
     }
     if (type == disk2Sphi) {
-      table_.push_back(settings_.rphicut2S(iSeed, layerdisk - N_LAYER) / (settings_.kphi() * settings_.kr()));
+      name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_2Sphicut.tab";
     }
     if (type == disk2Sr) {
-      table_.push_back(settings_.rcut2S(iSeed, layerdisk - N_LAYER) / settings_.krprojshiftdisk());
+      name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_2Srcut.tab";
     }
     if (type == diskPSr) {
-      table_.push_back(settings_.rcutPS(iSeed, layerdisk - N_LAYER) / settings_.krprojshiftdisk());
+      name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_PSrcut.tab";
     }
-  }
-  if (type == alphainner) {
-    for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
-      table_.push_back((1 << settings_.alphashift()) * settings_.krprojshiftdisk() * settings_.half2SmoduleWidth() /
-                       (1 << (settings_.nbitsalpha() - 1)) / (settings_.rDSSinner(i) * settings_.rDSSinner(i)) /
-                       settings_.kphi());
+    if (type == alphainner) {
+      name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_alphainner.tab";
     }
-  }
-  if (type == alphaouter) {
-    for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
-      table_.push_back((1 << settings_.alphashift()) * settings_.krprojshiftdisk() * settings_.half2SmoduleWidth() /
-                       (1 << (settings_.nbitsalpha() - 1)) / (settings_.rDSSouter(i) * settings_.rDSSouter(i)) /
-                       settings_.kphi());
+    if (type == alphaouter) {
+      name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_alphaouter.tab";
     }
-  }
-  if (type == rSSinner) {
-    for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
-      table_.push_back(settings_.rDSSinner(i) / settings_.kr());
+    if (type == rSSinner) {
+      name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_rDSSinner.tab";
     }
-  }
-  if (type == rSSouter) {
-    for (unsigned int i = 0; i < N_DSS_MOD * 2; i++) {
-      table_.push_back(settings_.rDSSouter(i) / settings_.kr());
+    if (type == rSSouter) {
+      name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_rDSSouter.tab";
     }
+
+    positive_ = false;
+
+    writeTable();
   }
 
-  name_ = settings_.combined() ? "MP_" : "MC_";
+  void TrackletLUT::initTPlut(bool fillInner,
+                              unsigned int iSeed,
+                              unsigned int layerdisk1,
+                              unsigned int layerdisk2,
+                              unsigned int nbitsfinephidiff,
+                              unsigned int iTP) {
+    //number of fine phi bins in sector
+    int nfinephibins =
+        settings_.nallstubs(layerdisk2) * settings_.nvmte(1, iSeed) * (1 << settings_.nfinephi(1, iSeed));
+    double dfinephi = settings_.dphisectorHG() / nfinephibins;
 
-  if (type == barrelphi) {
-    name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_phicut.tab";
-  }
-  if (type == barrelz) {
-    name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_zcut.tab";
-  }
-  if (type == diskPSphi) {
-    name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_PSphicut.tab";
-  }
-  if (type == disk2Sphi) {
-    name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_2Sphicut.tab";
-  }
-  if (type == disk2Sr) {
-    name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_2Srcut.tab";
-  }
-  if (type == diskPSr) {
-    name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_PSrcut.tab";
-  }
-  if (type == alphainner) {
-    name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_alphainner.tab";
-  }
-  if (type == alphaouter) {
-    name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_alphaouter.tab";
-  }
-  if (type == rSSinner) {
-    name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_rDSSinner.tab";
-  }
-  if (type == rSSouter) {
-    name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_rDSSouter.tab";
-  }
+    int outerrbits = 3;
 
-  positive_ = false;
-
-  writeTable();
-}
-
-void TrackletLUT::initTPlut(bool fillInner,
-                            unsigned int iSeed,
-                            unsigned int layerdisk1,
-                            unsigned int layerdisk2,
-                            unsigned int nbitsfinephidiff,
-                            unsigned int iTP) {
-  //number of fine phi bins in sector
-  int nfinephibins = settings_.nallstubs(layerdisk2) * settings_.nvmte(1, iSeed) * (1 << settings_.nfinephi(1, iSeed));
-  double dfinephi = settings_.dphisectorHG() / nfinephibins;
-
-  int outerrbits = 3;
-
-  if (iSeed == Seed::L1L2 || iSeed == Seed::L2L3 || iSeed == Seed::L3L4 || iSeed == Seed::L5L6) {
-    outerrbits = 0;
-  }
-
-  int outerrbins = (1 << outerrbits);
-
-  double dphi[2];
-  double router[2];
-
-  bool isPSinner;
-  bool isPSouter;
-
-  if (iSeed == Seed::L3L4) {
-    isPSinner = true;
-    isPSouter = false;
-  } else if (iSeed == Seed::L5L6) {
-    isPSinner = false;
-    isPSouter = false;
-  } else {
-    isPSinner = true;
-    isPSouter = true;
-  }
-
-  unsigned int nbendbitsinner = isPSinner ? N_BENDBITS_PS : N_BENDBITS_2S;
-  unsigned int nbendbitsouter = isPSouter ? N_BENDBITS_PS : N_BENDBITS_2S;
-
-  double z0 = settings_.z0cut();
-
-  int nbinsfinephidiff = (1 << nbitsfinephidiff);
-
-  for (int iphibin = 0; iphibin < nbinsfinephidiff; iphibin++) {
-    int iphidiff = iphibin;
-    if (iphibin >= nbinsfinephidiff / 2) {
-      iphidiff = iphibin - nbinsfinephidiff;
+    if (iSeed == Seed::L1L2 || iSeed == Seed::L2L3 || iSeed == Seed::L3L4 || iSeed == Seed::L5L6) {
+      outerrbits = 0;
     }
-    //min and max dphi
-    //ramge of dphi to consider due to resolution
-    double deltaphi = 1.5;
-    dphi[0] = (iphidiff - deltaphi) * dfinephi;
-    dphi[1] = (iphidiff + deltaphi) * dfinephi;
+
+    int outerrbins = (1 << outerrbits);
+
+    double dphi[2];
+    double router[2];
+
+    bool isPSinner;
+    bool isPSouter;
+
+    if (iSeed == Seed::L3L4) {
+      isPSinner = true;
+      isPSouter = false;
+    } else if (iSeed == Seed::L5L6) {
+      isPSinner = false;
+      isPSouter = false;
+    } else {
+      isPSinner = true;
+      isPSouter = true;
+    }
+
+    unsigned int nbendbitsinner = isPSinner ? N_BENDBITS_PS : N_BENDBITS_2S;
+    unsigned int nbendbitsouter = isPSouter ? N_BENDBITS_PS : N_BENDBITS_2S;
+
+    double z0 = settings_.z0cut();
+
+    int nbinsfinephidiff = (1 << nbitsfinephidiff);
+
+    for (int iphibin = 0; iphibin < nbinsfinephidiff; iphibin++) {
+      int iphidiff = iphibin;
+      if (iphibin >= nbinsfinephidiff / 2) {
+        iphidiff = iphibin - nbinsfinephidiff;
+      }
+      //min and max dphi
+      //ramge of dphi to consider due to resolution
+      double deltaphi = 1.5;
+      dphi[0] = (iphidiff - deltaphi) * dfinephi;
+      dphi[1] = (iphidiff + deltaphi) * dfinephi;
+      for (int irouterbin = 0; irouterbin < outerrbins; irouterbin++) {
+        if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4 || iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
+          router[0] =
+              settings_.rmindiskvm() + irouterbin * (settings_.rmaxdiskvm() - settings_.rmindiskvm()) / outerrbins;
+          router[1] = settings_.rmindiskvm() +
+                      (irouterbin + 1) * (settings_.rmaxdiskvm() - settings_.rmindiskvm()) / outerrbins;
+        } else {
+          router[0] = settings_.rmean(layerdisk2);
+          router[1] = settings_.rmean(layerdisk2);
+        }
+
+        //Determine bend cuts using geometry
+        std::vector<std::array<double, 2>> bend_cuts_inner;
+        std::vector<std::array<double, 2>> bend_cuts_outer;
+
+        if (settings_.useCalcBendCuts) {
+          std::vector<const tt::SensorModule*> sminner;
+          std::vector<const tt::SensorModule*> smouter;
+
+          if (iSeed == Seed::L1L2 || iSeed == Seed::L2L3 || iSeed == Seed::L3L4 || iSeed == Seed::L5L6) {
+            double outer_tan_max = tan_theta(settings_.rmean(layerdisk2), settings_.zlength(), z0, true);
+            std::array<double, 2> tan_range = {{0, outer_tan_max}};
+
+            smouter = getSensorModules(layerdisk2, isPSouter, tan_range);
+            sminner = getSensorModules(layerdisk1, isPSinner, tan_range);
+
+          } else if (iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
+            double outer_tan_min = tan_theta(router[1], settings_.zmindisk(layerdisk2 - N_LAYER), z0, false);
+            double outer_tan_max = tan_theta(router[0], settings_.zmaxdisk(layerdisk2 - N_LAYER), z0, true);
+
+            smouter = getSensorModules(layerdisk2, isPSouter, {{outer_tan_min, outer_tan_max}});
+            std::array<double, 2> tan_range = getTanRange(smouter);
+            sminner = getSensorModules(layerdisk1, isPSinner, tan_range);
+
+          } else {  // D1D2 D3D4
+
+            double outer_tan_min = tan_theta(router[1], settings_.zmindisk(layerdisk2 - N_LAYER), z0, false);
+            double outer_tan_max = tan_theta(router[0], settings_.zmaxdisk(layerdisk2 - N_LAYER), z0, true);
+
+            smouter = getSensorModules(layerdisk2, isPSouter, {{outer_tan_min, outer_tan_max}});
+
+            std::array<double, 2> tan_range = getTanRange(smouter);
+            sminner = getSensorModules(layerdisk1, isPSinner, tan_range);
+          }
+
+          bend_cuts_inner = getBendCut(layerdisk1, sminner, isPSinner, settings_.bendcutTE(iSeed, true));
+          bend_cuts_outer = getBendCut(layerdisk2, smouter, isPSouter, settings_.bendcutTE(iSeed, false));
+
+        } else {
+          for (int ibend = 0; ibend < (1 << nbendbitsinner); ibend++) {
+            double mid = settings_.benddecode(ibend, layerdisk1, isPSinner);
+            double cut = settings_.bendcutte(ibend, layerdisk1, isPSinner);
+            bend_cuts_inner.push_back({{mid, cut}});
+          }
+          for (int ibend = 0; ibend < (1 << nbendbitsouter); ibend++) {
+            double mid = settings_.benddecode(ibend, layerdisk2, isPSouter);
+            double cut = settings_.bendcutte(ibend, layerdisk2, isPSouter);
+            bend_cuts_outer.push_back({{mid, cut}});
+          }
+        }
+
+        double bendinnermin = 20.0;
+        double bendinnermax = -20.0;
+        double bendoutermin = 20.0;
+        double bendoutermax = -20.0;
+        double rinvmin = 1.0;
+        double rinvmax = -1.0;
+        double absrinvmin = 1.0;
+
+        for (int i2 = 0; i2 < 2; i2++) {
+          for (int i3 = 0; i3 < 2; i3++) {
+            double rinner = 0.0;
+            if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4) {
+              rinner = router[i3] * settings_.zmean(layerdisk1 - N_LAYER) / settings_.zmean(layerdisk2 - N_LAYER);
+            } else {
+              rinner = settings_.rmean(layerdisk1);
+            }
+            if (settings_.useCalcBendCuts) {
+              if (rinner >= router[i3])
+                continue;
+            }
+            double rinv1 = (rinner < router[i3]) ? rinv(0.0, -dphi[i2], rinner, router[i3]) : 20.0;
+            double pitchinner = (rinner < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
+            double pitchouter =
+                (router[i3] < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
+            double abendinner = bendstrip(rinner, rinv1, pitchinner, settings_.sensorSpacing2S());
+            double abendouter = bendstrip(router[i3], rinv1, pitchouter, settings_.sensorSpacing2S());
+            if (abendinner < bendinnermin)
+              bendinnermin = abendinner;
+            if (abendinner > bendinnermax)
+              bendinnermax = abendinner;
+            if (abendouter < bendoutermin)
+              bendoutermin = abendouter;
+            if (abendouter > bendoutermax)
+              bendoutermax = abendouter;
+            if (std::abs(rinv1) < absrinvmin)
+              absrinvmin = std::abs(rinv1);
+            if (rinv1 > rinvmax)
+              rinvmax = rinv1;
+            if (rinv1 < rinvmin)
+              rinvmin = rinv1;
+          }
+        }
+
+        bool passptcut;
+        double bendfac;
+        double rinvcutte = settings_.rinvcutte();
+
+        if (settings_.useCalcBendCuts) {
+          double lowrinvcutte =
+              rinvcutte / 3;  //Somewhat arbitrary value, allows for better acceptance in bins with low rinv (high pt)
+          passptcut = rinvmin < rinvcutte and rinvmax > -rinvcutte;
+          bendfac = (rinvmin < lowrinvcutte and rinvmax > -lowrinvcutte)
+                        ? 1.05
+                        : 1.0;  //Somewhat arbirary value, bend cuts are 5% larger in bins with low rinv (high pt)
+        } else {
+          passptcut = absrinvmin < rinvcutte;
+          bendfac = 1.0;
+        }
+
+        if (fillInner) {
+          for (int ibend = 0; ibend < (1 << nbendbitsinner); ibend++) {
+            double bendminfac = (isPSinner and (ibend == 2 or ibend == 3)) ? bendfac : 1.0;
+            double bendmaxfac = (isPSinner and (ibend == 6 or ibend == 5)) ? bendfac : 1.0;
+
+            double mid = bend_cuts_inner.at(ibend)[0];
+            double cut = bend_cuts_inner.at(ibend)[1];
+
+            bool passinner = mid + cut * bendmaxfac > bendinnermin && mid - cut * bendminfac < bendinnermax;
+
+            table_.push_back(passinner && passptcut);
+          }
+        } else {
+          for (int ibend = 0; ibend < (1 << nbendbitsouter); ibend++) {
+            double bendminfac = (isPSouter and (ibend == 2 or ibend == 3)) ? bendfac : 1.0;
+            double bendmaxfac = (isPSouter and (ibend == 6 or ibend == 5)) ? bendfac : 1.0;
+
+            double mid = bend_cuts_outer.at(ibend)[0];
+            double cut = bend_cuts_outer.at(ibend)[1];
+
+            bool passouter = mid + cut * bendmaxfac > bendoutermin && mid - cut * bendminfac < bendoutermax;
+
+            table_.push_back(passouter && passptcut);
+          }
+        }
+      }
+    }
+
+    nbits_ = 8;
+
+    positive_ = false;
+    char cTP = 'A' + iTP;
+
+    name_ = "TP_" + TrackletConfigBuilder::LayerName(layerdisk1) + TrackletConfigBuilder::LayerName(layerdisk2) + cTP;
+
+    if (fillInner) {
+      name_ += "_stubptinnercut.tab";
+    } else {
+      name_ += "_stubptoutercut.tab";
+    }
+
+    writeTable();
+  }
+
+  void TrackletLUT::initTPregionlut(unsigned int iSeed,
+                                    unsigned int layerdisk1,
+                                    unsigned int layerdisk2,
+                                    unsigned int iAllStub,
+                                    unsigned int nbitsfinephidiff,
+                                    unsigned int nbitsfinephi,
+                                    const TrackletLUT& tplutinner,
+                                    unsigned int iTP) {
+    int nirbits = 0;
+    if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4 || iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
+      nirbits = 3;
+    }
+
+    unsigned int nbendbitsinner = 3;
+
+    if (iSeed == Seed::L5L6) {
+      nbendbitsinner = 4;
+    }
+
+    for (int innerfinephi = 0; innerfinephi < (1 << nbitsfinephi); innerfinephi++) {
+      for (int innerbend = 0; innerbend < (1 << nbendbitsinner); innerbend++) {
+        for (int ir = 0; ir < (1 << nirbits); ir++) {
+          unsigned int usereg = 0;
+          for (unsigned int ireg = 0; ireg < settings_.nvmte(1, iSeed); ireg++) {
+            bool match = false;
+            for (int ifinephiouter = 0; ifinephiouter < (1 << settings_.nfinephi(1, iSeed)); ifinephiouter++) {
+              int outerfinephi = iAllStub * (1 << (nbitsfinephi - settings_.nbitsallstubs(layerdisk2))) +
+                                 ireg * (1 << settings_.nfinephi(1, iSeed)) + ifinephiouter;
+              int idphi = outerfinephi - innerfinephi;
+              bool inrange = (idphi < (1 << (nbitsfinephidiff - 1))) && (idphi >= -(1 << (nbitsfinephidiff - 1)));
+              if (idphi < 0)
+                idphi = idphi + (1 << nbitsfinephidiff);
+              int idphi1 = idphi;
+              if (iSeed >= 4)
+                idphi1 = (idphi << 3) + ir;
+              int ptinnerindexnew = (idphi1 << nbendbitsinner) + innerbend;
+              match = match || (inrange && tplutinner.lookup(ptinnerindexnew));
+            }
+            if (match) {
+              usereg = usereg | (1 << ireg);
+            }
+          }
+
+          table_.push_back(usereg);
+        }
+      }
+    }
+
+    positive_ = false;
+    char cTP = 'A' + iTP;
+
+    name_ = "TP_" + TrackletConfigBuilder::LayerName(layerdisk1) + TrackletConfigBuilder::LayerName(layerdisk2) + cTP +
+            "_usereg.tab";
+
+    writeTable();
+  }
+
+  void TrackletLUT::initteptlut(bool fillInner,
+                                bool fillTEMem,
+                                unsigned int iSeed,
+                                unsigned int layerdisk1,
+                                unsigned int layerdisk2,
+                                unsigned int innerphibits,
+                                unsigned int outerphibits,
+                                double innerphimin,
+                                double innerphimax,
+                                double outerphimin,
+                                double outerphimax,
+                                const std::string& innermem,
+                                const std::string& outermem) {
+    int outerrbits = 0;
+    if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4 || iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
+      outerrbits = 3;
+    }
+
+    int outerrbins = (1 << outerrbits);
+    int innerphibins = (1 << innerphibits);
+    int outerphibins = (1 << outerphibits);
+
+    double phiinner[2];
+    double phiouter[2];
+    double router[2];
+
+    bool isPSinner;
+    bool isPSouter;
+
+    if (iSeed == Seed::L3L4) {
+      isPSinner = true;
+      isPSouter = false;
+    } else if (iSeed == Seed::L5L6) {
+      isPSinner = false;
+      isPSouter = false;
+    } else {
+      isPSinner = true;
+      isPSouter = true;
+    }
+
+    unsigned int nbendbitsinner = isPSinner ? N_BENDBITS_PS : N_BENDBITS_2S;
+    unsigned int nbendbitsouter = isPSouter ? N_BENDBITS_PS : N_BENDBITS_2S;
+
+    if (fillTEMem) {
+      if (fillInner) {
+        table_.resize((1 << nbendbitsinner), false);
+      } else {
+        table_.resize((1 << nbendbitsouter), false);
+      }
+    }
+
+    double z0 = settings_.z0cut();
+
     for (int irouterbin = 0; irouterbin < outerrbins; irouterbin++) {
       if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4 || iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
         router[0] =
@@ -373,1065 +648,794 @@ void TrackletLUT::initTPlut(bool fillInner,
 
       } else {
         for (int ibend = 0; ibend < (1 << nbendbitsinner); ibend++) {
-          double mid = settings_.benddecode(ibend, layerdisk1, isPSinner);
-          double cut = settings_.bendcutte(ibend, layerdisk1, isPSinner);
+          double mid = settings_.benddecode(ibend, layerdisk1, nbendbitsinner == 3);
+          double cut = settings_.bendcutte(ibend, layerdisk1, nbendbitsinner == 3);
           bend_cuts_inner.push_back({{mid, cut}});
         }
         for (int ibend = 0; ibend < (1 << nbendbitsouter); ibend++) {
-          double mid = settings_.benddecode(ibend, layerdisk2, isPSouter);
-          double cut = settings_.bendcutte(ibend, layerdisk2, isPSouter);
+          double mid = settings_.benddecode(ibend, layerdisk2, nbendbitsouter == 3);
+          double cut = settings_.bendcutte(ibend, layerdisk2, nbendbitsouter == 3);
           bend_cuts_outer.push_back({{mid, cut}});
         }
       }
 
-      double bendinnermin = 20.0;
-      double bendinnermax = -20.0;
-      double bendoutermin = 20.0;
-      double bendoutermax = -20.0;
-      double rinvmin = 1.0;
-      double rinvmax = -1.0;
-      double absrinvmin = 1.0;
+      for (int iphiinnerbin = 0; iphiinnerbin < innerphibins; iphiinnerbin++) {
+        phiinner[0] = innerphimin + iphiinnerbin * (innerphimax - innerphimin) / innerphibins;
+        phiinner[1] = innerphimin + (iphiinnerbin + 1) * (innerphimax - innerphimin) / innerphibins;
+        for (int iphiouterbin = 0; iphiouterbin < outerphibins; iphiouterbin++) {
+          phiouter[0] = outerphimin + iphiouterbin * (outerphimax - outerphimin) / outerphibins;
+          phiouter[1] = outerphimin + (iphiouterbin + 1) * (outerphimax - outerphimin) / outerphibins;
 
-      for (int i2 = 0; i2 < 2; i2++) {
-        for (int i3 = 0; i3 < 2; i3++) {
-          double rinner = 0.0;
-          if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4) {
-            rinner = router[i3] * settings_.zmean(layerdisk1 - N_LAYER) / settings_.zmean(layerdisk2 - N_LAYER);
-          } else {
-            rinner = settings_.rmean(layerdisk1);
+          double bendinnermin = 20.0;
+          double bendinnermax = -20.0;
+          double bendoutermin = 20.0;
+          double bendoutermax = -20.0;
+          double rinvmin = 1.0;
+          double rinvmax = -1.0;
+          double absrinvmin = 1.0;
+
+          for (int i1 = 0; i1 < 2; i1++) {
+            for (int i2 = 0; i2 < 2; i2++) {
+              for (int i3 = 0; i3 < 2; i3++) {
+                double rinner = 0.0;
+                if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4) {
+                  rinner = router[i3] * settings_.zmean(layerdisk1 - N_LAYER) / settings_.zmean(layerdisk2 - N_LAYER);
+                } else {
+                  rinner = settings_.rmean(layerdisk1);
+                }
+
+                if (settings_.useCalcBendCuts) {
+                  if (rinner >= router[i3])
+                    continue;
+                }
+
+                double rinv1 = (rinner < router[i3]) ? -rinv(phiinner[i1], phiouter[i2], rinner, router[i3]) : -20.0;
+                double pitchinner =
+                    (rinner < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
+                double pitchouter =
+                    (router[i3] < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
+
+                double abendinner = bendstrip(rinner, rinv1, pitchinner, settings_.sensorSpacing2S());
+                double abendouter = bendstrip(router[i3], rinv1, pitchouter, settings_.sensorSpacing2S());
+
+                if (abendinner < bendinnermin)
+                  bendinnermin = abendinner;
+                if (abendinner > bendinnermax)
+                  bendinnermax = abendinner;
+                if (abendouter < bendoutermin)
+                  bendoutermin = abendouter;
+                if (abendouter > bendoutermax)
+                  bendoutermax = abendouter;
+                if (std::abs(rinv1) < absrinvmin)
+                  absrinvmin = std::abs(rinv1);
+                if (rinv1 > rinvmax)
+                  rinvmax = rinv1;
+                if (rinv1 < rinvmin)
+                  rinvmin = rinv1;
+              }
+            }
           }
+
+          double lowrinvcutte = 0.002;
+
+          bool passptcut;
+          double bendfac;
+
           if (settings_.useCalcBendCuts) {
-            if (rinner >= router[i3])
-              continue;
+            passptcut = rinvmin < settings_.rinvcutte() and rinvmax > -settings_.rinvcutte();
+            bendfac =
+                (rinvmin < lowrinvcutte and rinvmax > -lowrinvcutte) ? 1.05 : 1.0;  // Better acceptance for high pt
+          } else {
+            passptcut = absrinvmin < settings_.rinvcutte();
+            bendfac = 1.0;
           }
-          double rinv1 = (rinner < router[i3]) ? rinv(0.0, -dphi[i2], rinner, router[i3]) : 20.0;
-          double pitchinner = (rinner < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
-          double pitchouter =
-              (router[i3] < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
-          double abendinner = bendstrip(rinner, rinv1, pitchinner, settings_.sensorSpacing2S());
-          double abendouter = bendstrip(router[i3], rinv1, pitchouter, settings_.sensorSpacing2S());
-          if (abendinner < bendinnermin)
-            bendinnermin = abendinner;
-          if (abendinner > bendinnermax)
-            bendinnermax = abendinner;
-          if (abendouter < bendoutermin)
-            bendoutermin = abendouter;
-          if (abendouter > bendoutermax)
-            bendoutermax = abendouter;
-          if (std::abs(rinv1) < absrinvmin)
-            absrinvmin = std::abs(rinv1);
-          if (rinv1 > rinvmax)
-            rinvmax = rinv1;
-          if (rinv1 < rinvmin)
-            rinvmin = rinv1;
+
+          if (fillInner) {
+            for (int ibend = 0; ibend < (1 << nbendbitsinner); ibend++) {
+              double bendminfac = (isPSinner and (ibend == 2 or ibend == 3)) ? bendfac : 1.0;
+              double bendmaxfac = (isPSinner and (ibend == 6 or ibend == 5)) ? bendfac : 1.0;
+
+              double mid = bend_cuts_inner.at(ibend)[0];
+              double cut = bend_cuts_inner.at(ibend)[1];
+
+              bool passinner = mid + cut * bendmaxfac > bendinnermin && mid - cut * bendminfac < bendinnermax;
+
+              if (fillTEMem) {
+                if (passinner)
+                  table_[ibend] = 1;
+              } else {
+                table_.push_back(passinner && passptcut);
+              }
+            }
+          } else {
+            for (int ibend = 0; ibend < (1 << nbendbitsouter); ibend++) {
+              double bendminfac = (isPSouter and (ibend == 2 or ibend == 3)) ? bendfac : 1.0;
+              double bendmaxfac = (isPSouter and (ibend == 6 or ibend == 5)) ? bendfac : 1.0;
+
+              double mid = bend_cuts_outer.at(ibend)[0];
+              double cut = bend_cuts_outer.at(ibend)[1];
+
+              bool passouter = mid + cut * bendmaxfac > bendoutermin && mid - cut * bendminfac < bendoutermax;
+
+              if (fillTEMem) {
+                if (passouter)
+                  table_[ibend] = 1;
+              } else {
+                table_.push_back(passouter && passptcut);
+              }
+            }
+          }
         }
       }
+    }
 
-      bool passptcut;
-      double bendfac;
-      double rinvcutte = settings_.rinvcutte();
+    positive_ = false;
+
+    if (fillTEMem) {
+      if (fillInner) {
+        name_ = "VMSTE_" + innermem + "_vmbendcut.tab";
+      } else {
+        name_ = "VMSTE_" + outermem + "_vmbendcut.tab";
+      }
+    } else {
+      name_ = "TE_" + innermem.substr(0, innermem.size() - 2) + "_" + outermem.substr(0, outermem.size() - 2);
+      if (fillInner) {
+        name_ += "_stubptinnercut.tab";
+      } else {
+        name_ += "_stubptoutercut.tab";
+      }
+    }
+    writeTable();
+  }
+
+  void TrackletLUT::initProjectionBend(double k_phider,
+                                       unsigned int idisk,
+                                       unsigned int nrbits,
+                                       unsigned int nphiderbits) {
+    unsigned int nsignbins = 2;
+    unsigned int nrbins = 1 << (nrbits);
+    unsigned int nphiderbins = 1 << (nphiderbits);
+
+    for (unsigned int isignbin = 0; isignbin < nsignbins; isignbin++) {
+      for (unsigned int irbin = 0; irbin < nrbins; irbin++) {
+        int ir = irbin;
+        if (ir > (1 << (nrbits - 1)))
+          ir -= (1 << nrbits);
+        ir = ir << (settings_.nrbitsstub(N_LAYER) - nrbits);
+        for (unsigned int iphiderbin = 0; iphiderbin < nphiderbins; iphiderbin++) {
+          int iphider = iphiderbin;
+          if (iphider > (1 << (nphiderbits - 1)))
+            iphider -= (1 << nphiderbits);
+          iphider = iphider << (settings_.nbitsphiprojderL123() - nphiderbits);
+
+          double rproj = ir * settings_.krprojshiftdisk();
+          double phider = iphider * k_phider;
+          double t = settings_.zmean(idisk) / rproj;
+
+          if (isignbin)
+            t = -t;
+
+          double rinv = -phider * (2.0 * t);
+
+          double stripPitch = (rproj < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
+          double bendproj = bendstrip(rproj, rinv, stripPitch, settings_.sensorSpacing2S());
+
+          static double maxbend = (1 << NRINVBITS) - 1;
+
+          int ibendproj = 2.0 * bendproj + 0.5 * maxbend;
+          if (ibendproj < 0)
+            ibendproj = 0;
+          if (ibendproj > maxbend)
+            ibendproj = maxbend;
+
+          table_.push_back(ibendproj);
+        }
+      }
+    }
+
+    positive_ = false;
+    name_ = settings_.combined() ? "MP_" : "PR_";
+    name_ += "ProjectionBend_" + TrackletConfigBuilder::LayerName(N_LAYER + idisk) + ".tab";
+
+    writeTable();
+  }
+
+  void TrackletLUT::initProjectionDiskRadius(int nrbits) {
+    //When a projection to a disk is considered this offset and added and subtracted to calculate
+    //the bin the projection is pointing to. This is to account for resolution effects such that
+    //projections that are near a bin boundary will be assigned to both bins. The value (3 cm) should
+    //cover the uncertanty in the resolution.
+    double roffset = 3.0;
+
+    for (unsigned int ir = 0; ir < (1u << nrbits); ir++) {
+      double r = ir * settings_.rmaxdisk() / (1u << nrbits);
+
+      int rbin1 =
+          (1 << N_RZBITS) * (r - roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
+      int rbin2 =
+          (1 << N_RZBITS) * (r + roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
+
+      if (rbin1 < 0) {
+        rbin1 = 0;
+      }
+      rbin2 = clamp(rbin2, 0, ((1 << N_RZBITS) - 1));
+
+      assert(rbin1 <= rbin2);
+      assert(rbin2 - rbin1 <= 1);
+
+      int d = rbin1 != rbin2;
+
+      int finer =
+          (1 << (N_RZBITS + NFINERZBITS)) *
+          ((r - settings_.rmindiskvm()) - rbin1 * (settings_.rmaxdisk() - settings_.rmindiskvm()) / (1 << N_RZBITS)) /
+          (settings_.rmaxdisk() - settings_.rmindiskvm());
+
+      finer = clamp(finer, 0, ((1 << (NFINERZBITS + 1)) - 1));
+
+      //Pack the data in a 8 bit word (ffffrrrd) where f is finer, r is rbin1, and d is difference
+      int N_DIFF_FLAG = 1;  // Single bit for bool flag
+
+      int word = (finer << (N_RZBITS + N_DIFF_FLAG)) + (rbin1 << N_DIFF_FLAG) + d;
+
+      table_.push_back(word);
+    }
+
+    //Size of the data word from above (8 bits)
+    nbits_ = NFINERZBITS + 1 + N_RZBITS + 1;
+    positive_ = true;
+    name_ = "ProjectionDiskRadius.tab";
+    writeTable();
+  }
+
+  void TrackletLUT::initBendMatch(unsigned int layerdisk) {
+    unsigned int nrinv = NRINVBITS;
+    double rinvhalf = 0.5 * ((1 << nrinv) - 1);
+
+    bool barrel = layerdisk < N_LAYER;
+
+    if (barrel) {
+      bool isPSmodule = layerdisk < N_PSLAYER;
+      double stripPitch = settings_.stripPitch(isPSmodule);
+      unsigned int nbits = isPSmodule ? N_BENDBITS_PS : N_BENDBITS_2S;
+
+      std::vector<std::array<double, 2>> bend_cuts;
 
       if (settings_.useCalcBendCuts) {
-        double lowrinvcutte =
-            rinvcutte / 3;  //Somewhat arbitrary value, allows for better acceptance in bins with low rinv (high pt)
-        passptcut = rinvmin < rinvcutte and rinvmax > -rinvcutte;
-        bendfac = (rinvmin < lowrinvcutte and rinvmax > -lowrinvcutte)
-                      ? 1.05
-                      : 1.0;  //Somewhat arbirary value, bend cuts are 5% larger in bins with low rinv (high pt)
+        double bendcutFE = settings_.bendcutME(layerdisk, isPSmodule);
+        std::vector<const tt::SensorModule*> sm = getSensorModules(layerdisk, isPSmodule);
+        bend_cuts = getBendCut(layerdisk, sm, isPSmodule, bendcutFE);
+
       } else {
-        passptcut = absrinvmin < rinvcutte;
-        bendfac = 1.0;
+        for (unsigned int ibend = 0; ibend < (1u << nbits); ibend++) {
+          double mid = settings_.benddecode(ibend, layerdisk, isPSmodule);
+          double cut = settings_.bendcutte(ibend, layerdisk, isPSmodule);
+          bend_cuts.push_back({{mid, cut}});
+        }
       }
 
-      if (fillInner) {
-        for (int ibend = 0; ibend < (1 << nbendbitsinner); ibend++) {
-          double bendminfac = (isPSinner and (ibend == 2 or ibend == 3)) ? bendfac : 1.0;
-          double bendmaxfac = (isPSinner and (ibend == 6 or ibend == 5)) ? bendfac : 1.0;
+      for (unsigned int irinv = 0; irinv < (1u << nrinv); irinv++) {
+        double rinv = (irinv - rinvhalf) * (1 << (settings_.nbitsrinv() - nrinv)) * settings_.krinvpars();
 
-          double mid = bend_cuts_inner.at(ibend)[0];
-          double cut = bend_cuts_inner.at(ibend)[1];
+        double projbend = bendstrip(settings_.rmean(layerdisk), rinv, stripPitch, settings_.sensorSpacing2S());
+        for (unsigned int ibend = 0; ibend < (1u << nbits); ibend++) {
+          double mid = bend_cuts[ibend][0];
+          double cut = bend_cuts[ibend][1];
 
-          bool passinner = mid + cut * bendmaxfac > bendinnermin && mid - cut * bendminfac < bendinnermax;
+          double pass = mid + cut > projbend && mid - cut < projbend;
 
-          table_.push_back(passinner && passptcut);
+          table_.push_back(pass);
         }
+      }
+    } else {
+      std::vector<std::array<double, 2>> bend_cuts_2S;
+      std::vector<std::array<double, 2>> bend_cuts_PS;
+
+      if (settings_.useCalcBendCuts) {
+        double bendcutFE2S = settings_.bendcutME(layerdisk, false);
+        std::vector<const tt::SensorModule*> sm2S = getSensorModules(layerdisk, false);
+        bend_cuts_2S = getBendCut(layerdisk, sm2S, false, bendcutFE2S);
+
+        double bendcutFEPS = settings_.bendcutME(layerdisk, true);
+        std::vector<const tt::SensorModule*> smPS = getSensorModules(layerdisk, true);
+        bend_cuts_PS = getBendCut(layerdisk, smPS, true, bendcutFEPS);
+
       } else {
-        for (int ibend = 0; ibend < (1 << nbendbitsouter); ibend++) {
-          double bendminfac = (isPSouter and (ibend == 2 or ibend == 3)) ? bendfac : 1.0;
-          double bendmaxfac = (isPSouter and (ibend == 6 or ibend == 5)) ? bendfac : 1.0;
+        for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_2S); ibend++) {
+          double mid = settings_.benddecode(ibend, layerdisk, false);
+          double cut = settings_.bendcutme(ibend, layerdisk, false);
+          bend_cuts_2S.push_back({{mid, cut}});
+        }
+        for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_PS); ibend++) {
+          double mid = settings_.benddecode(ibend, layerdisk, true);
+          double cut = settings_.bendcutme(ibend, layerdisk, true);
+          bend_cuts_PS.push_back({{mid, cut}});
+        }
+      }
 
-          double mid = bend_cuts_outer.at(ibend)[0];
-          double cut = bend_cuts_outer.at(ibend)[1];
+      for (unsigned int iprojbend = 0; iprojbend < (1u << nrinv); iprojbend++) {
+        double projbend = 0.5 * (iprojbend - rinvhalf);
+        for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_2S); ibend++) {
+          double mid = bend_cuts_2S[ibend][0];
+          double cut = bend_cuts_2S[ibend][1];
 
-          bool passouter = mid + cut * bendmaxfac > bendoutermin && mid - cut * bendminfac < bendoutermax;
+          double pass = mid + cut > projbend && mid - cut < projbend;
 
-          table_.push_back(passouter && passptcut);
+          table_.push_back(pass);
+        }
+      }
+      for (unsigned int iprojbend = 0; iprojbend < (1u << nrinv); iprojbend++) {  //Should this be binned in r?
+        double projbend = 0.5 * (iprojbend - rinvhalf);
+        for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_PS); ibend++) {
+          double mid = bend_cuts_PS[ibend][0];
+          double cut = bend_cuts_PS[ibend][1];
+
+          double pass = mid + cut > projbend && mid - cut < projbend;
+
+          table_.push_back(pass);
         }
       }
     }
+
+    positive_ = false;
+
+    name_ = "METable_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
+
+    writeTable();
   }
 
-  nbits_ = 8;
+  void TrackletLUT::initVMRTable(unsigned int layerdisk, VMRTableType type, int region) {
+    unsigned int zbits = settings_.vmrlutzbits(layerdisk);
+    unsigned int rbits = settings_.vmrlutrbits(layerdisk);
 
-  positive_ = false;
-  char cTP = 'A' + iTP;
+    unsigned int rbins = (1 << rbits);
+    unsigned int zbins = (1 << zbits);
 
-  name_ = "TP_" + TrackletConfigBuilder::LayerName(layerdisk1) + TrackletConfigBuilder::LayerName(layerdisk2) + cTP;
+    double zmin, zmax, rmin, rmax;
 
-  if (fillInner) {
-    name_ += "_stubptinnercut.tab";
-  } else {
-    name_ += "_stubptoutercut.tab";
-  }
-
-  writeTable();
-}
-
-void TrackletLUT::initTPregionlut(unsigned int iSeed,
-                                  unsigned int layerdisk1,
-                                  unsigned int layerdisk2,
-                                  unsigned int iAllStub,
-                                  unsigned int nbitsfinephidiff,
-                                  unsigned int nbitsfinephi,
-                                  const TrackletLUT& tplutinner,
-                                  unsigned int iTP) {
-  int nirbits = 0;
-  if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4 || iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
-    nirbits = 3;
-  }
-
-  unsigned int nbendbitsinner = 3;
-
-  if (iSeed == Seed::L5L6) {
-    nbendbitsinner = 4;
-  }
-
-  for (int innerfinephi = 0; innerfinephi < (1 << nbitsfinephi); innerfinephi++) {
-    for (int innerbend = 0; innerbend < (1 << nbendbitsinner); innerbend++) {
-      for (int ir = 0; ir < (1 << nirbits); ir++) {
-        unsigned int usereg = 0;
-        for (unsigned int ireg = 0; ireg < settings_.nvmte(1, iSeed); ireg++) {
-          bool match = false;
-          for (int ifinephiouter = 0; ifinephiouter < (1 << settings_.nfinephi(1, iSeed)); ifinephiouter++) {
-            int outerfinephi = iAllStub * (1 << (nbitsfinephi - settings_.nbitsallstubs(layerdisk2))) +
-                               ireg * (1 << settings_.nfinephi(1, iSeed)) + ifinephiouter;
-            int idphi = outerfinephi - innerfinephi;
-            bool inrange = (idphi < (1 << (nbitsfinephidiff - 1))) && (idphi >= -(1 << (nbitsfinephidiff - 1)));
-            if (idphi < 0)
-              idphi = idphi + (1 << nbitsfinephidiff);
-            int idphi1 = idphi;
-            if (iSeed >= 4)
-              idphi1 = (idphi << 3) + ir;
-            int ptinnerindexnew = (idphi1 << nbendbitsinner) + innerbend;
-            match = match || (inrange && tplutinner.lookup(ptinnerindexnew));
-          }
-          if (match) {
-            usereg = usereg | (1 << ireg);
-          }
-        }
-
-        table_.push_back(usereg);
-      }
-    }
-  }
-
-  positive_ = false;
-  char cTP = 'A' + iTP;
-
-  name_ = "TP_" + TrackletConfigBuilder::LayerName(layerdisk1) + TrackletConfigBuilder::LayerName(layerdisk2) + cTP +
-          "_usereg.tab";
-
-  writeTable();
-}
-
-void TrackletLUT::initteptlut(bool fillInner,
-                              bool fillTEMem,
-                              unsigned int iSeed,
-                              unsigned int layerdisk1,
-                              unsigned int layerdisk2,
-                              unsigned int innerphibits,
-                              unsigned int outerphibits,
-                              double innerphimin,
-                              double innerphimax,
-                              double outerphimin,
-                              double outerphimax,
-                              const std::string& innermem,
-                              const std::string& outermem) {
-  int outerrbits = 0;
-  if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4 || iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
-    outerrbits = 3;
-  }
-
-  int outerrbins = (1 << outerrbits);
-  int innerphibins = (1 << innerphibits);
-  int outerphibins = (1 << outerphibits);
-
-  double phiinner[2];
-  double phiouter[2];
-  double router[2];
-
-  bool isPSinner;
-  bool isPSouter;
-
-  if (iSeed == Seed::L3L4) {
-    isPSinner = true;
-    isPSouter = false;
-  } else if (iSeed == Seed::L5L6) {
-    isPSinner = false;
-    isPSouter = false;
-  } else {
-    isPSinner = true;
-    isPSouter = true;
-  }
-
-  unsigned int nbendbitsinner = isPSinner ? N_BENDBITS_PS : N_BENDBITS_2S;
-  unsigned int nbendbitsouter = isPSouter ? N_BENDBITS_PS : N_BENDBITS_2S;
-
-  if (fillTEMem) {
-    if (fillInner) {
-      table_.resize((1 << nbendbitsinner), false);
+    if (layerdisk < N_LAYER) {
+      zmin = -settings_.zlength();
+      zmax = settings_.zlength();
+      rmin = settings_.rmean(layerdisk) - settings_.drmax();
+      rmax = settings_.rmean(layerdisk) + settings_.drmax();
     } else {
-      table_.resize((1 << nbendbitsouter), false);
-    }
-  }
-
-  double z0 = settings_.z0cut();
-
-  for (int irouterbin = 0; irouterbin < outerrbins; irouterbin++) {
-    if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4 || iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
-      router[0] = settings_.rmindiskvm() + irouterbin * (settings_.rmaxdiskvm() - settings_.rmindiskvm()) / outerrbins;
-      router[1] =
-          settings_.rmindiskvm() + (irouterbin + 1) * (settings_.rmaxdiskvm() - settings_.rmindiskvm()) / outerrbins;
-    } else {
-      router[0] = settings_.rmean(layerdisk2);
-      router[1] = settings_.rmean(layerdisk2);
+      rmin = 0;
+      rmax = settings_.rmaxdisk();
+      zmin = settings_.zmean(layerdisk - N_LAYER) - settings_.dzmax();
+      zmax = settings_.zmean(layerdisk - N_LAYER) + settings_.dzmax();
     }
 
-    //Determine bend cuts using geometry
-    std::vector<std::array<double, 2>> bend_cuts_inner;
-    std::vector<std::array<double, 2>> bend_cuts_outer;
-
-    if (settings_.useCalcBendCuts) {
-      std::vector<const tt::SensorModule*> sminner;
-      std::vector<const tt::SensorModule*> smouter;
-
-      if (iSeed == Seed::L1L2 || iSeed == Seed::L2L3 || iSeed == Seed::L3L4 || iSeed == Seed::L5L6) {
-        double outer_tan_max = tan_theta(settings_.rmean(layerdisk2), settings_.zlength(), z0, true);
-        std::array<double, 2> tan_range = {{0, outer_tan_max}};
-
-        smouter = getSensorModules(layerdisk2, isPSouter, tan_range);
-        sminner = getSensorModules(layerdisk1, isPSinner, tan_range);
-
-      } else if (iSeed == Seed::L1D1 || iSeed == Seed::L2D1) {
-        double outer_tan_min = tan_theta(router[1], settings_.zmindisk(layerdisk2 - N_LAYER), z0, false);
-        double outer_tan_max = tan_theta(router[0], settings_.zmaxdisk(layerdisk2 - N_LAYER), z0, true);
-
-        smouter = getSensorModules(layerdisk2, isPSouter, {{outer_tan_min, outer_tan_max}});
-        std::array<double, 2> tan_range = getTanRange(smouter);
-        sminner = getSensorModules(layerdisk1, isPSinner, tan_range);
-
-      } else {  // D1D2 D3D4
-
-        double outer_tan_min = tan_theta(router[1], settings_.zmindisk(layerdisk2 - N_LAYER), z0, false);
-        double outer_tan_max = tan_theta(router[0], settings_.zmaxdisk(layerdisk2 - N_LAYER), z0, true);
-
-        smouter = getSensorModules(layerdisk2, isPSouter, {{outer_tan_min, outer_tan_max}});
-
-        std::array<double, 2> tan_range = getTanRange(smouter);
-        sminner = getSensorModules(layerdisk1, isPSinner, tan_range);
-      }
-
-      bend_cuts_inner = getBendCut(layerdisk1, sminner, isPSinner, settings_.bendcutTE(iSeed, true));
-      bend_cuts_outer = getBendCut(layerdisk2, smouter, isPSouter, settings_.bendcutTE(iSeed, false));
-
-    } else {
-      for (int ibend = 0; ibend < (1 << nbendbitsinner); ibend++) {
-        double mid = settings_.benddecode(ibend, layerdisk1, nbendbitsinner == 3);
-        double cut = settings_.bendcutte(ibend, layerdisk1, nbendbitsinner == 3);
-        bend_cuts_inner.push_back({{mid, cut}});
-      }
-      for (int ibend = 0; ibend < (1 << nbendbitsouter); ibend++) {
-        double mid = settings_.benddecode(ibend, layerdisk2, nbendbitsouter == 3);
-        double cut = settings_.bendcutte(ibend, layerdisk2, nbendbitsouter == 3);
-        bend_cuts_outer.push_back({{mid, cut}});
-      }
-    }
-
-    for (int iphiinnerbin = 0; iphiinnerbin < innerphibins; iphiinnerbin++) {
-      phiinner[0] = innerphimin + iphiinnerbin * (innerphimax - innerphimin) / innerphibins;
-      phiinner[1] = innerphimin + (iphiinnerbin + 1) * (innerphimax - innerphimin) / innerphibins;
-      for (int iphiouterbin = 0; iphiouterbin < outerphibins; iphiouterbin++) {
-        phiouter[0] = outerphimin + iphiouterbin * (outerphimax - outerphimin) / outerphibins;
-        phiouter[1] = outerphimin + (iphiouterbin + 1) * (outerphimax - outerphimin) / outerphibins;
-
-        double bendinnermin = 20.0;
-        double bendinnermax = -20.0;
-        double bendoutermin = 20.0;
-        double bendoutermax = -20.0;
-        double rinvmin = 1.0;
-        double rinvmax = -1.0;
-        double absrinvmin = 1.0;
-
-        for (int i1 = 0; i1 < 2; i1++) {
-          for (int i2 = 0; i2 < 2; i2++) {
-            for (int i3 = 0; i3 < 2; i3++) {
-              double rinner = 0.0;
-              if (iSeed == Seed::D1D2 || iSeed == Seed::D3D4) {
-                rinner = router[i3] * settings_.zmean(layerdisk1 - N_LAYER) / settings_.zmean(layerdisk2 - N_LAYER);
-              } else {
-                rinner = settings_.rmean(layerdisk1);
-              }
-
-              if (settings_.useCalcBendCuts) {
-                if (rinner >= router[i3])
-                  continue;
-              }
-
-              double rinv1 = (rinner < router[i3]) ? -rinv(phiinner[i1], phiouter[i2], rinner, router[i3]) : -20.0;
-              double pitchinner =
-                  (rinner < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
-              double pitchouter =
-                  (router[i3] < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
-
-              double abendinner = bendstrip(rinner, rinv1, pitchinner, settings_.sensorSpacing2S());
-              double abendouter = bendstrip(router[i3], rinv1, pitchouter, settings_.sensorSpacing2S());
-
-              if (abendinner < bendinnermin)
-                bendinnermin = abendinner;
-              if (abendinner > bendinnermax)
-                bendinnermax = abendinner;
-              if (abendouter < bendoutermin)
-                bendoutermin = abendouter;
-              if (abendouter > bendoutermax)
-                bendoutermax = abendouter;
-              if (std::abs(rinv1) < absrinvmin)
-                absrinvmin = std::abs(rinv1);
-              if (rinv1 > rinvmax)
-                rinvmax = rinv1;
-              if (rinv1 < rinvmin)
-                rinvmin = rinv1;
-            }
-          }
-        }
-
-        double lowrinvcutte = 0.002;
-
-        bool passptcut;
-        double bendfac;
-
-        if (settings_.useCalcBendCuts) {
-          passptcut = rinvmin < settings_.rinvcutte() and rinvmax > -settings_.rinvcutte();
-          bendfac = (rinvmin < lowrinvcutte and rinvmax > -lowrinvcutte) ? 1.05 : 1.0;  // Better acceptance for high pt
-        } else {
-          passptcut = absrinvmin < settings_.rinvcutte();
-          bendfac = 1.0;
-        }
-
-        if (fillInner) {
-          for (int ibend = 0; ibend < (1 << nbendbitsinner); ibend++) {
-            double bendminfac = (isPSinner and (ibend == 2 or ibend == 3)) ? bendfac : 1.0;
-            double bendmaxfac = (isPSinner and (ibend == 6 or ibend == 5)) ? bendfac : 1.0;
-
-            double mid = bend_cuts_inner.at(ibend)[0];
-            double cut = bend_cuts_inner.at(ibend)[1];
-
-            bool passinner = mid + cut * bendmaxfac > bendinnermin && mid - cut * bendminfac < bendinnermax;
-
-            if (fillTEMem) {
-              if (passinner)
-                table_[ibend] = 1;
-            } else {
-              table_.push_back(passinner && passptcut);
-            }
-          }
-        } else {
-          for (int ibend = 0; ibend < (1 << nbendbitsouter); ibend++) {
-            double bendminfac = (isPSouter and (ibend == 2 or ibend == 3)) ? bendfac : 1.0;
-            double bendmaxfac = (isPSouter and (ibend == 6 or ibend == 5)) ? bendfac : 1.0;
-
-            double mid = bend_cuts_outer.at(ibend)[0];
-            double cut = bend_cuts_outer.at(ibend)[1];
-
-            bool passouter = mid + cut * bendmaxfac > bendoutermin && mid - cut * bendminfac < bendoutermax;
-
-            if (fillTEMem) {
-              if (passouter)
-                table_[ibend] = 1;
-            } else {
-              table_.push_back(passouter && passptcut);
-            }
-          }
-        }
-      }
-    }
-  }
-
-  positive_ = false;
-
-  if (fillTEMem) {
-    if (fillInner) {
-      name_ = "VMSTE_" + innermem + "_vmbendcut.tab";
-    } else {
-      name_ = "VMSTE_" + outermem + "_vmbendcut.tab";
-    }
-  } else {
-    name_ = "TE_" + innermem.substr(0, innermem.size() - 2) + "_" + outermem.substr(0, outermem.size() - 2);
-    if (fillInner) {
-      name_ += "_stubptinnercut.tab";
-    } else {
-      name_ += "_stubptoutercut.tab";
-    }
-  }
-  writeTable();
-}
-
-void TrackletLUT::initProjectionBend(double k_phider,
-                                     unsigned int idisk,
-                                     unsigned int nrbits,
-                                     unsigned int nphiderbits) {
-  unsigned int nsignbins = 2;
-  unsigned int nrbins = 1 << (nrbits);
-  unsigned int nphiderbins = 1 << (nphiderbits);
-
-  for (unsigned int isignbin = 0; isignbin < nsignbins; isignbin++) {
-    for (unsigned int irbin = 0; irbin < nrbins; irbin++) {
-      int ir = irbin;
-      if (ir > (1 << (nrbits - 1)))
-        ir -= (1 << nrbits);
-      ir = ir << (settings_.nrbitsstub(N_LAYER) - nrbits);
-      for (unsigned int iphiderbin = 0; iphiderbin < nphiderbins; iphiderbin++) {
-        int iphider = iphiderbin;
-        if (iphider > (1 << (nphiderbits - 1)))
-          iphider -= (1 << nphiderbits);
-        iphider = iphider << (settings_.nbitsphiprojderL123() - nphiderbits);
-
-        double rproj = ir * settings_.krprojshiftdisk();
-        double phider = iphider * k_phider;
-        double t = settings_.zmean(idisk) / rproj;
-
-        if (isignbin)
-          t = -t;
-
-        double rinv = -phider * (2.0 * t);
-
-        double stripPitch = (rproj < settings_.rcrit()) ? settings_.stripPitch(true) : settings_.stripPitch(false);
-        double bendproj = bendstrip(rproj, rinv, stripPitch, settings_.sensorSpacing2S());
-
-        static double maxbend = (1 << NRINVBITS) - 1;
-
-        int ibendproj = 2.0 * bendproj + 0.5 * maxbend;
-        if (ibendproj < 0)
-          ibendproj = 0;
-        if (ibendproj > maxbend)
-          ibendproj = maxbend;
-
-        table_.push_back(ibendproj);
-      }
-    }
-  }
-
-  positive_ = false;
-  name_ = settings_.combined() ? "MP_" : "PR_";
-  name_ += "ProjectionBend_" + TrackletConfigBuilder::LayerName(N_LAYER + idisk) + ".tab";
-
-  writeTable();
-}
-
-void TrackletLUT::initProjectionDiskRadius(int nrbits) {
-  //When a projection to a disk is considered this offset and added and subtracted to calculate
-  //the bin the projection is pointing to. This is to account for resolution effects such that
-  //projections that are near a bin boundary will be assigned to both bins. The value (3 cm) should
-  //cover the uncertanty in the resolution.
-  double roffset = 3.0;
-
-  for (unsigned int ir = 0; ir < (1u << nrbits); ir++) {
-    double r = ir * settings_.rmaxdisk() / (1u << nrbits);
-
-    int rbin1 =
-        (1 << N_RZBITS) * (r - roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
-    int rbin2 =
-        (1 << N_RZBITS) * (r + roffset - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
-
-    if (rbin1 < 0) {
-      rbin1 = 0;
-    }
-    rbin2 = clamp(rbin2, 0, ((1 << N_RZBITS) - 1));
-
-    assert(rbin1 <= rbin2);
-    assert(rbin2 - rbin1 <= 1);
-
-    int d = rbin1 != rbin2;
-
-    int finer =
-        (1 << (N_RZBITS + NFINERZBITS)) *
-        ((r - settings_.rmindiskvm()) - rbin1 * (settings_.rmaxdisk() - settings_.rmindiskvm()) / (1 << N_RZBITS)) /
-        (settings_.rmaxdisk() - settings_.rmindiskvm());
-
-    finer = clamp(finer, 0, ((1 << (NFINERZBITS + 1)) - 1));
-
-    //Pack the data in a 8 bit word (ffffrrrd) where f is finer, r is rbin1, and d is difference
-    int N_DIFF_FLAG = 1;  // Single bit for bool flag
-
-    int word = (finer << (N_RZBITS + N_DIFF_FLAG)) + (rbin1 << N_DIFF_FLAG) + d;
-
-    table_.push_back(word);
-  }
-
-  //Size of the data word from above (8 bits)
-  nbits_ = NFINERZBITS + 1 + N_RZBITS + 1;
-  positive_ = true;
-  name_ = "ProjectionDiskRadius.tab";
-  writeTable();
-}
-
-void TrackletLUT::initBendMatch(unsigned int layerdisk) {
-  unsigned int nrinv = NRINVBITS;
-  double rinvhalf = 0.5 * ((1 << nrinv) - 1);
-
-  bool barrel = layerdisk < N_LAYER;
-
-  if (barrel) {
-    bool isPSmodule = layerdisk < N_PSLAYER;
-    double stripPitch = settings_.stripPitch(isPSmodule);
-    unsigned int nbits = isPSmodule ? N_BENDBITS_PS : N_BENDBITS_2S;
-
-    std::vector<std::array<double, 2>> bend_cuts;
-
-    if (settings_.useCalcBendCuts) {
-      double bendcutFE = settings_.bendcutME(layerdisk, isPSmodule);
-      std::vector<const tt::SensorModule*> sm = getSensorModules(layerdisk, isPSmodule);
-      bend_cuts = getBendCut(layerdisk, sm, isPSmodule, bendcutFE);
-
-    } else {
-      for (unsigned int ibend = 0; ibend < (1u << nbits); ibend++) {
-        double mid = settings_.benddecode(ibend, layerdisk, isPSmodule);
-        double cut = settings_.bendcutte(ibend, layerdisk, isPSmodule);
-        bend_cuts.push_back({{mid, cut}});
-      }
-    }
-
-    for (unsigned int irinv = 0; irinv < (1u << nrinv); irinv++) {
-      double rinv = (irinv - rinvhalf) * (1 << (settings_.nbitsrinv() - nrinv)) * settings_.krinvpars();
-
-      double projbend = bendstrip(settings_.rmean(layerdisk), rinv, stripPitch, settings_.sensorSpacing2S());
-      for (unsigned int ibend = 0; ibend < (1u << nbits); ibend++) {
-        double mid = bend_cuts[ibend][0];
-        double cut = bend_cuts[ibend][1];
-
-        double pass = mid + cut > projbend && mid - cut < projbend;
-
-        table_.push_back(pass);
-      }
-    }
-  } else {
-    std::vector<std::array<double, 2>> bend_cuts_2S;
-    std::vector<std::array<double, 2>> bend_cuts_PS;
-
-    if (settings_.useCalcBendCuts) {
-      double bendcutFE2S = settings_.bendcutME(layerdisk, false);
-      std::vector<const tt::SensorModule*> sm2S = getSensorModules(layerdisk, false);
-      bend_cuts_2S = getBendCut(layerdisk, sm2S, false, bendcutFE2S);
-
-      double bendcutFEPS = settings_.bendcutME(layerdisk, true);
-      std::vector<const tt::SensorModule*> smPS = getSensorModules(layerdisk, true);
-      bend_cuts_PS = getBendCut(layerdisk, smPS, true, bendcutFEPS);
-
-    } else {
-      for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_2S); ibend++) {
-        double mid = settings_.benddecode(ibend, layerdisk, false);
-        double cut = settings_.bendcutme(ibend, layerdisk, false);
-        bend_cuts_2S.push_back({{mid, cut}});
-      }
-      for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_PS); ibend++) {
-        double mid = settings_.benddecode(ibend, layerdisk, true);
-        double cut = settings_.bendcutme(ibend, layerdisk, true);
-        bend_cuts_PS.push_back({{mid, cut}});
-      }
-    }
-
-    for (unsigned int iprojbend = 0; iprojbend < (1u << nrinv); iprojbend++) {
-      double projbend = 0.5 * (iprojbend - rinvhalf);
-      for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_2S); ibend++) {
-        double mid = bend_cuts_2S[ibend][0];
-        double cut = bend_cuts_2S[ibend][1];
-
-        double pass = mid + cut > projbend && mid - cut < projbend;
-
-        table_.push_back(pass);
-      }
-    }
-    for (unsigned int iprojbend = 0; iprojbend < (1u << nrinv); iprojbend++) {  //Should this be binned in r?
-      double projbend = 0.5 * (iprojbend - rinvhalf);
-      for (unsigned int ibend = 0; ibend < (1 << N_BENDBITS_PS); ibend++) {
-        double mid = bend_cuts_PS[ibend][0];
-        double cut = bend_cuts_PS[ibend][1];
-
-        double pass = mid + cut > projbend && mid - cut < projbend;
-
-        table_.push_back(pass);
-      }
-    }
-  }
-
-  positive_ = false;
-
-  name_ = "METable_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
-
-  writeTable();
-}
-
-void TrackletLUT::initVMRTable(unsigned int layerdisk, VMRTableType type, int region) {
-  unsigned int zbits = settings_.vmrlutzbits(layerdisk);
-  unsigned int rbits = settings_.vmrlutrbits(layerdisk);
-
-  unsigned int rbins = (1 << rbits);
-  unsigned int zbins = (1 << zbits);
-
-  double zmin, zmax, rmin, rmax;
-
-  if (layerdisk < N_LAYER) {
-    zmin = -settings_.zlength();
-    zmax = settings_.zlength();
-    rmin = settings_.rmean(layerdisk) - settings_.drmax();
-    rmax = settings_.rmean(layerdisk) + settings_.drmax();
-  } else {
-    rmin = 0;
-    rmax = settings_.rmaxdisk();
-    zmin = settings_.zmean(layerdisk - N_LAYER) - settings_.dzmax();
-    zmax = settings_.zmean(layerdisk - N_LAYER) + settings_.dzmax();
-  }
-
-  double dr = (rmax - rmin) / rbins;
-  double dz = (zmax - zmin) / zbins;
-
-  int NBINS = settings_.NLONGVMBINS() * settings_.NLONGVMBINS();
-
-  for (unsigned int izbin = 0; izbin < zbins; izbin++) {
-    for (unsigned int irbin = 0; irbin < rbins; irbin++) {
-      double r = rmin + (irbin + 0.5) * dr;
-      double z = zmin + (izbin + 0.5) * dz;
-
-      if (settings_.combined()) {
-        int iznew = izbin - (1 << (zbits - 1));
-        if (iznew < 0)
-          iznew += (1 << zbits);
-        assert(iznew >= 0);
-        assert(iznew < (1 << zbits));
-        z = zmin + (iznew + 0.5) * dz;
-        if (layerdisk < N_LAYER) {
-          int irnew = irbin - (1 << (rbits - 1));
-          if (irnew < 0)
-            irnew += (1 << rbits);
-          assert(irnew >= 0);
-          assert(irnew < (1 << rbits));
-          r = rmin + (irnew + 0.5) * dr;
-        }
-      }
-
-      unsigned int NRING =
-          5;  //number of 2S rings in disks. This is multiplied below by two since we have two halfs of a module
-      if (layerdisk >= N_LAYER && irbin < 2 * NRING)  //special case for the tabulated radii in 2S disks
-        r = (layerdisk < N_LAYER + 2) ? settings_.rDSSinner(irbin) : settings_.rDSSouter(irbin);
-
-      int bin;
-      if (layerdisk < N_LAYER) {
-        double zproj = z * settings_.rmean(layerdisk) / r;
-        bin = NBINS * (zproj + settings_.zlength()) / (2 * settings_.zlength());
-      } else {
-        double rproj = r * settings_.zmean(layerdisk - N_LAYER) / z;
-        bin = NBINS * (rproj - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
-      }
-      if (bin < 0)
-        bin = 0;
-      if (bin >= NBINS)
-        bin = NBINS - 1;
-
-      if (type == VMRTableType::me) {
-        table_.push_back(bin);
-      }
-
-      if (type == VMRTableType::disk) {
-        if (layerdisk >= N_LAYER) {
-          double rproj = r * settings_.zmean(layerdisk - N_LAYER) / z;
-          bin = 0.5 * NBINS * (rproj - settings_.rmindiskvm()) / (settings_.rmaxdiskvm() - settings_.rmindiskvm());
-          //bin value of zero indicates that stub is out of range
-          if (bin < 0)
-            bin = 0;
-          if (bin >= NBINS / 2)
-            bin = 0;
-          table_.push_back(bin);
-        }
-      }
-
-      if (type == VMRTableType::inner) {
-        if (layerdisk == LayerDisk::L1 || layerdisk == LayerDisk::L3 || layerdisk == LayerDisk::L5 ||
-            layerdisk == LayerDisk::D1 || layerdisk == LayerDisk::D3) {
-          table_.push_back(getVMRLookup(layerdisk + 1, z, r, dz, dr));
-        }
-        if (layerdisk == LayerDisk::L2) {
-          table_.push_back(getVMRLookup(layerdisk + 1, z, r, dz, dr, Seed::L2L3));
-        }
-      }
-
-      if (type == VMRTableType::inneroverlap) {
-        if (layerdisk == LayerDisk::L1 || layerdisk == LayerDisk::L2) {
-          table_.push_back(getVMRLookup(6, z, r, dz, dr, layerdisk + 6));
-        }
-      }
-
-      if (type == VMRTableType::innerthird) {
-        if (layerdisk == LayerDisk::L2) {  //projection from L2 to D1 for L2L3D1 seeding
-          table_.push_back(getVMRLookup(LayerDisk::D1, z, r, dz, dr, Seed::L2L3D1));
-        }
-
-        if (layerdisk == LayerDisk::L5) {  //projection from L5 to L4 for L5L6L4 seeding
-          table_.push_back(getVMRLookup(LayerDisk::L4, z, r, dz, dr));
-        }
-
-        if (layerdisk == LayerDisk::L3) {  //projection from L3 to L5 for L3L4L2 seeding
-          table_.push_back(getVMRLookup(LayerDisk::L2, z, r, dz, dr));
-        }
-
-        if (layerdisk == LayerDisk::D1) {  //projection from D1 to L2 for D1D2L2 seeding
-          table_.push_back(getVMRLookup(LayerDisk::L2, z, r, dz, dr));
-        }
-      }
-    }
-  }
-
-  if (settings_.combined()) {
-    if (type == VMRTableType::me) {
-      nbits_ = 2 * settings_.NLONGVMBITS();
-      positive_ = false;
-      name_ = "VMRME_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
-    }
-    if (type == VMRTableType::disk) {
-      nbits_ = 2 * settings_.NLONGVMBITS();
-      positive_ = false;
-      name_ = "VMRTE_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
-    }
-    if (type == VMRTableType::inner) {
-      positive_ = true;
-      nbits_ = 10;
-      name_ = "TP_" + TrackletConfigBuilder::LayerName(layerdisk) + TrackletConfigBuilder::LayerName(layerdisk + 1) +
-              ".tab";
-    }
-
-    if (type == VMRTableType::inneroverlap) {
-      positive_ = true;
-      nbits_ = 10;
-      name_ = "TP_" + TrackletConfigBuilder::LayerName(layerdisk) + TrackletConfigBuilder::LayerName(N_LAYER) + ".tab";
-    }
-
-  } else {
-    if (type == VMRTableType::me) {
-      //This if a hack where the same memory is used in both ME and TE modules
-      if (layerdisk == LayerDisk::L2 || layerdisk == LayerDisk::L3 || layerdisk == LayerDisk::L4 ||
-          layerdisk == LayerDisk::L6) {
-        positive_ = false;
-        name_ = "VMTableOuter" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
-        writeTable();
-      }
-
-      assert(region >= 0);
-      char cregion = 'A' + region;
-      name_ = "VMR_" + TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_finebin.tab";
-      positive_ = false;
-    }
-
-    if (type == VMRTableType::inner) {
-      positive_ = false;
-      name_ = "VMTableInner" + TrackletConfigBuilder::LayerName(layerdisk) +
-              TrackletConfigBuilder::LayerName(layerdisk + 1) + ".tab";
-    }
-
-    if (type == VMRTableType::inneroverlap) {
-      positive_ = false;
-      name_ = "VMTableInner" + TrackletConfigBuilder::LayerName(layerdisk) + TrackletConfigBuilder::LayerName(N_LAYER) +
-              ".tab";
-    }
-
-    if (type == VMRTableType::disk) {
-      positive_ = false;
-      name_ = "VMTableOuter" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
-    }
-  }
-
-  writeTable();
-}
-
-int TrackletLUT::getVMRLookup(unsigned int layerdisk, double z, double r, double dz, double dr, int iseed) const {
-  double z0cut = settings_.z0cut();
-
-  if (layerdisk < N_LAYER) {
-    double zcutL2L3 = 52.0;  //Stubs closer to IP in z will not be used for L2L3 seeds
-    if (iseed == Seed::L2L3 && std::abs(z) < zcutL2L3)
-      return -1;
-
-    double rmean = settings_.rmean(layerdisk);
-
-    double rratio1 = rmean / (r + 0.5 * dr);
-    double rratio2 = rmean / (r - 0.5 * dr);
-
-    double z1 = (z - 0.5 * dz) * rratio1 + z0cut * (rratio1 - 1.0);
-    double z2 = (z + 0.5 * dz) * rratio1 + z0cut * (rratio1 - 1.0);
-    double z3 = (z - 0.5 * dz) * rratio2 + z0cut * (rratio2 - 1.0);
-    double z4 = (z + 0.5 * dz) * rratio2 + z0cut * (rratio2 - 1.0);
-    double z5 = (z - 0.5 * dz) * rratio1 - z0cut * (rratio1 - 1.0);
-    double z6 = (z + 0.5 * dz) * rratio1 - z0cut * (rratio1 - 1.0);
-    double z7 = (z - 0.5 * dz) * rratio2 - z0cut * (rratio2 - 1.0);
-    double z8 = (z + 0.5 * dz) * rratio2 - z0cut * (rratio2 - 1.0);
-
-    double zmin = std::min({z1, z2, z3, z4, z5, z6, z7, z8});
-    double zmax = std::max({z1, z2, z3, z4, z5, z6, z7, z8});
+    double dr = (rmax - rmin) / rbins;
+    double dz = (zmax - zmin) / zbins;
 
     int NBINS = settings_.NLONGVMBINS() * settings_.NLONGVMBINS();
 
-    int zbin1 = NBINS * (zmin + settings_.zlength()) / (2 * settings_.zlength());
-    int zbin2 = NBINS * (zmax + settings_.zlength()) / (2 * settings_.zlength());
+    for (unsigned int izbin = 0; izbin < zbins; izbin++) {
+      for (unsigned int irbin = 0; irbin < rbins; irbin++) {
+        double r = rmin + (irbin + 0.5) * dr;
+        double z = zmin + (izbin + 0.5) * dz;
 
-    if (zbin1 >= NBINS)
-      return -1;
-    if (zbin2 < 0)
-      return -1;
+        if (settings_.combined()) {
+          int iznew = izbin - (1 << (zbits - 1));
+          if (iznew < 0)
+            iznew += (1 << zbits);
+          assert(iznew >= 0);
+          assert(iznew < (1 << zbits));
+          z = zmin + (iznew + 0.5) * dz;
+          if (layerdisk < N_LAYER) {
+            int irnew = irbin - (1 << (rbits - 1));
+            if (irnew < 0)
+              irnew += (1 << rbits);
+            assert(irnew >= 0);
+            assert(irnew < (1 << rbits));
+            r = rmin + (irnew + 0.5) * dr;
+          }
+        }
 
-    if (zbin2 >= NBINS)
-      zbin2 = NBINS - 1;
-    if (zbin1 < 0)
-      zbin1 = 0;
+        unsigned int NRING =
+            5;  //number of 2S rings in disks. This is multiplied below by two since we have two halfs of a module
+        if (layerdisk >= N_LAYER && irbin < 2 * NRING)  //special case for the tabulated radii in 2S disks
+          r = (layerdisk < N_LAYER + 2) ? settings_.rDSSinner(irbin) : settings_.rDSSouter(irbin);
 
-    // This is a 10 bit word:
-    // xxx|yyy|z|rrr
-    // xxx is the delta z window
-    // yyy is the z bin
-    // z is flag to look in next bin
-    // rrr first fine z bin
-    // NOTE : this encoding is not efficient z is one if xxx+rrr is greater than 8
-    //        and xxx is only 1,2, or 3
-    //        should also reject xxx=0 as this means projection is outside range
+        int bin;
+        if (layerdisk < N_LAYER) {
+          double zproj = z * settings_.rmean(layerdisk) / r;
+          bin = NBINS * (zproj + settings_.zlength()) / (2 * settings_.zlength());
+        } else {
+          double rproj = r * settings_.zmean(layerdisk - N_LAYER) / z;
+          bin = NBINS * (rproj - settings_.rmindiskvm()) / (settings_.rmaxdisk() - settings_.rmindiskvm());
+        }
+        if (bin < 0)
+          bin = 0;
+        if (bin >= NBINS)
+          bin = NBINS - 1;
 
-    int value = zbin1 / 8;
-    value *= 2;
-    if (zbin2 / 8 - zbin1 / 8 > 0)
-      value += 1;
-    value *= 8;
-    value += (zbin1 & 7);
-    assert(value / 8 < 15);
-    int deltaz = zbin2 - zbin1;
-    if (deltaz > 7) {
-      deltaz = 7;
+        if (type == VMRTableType::me) {
+          table_.push_back(bin);
+        }
+
+        if (type == VMRTableType::disk) {
+          if (layerdisk >= N_LAYER) {
+            double rproj = r * settings_.zmean(layerdisk - N_LAYER) / z;
+            bin = 0.5 * NBINS * (rproj - settings_.rmindiskvm()) / (settings_.rmaxdiskvm() - settings_.rmindiskvm());
+            //bin value of zero indicates that stub is out of range
+            if (bin < 0)
+              bin = 0;
+            if (bin >= NBINS / 2)
+              bin = 0;
+            table_.push_back(bin);
+          }
+        }
+
+        if (type == VMRTableType::inner) {
+          if (layerdisk == LayerDisk::L1 || layerdisk == LayerDisk::L3 || layerdisk == LayerDisk::L5 ||
+              layerdisk == LayerDisk::D1 || layerdisk == LayerDisk::D3) {
+            table_.push_back(getVMRLookup(layerdisk + 1, z, r, dz, dr));
+          }
+          if (layerdisk == LayerDisk::L2) {
+            table_.push_back(getVMRLookup(layerdisk + 1, z, r, dz, dr, Seed::L2L3));
+          }
+        }
+
+        if (type == VMRTableType::inneroverlap) {
+          if (layerdisk == LayerDisk::L1 || layerdisk == LayerDisk::L2) {
+            table_.push_back(getVMRLookup(6, z, r, dz, dr, layerdisk + 6));
+          }
+        }
+
+        if (type == VMRTableType::innerthird) {
+          if (layerdisk == LayerDisk::L2) {  //projection from L2 to D1 for L2L3D1 seeding
+            table_.push_back(getVMRLookup(LayerDisk::D1, z, r, dz, dr, Seed::L2L3D1));
+          }
+
+          if (layerdisk == LayerDisk::L5) {  //projection from L5 to L4 for L5L6L4 seeding
+            table_.push_back(getVMRLookup(LayerDisk::L4, z, r, dz, dr));
+          }
+
+          if (layerdisk == LayerDisk::L3) {  //projection from L3 to L5 for L3L4L2 seeding
+            table_.push_back(getVMRLookup(LayerDisk::L2, z, r, dz, dr));
+          }
+
+          if (layerdisk == LayerDisk::D1) {  //projection from D1 to L2 for D1D2L2 seeding
+            table_.push_back(getVMRLookup(LayerDisk::L2, z, r, dz, dr));
+          }
+        }
+      }
     }
-    assert(deltaz < 8);
-    value += (deltaz << 7);
 
-    return value;
+    if (settings_.combined()) {
+      if (type == VMRTableType::me) {
+        nbits_ = 2 * settings_.NLONGVMBITS();
+        positive_ = false;
+        name_ = "VMRME_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
+      }
+      if (type == VMRTableType::disk) {
+        nbits_ = 2 * settings_.NLONGVMBITS();
+        positive_ = false;
+        name_ = "VMRTE_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
+      }
+      if (type == VMRTableType::inner) {
+        positive_ = true;
+        nbits_ = 10;
+        name_ = "TP_" + TrackletConfigBuilder::LayerName(layerdisk) + TrackletConfigBuilder::LayerName(layerdisk + 1) +
+                ".tab";
+      }
 
-  } else {
-    if (std::abs(z) < 2.0 * z0cut)
-      return -1;
+      if (type == VMRTableType::inneroverlap) {
+        positive_ = true;
+        nbits_ = 10;
+        name_ =
+            "TP_" + TrackletConfigBuilder::LayerName(layerdisk) + TrackletConfigBuilder::LayerName(N_LAYER) + ".tab";
+      }
 
-    double zmean = settings_.zmean(layerdisk - N_LAYER);
-    if (z < 0.0)
-      zmean = -zmean;
-
-    double r1 = (r + 0.5 * dr) * (zmean + z0cut) / (z + 0.5 * dz + z0cut);
-    double r2 = (r - 0.5 * dr) * (zmean - z0cut) / (z + 0.5 * dz - z0cut);
-    double r3 = (r + 0.5 * dr) * (zmean + z0cut) / (z - 0.5 * dz + z0cut);
-    double r4 = (r - 0.5 * dr) * (zmean - z0cut) / (z - 0.5 * dz - z0cut);
-    double r5 = (r + 0.5 * dr) * (zmean - z0cut) / (z + 0.5 * dz - z0cut);
-    double r6 = (r - 0.5 * dr) * (zmean + z0cut) / (z + 0.5 * dz + z0cut);
-    double r7 = (r + 0.5 * dr) * (zmean - z0cut) / (z - 0.5 * dz - z0cut);
-    double r8 = (r - 0.5 * dr) * (zmean + z0cut) / (z - 0.5 * dz + z0cut);
-
-    double rmin = std::min({r1, r2, r3, r4, r5, r6, r7, r8});
-    double rmax = std::max({r1, r2, r3, r4, r5, r6, r7, r8});
-
-    int NBINS = settings_.NLONGVMBINS() * settings_.NLONGVMBINS() / 2;
-
-    double rmindisk = settings_.rmindiskvm();
-    double rmaxdisk = settings_.rmaxdiskvm();
-
-    if (iseed == Seed::L1D1)
-      rmaxdisk = settings_.rmaxdiskl1overlapvm();
-    if (iseed == Seed::L2D1)
-      rmindisk = settings_.rmindiskl2overlapvm();
-    if (iseed == Seed::L2L3D1)
-      rmaxdisk = settings_.rmaxdisk();
-
-    if (rmin > rmaxdisk)
-      return -1;
-    if (rmax > rmaxdisk)
-      rmax = rmaxdisk;
-
-    if (rmax < rmindisk)
-      return -1;
-    if (rmin < rmindisk)
-      rmin = rmindisk;
-
-    int rbin1 = NBINS * (rmin - settings_.rmindiskvm()) / (settings_.rmaxdiskvm() - settings_.rmindiskvm());
-    int rbin2 = NBINS * (rmax - settings_.rmindiskvm()) / (settings_.rmaxdiskvm() - settings_.rmindiskvm());
-
-    if (iseed == Seed::L2L3D1) {
-      constexpr double rminspec = 40.0;
-      rbin1 = NBINS * (rmin - rminspec) / (settings_.rmaxdisk() - rminspec);
-      rbin2 = NBINS * (rmax - rminspec) / (settings_.rmaxdisk() - rminspec);
-    }
-
-    if (rbin2 >= NBINS)
-      rbin2 = NBINS - 1;
-    if (rbin1 < 0)
-      rbin1 = 0;
-
-    // This is a 9 bit word:
-    // xxx|yy|z|rrr
-    // xxx is the delta r window
-    // yy is the r bin yy is three bits for overlaps
-    // z is flag to look in next bin
-    // rrr fine r bin
-    // NOTE : this encoding is not efficient z is one if xxx+rrr is greater than 8
-    //        and xxx is only 1,2, or 3
-    //        should also reject xxx=0 as this means projection is outside range
-
-    bool overlap = iseed == Seed::L1D1 || iseed == Seed::L2D1 || iseed == Seed::L2L3D1;
-
-    int value = rbin1 / 8;
-    if (overlap) {
-      if (z < 0.0)
-        value += 4;
-    }
-    value *= 2;
-    if (rbin2 / 8 - rbin1 / 8 > 0)
-      value += 1;
-    value *= 8;
-    value += (rbin1 & 7);
-    assert(value / 8 < 15);
-    int deltar = rbin2 - rbin1;
-    if (deltar > 7)
-      deltar = 7;
-    if (overlap) {
-      value += (deltar << 7);
     } else {
-      value += (deltar << 6);
+      if (type == VMRTableType::me) {
+        //This if a hack where the same memory is used in both ME and TE modules
+        if (layerdisk == LayerDisk::L2 || layerdisk == LayerDisk::L3 || layerdisk == LayerDisk::L4 ||
+            layerdisk == LayerDisk::L6) {
+          positive_ = false;
+          name_ = "VMTableOuter" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
+          writeTable();
+        }
+
+        assert(region >= 0);
+        char cregion = 'A' + region;
+        name_ = "VMR_" + TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_finebin.tab";
+        positive_ = false;
+      }
+
+      if (type == VMRTableType::inner) {
+        positive_ = false;
+        name_ = "VMTableInner" + TrackletConfigBuilder::LayerName(layerdisk) +
+                TrackletConfigBuilder::LayerName(layerdisk + 1) + ".tab";
+      }
+
+      if (type == VMRTableType::inneroverlap) {
+        positive_ = false;
+        name_ = "VMTableInner" + TrackletConfigBuilder::LayerName(layerdisk) +
+                TrackletConfigBuilder::LayerName(N_LAYER) + ".tab";
+      }
+
+      if (type == VMRTableType::disk) {
+        positive_ = false;
+        name_ = "VMTableOuter" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
+      }
     }
 
-    return value;
+    writeTable();
   }
-}
 
-void TrackletLUT::initPhiCorrTable(unsigned int layerdisk, unsigned int rbits) {
-  bool psmodule = layerdisk < N_PSLAYER;
+  int TrackletLUT::getVMRLookup(unsigned int layerdisk, double z, double r, double dz, double dr, int iseed) const {
+    double z0cut = settings_.z0cut();
 
-  unsigned int bendbits = psmodule ? N_BENDBITS_PS : N_BENDBITS_2S;
+    if (layerdisk < N_LAYER) {
+      double zcutL2L3 = 52.0;  //Stubs closer to IP in z will not be used for L2L3 seeds
+      if (iseed == Seed::L2L3 && std::abs(z) < zcutL2L3)
+        return -1;
 
-  unsigned int rbins = (1 << rbits);
+      double rmean = settings_.rmean(layerdisk);
 
-  double rmean = settings_.rmean(layerdisk);
-  double drmax = settings_.drmax();
+      double rratio1 = rmean / (r + 0.5 * dr);
+      double rratio2 = rmean / (r - 0.5 * dr);
 
-  double dr = 2.0 * drmax / rbins;
+      double z1 = (z - 0.5 * dz) * rratio1 + z0cut * (rratio1 - 1.0);
+      double z2 = (z + 0.5 * dz) * rratio1 + z0cut * (rratio1 - 1.0);
+      double z3 = (z - 0.5 * dz) * rratio2 + z0cut * (rratio2 - 1.0);
+      double z4 = (z + 0.5 * dz) * rratio2 + z0cut * (rratio2 - 1.0);
+      double z5 = (z - 0.5 * dz) * rratio1 - z0cut * (rratio1 - 1.0);
+      double z6 = (z + 0.5 * dz) * rratio1 - z0cut * (rratio1 - 1.0);
+      double z7 = (z - 0.5 * dz) * rratio2 - z0cut * (rratio2 - 1.0);
+      double z8 = (z + 0.5 * dz) * rratio2 - z0cut * (rratio2 - 1.0);
 
-  std::vector<std::array<double, 2>> bend_vals;
+      double zmin = std::min({z1, z2, z3, z4, z5, z6, z7, z8});
+      double zmax = std::max({z1, z2, z3, z4, z5, z6, z7, z8});
 
-  if (settings_.useCalcBendCuts) {
-    std::vector<const tt::SensorModule*> sm = getSensorModules(layerdisk, psmodule);
-    bend_vals = getBendCut(layerdisk, sm, psmodule);
+      int NBINS = settings_.NLONGVMBINS() * settings_.NLONGVMBINS();
 
-  } else {
+      int zbin1 = NBINS * (zmin + settings_.zlength()) / (2 * settings_.zlength());
+      int zbin2 = NBINS * (zmax + settings_.zlength()) / (2 * settings_.zlength());
+
+      if (zbin1 >= NBINS)
+        return -1;
+      if (zbin2 < 0)
+        return -1;
+
+      if (zbin2 >= NBINS)
+        zbin2 = NBINS - 1;
+      if (zbin1 < 0)
+        zbin1 = 0;
+
+      // This is a 10 bit word:
+      // xxx|yyy|z|rrr
+      // xxx is the delta z window
+      // yyy is the z bin
+      // z is flag to look in next bin
+      // rrr first fine z bin
+      // NOTE : this encoding is not efficient z is one if xxx+rrr is greater than 8
+      //        and xxx is only 1,2, or 3
+      //        should also reject xxx=0 as this means projection is outside range
+
+      int value = zbin1 / 8;
+      value *= 2;
+      if (zbin2 / 8 - zbin1 / 8 > 0)
+        value += 1;
+      value *= 8;
+      value += (zbin1 & 7);
+      assert(value / 8 < 15);
+      int deltaz = zbin2 - zbin1;
+      if (deltaz > 7) {
+        deltaz = 7;
+      }
+      assert(deltaz < 8);
+      value += (deltaz << 7);
+
+      return value;
+
+    } else {
+      if (std::abs(z) < 2.0 * z0cut)
+        return -1;
+
+      double zmean = settings_.zmean(layerdisk - N_LAYER);
+      if (z < 0.0)
+        zmean = -zmean;
+
+      double r1 = (r + 0.5 * dr) * (zmean + z0cut) / (z + 0.5 * dz + z0cut);
+      double r2 = (r - 0.5 * dr) * (zmean - z0cut) / (z + 0.5 * dz - z0cut);
+      double r3 = (r + 0.5 * dr) * (zmean + z0cut) / (z - 0.5 * dz + z0cut);
+      double r4 = (r - 0.5 * dr) * (zmean - z0cut) / (z - 0.5 * dz - z0cut);
+      double r5 = (r + 0.5 * dr) * (zmean - z0cut) / (z + 0.5 * dz - z0cut);
+      double r6 = (r - 0.5 * dr) * (zmean + z0cut) / (z + 0.5 * dz + z0cut);
+      double r7 = (r + 0.5 * dr) * (zmean - z0cut) / (z - 0.5 * dz - z0cut);
+      double r8 = (r - 0.5 * dr) * (zmean + z0cut) / (z - 0.5 * dz + z0cut);
+
+      double rmin = std::min({r1, r2, r3, r4, r5, r6, r7, r8});
+      double rmax = std::max({r1, r2, r3, r4, r5, r6, r7, r8});
+
+      int NBINS = settings_.NLONGVMBINS() * settings_.NLONGVMBINS() / 2;
+
+      double rmindisk = settings_.rmindiskvm();
+      double rmaxdisk = settings_.rmaxdiskvm();
+
+      if (iseed == Seed::L1D1)
+        rmaxdisk = settings_.rmaxdiskl1overlapvm();
+      if (iseed == Seed::L2D1)
+        rmindisk = settings_.rmindiskl2overlapvm();
+      if (iseed == Seed::L2L3D1)
+        rmaxdisk = settings_.rmaxdisk();
+
+      if (rmin > rmaxdisk)
+        return -1;
+      if (rmax > rmaxdisk)
+        rmax = rmaxdisk;
+
+      if (rmax < rmindisk)
+        return -1;
+      if (rmin < rmindisk)
+        rmin = rmindisk;
+
+      int rbin1 = NBINS * (rmin - settings_.rmindiskvm()) / (settings_.rmaxdiskvm() - settings_.rmindiskvm());
+      int rbin2 = NBINS * (rmax - settings_.rmindiskvm()) / (settings_.rmaxdiskvm() - settings_.rmindiskvm());
+
+      if (iseed == Seed::L2L3D1) {
+        constexpr double rminspec = 40.0;
+        rbin1 = NBINS * (rmin - rminspec) / (settings_.rmaxdisk() - rminspec);
+        rbin2 = NBINS * (rmax - rminspec) / (settings_.rmaxdisk() - rminspec);
+      }
+
+      if (rbin2 >= NBINS)
+        rbin2 = NBINS - 1;
+      if (rbin1 < 0)
+        rbin1 = 0;
+
+      // This is a 9 bit word:
+      // xxx|yy|z|rrr
+      // xxx is the delta r window
+      // yy is the r bin yy is three bits for overlaps
+      // z is flag to look in next bin
+      // rrr fine r bin
+      // NOTE : this encoding is not efficient z is one if xxx+rrr is greater than 8
+      //        and xxx is only 1,2, or 3
+      //        should also reject xxx=0 as this means projection is outside range
+
+      bool overlap = iseed == Seed::L1D1 || iseed == Seed::L2D1 || iseed == Seed::L2L3D1;
+
+      int value = rbin1 / 8;
+      if (overlap) {
+        if (z < 0.0)
+          value += 4;
+      }
+      value *= 2;
+      if (rbin2 / 8 - rbin1 / 8 > 0)
+        value += 1;
+      value *= 8;
+      value += (rbin1 & 7);
+      assert(value / 8 < 15);
+      int deltar = rbin2 - rbin1;
+      if (deltar > 7)
+        deltar = 7;
+      if (overlap) {
+        value += (deltar << 7);
+      } else {
+        value += (deltar << 6);
+      }
+
+      return value;
+    }
+  }
+
+  void TrackletLUT::initPhiCorrTable(unsigned int layerdisk, unsigned int rbits) {
+    bool psmodule = layerdisk < N_PSLAYER;
+
+    unsigned int bendbits = psmodule ? N_BENDBITS_PS : N_BENDBITS_2S;
+
+    unsigned int rbins = (1 << rbits);
+
+    double rmean = settings_.rmean(layerdisk);
+    double drmax = settings_.drmax();
+
+    double dr = 2.0 * drmax / rbins;
+
+    std::vector<std::array<double, 2>> bend_vals;
+
+    if (settings_.useCalcBendCuts) {
+      std::vector<const tt::SensorModule*> sm = getSensorModules(layerdisk, psmodule);
+      bend_vals = getBendCut(layerdisk, sm, psmodule);
+
+    } else {
+      for (int ibend = 0; ibend < 1 << bendbits; ibend++) {
+        bend_vals.push_back({{settings_.benddecode(ibend, layerdisk, layerdisk < N_PSLAYER), 0}});
+      }
+    }
+
     for (int ibend = 0; ibend < 1 << bendbits; ibend++) {
-      bend_vals.push_back({{settings_.benddecode(ibend, layerdisk, layerdisk < N_PSLAYER), 0}});
-    }
-  }
-
-  for (int ibend = 0; ibend < 1 << bendbits; ibend++) {
-    for (unsigned int irbin = 0; irbin < rbins; irbin++) {
-      double bend = -bend_vals[ibend][0];
-      int value = getphiCorrValue(layerdisk, bend, irbin, rmean, dr, drmax);
-      table_.push_back(value);
-    }
-  }
-
-  name_ = "VMPhiCorrL" + std::to_string(layerdisk + 1) + ".tab";
-  nbits_ = 14;
-  positive_ = false;
-
-  writeTable();
-}
-
-int TrackletLUT::getphiCorrValue(
-    unsigned int layerdisk, double bend, unsigned int irbin, double rmean, double dr, double drmax) const {
-  bool psmodule = layerdisk < N_PSLAYER;
-
-  //for the rbin - calculate the distance to the nominal layer radius
-  double Delta = (irbin + 0.5) * dr - drmax;
-
-  //calculate the phi correction - this is a somewhat approximate formula
-  double drnom = 0.18;  //This is the nominal module separation for which bend is referenced
-  double dphi = (Delta / drnom) * bend * settings_.stripPitch(psmodule) / rmean;
-
-  double kphi = psmodule ? settings_.kphi() : settings_.kphi1();
-
-  int idphi = dphi / kphi;
-
-  return idphi;
-}
-
-// Write LUT table.
-void TrackletLUT::writeTable() const {
-  if (!settings_.writeTable()) {
-    return;
-  }
-
-  if (name_.empty()) {
-    return;
-  }
-
-  ofstream out = openfile(settings_.tablePath(), name_, __FILE__, __LINE__);
-
-  out << "{" << endl;
-  for (unsigned int i = 0; i < table_.size(); i++) {
-    if (i != 0) {
-      out << "," << endl;
-    }
-
-    int itable = table_[i];
-    if (positive_) {
-      if (table_[i] < 0) {
-        itable = (1 << nbits_) - 1;
+      for (unsigned int irbin = 0; irbin < rbins; irbin++) {
+        double bend = -bend_vals[ibend][0];
+        int value = getphiCorrValue(layerdisk, bend, irbin, rmean, dr, drmax);
+        table_.push_back(value);
       }
     }
 
-    out << itable;
+    name_ = "VMPhiCorrL" + std::to_string(layerdisk + 1) + ".tab";
+    nbits_ = 14;
+    positive_ = false;
+
+    writeTable();
   }
-  out << endl << "};" << endl;
-  out.close();
 
-  string name = name_;
+  int TrackletLUT::getphiCorrValue(
+      unsigned int layerdisk, double bend, unsigned int irbin, double rmean, double dr, double drmax) const {
+    bool psmodule = layerdisk < N_PSLAYER;
 
-  name[name_.size() - 3] = 'd';
-  name[name_.size() - 2] = 'a';
-  name[name_.size() - 1] = 't';
+    //for the rbin - calculate the distance to the nominal layer radius
+    double Delta = (irbin + 0.5) * dr - drmax;
 
-  out = openfile(settings_.tablePath(), name, __FILE__, __LINE__);
+    //calculate the phi correction - this is a somewhat approximate formula
+    double drnom = 0.18;  //This is the nominal module separation for which bend is referenced
+    double dphi = (Delta / drnom) * bend * settings_.stripPitch(psmodule) / rmean;
 
-  int width = (nbits_ + 3) / 4;
+    double kphi = psmodule ? settings_.kphi() : settings_.kphi1();
 
-  for (unsigned int i = 0; i < table_.size(); i++) {
-    int itable = table_[i];
-    if (positive_) {
-      if (table_[i] < 0) {
-        itable = (1 << nbits_) - 1;
-      }
+    int idphi = dphi / kphi;
+
+    return idphi;
+  }
+
+  // Write LUT table.
+  void TrackletLUT::writeTable() const {
+    if (!settings_.writeTable()) {
+      return;
     }
 
-    out << uppercase << setfill('0') << setw(width) << hex << itable << dec << endl;
+    if (name_.empty()) {
+      return;
+    }
+
+    ofstream out = openfile(settings_.tablePath(), name_, __FILE__, __LINE__);
+
+    out << "{" << endl;
+    for (unsigned int i = 0; i < table_.size(); i++) {
+      if (i != 0) {
+        out << "," << endl;
+      }
+
+      int itable = table_[i];
+      if (positive_) {
+        if (table_[i] < 0) {
+          itable = (1 << nbits_) - 1;
+        }
+      }
+
+      out << itable;
+    }
+    out << endl << "};" << endl;
+    out.close();
+
+    string name = name_;
+
+    name[name_.size() - 3] = 'd';
+    name[name_.size() - 2] = 'a';
+    name[name_.size() - 1] = 't';
+
+    out = openfile(settings_.tablePath(), name, __FILE__, __LINE__);
+
+    int width = (nbits_ + 3) / 4;
+
+    for (unsigned int i = 0; i < table_.size(); i++) {
+      int itable = table_[i];
+      if (positive_) {
+        if (table_[i] < 0) {
+          itable = (1 << nbits_) - 1;
+        }
+      }
+
+      out << uppercase << setfill('0') << setw(width) << hex << itable << dec << endl;
+    }
+
+    out.close();
   }
 
-  out.close();
-}
+  int TrackletLUT::lookup(unsigned int index) const {
+    assert(index < table_.size());
+    return table_[index];
+  }
 
-int TrackletLUT::lookup(unsigned int index) const {
-  assert(index < table_.size());
-  return table_[index];
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletParametersMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletParametersMemory.cc
@@ -9,39 +9,39 @@ using namespace std;
 
 namespace trklet {
 
-TrackletParametersMemory::TrackletParametersMemory(string name, Settings const& settings)
-    : MemoryBase(name, settings) {}
+  TrackletParametersMemory::TrackletParametersMemory(string name, Settings const& settings)
+      : MemoryBase(name, settings) {}
 
-void TrackletParametersMemory::clean() {
-  for (auto& tracklet : tracklets_) {
-    delete tracklet;
+  void TrackletParametersMemory::clean() {
+    for (auto& tracklet : tracklets_) {
+      delete tracklet;
+    }
+    tracklets_.clear();
   }
-  tracklets_.clear();
-}
 
-void TrackletParametersMemory::writeTPAR(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirTP = settings_.memPath() + "TrackletParameters/";
+  void TrackletParametersMemory::writeTPAR(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirTP = settings_.memPath() + "TrackletParameters/";
 
-  std::ostringstream oss;
-  oss << dirTP << "TrackletParameters_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1)
-      << ".dat";
-  auto const& fname = oss.str();
+    std::ostringstream oss;
+    oss << dirTP << "TrackletParameters_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1)
+        << ".dat";
+    auto const& fname = oss.str();
 
-  openfile(out_, first, dirTP, fname, __FILE__, __LINE__);
+    openfile(out_, first, dirTP, fname, __FILE__, __LINE__);
 
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
 
-  for (unsigned int j = 0; j < tracklets_.size(); j++) {
-    string tpar = tracklets_[j]->trackletparstr();
-    out_ << hexstr(j) << " " << tpar << " " << trklet::hexFormat(tpar) << endl;
+    for (unsigned int j = 0; j < tracklets_.size(); j++) {
+      string tpar = tracklets_[j]->trackletparstr();
+      out_ << hexstr(j) << " " << tpar << " " << trklet::hexFormat(tpar) << endl;
+    }
+    out_.close();
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
   }
-  out_.close();
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletParametersMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletParametersMemory.cc
@@ -6,7 +6,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletParametersMemory::TrackletParametersMemory(string name, Settings const& settings)
     : MemoryBase(name, settings) {}
@@ -41,4 +42,6 @@ void TrackletParametersMemory::writeTPAR(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
@@ -17,525 +17,527 @@ using namespace std;
 
 namespace trklet {
 
-TrackletProcessor::TrackletProcessor(string name, Settings const& settings, Globals* globals)
-    : TrackletCalculatorBase(name, settings, globals),
-      tebuffer_(CircularBuffer<TEData>(3), 0, 0, 0, 0),
-      pttableinner_(settings),
-      pttableouter_(settings),
-      useregiontable_(settings),
-      innerTable_(settings),
-      innerOverlapTable_(settings) {
-  iAllStub_ = -1;
+  TrackletProcessor::TrackletProcessor(string name, Settings const& settings, Globals* globals)
+      : TrackletCalculatorBase(name, settings, globals),
+        tebuffer_(CircularBuffer<TEData>(3), 0, 0, 0, 0),
+        pttableinner_(settings),
+        pttableouter_(settings),
+        useregiontable_(settings),
+        innerTable_(settings),
+        innerOverlapTable_(settings) {
+    iAllStub_ = -1;
 
-  for (unsigned int ilayer = 0; ilayer < N_LAYER; ilayer++) {
-    vector<TrackletProjectionsMemory*> tmp(settings_.nallstubs(ilayer), nullptr);
-    trackletprojlayers_.push_back(tmp);
-  }
-
-  for (unsigned int idisk = 0; idisk < N_DISK; idisk++) {
-    vector<TrackletProjectionsMemory*> tmp(settings_.nallstubs(idisk + N_LAYER), nullptr);
-    trackletprojdisks_.push_back(tmp);
-  }
-
-  outervmstubs_ = nullptr;
-
-  initLayerDisksandISeed(layerdisk1_, layerdisk2_, iSeed_);
-
-  double rmin = -1.0;
-  double rmax = -1.0;
-
-  if (iSeed_ == Seed::L1L2 || iSeed_ == Seed::L2L3 || iSeed_ == Seed::L3L4 || iSeed_ == Seed::L5L6) {
-    rmin = settings_.rmean(layerdisk1_);
-    rmax = settings_.rmean(layerdisk2_);
-  } else {
-    if (iSeed_ == Seed::L1D1) {
-      rmax = settings_.rmaxdiskl1overlapvm();
-      rmin = settings_.rmean(layerdisk1_);
-    } else if (iSeed_ == Seed::L2D1) {
-      rmax = settings_.rmaxdiskvm();
-      rmin = settings_.rmean(layerdisk1_);
-    } else {
-      rmax = settings_.rmaxdiskvm();
-      rmin = rmax * settings_.zmean(layerdisk2_ - N_LAYER - 1) / settings_.zmean(layerdisk2_ - N_LAYER);
+    for (unsigned int ilayer = 0; ilayer < N_LAYER; ilayer++) {
+      vector<TrackletProjectionsMemory*> tmp(settings_.nallstubs(ilayer), nullptr);
+      trackletprojlayers_.push_back(tmp);
     }
+
+    for (unsigned int idisk = 0; idisk < N_DISK; idisk++) {
+      vector<TrackletProjectionsMemory*> tmp(settings_.nallstubs(idisk + N_LAYER), nullptr);
+      trackletprojdisks_.push_back(tmp);
+    }
+
+    outervmstubs_ = nullptr;
+
+    initLayerDisksandISeed(layerdisk1_, layerdisk2_, iSeed_);
+
+    double rmin = -1.0;
+    double rmax = -1.0;
+
+    if (iSeed_ == Seed::L1L2 || iSeed_ == Seed::L2L3 || iSeed_ == Seed::L3L4 || iSeed_ == Seed::L5L6) {
+      rmin = settings_.rmean(layerdisk1_);
+      rmax = settings_.rmean(layerdisk2_);
+    } else {
+      if (iSeed_ == Seed::L1D1) {
+        rmax = settings_.rmaxdiskl1overlapvm();
+        rmin = settings_.rmean(layerdisk1_);
+      } else if (iSeed_ == Seed::L2D1) {
+        rmax = settings_.rmaxdiskvm();
+        rmin = settings_.rmean(layerdisk1_);
+      } else {
+        rmax = settings_.rmaxdiskvm();
+        rmin = rmax * settings_.zmean(layerdisk2_ - N_LAYER - 1) / settings_.zmean(layerdisk2_ - N_LAYER);
+      }
+    }
+
+    double dphimax = asin(0.5 * settings_.maxrinv() * rmax) - asin(0.5 * settings_.maxrinv() * rmin);
+
+    //number of fine phi bins in sector
+    int nfinephibins =
+        settings_.nallstubs(layerdisk2_) * settings_.nvmte(1, iSeed_) * (1 << settings_.nfinephi(1, iSeed_));
+    double dfinephi = settings_.dphisectorHG() / nfinephibins;
+
+    nbitsfinephi_ =
+        settings_.nbitsallstubs(layerdisk2_) + settings_.nbitsvmte(1, iSeed_) + settings_.nfinephi(1, iSeed_);
+
+    int nbins = 2.0 * (dphimax / dfinephi + 1.0);
+
+    nbitsfinephidiff_ = log(nbins) / log(2.0) + 1;
+
+    nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk1_);
+    nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk1_);
+
+    nbitsrzbin_ = N_RZBITS;
+    if (iSeed_ == Seed::D1D2 || iSeed_ == Seed::D3D4)
+      nbitsrzbin_ = 2;
+
+    innerphibits_ = settings_.nfinephi(0, iSeed_);
+    outerphibits_ = settings_.nfinephi(1, iSeed_);
+
+    if (layerdisk1_ == LayerDisk::L1 || layerdisk1_ == LayerDisk::L2 || layerdisk1_ == LayerDisk::L3 ||
+        layerdisk1_ == LayerDisk::L5 || layerdisk1_ == LayerDisk::D1 || layerdisk1_ == LayerDisk::D3) {
+      innerTable_.initVMRTable(layerdisk1_, TrackletLUT::VMRTableType::inner);  //projection to next layer/disk
+    }
+
+    if (layerdisk1_ == LayerDisk::L1 || layerdisk1_ == LayerDisk::L2) {
+      innerOverlapTable_.initVMRTable(layerdisk1_,
+                                      TrackletLUT::VMRTableType::inneroverlap);  //projection to disk from layer
+    }
+
+    // set TC index
+    iTC_ = name_[7] - 'A';
+    assert(iTC_ >= 0 && iTC_ < 14);
+
+    TCIndex_ = (iSeed_ << 4) + iTC_;
+    assert(TCIndex_ >= 0 && TCIndex_ <= (int)settings_.ntrackletmax());
+
+    maxStep_ = settings_.maxStep("TP");
   }
 
-  double dphimax = asin(0.5 * settings_.maxrinv() * rmax) - asin(0.5 * settings_.maxrinv() * rmin);
-
-  //number of fine phi bins in sector
-  int nfinephibins =
-      settings_.nallstubs(layerdisk2_) * settings_.nvmte(1, iSeed_) * (1 << settings_.nfinephi(1, iSeed_));
-  double dfinephi = settings_.dphisectorHG() / nfinephibins;
-
-  nbitsfinephi_ = settings_.nbitsallstubs(layerdisk2_) + settings_.nbitsvmte(1, iSeed_) + settings_.nfinephi(1, iSeed_);
-
-  int nbins = 2.0 * (dphimax / dfinephi + 1.0);
-
-  nbitsfinephidiff_ = log(nbins) / log(2.0) + 1;
-
-  nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk1_);
-  nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk1_);
-
-  nbitsrzbin_ = N_RZBITS;
-  if (iSeed_ == Seed::D1D2 || iSeed_ == Seed::D3D4)
-    nbitsrzbin_ = 2;
-
-  innerphibits_ = settings_.nfinephi(0, iSeed_);
-  outerphibits_ = settings_.nfinephi(1, iSeed_);
-
-  if (layerdisk1_ == LayerDisk::L1 || layerdisk1_ == LayerDisk::L2 || layerdisk1_ == LayerDisk::L3 ||
-      layerdisk1_ == LayerDisk::L5 || layerdisk1_ == LayerDisk::D1 || layerdisk1_ == LayerDisk::D3) {
-    innerTable_.initVMRTable(layerdisk1_, TrackletLUT::VMRTableType::inner);  //projection to next layer/disk
+  void TrackletProcessor::addOutputProjection(TrackletProjectionsMemory*& outputProj, MemoryBase* memory) {
+    outputProj = dynamic_cast<TrackletProjectionsMemory*>(memory);
+    assert(outputProj != nullptr);
   }
 
-  if (layerdisk1_ == LayerDisk::L1 || layerdisk1_ == LayerDisk::L2) {
-    innerOverlapTable_.initVMRTable(layerdisk1_,
-                                    TrackletLUT::VMRTableType::inneroverlap);  //projection to disk from layer
-  }
-
-  // set TC index
-  iTC_ = name_[7] - 'A';
-  assert(iTC_ >= 0 && iTC_ < 14);
-
-  TCIndex_ = (iSeed_ << 4) + iTC_;
-  assert(TCIndex_ >= 0 && TCIndex_ <= (int)settings_.ntrackletmax());
-
-  maxStep_ = settings_.maxStep("TP");
-}
-
-void TrackletProcessor::addOutputProjection(TrackletProjectionsMemory*& outputProj, MemoryBase* memory) {
-  outputProj = dynamic_cast<TrackletProjectionsMemory*>(memory);
-  assert(outputProj != nullptr);
-}
-
-void TrackletProcessor::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-  if (output == "trackpar") {
-    auto* tmp = dynamic_cast<TrackletParametersMemory*>(memory);
-    assert(tmp != nullptr);
-    trackletpars_ = tmp;
-    return;
-  }
-
-  if (output.substr(0, 7) == "projout") {
-    //output is on the form 'projoutL2PHIC' or 'projoutD3PHIB'
-    auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
-    assert(tmp != nullptr);
-
-    unsigned int layerdisk = output[8] - '1';   //layer or disk counting from 0
-    unsigned int phiregion = output[12] - 'A';  //phiregion counting from 0
-
-    if (output[7] == 'L') {
-      assert(layerdisk < N_LAYER);
-      assert(phiregion < trackletprojlayers_[layerdisk].size());
-      //check that phiregion not already initialized
-      assert(trackletprojlayers_[layerdisk][phiregion] == nullptr);
-      trackletprojlayers_[layerdisk][phiregion] = tmp;
+  void TrackletProcessor::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
+    if (output == "trackpar") {
+      auto* tmp = dynamic_cast<TrackletParametersMemory*>(memory);
+      assert(tmp != nullptr);
+      trackletpars_ = tmp;
       return;
     }
 
-    if (output[7] == 'D') {
-      assert(layerdisk < N_DISK);
-      assert(phiregion < trackletprojdisks_[layerdisk].size());
-      //check that phiregion not already initialized
-      assert(trackletprojdisks_[layerdisk][phiregion] == nullptr);
-      trackletprojdisks_[layerdisk][phiregion] = tmp;
+    if (output.substr(0, 7) == "projout") {
+      //output is on the form 'projoutL2PHIC' or 'projoutD3PHIB'
+      auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
+      assert(tmp != nullptr);
+
+      unsigned int layerdisk = output[8] - '1';   //layer or disk counting from 0
+      unsigned int phiregion = output[12] - 'A';  //phiregion counting from 0
+
+      if (output[7] == 'L') {
+        assert(layerdisk < N_LAYER);
+        assert(phiregion < trackletprojlayers_[layerdisk].size());
+        //check that phiregion not already initialized
+        assert(trackletprojlayers_[layerdisk][phiregion] == nullptr);
+        trackletprojlayers_[layerdisk][phiregion] = tmp;
+        return;
+      }
+
+      if (output[7] == 'D') {
+        assert(layerdisk < N_DISK);
+        assert(phiregion < trackletprojdisks_[layerdisk].size());
+        //check that phiregion not already initialized
+        assert(trackletprojdisks_[layerdisk][phiregion] == nullptr);
+        trackletprojdisks_[layerdisk][phiregion] = tmp;
+        return;
+      }
+    }
+
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
+  }
+
+  void TrackletProcessor::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+
+    if (input == "outervmstubin") {
+      auto* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
+      assert(tmp != nullptr);
+      outervmstubs_ = tmp;
+      iAllStub_ = tmp->getName()[11] - 'A';
+      if (iSeed_ == Seed::L2L3)
+        iAllStub_ = tmp->getName()[11] - 'I';
+      if (iSeed_ == Seed::L1D1 || iSeed_ == Seed::L2D1) {
+        if (tmp->getName()[11] == 'X')
+          iAllStub_ = 0;
+        if (tmp->getName()[11] == 'Y')
+          iAllStub_ = 1;
+        if (tmp->getName()[11] == 'Z')
+          iAllStub_ = 2;
+        if (tmp->getName()[11] == 'W')
+          iAllStub_ = 3;
+      }
+
+      unsigned int iTP = getName()[7] - 'A';
+
+      pttableinner_.initTPlut(true, iSeed_, layerdisk1_, layerdisk2_, nbitsfinephidiff_, iTP);
+      pttableouter_.initTPlut(false, iSeed_, layerdisk1_, layerdisk2_, nbitsfinephidiff_, iTP);
+
+      //need iAllStub_ set before building the table
+
+      useregiontable_.initTPregionlut(
+          iSeed_, layerdisk1_, layerdisk2_, iAllStub_, nbitsfinephidiff_, nbitsfinephi_, pttableinner_, iTP);
+
+      TrackletEngineUnit teunit(&settings_,
+                                nbitsfinephi_,
+                                layerdisk1_,
+                                layerdisk2_,
+                                iSeed_,
+                                nbitsfinephidiff_,
+                                iAllStub_,
+                                &pttableinner_,
+                                &pttableouter_,
+                                outervmstubs_);
+
+      teunits_.resize(settings_.teunits(iSeed_), teunit);
+
       return;
     }
+
+    if (input == "innerallstubin") {
+      auto* tmp = dynamic_cast<AllInnerStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      if (innerallstubs_.size() == 2) {  //FIXME this should be done with better logic with reading the input stubs
+        innerallstubs_.insert(innerallstubs_.begin(), tmp);
+      } else {
+        innerallstubs_.push_back(tmp);
+      }
+
+      //FIXME should be done once after all inputs are added
+      tebuffer_ = tuple<CircularBuffer<TEData>, unsigned int, unsigned int, unsigned int, unsigned int>(
+          CircularBuffer<TEData>(3), 0, 0, 0, innerallstubs_.size());
+
+      return;
+    }
+    if (input == "outerallstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      outerallstubs_.push_back(tmp);
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
   }
 
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
-}
+  void TrackletProcessor::execute(unsigned int iSector, double phimin, double phimax) {
+    bool print = (iSector == 3) && (getName() == "TP_L1L2D");
+    print = false;
 
-void TrackletProcessor::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
+    phimin_ = phimin;
+    phimax_ = phimax;
+    iSector_ = iSector;
 
-  if (input == "outervmstubin") {
-    auto* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
-    assert(tmp != nullptr);
-    outervmstubs_ = tmp;
-    iAllStub_ = tmp->getName()[11] - 'A';
-    if (iSeed_ == Seed::L2L3)
-      iAllStub_ = tmp->getName()[11] - 'I';
-    if (iSeed_ == Seed::L1D1 || iSeed_ == Seed::L2D1) {
-      if (tmp->getName()[11] == 'X')
-        iAllStub_ = 0;
-      if (tmp->getName()[11] == 'Y')
-        iAllStub_ = 1;
-      if (tmp->getName()[11] == 'Z')
-        iAllStub_ = 2;
-      if (tmp->getName()[11] == 'W')
-        iAllStub_ = 3;
+    if (!settings_.useSeed(iSeed_))
+      return;
+
+    //Not most elegant solution; but works
+    int donecount = 0;
+
+    //Consistency checks
+    assert(iAllStub_ >= 0);
+    assert(iAllStub_ < (int)settings_.nallstubs(layerdisk2_));
+    assert(outervmstubs_ != nullptr);
+
+    //used to collect performance data
+    unsigned int countall = 0;
+    unsigned int countsel = 0;
+
+    unsigned int countteall = 0;
+    unsigned int stubpairs = 0;
+
+    unsigned int ntedata = 0;
+
+    unsigned int ninnerstubs = 0;
+
+    //Actual implemenation starts here
+
+    //Reset the tebuffer
+    std::get<0>(tebuffer_).reset();
+    std::get<1>(tebuffer_) = 0;
+    std::get<2>(tebuffer_) = std::get<3>(tebuffer_);
+
+    //Reset the teunits
+    for (auto& teunit : teunits_) {
+      teunit.reset();
     }
 
-    unsigned int iTP = getName()[7] - 'A';
+    TEData tedata;
+    TEData tedata__;
+    TEData tedata___;
+    bool goodtedata = false;
+    bool goodtedata__ = false;
+    bool goodtedata___ = false;
 
-    pttableinner_.initTPlut(true, iSeed_, layerdisk1_, layerdisk2_, nbitsfinephidiff_, iTP);
-    pttableouter_.initTPlut(false, iSeed_, layerdisk1_, layerdisk2_, nbitsfinephidiff_, iTP);
+    bool tebuffernearfull;
 
-    //need iAllStub_ set before building the table
+    for (unsigned int istep = 0; istep < maxStep_; istep++) {
+      // These print statements are not on by defaul but can be enabled for the
+      // comparison with HLS code to track differences.
+      if (print) {
+        CircularBuffer<TEData>& tedatabuffer = std::get<0>(tebuffer_);
+        unsigned int& istub = std::get<1>(tebuffer_);
+        unsigned int& imem = std::get<2>(tebuffer_);
+        cout << "istep=" << istep << " TEBuffer: " << istub << " " << imem << " " << tedatabuffer.rptr() << " "
+             << tedatabuffer.wptr();
+        int k = -1;
+        for (auto& teunit : teunits_) {
+          k++;
+          cout << " [" << k << " " << teunit.rptr() << " " << teunit.wptr() << " " << teunit.idle() << "]";
+        }
+        cout << endl;
+      }
 
-    useregiontable_.initTPregionlut(
-        iSeed_, layerdisk1_, layerdisk2_, iAllStub_, nbitsfinephidiff_, nbitsfinephi_, pttableinner_, iTP);
-
-    TrackletEngineUnit teunit(&settings_,
-                              nbitsfinephi_,
-                              layerdisk1_,
-                              layerdisk2_,
-                              iSeed_,
-                              nbitsfinephidiff_,
-                              iAllStub_,
-                              &pttableinner_,
-                              &pttableouter_,
-                              outervmstubs_);
-
-    teunits_.resize(settings_.teunits(iSeed_), teunit);
-
-    return;
-  }
-
-  if (input == "innerallstubin") {
-    auto* tmp = dynamic_cast<AllInnerStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    if (innerallstubs_.size() == 2) {  //FIXME this should be done with better logic with reading the input stubs
-      innerallstubs_.insert(innerallstubs_.begin(), tmp);
-    } else {
-      innerallstubs_.push_back(tmp);
-    }
-
-    //FIXME should be done once after all inputs are added
-    tebuffer_ = tuple<CircularBuffer<TEData>, unsigned int, unsigned int, unsigned int, unsigned int>(
-        CircularBuffer<TEData>(3), 0, 0, 0, innerallstubs_.size());
-
-    return;
-  }
-  if (input == "outerallstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    outerallstubs_.push_back(tmp);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
-}
-
-void TrackletProcessor::execute(unsigned int iSector, double phimin, double phimax) {
-  bool print = (iSector == 3) && (getName() == "TP_L1L2D");
-  print = false;
-
-  phimin_ = phimin;
-  phimax_ = phimax;
-  iSector_ = iSector;
-
-  if (!settings_.useSeed(iSeed_))
-    return;
-
-  //Not most elegant solution; but works
-  int donecount = 0;
-
-  //Consistency checks
-  assert(iAllStub_ >= 0);
-  assert(iAllStub_ < (int)settings_.nallstubs(layerdisk2_));
-  assert(outervmstubs_ != nullptr);
-
-  //used to collect performance data
-  unsigned int countall = 0;
-  unsigned int countsel = 0;
-
-  unsigned int countteall = 0;
-  unsigned int stubpairs = 0;
-
-  unsigned int ntedata = 0;
-
-  unsigned int ninnerstubs = 0;
-
-  //Actual implemenation starts here
-
-  //Reset the tebuffer
-  std::get<0>(tebuffer_).reset();
-  std::get<1>(tebuffer_) = 0;
-  std::get<2>(tebuffer_) = std::get<3>(tebuffer_);
-
-  //Reset the teunits
-  for (auto& teunit : teunits_) {
-    teunit.reset();
-  }
-
-  TEData tedata;
-  TEData tedata__;
-  TEData tedata___;
-  bool goodtedata = false;
-  bool goodtedata__ = false;
-  bool goodtedata___ = false;
-
-  bool tebuffernearfull;
-
-  for (unsigned int istep = 0; istep < maxStep_; istep++) {
-    // These print statements are not on by defaul but can be enabled for the
-    // comparison with HLS code to track differences.
-    if (print) {
       CircularBuffer<TEData>& tedatabuffer = std::get<0>(tebuffer_);
-      unsigned int& istub = std::get<1>(tebuffer_);
-      unsigned int& imem = std::get<2>(tebuffer_);
-      cout << "istep=" << istep << " TEBuffer: " << istub << " " << imem << " " << tedatabuffer.rptr() << " "
-           << tedatabuffer.wptr();
-      int k = -1;
+      tebuffernearfull = tedatabuffer.nearfull();
+
+      //
+      // First block here checks if there is a teunit with data that should should be used
+      // to calculate the tracklet parameters
+      //
+
+      TrackletEngineUnit* teunitptr = nullptr;
+
       for (auto& teunit : teunits_) {
-        k++;
-        cout << " [" << k << " " << teunit.rptr() << " " << teunit.wptr() << " " << teunit.idle() << "]";
-      }
-      cout << endl;
-    }
-
-    CircularBuffer<TEData>& tedatabuffer = std::get<0>(tebuffer_);
-    tebuffernearfull = tedatabuffer.nearfull();
-
-    //
-    // First block here checks if there is a teunit with data that should should be used
-    // to calculate the tracklet parameters
-    //
-
-    TrackletEngineUnit* teunitptr = nullptr;
-
-    for (auto& teunit : teunits_) {
-      teunit.setNearFull();
-      if (!teunit.empty()) {
-        teunitptr = &teunit;
-      }
-    }
-
-    if (teunitptr != nullptr) {
-      auto stubpair = teunitptr->read();
-      stubpairs++;
-
-      if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
-        edm::LogVerbatim("Tracklet") << "Will break on too many tracklets in " << getName();
-        break;
-      }
-      countall++;
-      const Stub* innerFPGAStub = stubpair.first;
-      const L1TStub* innerStub = innerFPGAStub->l1tstub();
-
-      const Stub* outerFPGAStub = stubpair.second;
-      const L1TStub* outerStub = outerFPGAStub->l1tstub();
-
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "TrackletProcessor execute " << getName() << "[" << iSector_ << "]";
-      }
-
-      bool accept = false;
-
-      if (iSeed_ == Seed::L1L2 || iSeed_ == Seed::L2L3 || iSeed_ == Seed::L3L4 || iSeed_ == Seed::L5L6) {
-        accept = barrelSeeding(innerFPGAStub, innerStub, outerFPGAStub, outerStub);
-      } else if (iSeed_ == Seed::D1D2 || iSeed_ == Seed::D3D4) {
-        accept = diskSeeding(innerFPGAStub, innerStub, outerFPGAStub, outerStub);
-      } else {
-        accept = overlapSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub);
-      }
-
-      if (accept)
-        countsel++;
-
-      if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
-        edm::LogVerbatim("Tracklet") << "Will break on number of tracklets in " << getName();
-        assert(0);
-        break;
-      }
-
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "TrackletProcessor execute done";
-      }
-    }
-
-    //
-    // The second block fills the teunit if data in buffer and process TEUnit step
-    //
-    //
-
-    bool notemptytebuffer = !tedatabuffer.empty();
-
-    int ite = -1;
-    for (auto& teunit : teunits_) {
-      ite++;
-      if (teunit.idle()) {
-        if (notemptytebuffer) {
-          teunit.init(std::get<0>(tebuffer_).read());
-          notemptytebuffer = false;  //prevent initialzing another TE unit
+        teunit.setNearFull();
+        if (!teunit.empty()) {
+          teunitptr = &teunit;
         }
       }
-      teunit.step(print, istep, ite);
-    }
 
-    //
-    // The third block here checks if we have input stubs to process
-    //
-    //
+      if (teunitptr != nullptr) {
+        auto stubpair = teunitptr->read();
+        stubpairs++;
 
-    if (goodtedata___)
-      tedatabuffer.store(tedata___);
-
-    goodtedata = false;
-
-    unsigned int& istub = std::get<1>(tebuffer_);
-    unsigned int& imem = std::get<2>(tebuffer_);
-    unsigned int imemend = std::get<4>(tebuffer_);
-
-    if ((!tebuffernearfull) && imem < imemend && istub < innerallstubs_[imem]->nStubs()) {
-      ninnerstubs++;
-
-      const Stub* stub = innerallstubs_[imem]->getStub(istub);
-
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << getName() << " Have stub in " << innerallstubs_[imem]->getName();
-      }
-
-      bool negdisk = (stub->disk().value() < 0);  //FIXME stub needs to contain bit for +/- z disk
-
-      FPGAWord phicorr = stub->phicorr();
-      int innerfinephi = phicorr.bits(phicorr.nbits() - nbitsfinephi_, nbitsfinephi_);
-      FPGAWord innerbend = stub->bend();
-
-      //Take the top nbitszfinebintable_ bits of the z coordinate
-      int indexz = (stub->z().value() >> (stub->z().nbits() - nbitszfinebintable_)) & ((1 << nbitszfinebintable_) - 1);
-      int indexr = -1;
-      if (layerdisk1_ > (N_LAYER - 1)) {
-        if (negdisk) {
-          indexz = ((1 << nbitszfinebintable_) - 1) - indexz;
+        if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
+          edm::LogVerbatim("Tracklet") << "Will break on too many tracklets in " << getName();
+          break;
         }
-        indexr = stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_);
-      } else {  //Take the top nbitsfinebintable_ bits of the z coordinate
-        indexr = (stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_)) & ((1 << nbitsrfinebintable_) - 1);
-      }
+        countall++;
+        const Stub* innerFPGAStub = stubpair.first;
+        const L1TStub* innerStub = innerFPGAStub->l1tstub();
 
-      int lutval = -1;
-      if (iSeed_ < 6) {  //FIXME should only be one table - but will need coordination with HLS code.
-        lutval = innerTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-      } else {
-        lutval = innerOverlapTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-      }
+        const Stub* outerFPGAStub = stubpair.second;
+        const L1TStub* outerStub = outerFPGAStub->l1tstub();
 
-      if (lutval != -1) {
-        unsigned int lutwidth = settings_.lutwidthtab(0, iSeed_);
-        FPGAWord lookupbits(lutval, lutwidth, true, __LINE__, __FILE__);
-
-        int rzfinebinfirst = lookupbits.bits(0, NFINERZBITS);       //finerz
-        int next = lookupbits.bits(NFINERZBITS, 1);                 //use next r/z bin
-        int start = lookupbits.bits(NFINERZBITS + 1, nbitsrzbin_);  //rz bin
-        int rzdiffmax = lookupbits.bits(NFINERZBITS + 1 + nbitsrzbin_, NFINERZBITS);
-
-        if ((iSeed_ == Seed::D1D2 || iSeed_ == Seed::D3D4) && negdisk) {  //TODO - need to store negative disk
-          start += (1 << nbitsrzbin_);
-        }
-        int last = start + next;
-
-        int nbins = (1 << N_RZBITS);
-
-        unsigned int useregindex = (innerfinephi << innerbend.nbits()) + innerbend.value();
-        if (iSeed_ == Seed::D1D2 || iSeed_ == Seed::D3D4 || iSeed_ == Seed::L1D1 || iSeed_ == Seed::L2D1) {
-          //FIXME If the lookupbits were rationally organized this would be much simpler
-          unsigned int nrbits = 3;
-          int ir = ((start & ((1 << (nrbits - 1)) - 1)) << 1) + (rzfinebinfirst >> (NFINERZBITS - 1));
-          useregindex = (useregindex << nrbits) + ir;
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << "TrackletProcessor execute " << getName() << "[" << iSector_ << "]";
         }
 
-        unsigned int usereg = useregiontable_.lookup(useregindex);
+        bool accept = false;
 
-        tedata.regions_.clear();
-        tedata.stub_ = stub;
-        tedata.rzbinfirst_ = rzfinebinfirst;
-        tedata.start_ = start;
-        tedata.innerfinephi_ = innerfinephi;
-        tedata.rzdiffmax_ = rzdiffmax;
-        tedata.innerbend_ = innerbend;
+        if (iSeed_ == Seed::L1L2 || iSeed_ == Seed::L2L3 || iSeed_ == Seed::L3L4 || iSeed_ == Seed::L5L6) {
+          accept = barrelSeeding(innerFPGAStub, innerStub, outerFPGAStub, outerStub);
+        } else if (iSeed_ == Seed::D1D2 || iSeed_ == Seed::D3D4) {
+          accept = diskSeeding(innerFPGAStub, innerStub, outerFPGAStub, outerStub);
+        } else {
+          accept = overlapSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub);
+        }
 
-        std::string mask = "";
+        if (accept)
+          countsel++;
 
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int ireg = 0; ireg < settings_.nvmte(1, iSeed_); ireg++) {
-            if (!(usereg & (1 << ireg))) {
-              mask = "0" + mask;
-              continue;
-            }
+        if (trackletpars_->nTracklets() >= settings_.ntrackletmax()) {
+          edm::LogVerbatim("Tracklet") << "Will break on number of tracklets in " << getName();
+          assert(0);
+          break;
+        }
 
-            if (settings_.debugTracklet()) {
-              edm::LogVerbatim("Tracklet") << getName() << " looking for matching stub in bin " << ibin << " with "
-                                           << outervmstubs_->nVMStubsBinned(ireg * nbins + ibin) << " stubs";
-            }
-            assert(ireg * nbins + ibin < outervmstubs_->nBin());
-            int nstubs = outervmstubs_->nVMStubsBinned(ireg * nbins + ibin);
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << "TrackletProcessor execute done";
+        }
+      }
 
-            if (nstubs > 0) {
-              mask = "1" + mask;
-              tedata.regions_.emplace_back(tuple<int, int, int>(ibin - start, ireg, nstubs));
-              countteall += nstubs;
-            } else {
-              mask = "0" + mask;
-            }
+      //
+      // The second block fills the teunit if data in buffer and process TEUnit step
+      //
+      //
+
+      bool notemptytebuffer = !tedatabuffer.empty();
+
+      int ite = -1;
+      for (auto& teunit : teunits_) {
+        ite++;
+        if (teunit.idle()) {
+          if (notemptytebuffer) {
+            teunit.init(std::get<0>(tebuffer_).read());
+            notemptytebuffer = false;  //prevent initialzing another TE unit
           }
         }
-
-        if (!tedata.regions_.empty()) {
-          ntedata++;
-          goodtedata = true;
-        }
+        teunit.step(print, istep, ite);
       }
-      istub++;
-      if (istub >= innerallstubs_[imem]->nStubs()) {
-        istub = 0;
+
+      //
+      // The third block here checks if we have input stubs to process
+      //
+      //
+
+      if (goodtedata___)
+        tedatabuffer.store(tedata___);
+
+      goodtedata = false;
+
+      unsigned int& istub = std::get<1>(tebuffer_);
+      unsigned int& imem = std::get<2>(tebuffer_);
+      unsigned int imemend = std::get<4>(tebuffer_);
+
+      if ((!tebuffernearfull) && imem < imemend && istub < innerallstubs_[imem]->nStubs()) {
+        ninnerstubs++;
+
+        const Stub* stub = innerallstubs_[imem]->getStub(istub);
+
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << getName() << " Have stub in " << innerallstubs_[imem]->getName();
+        }
+
+        bool negdisk = (stub->disk().value() < 0);  //FIXME stub needs to contain bit for +/- z disk
+
+        FPGAWord phicorr = stub->phicorr();
+        int innerfinephi = phicorr.bits(phicorr.nbits() - nbitsfinephi_, nbitsfinephi_);
+        FPGAWord innerbend = stub->bend();
+
+        //Take the top nbitszfinebintable_ bits of the z coordinate
+        int indexz =
+            (stub->z().value() >> (stub->z().nbits() - nbitszfinebintable_)) & ((1 << nbitszfinebintable_) - 1);
+        int indexr = -1;
+        if (layerdisk1_ > (N_LAYER - 1)) {
+          if (negdisk) {
+            indexz = ((1 << nbitszfinebintable_) - 1) - indexz;
+          }
+          indexr = stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_);
+        } else {  //Take the top nbitsfinebintable_ bits of the z coordinate
+          indexr = (stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_)) & ((1 << nbitsrfinebintable_) - 1);
+        }
+
+        int lutval = -1;
+        if (iSeed_ < 6) {  //FIXME should only be one table - but will need coordination with HLS code.
+          lutval = innerTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+        } else {
+          lutval = innerOverlapTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+        }
+
+        if (lutval != -1) {
+          unsigned int lutwidth = settings_.lutwidthtab(0, iSeed_);
+          FPGAWord lookupbits(lutval, lutwidth, true, __LINE__, __FILE__);
+
+          int rzfinebinfirst = lookupbits.bits(0, NFINERZBITS);       //finerz
+          int next = lookupbits.bits(NFINERZBITS, 1);                 //use next r/z bin
+          int start = lookupbits.bits(NFINERZBITS + 1, nbitsrzbin_);  //rz bin
+          int rzdiffmax = lookupbits.bits(NFINERZBITS + 1 + nbitsrzbin_, NFINERZBITS);
+
+          if ((iSeed_ == Seed::D1D2 || iSeed_ == Seed::D3D4) && negdisk) {  //TODO - need to store negative disk
+            start += (1 << nbitsrzbin_);
+          }
+          int last = start + next;
+
+          int nbins = (1 << N_RZBITS);
+
+          unsigned int useregindex = (innerfinephi << innerbend.nbits()) + innerbend.value();
+          if (iSeed_ == Seed::D1D2 || iSeed_ == Seed::D3D4 || iSeed_ == Seed::L1D1 || iSeed_ == Seed::L2D1) {
+            //FIXME If the lookupbits were rationally organized this would be much simpler
+            unsigned int nrbits = 3;
+            int ir = ((start & ((1 << (nrbits - 1)) - 1)) << 1) + (rzfinebinfirst >> (NFINERZBITS - 1));
+            useregindex = (useregindex << nrbits) + ir;
+          }
+
+          unsigned int usereg = useregiontable_.lookup(useregindex);
+
+          tedata.regions_.clear();
+          tedata.stub_ = stub;
+          tedata.rzbinfirst_ = rzfinebinfirst;
+          tedata.start_ = start;
+          tedata.innerfinephi_ = innerfinephi;
+          tedata.rzdiffmax_ = rzdiffmax;
+          tedata.innerbend_ = innerbend;
+
+          std::string mask = "";
+
+          for (int ibin = start; ibin <= last; ibin++) {
+            for (unsigned int ireg = 0; ireg < settings_.nvmte(1, iSeed_); ireg++) {
+              if (!(usereg & (1 << ireg))) {
+                mask = "0" + mask;
+                continue;
+              }
+
+              if (settings_.debugTracklet()) {
+                edm::LogVerbatim("Tracklet") << getName() << " looking for matching stub in bin " << ibin << " with "
+                                             << outervmstubs_->nVMStubsBinned(ireg * nbins + ibin) << " stubs";
+              }
+              assert(ireg * nbins + ibin < outervmstubs_->nBin());
+              int nstubs = outervmstubs_->nVMStubsBinned(ireg * nbins + ibin);
+
+              if (nstubs > 0) {
+                mask = "1" + mask;
+                tedata.regions_.emplace_back(tuple<int, int, int>(ibin - start, ireg, nstubs));
+                countteall += nstubs;
+              } else {
+                mask = "0" + mask;
+              }
+            }
+          }
+
+          if (!tedata.regions_.empty()) {
+            ntedata++;
+            goodtedata = true;
+          }
+        }
+        istub++;
+        if (istub >= innerallstubs_[imem]->nStubs()) {
+          istub = 0;
+          imem++;
+        }
+      } else if ((!tebuffernearfull) && imem < imemend && istub == 0) {
         imem++;
       }
-    } else if ((!tebuffernearfull) && imem < imemend && istub == 0) {
-      imem++;
-    }
 
-    goodtedata___ = goodtedata__;
-    goodtedata__ = goodtedata;
+      goodtedata___ = goodtedata__;
+      goodtedata__ = goodtedata;
 
-    tedata___ = tedata__;
-    tedata__ = tedata;
+      tedata___ = tedata__;
+      tedata__ = tedata;
 
-    //
-    // stop looping over istep if done
-    //
+      //
+      // stop looping over istep if done
+      //
 
-    bool done = true;
+      bool done = true;
 
-    if (imem < imemend || (!tedatabuffer.empty())) {
-      done = false;
-    }
-
-    for (auto& teunit : teunits_) {
-      if (!(teunit.idle() && teunit.empty()))
+      if (imem < imemend || (!tedatabuffer.empty())) {
         done = false;
+      }
+
+      for (auto& teunit : teunits_) {
+        if (!(teunit.idle() && teunit.empty()))
+          done = false;
+      }
+
+      if (done) {
+        donecount++;
+      }
+
+      //FIXME This should be done cleaner... Not too hard, but need to check fully the TEBuffer and TEUnit buffer.
+      if (donecount > 4) {
+        break;
+      }
     }
 
-    if (done) {
-      donecount++;
-    }
+    //
+    // Done with processing - collect performance statistics
+    //
 
-    //FIXME This should be done cleaner... Not too hard, but need to check fully the TEBuffer and TEUnit buffer.
-    if (donecount > 4) {
-      break;
+    if (settings_.writeMonitorData("TP")) {
+      globals_->ofstream("trackletprocessor.txt") << getName() << " " << ninnerstubs   //# inner stubs
+                                                  << " " << outervmstubs_->nVMStubs()  //# outer stubs
+                                                  << " " << countteall                 //# pairs tried in TE
+                                                  << " " << stubpairs                  //# stubs pairs
+                                                  << " " << countsel                   //# tracklets found
+                                                  << endl;
     }
   }
 
-  //
-  // Done with processing - collect performance statistics
-  //
-
-  if (settings_.writeMonitorData("TP")) {
-    globals_->ofstream("trackletprocessor.txt") << getName() << " " << ninnerstubs   //# inner stubs
-                                                << " " << outervmstubs_->nVMStubs()  //# outer stubs
-                                                << " " << countteall                 //# pairs tried in TE
-                                                << " " << stubpairs                  //# stubs pairs
-                                                << " " << countsel                   //# tracklets found
-                                                << endl;
-  }
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
@@ -14,7 +14,8 @@
 #include <tuple>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletProcessor::TrackletProcessor(string name, Settings const& settings, Globals* globals)
     : TrackletCalculatorBase(name, settings, globals),
@@ -535,4 +536,6 @@ void TrackletProcessor::execute(unsigned int iSector, double phimin, double phim
                                                 << " " << countsel                   //# tracklets found
                                                 << endl;
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -19,426 +19,545 @@ using namespace std;
 
 namespace trklet {
 
-TrackletProcessorDisplaced::TrackletProcessorDisplaced(string name, Settings const& settings, Globals* globals)
-    : TrackletCalculatorDisplaced(name, settings, globals),
-      innerTable_(settings),
-      innerOverlapTable_(settings),
-      innerThirdTable_(settings) {
-  innerallstubs_.clear();
-  middleallstubs_.clear();
-  outerallstubs_.clear();
-  stubpairs_.clear();
-  innervmstubs_.clear();
-  outervmstubs_.clear();
+  TrackletProcessorDisplaced::TrackletProcessorDisplaced(string name, Settings const& settings, Globals* globals)
+      : TrackletCalculatorDisplaced(name, settings, globals),
+        innerTable_(settings),
+        innerOverlapTable_(settings),
+        innerThirdTable_(settings) {
+    innerallstubs_.clear();
+    middleallstubs_.clear();
+    outerallstubs_.clear();
+    stubpairs_.clear();
+    innervmstubs_.clear();
+    outervmstubs_.clear();
 
-  const unsigned layerdiskPosInName = 4;
-  const unsigned regionPosInName1 = 9;
+    const unsigned layerdiskPosInName = 4;
+    const unsigned regionPosInName1 = 9;
 
-  // iAllStub_ = -1;
-  layerdisk_ = initLayerDisk(layerdiskPosInName);
+    // iAllStub_ = -1;
+    layerdisk_ = initLayerDisk(layerdiskPosInName);
 
-  unsigned int region = name.substr(1)[regionPosInName1] - 'A';
-  // assert(region < settings_.nallstubs(layerdisk_));
+    unsigned int region = name.substr(1)[regionPosInName1] - 'A';
+    // assert(region < settings_.nallstubs(layerdisk_));
 
-  if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3 ||
-      layerdisk_ == LayerDisk::L5 || layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D3) {
-    innerTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::inner, region);  //projection to next layer/disk
+    if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3 ||
+        layerdisk_ == LayerDisk::L5 || layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D3) {
+      innerTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::inner, region);  //projection to next layer/disk
+    }
+
+    if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2) {
+      innerOverlapTable_.initVMRTable(
+          layerdisk_, TrackletLUT::VMRTableType::inneroverlap, region);  //projection to disk from layer
+    }
+
+    if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3 || layerdisk_ == LayerDisk::L5 ||
+        layerdisk_ == LayerDisk::D1) {
+      innerThirdTable_.initVMRTable(
+          layerdisk_, TrackletLUT::VMRTableType::innerthird, region);  //projection to third layer/disk
+    }
+
+    nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk_);
+    nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk_);
+
+    for (unsigned int ilayer = 0; ilayer < N_LAYER; ilayer++) {
+      vector<TrackletProjectionsMemory*> tmp(settings_.nallstubs(ilayer), nullptr);
+      trackletprojlayers_.push_back(tmp);
+    }
+
+    for (unsigned int idisk = 0; idisk < N_DISK; idisk++) {
+      vector<TrackletProjectionsMemory*> tmp(settings_.nallstubs(idisk + N_LAYER), nullptr);
+      trackletprojdisks_.push_back(tmp);
+    }
+
+    // initLayerDisksandISeed(layerdisk1_, layerdisk2_, iSeed_);
+
+    layer_ = 0;
+    disk_ = 0;
+    layer1_ = 0;
+    layer2_ = 0;
+    layer3_ = 0;
+    disk1_ = 0;
+    disk2_ = 0;
+    disk3_ = 0;
+
+    constexpr unsigned layerPosInName1 = 4;
+    constexpr unsigned diskPosInName1 = 4;
+    constexpr unsigned layer1PosInName1 = 4;
+    constexpr unsigned disk1PosInName1 = 4;
+    constexpr unsigned layer2PosInName1 = 6;
+    constexpr unsigned disk2PosInName1 = 6;
+
+    string name1 = name.substr(1);  //this is to correct for "TPD" having one more letter then "TP"
+    if (name1[3] == 'L')
+      layer_ = name1[layerPosInName1] - '0';
+    if (name1[3] == 'D')
+      disk_ = name1[diskPosInName1] - '0';
+
+    if (name1[3] == 'L')
+      layer1_ = name1[layer1PosInName1] - '0';
+    if (name1[3] == 'D')
+      disk1_ = name1[disk1PosInName1] - '0';
+    if (name1[5] == 'L')
+      layer2_ = name1[layer2PosInName1] - '0';
+    if (name1[5] == 'D')
+      disk2_ = name1[disk2PosInName1] - '0';
+
+    // set TC index
+    iSeed_ = 0;
+
+    int iTC = name1[regionPosInName1] - 'A';
+
+    if (name1.substr(3, 6) == "L3L4L2") {
+      iSeed_ = 8;
+      layer3_ = 2;
+    } else if (name1.substr(3, 6) == "L5L6L4") {
+      iSeed_ = 9;
+      layer3_ = 4;
+    } else if (name1.substr(3, 6) == "L2L3D1") {
+      iSeed_ = 10;
+      disk3_ = 1;
+    } else if (name1.substr(3, 6) == "D1D2L2") {
+      iSeed_ = 11;
+      layer3_ = 2;
+    }
+    assert(iSeed_ != 0);
+
+    constexpr int TCIndexMin = 128;
+    constexpr int TCIndexMax = 191;
+
+    TCIndex_ = (iSeed_ << 4) + iTC;
+    assert(TCIndex_ >= TCIndexMin && TCIndex_ < TCIndexMax);
+
+    assert((layer_ != 0) || (disk_ != 0));
   }
 
-  if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2) {
-    innerOverlapTable_.initVMRTable(
-        layerdisk_, TrackletLUT::VMRTableType::inneroverlap, region);  //projection to disk from layer
+  void TrackletProcessorDisplaced::addOutputProjection(TrackletProjectionsMemory*& outputProj, MemoryBase* memory) {
+    outputProj = dynamic_cast<TrackletProjectionsMemory*>(memory);
+    assert(outputProj != nullptr);
   }
 
-  if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3 || layerdisk_ == LayerDisk::L5 ||
-      layerdisk_ == LayerDisk::D1) {
-    innerThirdTable_.initVMRTable(
-        layerdisk_, TrackletLUT::VMRTableType::innerthird, region);  //projection to third layer/disk
-  }
+  void TrackletProcessorDisplaced::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
 
-  nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk_);
-  nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk_);
-
-  for (unsigned int ilayer = 0; ilayer < N_LAYER; ilayer++) {
-    vector<TrackletProjectionsMemory*> tmp(settings_.nallstubs(ilayer), nullptr);
-    trackletprojlayers_.push_back(tmp);
-  }
-
-  for (unsigned int idisk = 0; idisk < N_DISK; idisk++) {
-    vector<TrackletProjectionsMemory*> tmp(settings_.nallstubs(idisk + N_LAYER), nullptr);
-    trackletprojdisks_.push_back(tmp);
-  }
-
-  // initLayerDisksandISeed(layerdisk1_, layerdisk2_, iSeed_);
-
-  layer_ = 0;
-  disk_ = 0;
-  layer1_ = 0;
-  layer2_ = 0;
-  layer3_ = 0;
-  disk1_ = 0;
-  disk2_ = 0;
-  disk3_ = 0;
-
-  constexpr unsigned layerPosInName1 = 4;
-  constexpr unsigned diskPosInName1 = 4;
-  constexpr unsigned layer1PosInName1 = 4;
-  constexpr unsigned disk1PosInName1 = 4;
-  constexpr unsigned layer2PosInName1 = 6;
-  constexpr unsigned disk2PosInName1 = 6;
-
-  string name1 = name.substr(1);  //this is to correct for "TPD" having one more letter then "TP"
-  if (name1[3] == 'L')
-    layer_ = name1[layerPosInName1] - '0';
-  if (name1[3] == 'D')
-    disk_ = name1[diskPosInName1] - '0';
-
-  if (name1[3] == 'L')
-    layer1_ = name1[layer1PosInName1] - '0';
-  if (name1[3] == 'D')
-    disk1_ = name1[disk1PosInName1] - '0';
-  if (name1[5] == 'L')
-    layer2_ = name1[layer2PosInName1] - '0';
-  if (name1[5] == 'D')
-    disk2_ = name1[disk2PosInName1] - '0';
-
-  // set TC index
-  iSeed_ = 0;
-
-  int iTC = name1[regionPosInName1] - 'A';
-
-  if (name1.substr(3, 6) == "L3L4L2") {
-    iSeed_ = 8;
-    layer3_ = 2;
-  } else if (name1.substr(3, 6) == "L5L6L4") {
-    iSeed_ = 9;
-    layer3_ = 4;
-  } else if (name1.substr(3, 6) == "L2L3D1") {
-    iSeed_ = 10;
-    disk3_ = 1;
-  } else if (name1.substr(3, 6) == "D1D2L2") {
-    iSeed_ = 11;
-    layer3_ = 2;
-  }
-  assert(iSeed_ != 0);
-
-  constexpr int TCIndexMin = 128;
-  constexpr int TCIndexMax = 191;
-
-  TCIndex_ = (iSeed_ << 4) + iTC;
-  assert(TCIndex_ >= TCIndexMin && TCIndex_ < TCIndexMax);
-
-  assert((layer_ != 0) || (disk_ != 0));
-}
-
-void TrackletProcessorDisplaced::addOutputProjection(TrackletProjectionsMemory*& outputProj, MemoryBase* memory) {
-  outputProj = dynamic_cast<TrackletProjectionsMemory*>(memory);
-  assert(outputProj != nullptr);
-}
-
-void TrackletProcessorDisplaced::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-
-  if (output == "trackpar") {
-    auto* tmp = dynamic_cast<TrackletParametersMemory*>(memory);
-    assert(tmp != nullptr);
-    trackletpars_ = tmp;
-    return;
-  }
-
-  if (output.substr(0, 7) == "projout") {
-    //output is on the form 'projoutL2PHIC' or 'projoutD3PHIB'
-    auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
-    assert(tmp != nullptr);
-
-    constexpr unsigned layerdiskPosInprojout = 8;
-    constexpr unsigned phiPosInprojout = 12;
-
-    unsigned int layerdisk = output[layerdiskPosInprojout] - '1';  //layer or disk counting from 0
-    unsigned int phiregion = output[phiPosInprojout] - 'A';        //phiregion counting from 0
-
-    if (output[7] == 'L') {
-      assert(layerdisk < N_LAYER);
-      assert(phiregion < trackletprojlayers_[layerdisk].size());
-      //check that phiregion not already initialized
-      assert(trackletprojlayers_[layerdisk][phiregion] == nullptr);
-      trackletprojlayers_[layerdisk][phiregion] = tmp;
+    if (output == "trackpar") {
+      auto* tmp = dynamic_cast<TrackletParametersMemory*>(memory);
+      assert(tmp != nullptr);
+      trackletpars_ = tmp;
       return;
     }
 
-    if (output[7] == 'D') {
-      assert(layerdisk < N_DISK);
-      assert(phiregion < trackletprojdisks_[layerdisk].size());
-      //check that phiregion not already initialized
-      assert(trackletprojdisks_[layerdisk][phiregion] == nullptr);
-      trackletprojdisks_[layerdisk][phiregion] = tmp;
+    if (output.substr(0, 7) == "projout") {
+      //output is on the form 'projoutL2PHIC' or 'projoutD3PHIB'
+      auto* tmp = dynamic_cast<TrackletProjectionsMemory*>(memory);
+      assert(tmp != nullptr);
+
+      constexpr unsigned layerdiskPosInprojout = 8;
+      constexpr unsigned phiPosInprojout = 12;
+
+      unsigned int layerdisk = output[layerdiskPosInprojout] - '1';  //layer or disk counting from 0
+      unsigned int phiregion = output[phiPosInprojout] - 'A';        //phiregion counting from 0
+
+      if (output[7] == 'L') {
+        assert(layerdisk < N_LAYER);
+        assert(phiregion < trackletprojlayers_[layerdisk].size());
+        //check that phiregion not already initialized
+        assert(trackletprojlayers_[layerdisk][phiregion] == nullptr);
+        trackletprojlayers_[layerdisk][phiregion] = tmp;
+        return;
+      }
+
+      if (output[7] == 'D') {
+        assert(layerdisk < N_DISK);
+        assert(phiregion < trackletprojdisks_[layerdisk].size());
+        //check that phiregion not already initialized
+        assert(trackletprojdisks_[layerdisk][phiregion] == nullptr);
+        trackletprojdisks_[layerdisk][phiregion] = tmp;
+        return;
+      }
+    }
+
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
+  }
+
+  void TrackletProcessorDisplaced::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+
+    if (input == "thirdallstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      innerallstubs_.push_back(tmp);
       return;
     }
+    if (input == "firstallstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      middleallstubs_.push_back(tmp);
+      return;
+    }
+    if (input == "secondallstubin") {
+      auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      assert(tmp != nullptr);
+      outerallstubs_.push_back(tmp);
+      return;
+    }
+    if (input.substr(0, 8) == "stubpair") {
+      auto* tmp = dynamic_cast<StubPairsMemory*>(memory);
+      assert(tmp != nullptr);
+      stubpairs_.push_back(tmp);
+      return;
+    }
+
+    if (input == "thirdvmstubin") {
+      auto* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
+      assert(tmp != nullptr);
+      innervmstubs_.push_back(tmp);
+      return;
+    }
+    if (input == "secondvmstubin") {
+      auto* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
+      assert(tmp != nullptr);
+      // outervmstubs_ = tmp;
+      outervmstubs_.push_back(tmp);
+      return;
+    }
+
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
   }
 
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
-}
+  void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, double phimax) {
+    unsigned int countall = 0;
+    unsigned int countall_ = 0;
+    unsigned int countsel = 0;
+    unsigned int countpass = 0;
+    unsigned int countpass_ = 0;
+    // unsigned int nThirdStubs = 0;
+    unsigned int nInnerStubs = 0;
+    // unsigned int nOuterStubs = 0;
+    count_ = 0;
 
-void TrackletProcessorDisplaced::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
+    phimin_ = phimin;
+    phimax_ = phimax;
+    iSector_ = iSector;
 
-  if (input == "thirdallstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    innerallstubs_.push_back(tmp);
-    return;
-  }
-  if (input == "firstallstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    middleallstubs_.push_back(tmp);
-    return;
-  }
-  if (input == "secondallstubin") {
-    auto* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    outerallstubs_.push_back(tmp);
-    return;
-  }
-  if (input.substr(0, 8) == "stubpair") {
-    auto* tmp = dynamic_cast<StubPairsMemory*>(memory);
-    assert(tmp != nullptr);
-    stubpairs_.push_back(tmp);
-    return;
-  }
+    for (unsigned int iInnerMem = 0; iInnerMem < middleallstubs_.size();
+         nInnerStubs += middleallstubs_.at(iInnerMem)->nStubs(), iInnerMem++)
+      ;
 
-  if (input == "thirdvmstubin") {
-    auto* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
-    assert(tmp != nullptr);
-    innervmstubs_.push_back(tmp);
-    return;
-  }
-  if (input == "secondvmstubin") {
-    auto* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
-    assert(tmp != nullptr);
-    // outervmstubs_ = tmp;
-    outervmstubs_.push_back(tmp);
-    return;
-  }
+    assert(!innerallstubs_.empty());
+    assert(!middleallstubs_.empty());
+    assert(!outerallstubs_.empty());
+    assert(!innervmstubs_.empty());
+    assert(!outervmstubs_.empty());
+    assert(stubpairs_.empty());
 
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
-}
-
-void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, double phimax) {
-  unsigned int countall = 0;
-  unsigned int countall_ = 0;
-  unsigned int countsel = 0;
-  unsigned int countpass = 0;
-  unsigned int countpass_ = 0;
-  // unsigned int nThirdStubs = 0;
-  unsigned int nInnerStubs = 0;
-  // unsigned int nOuterStubs = 0;
-  count_ = 0;
-
-  phimin_ = phimin;
-  phimax_ = phimax;
-  iSector_ = iSector;
-
-  for (unsigned int iInnerMem = 0; iInnerMem < middleallstubs_.size();
-       nInnerStubs += middleallstubs_.at(iInnerMem)->nStubs(), iInnerMem++)
-    ;
-
-  assert(!innerallstubs_.empty());
-  assert(!middleallstubs_.empty());
-  assert(!outerallstubs_.empty());
-  assert(!innervmstubs_.empty());
-  assert(!outervmstubs_.empty());
-  assert(stubpairs_.empty());
-
-  for (auto& iInnerMem : middleallstubs_) {
-    assert(iInnerMem->nStubs() == iInnerMem->nStubs());
-    for (unsigned int j = 0; j < iInnerMem->nStubs(); j++) {
-      const Stub* firstallstub = iInnerMem->getStub(j);
-
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "In " << getName() << " have first stub\n";
-      }
-
-      int inner = 0;
-      bool negdisk = (firstallstub->disk().value() < 0);
-      int indexz = (((1 << (firstallstub->z().nbits() - 1)) + firstallstub->z().value()) >>
-                    (firstallstub->z().nbits() - nbitszfinebintable_));
-      int indexr = -1;
-      if (layerdisk_ > (N_LAYER - 1)) {
-        if (negdisk) {
-          indexz = (1 << nbitszfinebintable_) - indexz;
-        }
-        indexr = firstallstub->r().value();
-        if (firstallstub->isPSmodule()) {
-          indexr = firstallstub->r().value() >> (firstallstub->r().nbits() - nbitsrfinebintable_);
-        }
-      } else {
-        //Take the top nbitsfinebintable_ bits of the z coordinate. The & is to handle the negative z values.
-        indexr = (((1 << (firstallstub->r().nbits() - 1)) + firstallstub->r().value()) >>
-                  (firstallstub->r().nbits() - nbitsrfinebintable_));
-      }
-
-      assert(indexz >= 0);
-      assert(indexr >= 0);
-      assert(indexz < (1 << nbitszfinebintable_));
-      assert(indexr < (1 << nbitsrfinebintable_));
-
-      // int melut = meTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-      // assert(melut >= 0);
-
-      unsigned int lutwidth = settings_.lutwidthtab(inner, iSeed_);
-      if (settings_.extended()) {
-        lutwidth = settings_.lutwidthtabextended(inner, iSeed_);
-      }
-
-      int lutval = -999;
-
-      if (iSeed_ < Seed::L1D1 || iSeed_ > Seed::L2D1) {
-        lutval = innerTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-      } else {
-        lutval = innerOverlapTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-      }
-
-      if (lutval == -1)
-        continue;
-      if (settings_.extended() &&
-          (iSeed_ == Seed::L2L3L4 || iSeed_ == Seed::L4L5L6 || iSeed_ == Seed::D1D2L2 || iSeed_ == Seed::L2L3D1)) {
-        int lutval2 = innerThirdTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-        if (lutval2 != -1)
-          lutval += (lutval2 << 10);
-      }
-
-      assert(lutval >= 0);
-      // assert(lutwidth > 0);
-
-      FPGAWord binlookup(lutval, lutwidth, true, __LINE__, __FILE__);
-
-      if ((layer1_ == 3 && layer2_ == 4) || (layer1_ == 5 && layer2_ == 6)) {
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << getName() << " Layer-layer pair\n";
-        }
-
-        constexpr int andlookupbits = 1023;
-        constexpr int shiftzdiffmax = 7;
-        constexpr int andnewbin = 127;
-        constexpr int divbin = 8;
-        constexpr int andzbinfirst = 7;
-        constexpr int shiftstart = 1;
-        constexpr int andlast = 1;
-        constexpr int maxlast = 8;
-
-        int lookupbits = binlookup.value() & andlookupbits;
-        int zdiffmax = (lookupbits >> shiftzdiffmax);
-        int newbin = (lookupbits & andnewbin);
-        int bin = newbin / divbin;
-
-        int zbinfirst = newbin & andzbinfirst;
-
-        int start = (bin >> shiftstart);
-        int last = start + (bin & andlast);
-
-        assert(last < maxlast);
+    for (auto& iInnerMem : middleallstubs_) {
+      assert(iInnerMem->nStubs() == iInnerMem->nStubs());
+      for (unsigned int j = 0; j < iInnerMem->nStubs(); j++) {
+        const Stub* firstallstub = iInnerMem->getStub(j);
 
         if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last << endl;
+          edm::LogVerbatim("Tracklet") << "In " << getName() << " have first stub\n";
         }
 
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
-            for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
-              if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet")
-                    << "In " << getName() << " have second stub(1) " << ibin << " " << j << endl;
-              }
+        int inner = 0;
+        bool negdisk = (firstallstub->disk().value() < 0);
+        int indexz = (((1 << (firstallstub->z().nbits() - 1)) + firstallstub->z().value()) >>
+                      (firstallstub->z().nbits() - nbitszfinebintable_));
+        int indexr = -1;
+        if (layerdisk_ > (N_LAYER - 1)) {
+          if (negdisk) {
+            indexz = (1 << nbitszfinebintable_) - indexz;
+          }
+          indexr = firstallstub->r().value();
+          if (firstallstub->isPSmodule()) {
+            indexr = firstallstub->r().value() >> (firstallstub->r().nbits() - nbitsrfinebintable_);
+          }
+        } else {
+          //Take the top nbitsfinebintable_ bits of the z coordinate. The & is to handle the negative z values.
+          indexr = (((1 << (firstallstub->r().nbits() - 1)) + firstallstub->r().value()) >>
+                    (firstallstub->r().nbits() - nbitsrfinebintable_));
+        }
 
-              const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
+        assert(indexz >= 0);
+        assert(indexr >= 0);
+        assert(indexz < (1 << nbitszfinebintable_));
+        assert(indexr < (1 << nbitsrfinebintable_));
 
-              int zbin = (secondvmstub.vmbits().value() & 7);
-              if (start != ibin)
-                zbin += 8;
-              if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
-                if (settings_.debugTracklet()) {
-                  edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
-                }
-                continue;
-              }
+        // int melut = meTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+        // assert(melut >= 0);
 
-              countpass++;
+        unsigned int lutwidth = settings_.lutwidthtab(inner, iSeed_);
+        if (settings_.extended()) {
+          lutwidth = settings_.lutwidthtabextended(inner, iSeed_);
+        }
 
-              if ((layer2_ == 4 && layer3_ == 2) || (layer2_ == 6 && layer3_ == 4)) {
-                constexpr int vmbitshift = 10;
-                constexpr int andlookupbits_ = 1023;
-                constexpr int andnewbin_ = 127;
-                constexpr int divbin_ = 8;
-                constexpr int shiftstart_ = 1;
-                constexpr int andlast_ = 1;
+        int lutval = -999;
 
-                int lookupbits_ = (int)((binlookup.value() >> vmbitshift) & andlookupbits_);
-                int newbin_ = (lookupbits_ & andnewbin_);
-                int bin_ = newbin_ / divbin_;
+        if (iSeed_ < Seed::L1D1 || iSeed_ > Seed::L2D1) {
+          lutval = innerTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+        } else {
+          lutval = innerOverlapTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+        }
 
-                int start_ = (bin_ >> shiftstart_);
-                int last_ = start_ + (bin_ & andlast_);
+        if (lutval == -1)
+          continue;
+        if (settings_.extended() &&
+            (iSeed_ == Seed::L2L3L4 || iSeed_ == Seed::L4L5L6 || iSeed_ == Seed::D1D2L2 || iSeed_ == Seed::L2L3D1)) {
+          int lutval2 = innerThirdTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+          if (lutval2 != -1)
+            lutval += (lutval2 << 10);
+        }
 
+        assert(lutval >= 0);
+        // assert(lutwidth > 0);
+
+        FPGAWord binlookup(lutval, lutwidth, true, __LINE__, __FILE__);
+
+        if ((layer1_ == 3 && layer2_ == 4) || (layer1_ == 5 && layer2_ == 6)) {
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << getName() << " Layer-layer pair\n";
+          }
+
+          constexpr int andlookupbits = 1023;
+          constexpr int shiftzdiffmax = 7;
+          constexpr int andnewbin = 127;
+          constexpr int divbin = 8;
+          constexpr int andzbinfirst = 7;
+          constexpr int shiftstart = 1;
+          constexpr int andlast = 1;
+          constexpr int maxlast = 8;
+
+          int lookupbits = binlookup.value() & andlookupbits;
+          int zdiffmax = (lookupbits >> shiftzdiffmax);
+          int newbin = (lookupbits & andnewbin);
+          int bin = newbin / divbin;
+
+          int zbinfirst = newbin & andzbinfirst;
+
+          int start = (bin >> shiftstart);
+          int last = start + (bin & andlast);
+
+          assert(last < maxlast);
+
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last << endl;
+          }
+
+          for (int ibin = start; ibin <= last; ibin++) {
+            for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
+              for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
                 if (settings_.debugTracklet()) {
                   edm::LogVerbatim("Tracklet")
-                      << "Will look in zbins for third stub" << start_ << " to " << last_ << endl;
+                      << "In " << getName() << " have second stub(1) " << ibin << " " << j << endl;
                 }
 
-                for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
-                  for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
-                    for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub\n";
+                const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
+
+                int zbin = (secondvmstub.vmbits().value() & 7);
+                if (start != ibin)
+                  zbin += 8;
+                if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
+                  if (settings_.debugTracklet()) {
+                    edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
+                  }
+                  continue;
+                }
+
+                countpass++;
+
+                if ((layer2_ == 4 && layer3_ == 2) || (layer2_ == 6 && layer3_ == 4)) {
+                  constexpr int vmbitshift = 10;
+                  constexpr int andlookupbits_ = 1023;
+                  constexpr int andnewbin_ = 127;
+                  constexpr int divbin_ = 8;
+                  constexpr int shiftstart_ = 1;
+                  constexpr int andlast_ = 1;
+
+                  int lookupbits_ = (int)((binlookup.value() >> vmbitshift) & andlookupbits_);
+                  int newbin_ = (lookupbits_ & andnewbin_);
+                  int bin_ = newbin_ / divbin_;
+
+                  int start_ = (bin_ >> shiftstart_);
+                  int last_ = start_ + (bin_ & andlast_);
+
+                  if (settings_.debugTracklet()) {
+                    edm::LogVerbatim("Tracklet")
+                        << "Will look in zbins for third stub" << start_ << " to " << last_ << endl;
+                  }
+
+                  for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
+                    for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
+                      for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub\n";
+                        }
+
+                        countall_++;
+
+                        const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
+
+                        countpass_++;
+
+                        const Stub* innerFPGAStub = firstallstub;
+                        const Stub* middleFPGAStub = secondvmstub.stub();
+                        const Stub* outerFPGAStub = thirdvmstub.stub();
+
+                        const L1TStub* innerStub = innerFPGAStub->l1tstub();
+                        const L1TStub* middleStub = middleFPGAStub->l1tstub();
+                        const L1TStub* outerStub = outerFPGAStub->l1tstub();
+
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet")
+                              << "LLL seeding\n"
+                              << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
+                              << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
+                              << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk()
+                              << outerFPGAStub->layerdisk();
+                        }
+
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet")
+                              << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
+                        }
+
+                        if (innerFPGAStub->layerdisk() < N_LAYER && middleFPGAStub->layerdisk() < N_LAYER &&
+                            outerFPGAStub->layerdisk() < N_LAYER) {
+                          bool accept = LLLSeeding(
+                              outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+
+                          if (accept)
+                            countsel++;
+                        } else if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
+                                   outerFPGAStub->layerdisk() >= N_LAYER) {
+                          throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
+                        }
+
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
+                        }
                       }
+                    }
+                  }
+                }
+              }
+            }
+          }
 
-                      countall_++;
+        } else if (layer1_ == 2 && layer2_ == 3) {
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << getName() << " Layer-layer pair";
+          }
 
-                      const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
+          constexpr int andlookupbits = 1023;
+          constexpr int shiftzdiffmax = 7;
+          constexpr int andnewbin = 127;
+          constexpr int divbin = 8;
+          constexpr int andzbinfirst = 7;
+          constexpr int shiftstart = 1;
+          constexpr int andlast = 1;
+          constexpr int maxlast = 8;
 
-                      countpass_++;
+          int lookupbits = binlookup.value() & andlookupbits;
+          int zdiffmax = (lookupbits >> shiftzdiffmax);
+          int newbin = (lookupbits & andnewbin);
+          int bin = newbin / divbin;
 
-                      const Stub* innerFPGAStub = firstallstub;
-                      const Stub* middleFPGAStub = secondvmstub.stub();
-                      const Stub* outerFPGAStub = thirdvmstub.stub();
+          int zbinfirst = newbin & andzbinfirst;
 
-                      const L1TStub* innerStub = innerFPGAStub->l1tstub();
-                      const L1TStub* middleStub = middleFPGAStub->l1tstub();
-                      const L1TStub* outerStub = outerFPGAStub->l1tstub();
+          int start = (bin >> shiftstart);
+          int last = start + (bin & andlast);
 
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet")
-                            << "LLL seeding\n"
-                            << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
-                            << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
-                            << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk() << outerFPGAStub->layerdisk();
-                      }
+          assert(last < maxlast);
 
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet")
-                            << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
-                      }
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last;
+          }
 
-                      if (innerFPGAStub->layerdisk() < N_LAYER && middleFPGAStub->layerdisk() < N_LAYER &&
-                          outerFPGAStub->layerdisk() < N_LAYER) {
+          for (int ibin = start; ibin <= last; ibin++) {
+            for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
+              for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
+                if (settings_.debugTracklet()) {
+                  edm::LogVerbatim("Tracklet") << "In " << getName() << " have second stub(1) " << ibin << " " << j;
+                }
+
+                countall++;
+                const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
+
+                int zbin = (secondvmstub.vmbits().value() & 7);
+                if (start != ibin)
+                  zbin += 8;
+                if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
+                  if (settings_.debugTracklet()) {
+                    edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
+                  }
+                  continue;
+                }
+
+                if (layer2_ == 3 && disk3_ == 1) {
+                  constexpr int vmbitshift = 10;
+                  constexpr int andlookupbits_ = 1023;
+                  constexpr int andnewbin_ = 127;
+                  constexpr int divbin_ = 8;
+                  constexpr int shiftstart_ = 1;
+                  constexpr int andlast_ = 1;
+
+                  int lookupbits_ = (int)((binlookup.value() >> vmbitshift) & andlookupbits_);
+                  int newbin_ = (lookupbits_ & andnewbin_);
+                  int bin_ = newbin_ / divbin_;
+
+                  int start_ = (bin_ >> shiftstart_);
+                  int last_ = start_ + (bin_ & andlast_);
+
+                  for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
+                    for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
+                      for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
+                        }
+
+                        countall_++;
+
+                        const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
+
+                        countpass_++;
+
+                        const Stub* innerFPGAStub = firstallstub;
+                        const Stub* middleFPGAStub = secondvmstub.stub();
+                        const Stub* outerFPGAStub = thirdvmstub.stub();
+
+                        const L1TStub* innerStub = innerFPGAStub->l1tstub();
+                        const L1TStub* middleStub = middleFPGAStub->l1tstub();
+                        const L1TStub* outerStub = outerFPGAStub->l1tstub();
+
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet")
+                              << "LLD seeding\n"
+                              << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
+                              << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
+                              << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk()
+                              << outerFPGAStub->layerdisk();
+                        }
+
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet")
+                              << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
+                        }
+
                         bool accept =
-                            LLLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+                            LLDSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
 
                         if (accept)
                           countsel++;
-                      } else if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
-                                 outerFPGAStub->layerdisk() >= N_LAYER) {
-                        throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
-                      }
 
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
+                        }
                       }
                     }
                   }
@@ -446,233 +565,118 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
               }
             }
           }
-        }
 
-      } else if (layer1_ == 2 && layer2_ == 3) {
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << getName() << " Layer-layer pair";
-        }
+        } else if (disk1_ == 1 && disk2_ == 2) {
+          if (settings_.debugTracklet())
+            edm::LogVerbatim("Tracklet") << getName() << " Disk-disk pair";
 
-        constexpr int andlookupbits = 1023;
-        constexpr int shiftzdiffmax = 7;
-        constexpr int andnewbin = 127;
-        constexpr int divbin = 8;
-        constexpr int andzbinfirst = 7;
-        constexpr int shiftstart = 1;
-        constexpr int andlast = 1;
-        constexpr int maxlast = 8;
+          constexpr int andlookupbits = 511;
+          constexpr int shiftrdiffmax = 6;
+          constexpr int andnewbin = 63;
+          constexpr int divbin = 8;
+          constexpr int andrbinfirst = 7;
+          constexpr int shiftstart = 1;
+          constexpr int andlast = 1;
+          constexpr int maxlast = 8;
 
-        int lookupbits = binlookup.value() & andlookupbits;
-        int zdiffmax = (lookupbits >> shiftzdiffmax);
-        int newbin = (lookupbits & andnewbin);
-        int bin = newbin / divbin;
+          int lookupbits = binlookup.value() & andlookupbits;
+          bool negdisk = firstallstub->disk().value() < 0;
+          int rdiffmax = (lookupbits >> shiftrdiffmax);
+          int newbin = (lookupbits & andnewbin);
+          int bin = newbin / divbin;
 
-        int zbinfirst = newbin & andzbinfirst;
+          int rbinfirst = newbin & andrbinfirst;
 
-        int start = (bin >> shiftstart);
-        int last = start + (bin & andlast);
+          int start = (bin >> shiftstart);
+          if (negdisk)
+            start += 4;
+          int last = start + (bin & andlast);
+          assert(last < maxlast);
 
-        assert(last < maxlast);
-
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last;
-        }
-
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
-            for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
+          for (int ibin = start; ibin <= last; ibin++) {
+            for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
               if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet") << "In " << getName() << " have second stub(1) " << ibin << " " << j;
+                edm::LogVerbatim("Tracklet")
+                    << getName() << " looking for matching stub in " << outervmstubs_.at(m)->getName()
+                    << " in bin = " << ibin << " with " << outervmstubs_.at(m)->nVMStubsBinned(ibin) << " stubs";
               }
 
-              countall++;
-              const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
+              for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
+                countall++;
 
-              int zbin = (secondvmstub.vmbits().value() & 7);
-              if (start != ibin)
-                zbin += 8;
-              if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
-                if (settings_.debugTracklet()) {
-                  edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
-                }
-                continue;
-              }
+                const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
+                int rbin = (secondvmstub.vmbits().value() & 7);
+                if (start != ibin)
+                  rbin += 8;
+                if (rbin < rbinfirst)
+                  continue;
+                if (rbin - rbinfirst > rdiffmax)
+                  continue;
 
-              if (layer2_ == 3 && disk3_ == 1) {
-                constexpr int vmbitshift = 10;
-                constexpr int andlookupbits_ = 1023;
-                constexpr int andnewbin_ = 127;
-                constexpr int divbin_ = 8;
-                constexpr int shiftstart_ = 1;
-                constexpr int andlast_ = 1;
+                if (disk2_ == 2 && layer3_ == 2) {
+                  constexpr int vmbitshift = 10;
+                  constexpr int andlookupbits_ = 1023;
+                  constexpr int andnewbin_ = 127;
+                  constexpr int divbin_ = 8;
+                  constexpr int shiftstart_ = 1;
+                  constexpr int andlast_ = 1;
 
-                int lookupbits_ = (int)((binlookup.value() >> vmbitshift) & andlookupbits_);
-                int newbin_ = (lookupbits_ & andnewbin_);
-                int bin_ = newbin_ / divbin_;
+                  int lookupbits_ = (int)((binlookup.value() >> vmbitshift) & andlookupbits_);
+                  int newbin_ = (lookupbits_ & andnewbin_);
+                  int bin_ = newbin_ / divbin_;
 
-                int start_ = (bin_ >> shiftstart_);
-                int last_ = start_ + (bin_ & andlast_);
+                  int start_ = (bin_ >> shiftstart_);
+                  int last_ = start_ + (bin_ & andlast_);
 
-                for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
-                  for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
-                    for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
-                      }
-
-                      countall_++;
-
-                      const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
-
-                      countpass_++;
-
-                      const Stub* innerFPGAStub = firstallstub;
-                      const Stub* middleFPGAStub = secondvmstub.stub();
-                      const Stub* outerFPGAStub = thirdvmstub.stub();
-
-                      const L1TStub* innerStub = innerFPGAStub->l1tstub();
-                      const L1TStub* middleStub = middleFPGAStub->l1tstub();
-                      const L1TStub* outerStub = outerFPGAStub->l1tstub();
-
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet")
-                            << "LLD seeding\n"
-                            << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
-                            << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
-                            << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk() << outerFPGAStub->layerdisk();
-                      }
-
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet")
-                            << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
-                      }
-
-                      bool accept =
-                          LLDSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
-
-                      if (accept)
-                        countsel++;
-
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
-                      }
-                    }
+                  if (firstallstub->disk().value() < 0) {  //TODO - negative disk should come from memory
+                    start_ = settings_.NLONGVMBINS() - last_ - 1;
+                    last_ = settings_.NLONGVMBINS() - start_ - 1;
                   }
-                }
-              }
-            }
-          }
-        }
 
-      } else if (disk1_ == 1 && disk2_ == 2) {
-        if (settings_.debugTracklet())
-          edm::LogVerbatim("Tracklet") << getName() << " Disk-disk pair";
+                  for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
+                    for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
+                      for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
+                        }
 
-        constexpr int andlookupbits = 511;
-        constexpr int shiftrdiffmax = 6;
-        constexpr int andnewbin = 63;
-        constexpr int divbin = 8;
-        constexpr int andrbinfirst = 7;
-        constexpr int shiftstart = 1;
-        constexpr int andlast = 1;
-        constexpr int maxlast = 8;
+                        countall_++;
 
-        int lookupbits = binlookup.value() & andlookupbits;
-        bool negdisk = firstallstub->disk().value() < 0;
-        int rdiffmax = (lookupbits >> shiftrdiffmax);
-        int newbin = (lookupbits & andnewbin);
-        int bin = newbin / divbin;
+                        const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
 
-        int rbinfirst = newbin & andrbinfirst;
+                        countpass_++;
 
-        int start = (bin >> shiftstart);
-        if (negdisk)
-          start += 4;
-        int last = start + (bin & andlast);
-        assert(last < maxlast);
+                        const Stub* innerFPGAStub = firstallstub;
+                        const Stub* middleFPGAStub = secondvmstub.stub();
+                        const Stub* outerFPGAStub = thirdvmstub.stub();
 
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
-            if (settings_.debugTracklet()) {
-              edm::LogVerbatim("Tracklet")
-                  << getName() << " looking for matching stub in " << outervmstubs_.at(m)->getName()
-                  << " in bin = " << ibin << " with " << outervmstubs_.at(m)->nVMStubsBinned(ibin) << " stubs";
-            }
+                        const L1TStub* innerStub = innerFPGAStub->l1tstub();
+                        const L1TStub* middleStub = middleFPGAStub->l1tstub();
+                        const L1TStub* outerStub = outerFPGAStub->l1tstub();
 
-            for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
-              countall++;
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet")
+                              << "DDL seeding\n"
+                              << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
+                              << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
+                              << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk()
+                              << outerFPGAStub->layerdisk();
+                        }
 
-              const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
-              int rbin = (secondvmstub.vmbits().value() & 7);
-              if (start != ibin)
-                rbin += 8;
-              if (rbin < rbinfirst)
-                continue;
-              if (rbin - rbinfirst > rdiffmax)
-                continue;
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet")
+                              << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
+                        }
 
-              if (disk2_ == 2 && layer3_ == 2) {
-                constexpr int vmbitshift = 10;
-                constexpr int andlookupbits_ = 1023;
-                constexpr int andnewbin_ = 127;
-                constexpr int divbin_ = 8;
-                constexpr int shiftstart_ = 1;
-                constexpr int andlast_ = 1;
+                        bool accept =
+                            DDLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
 
-                int lookupbits_ = (int)((binlookup.value() >> vmbitshift) & andlookupbits_);
-                int newbin_ = (lookupbits_ & andnewbin_);
-                int bin_ = newbin_ / divbin_;
+                        if (accept)
+                          countsel++;
 
-                int start_ = (bin_ >> shiftstart_);
-                int last_ = start_ + (bin_ & andlast_);
-
-                if (firstallstub->disk().value() < 0) {  //TODO - negative disk should come from memory
-                  start_ = settings_.NLONGVMBINS() - last_ - 1;
-                  last_ = settings_.NLONGVMBINS() - start_ - 1;
-                }
-
-                for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
-                  for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
-                    for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
-                      }
-
-                      countall_++;
-
-                      const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
-
-                      countpass_++;
-
-                      const Stub* innerFPGAStub = firstallstub;
-                      const Stub* middleFPGAStub = secondvmstub.stub();
-                      const Stub* outerFPGAStub = thirdvmstub.stub();
-
-                      const L1TStub* innerStub = innerFPGAStub->l1tstub();
-                      const L1TStub* middleStub = middleFPGAStub->l1tstub();
-                      const L1TStub* outerStub = outerFPGAStub->l1tstub();
-
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet")
-                            << "DDL seeding\n"
-                            << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
-                            << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
-                            << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk() << outerFPGAStub->layerdisk();
-                      }
-
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet")
-                            << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
-                      }
-
-                      bool accept =
-                          DDLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
-
-                      if (accept)
-                        countsel++;
-
-                      if (settings_.debugTracklet()) {
-                        edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
+                        if (settings_.debugTracklet()) {
+                          edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
+                        }
                       }
                     }
                   }
@@ -684,6 +688,5 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
       }
     }
   }
-}
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -16,7 +16,8 @@
 #include <tuple>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletProcessorDisplaced::TrackletProcessorDisplaced(string name, Settings const& settings, Globals* globals)
     : TrackletCalculatorDisplaced(name, settings, globals),
@@ -683,4 +684,6 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
       }
     }
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
@@ -8,59 +8,59 @@ using namespace std;
 
 namespace trklet {
 
-TrackletProjectionsMemory::TrackletProjectionsMemory(string name, Settings const& settings)
-    : MemoryBase(name, settings) {
-  size_t pos = find_nth(name, 0, "_", 1);
-  assert(pos != string::npos);
-  initLayerDisk(pos + 1, layer_, disk_);
-  hasProj_ = false;
-}
+  TrackletProjectionsMemory::TrackletProjectionsMemory(string name, Settings const& settings)
+      : MemoryBase(name, settings) {
+    size_t pos = find_nth(name, 0, "_", 1);
+    assert(pos != string::npos);
+    initLayerDisk(pos + 1, layer_, disk_);
+    hasProj_ = false;
+  }
 
-void TrackletProjectionsMemory::addProj(Tracklet* tracklet) {
-  if (layer_ != 0 && disk_ == 0)
-    assert(tracklet->validProj(layer_ - 1));
-  if (layer_ == 0 && disk_ != 0)
-    assert(tracklet->validProj(N_LAYER + abs(disk_) - 1));
-  if (layer_ != 0 && disk_ != 0)
-    assert(tracklet->validProj(layer_ - 1) || tracklet->validProj(N_LAYER + abs(disk_) - 1));
+  void TrackletProjectionsMemory::addProj(Tracklet* tracklet) {
+    if (layer_ != 0 && disk_ == 0)
+      assert(tracklet->validProj(layer_ - 1));
+    if (layer_ == 0 && disk_ != 0)
+      assert(tracklet->validProj(N_LAYER + abs(disk_) - 1));
+    if (layer_ != 0 && disk_ != 0)
+      assert(tracklet->validProj(layer_ - 1) || tracklet->validProj(N_LAYER + abs(disk_) - 1));
 
-  for (auto& itracklet : tracklets_) {
-    if (itracklet == tracklet) {
-      edm::LogPrint("Tracklet") << "Adding same tracklet " << tracklet << " twice in " << getName();
+    for (auto& itracklet : tracklets_) {
+      if (itracklet == tracklet) {
+        edm::LogPrint("Tracklet") << "Adding same tracklet " << tracklet << " twice in " << getName();
+      }
+      assert(itracklet != tracklet);
     }
-    assert(itracklet != tracklet);
+
+    hasProj_ = true;
+    tracklets_.push_back(tracklet);
   }
 
-  hasProj_ = true;
-  tracklets_.push_back(tracklet);
-}
+  void TrackletProjectionsMemory::clean() { tracklets_.clear(); }
 
-void TrackletProjectionsMemory::clean() { tracklets_.clear(); }
+  void TrackletProjectionsMemory::writeTPROJ(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirTP = settings_.memPath() + "TrackletProjections/";
 
-void TrackletProjectionsMemory::writeTPROJ(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirTP = settings_.memPath() + "TrackletProjections/";
+    std::ostringstream oss;
+    oss << dirTP << "TrackletProjections_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1)
+        << ".dat";
+    auto const& fname = oss.str();
 
-  std::ostringstream oss;
-  oss << dirTP << "TrackletProjections_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1)
-      << ".dat";
-  auto const& fname = oss.str();
+    openfile(out_, first, dirTP, fname, __FILE__, __LINE__);
 
-  openfile(out_, first, dirTP, fname, __FILE__, __LINE__);
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
 
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+    for (unsigned int j = 0; j < tracklets_.size(); j++) {
+      string proj = (layer_ > 0 && tracklets_[j]->validProj(layer_ - 1)) ? tracklets_[j]->trackletprojstrlayer(layer_)
+                                                                         : tracklets_[j]->trackletprojstrdisk(disk_);
+      out_ << hexstr(j) << " " << proj << "  " << trklet::hexFormat(proj) << endl;
+    }
+    out_.close();
 
-  for (unsigned int j = 0; j < tracklets_.size(); j++) {
-    string proj = (layer_ > 0 && tracklets_[j]->validProj(layer_ - 1)) ? tracklets_[j]->trackletprojstrlayer(layer_)
-                                                                       : tracklets_[j]->trackletprojstrdisk(disk_);
-    out_ << hexstr(j) << " " << proj << "  " << trklet::hexFormat(proj) << endl;
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
   }
-  out_.close();
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
@@ -5,7 +5,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TrackletProjectionsMemory::TrackletProjectionsMemory(string name, Settings const& settings)
     : MemoryBase(name, settings) {
@@ -60,4 +61,6 @@ void TrackletProjectionsMemory::writeTPROJ(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
@@ -8,7 +8,8 @@
 #include <algorithm>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 TripletEngine::TripletEngine(string name, Settings const &settings, Globals *global)
     : ProcessBase(name, settings, global) {
@@ -482,4 +483,6 @@ void TripletEngine::writeTables() {
     }
     fout.close();
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TripletEngine.cc
@@ -11,478 +11,481 @@ using namespace std;
 
 namespace trklet {
 
-TripletEngine::TripletEngine(string name, Settings const &settings, Globals *global)
-    : ProcessBase(name, settings, global) {
-  stubpairs_.clear();
-  thirdvmstubs_.clear();
-  layer1_ = 0;
-  layer2_ = 0;
-  layer3_ = 0;
-  disk1_ = 0;
-  disk2_ = 0;
-  disk3_ = 0;
-  dct1_ = 0;
-  dct2_ = 0;
-  dct3_ = 0;
-  phi1_ = 0;
-  phi2_ = 0;
-  phi3_ = 0;
-  z1_ = 0;
-  z2_ = 0;
-  z3_ = 0;
-  r1_ = 0;
-  r2_ = 0;
-  r3_ = 0;
+  TripletEngine::TripletEngine(string name, Settings const &settings, Globals *global)
+      : ProcessBase(name, settings, global) {
+    stubpairs_.clear();
+    thirdvmstubs_.clear();
+    layer1_ = 0;
+    layer2_ = 0;
+    layer3_ = 0;
+    disk1_ = 0;
+    disk2_ = 0;
+    disk3_ = 0;
+    dct1_ = 0;
+    dct2_ = 0;
+    dct3_ = 0;
+    phi1_ = 0;
+    phi2_ = 0;
+    phi3_ = 0;
+    z1_ = 0;
+    z2_ = 0;
+    z3_ = 0;
+    r1_ = 0;
+    r2_ = 0;
+    r3_ = 0;
 
-  if (name_[4] == 'L')
-    layer1_ = name_[5] - '0';
-  if (name_[4] == 'D')
-    disk1_ = name_[5] - '0';
-  if (name_[7] == 'L')
-    layer2_ = name_[8] - '0';
-  if (name_[7] == 'D')
-    disk2_ = name_[8] - '0';
+    if (name_[4] == 'L')
+      layer1_ = name_[5] - '0';
+    if (name_[4] == 'D')
+      disk1_ = name_[5] - '0';
+    if (name_[7] == 'L')
+      layer2_ = name_[8] - '0';
+    if (name_[7] == 'D')
+      disk2_ = name_[8] - '0';
 
-  if (layer1_ == 3 && layer2_ == 4) {
-    layer3_ = 2;
-    iSeed_ = 8;
-  } else if (layer1_ == 5 && layer2_ == 6) {
-    layer3_ = 4;
-    iSeed_ = 9;
-  } else if (layer1_ == 2 && layer2_ == 3) {
-    disk3_ = 1;
-    iSeed_ = 10;
-  } else if (disk1_ == 1 && disk2_ == 2) {
-    layer3_ = 2;
-    iSeed_ = 11;
-  } else
-    throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
+    if (layer1_ == 3 && layer2_ == 4) {
+      layer3_ = 2;
+      iSeed_ = 8;
+    } else if (layer1_ == 5 && layer2_ == 6) {
+      layer3_ = 4;
+      iSeed_ = 9;
+    } else if (layer1_ == 2 && layer2_ == 3) {
+      disk3_ = 1;
+      iSeed_ = 10;
+    } else if (disk1_ == 1 && disk2_ == 2) {
+      layer3_ = 2;
+      iSeed_ = 11;
+    } else
+      throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
 
-  if ((layer2_ == 4 && layer3_ == 2) || (layer2_ == 6 && layer3_ == 4)) {
-    secondphibits_ = settings_.nfinephi(1, iSeed_);
-    thirdphibits_ = settings_.nfinephi(2, iSeed_);
-  }
-  if ((layer2_ == 3 && disk3_ == 1) || (disk2_ == 2 && layer3_ == 2)) {
-    secondphibits_ = settings_.nfinephi(1, iSeed_);
-    thirdphibits_ = settings_.nfinephi(2, iSeed_);
-  }
-  if (settings_.enableTripletTables() && !settings_.writeTripletTables())
-    readTables();
-}
-
-TripletEngine::~TripletEngine() {
-  if (settings_.writeTripletTables())
-    writeTables();
-}
-
-void TripletEngine::addOutput(MemoryBase *memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-  if (output == "stubtripout") {
-    auto *tmp = dynamic_cast<StubTripletsMemory *>(memory);
-    assert(tmp != nullptr);
-    stubtriplets_ = tmp;
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
-}
-
-void TripletEngine::addInput(MemoryBase *memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input == "thirdvmstubin") {
-    auto *tmp = dynamic_cast<VMStubsTEMemory *>(memory);
-    assert(tmp != nullptr);
-    thirdvmstubs_.push_back(tmp);
-    return;
-  }
-  if (input.substr(0, 8) == "stubpair") {
-    auto *tmp = dynamic_cast<StubPairsMemory *>(memory);
-    assert(tmp != nullptr);
-    stubpairs_.push_back(tmp);
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
-}
-
-void TripletEngine::execute() {
-  unsigned int countall = 0;
-  unsigned int countpass = 0;
-  unsigned int nThirdStubs = 0;
-  count_ = 0;
-
-  for (unsigned int iThirdMem = 0; iThirdMem < thirdvmstubs_.size();
-       nThirdStubs += thirdvmstubs_.at(iThirdMem)->nVMStubs(), iThirdMem++)
-    ;
-
-  assert(!thirdvmstubs_.empty());
-  assert(!stubpairs_.empty());
-
-  bool print = false && (getName().substr(0, 10) == "TRE_L2cL3c");
-
-  print = print && nThirdStubs > 0;
-
-  int hacksum = 0;
-  if (print) {
-    edm::LogVerbatim("Tracklet") << "In TripletEngine::execute : " << getName() << " " << nThirdStubs << ":";
-    for (unsigned int i = 0; i < thirdvmstubs_.size(); ++i) {
-      edm::LogVerbatim("Tracklet") << thirdvmstubs_.at(i)->getName() << " " << thirdvmstubs_.at(i)->nVMStubs();
+    if ((layer2_ == 4 && layer3_ == 2) || (layer2_ == 6 && layer3_ == 4)) {
+      secondphibits_ = settings_.nfinephi(1, iSeed_);
+      thirdphibits_ = settings_.nfinephi(2, iSeed_);
     }
-    int s = 0;
-    std::string oss = "";
+    if ((layer2_ == 3 && disk3_ == 1) || (disk2_ == 2 && layer3_ == 2)) {
+      secondphibits_ = settings_.nfinephi(1, iSeed_);
+      thirdphibits_ = settings_.nfinephi(2, iSeed_);
+    }
+    if (settings_.enableTripletTables() && !settings_.writeTripletTables())
+      readTables();
+  }
+
+  TripletEngine::~TripletEngine() {
+    if (settings_.writeTripletTables())
+      writeTables();
+  }
+
+  void TripletEngine::addOutput(MemoryBase *memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
+    if (output == "stubtripout") {
+      auto *tmp = dynamic_cast<StubTripletsMemory *>(memory);
+      assert(tmp != nullptr);
+      stubtriplets_ = tmp;
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
+  }
+
+  void TripletEngine::addInput(MemoryBase *memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input == "thirdvmstubin") {
+      auto *tmp = dynamic_cast<VMStubsTEMemory *>(memory);
+      assert(tmp != nullptr);
+      thirdvmstubs_.push_back(tmp);
+      return;
+    }
+    if (input.substr(0, 8) == "stubpair") {
+      auto *tmp = dynamic_cast<StubPairsMemory *>(memory);
+      assert(tmp != nullptr);
+      stubpairs_.push_back(tmp);
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
+  }
+
+  void TripletEngine::execute() {
+    unsigned int countall = 0;
+    unsigned int countpass = 0;
+    unsigned int nThirdStubs = 0;
+    count_ = 0;
+
+    for (unsigned int iThirdMem = 0; iThirdMem < thirdvmstubs_.size();
+         nThirdStubs += thirdvmstubs_.at(iThirdMem)->nVMStubs(), iThirdMem++)
+      ;
+
+    assert(!thirdvmstubs_.empty());
+    assert(!stubpairs_.empty());
+
+    bool print = false && (getName().substr(0, 10) == "TRE_L2cL3c");
+
+    print = print && nThirdStubs > 0;
+
+    int hacksum = 0;
+    if (print) {
+      edm::LogVerbatim("Tracklet") << "In TripletEngine::execute : " << getName() << " " << nThirdStubs << ":";
+      for (unsigned int i = 0; i < thirdvmstubs_.size(); ++i) {
+        edm::LogVerbatim("Tracklet") << thirdvmstubs_.at(i)->getName() << " " << thirdvmstubs_.at(i)->nVMStubs();
+      }
+      int s = 0;
+      std::string oss = "";
+      for (unsigned int i = 0; i < stubpairs_.size(); ++i) {
+        oss += std::to_string(stubpairs_.at(i)->nStubPairs());
+        oss += " ";
+        s += stubpairs_.at(i)->nStubPairs();
+      }
+      hacksum += nThirdStubs * s;
+      edm::LogVerbatim("Tracklet") << oss;
+      for (unsigned int i = 0; i < stubpairs_.size(); ++i) {
+        edm::LogVerbatim("Tracklet") << "                                          " << stubpairs_.at(i)->getName();
+      }
+    }
+
+    tmpSPTable_.clear();
+
     for (unsigned int i = 0; i < stubpairs_.size(); ++i) {
-      oss += std::to_string(stubpairs_.at(i)->nStubPairs());
-      oss += " ";
-      s += stubpairs_.at(i)->nStubPairs();
-    }
-    hacksum += nThirdStubs * s;
-    edm::LogVerbatim("Tracklet") << oss;
-    for (unsigned int i = 0; i < stubpairs_.size(); ++i) {
-      edm::LogVerbatim("Tracklet") << "                                          " << stubpairs_.at(i)->getName();
-    }
-  }
+      for (unsigned int j = 0; j < stubpairs_.at(i)->nStubPairs(); ++j) {
+        if (print)
+          edm::LogVerbatim("Tracklet") << "     *****    " << stubpairs_.at(i)->getName() << " "
+                                       << stubpairs_.at(i)->nStubPairs();
 
-  tmpSPTable_.clear();
+        auto firstvmstub = stubpairs_.at(i)->getVMStub1(j);
+        auto secondvmstub = stubpairs_.at(i)->getVMStub2(j);
 
-  for (unsigned int i = 0; i < stubpairs_.size(); ++i) {
-    for (unsigned int j = 0; j < stubpairs_.at(i)->nStubPairs(); ++j) {
-      if (print)
-        edm::LogVerbatim("Tracklet") << "     *****    " << stubpairs_.at(i)->getName() << " "
-                                     << stubpairs_.at(i)->nStubPairs();
+        if ((layer2_ == 4 && layer3_ == 2) || (layer2_ == 6 && layer3_ == 4)) {
+          constexpr unsigned int vmbitshift = 10;
+          int lookupbits = (int)((firstvmstub.vmbits().value() >> vmbitshift) & 1023);  //1023=2^vmbitshift-1
+          int newbin = (lookupbits & 127);
+          int bin = newbin / 8;
 
-      auto firstvmstub = stubpairs_.at(i)->getVMStub1(j);
-      auto secondvmstub = stubpairs_.at(i)->getVMStub2(j);
+          int start = (bin >> 1);
+          int last = start + (bin & 1);
 
-      if ((layer2_ == 4 && layer3_ == 2) || (layer2_ == 6 && layer3_ == 4)) {
-        constexpr unsigned int vmbitshift = 10;
-        int lookupbits = (int)((firstvmstub.vmbits().value() >> vmbitshift) & 1023);  //1023=2^vmbitshift-1
-        int newbin = (lookupbits & 127);
-        int bin = newbin / 8;
-
-        int start = (bin >> 1);
-        int last = start + (bin & 1);
-
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int k = 0; k < thirdvmstubs_.size(); k++) {
-            string vmsteSuffix = thirdvmstubs_.at(k)->getLastPartOfName();
-            vmsteSuffix = vmsteSuffix.substr(0, vmsteSuffix.find_last_of('n'));
-            if (stubpairs_.at(i)->getLastPartOfName() != vmsteSuffix)
-              continue;
-            for (unsigned int l = 0; l < thirdvmstubs_.at(k)->nVMStubsBinned(ibin); l++) {
-              if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
-              }
-
-              if (countall >= settings_.maxStep("TRE"))
-                break;
-              countall++;
-
-              const VMStubTE &thirdvmstub = thirdvmstubs_.at(k)->getVMStubTEBinned(ibin, l);
-
-              assert(secondphibits_ != -1);
-              assert(thirdphibits_ != -1);
-
-              unsigned int nvmsecond = settings_.nallstubs(layer2_ - 1) * settings_.nvmte(1, iSeed_);
-              unsigned int nvmbitssecond = nbits(nvmsecond);
-
-              FPGAWord iphisecondbin = secondvmstub.stub()->iphivmFineBins(nvmbitssecond, secondphibits_);
-
-              //currently not using same number of bits as in the TED
-              //assert(iphisecondbin==(int)secondvmstub.finephi());
-              FPGAWord iphithirdbin = thirdvmstub.finephi();
-
-              unsigned int index = (iphisecondbin.value() << thirdphibits_) + iphithirdbin.value();
-
-              FPGAWord secondbend = secondvmstub.bend();
-              FPGAWord thirdbend = thirdvmstub.bend();
-
-              index = (index << secondbend.nbits()) + secondbend.value();
-              index = (index << thirdbend.nbits()) + thirdbend.value();
-
-              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
-                  (index >= table_.size() || !table_[index])) {
-                if (settings_.debugTracklet()) {
-                  edm::LogVerbatim("Tracklet")
-                      << "Stub pair rejected because of stub pt cut bends : "
-                      << settings_.benddecode(secondvmstub.bend().value(), layer2_ - 1, secondvmstub.isPSmodule())
-                      << " " << settings_.benddecode(thirdvmstub.bend().value(), layer3_ - 1, thirdvmstub.isPSmodule());
-                }
-
-                //FIXME temporarily commented out until bend table fixed
-                //if (!settings_.writeTripletTables())
-                //  continue;
-              }
-              if (settings_.writeTripletTables()) {
-                if (index >= table_.size())
-                  table_.resize(index + 1, false);
-                table_[index] = true;
-
-                const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
-                const string &tedName = stubpairs_.at(i)->getTEDName(j);
-                if (!tmpSPTable_.count(tedName))
-                  tmpSPTable_[tedName];
-                if (spIndex >= tmpSPTable_.at(tedName).size())
-                  tmpSPTable_.at(tedName).resize(spIndex + 1);
-                tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
-              }
-
-              if (settings_.debugTracklet())
-                edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
-              if (settings_.writeMonitorData("Seeds")) {
-                ofstream fout("seeds.txt", ofstream::app);
-                fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
-                fout.close();
-              }
-              stubtriplets_->addStubs(thirdvmstub.stub(),
-                                      (stubpairs_.at(i))->getVMStub1(j).stub(),
-                                      (stubpairs_.at(i))->getVMStub2(j).stub());
-
-              countpass++;
-            }
-          }
-        }
-
-      }
-
-      else if (disk2_ == 2 && layer3_ == 2) {
-        int lookupbits = (int)((firstvmstub.vmbits().value() >> 10) & 1023);
-        int newbin = (lookupbits & 127);
-        int bin = newbin / 8;
-
-        int start = (bin >> 1);
-        int last = start + (bin & 1);
-
-        if (firstvmstub.stub()->disk().value() < 0) {  //TODO - negative disk should come from memory
-          start = settings_.NLONGVMBINS() - last - 1;
-          last = settings_.NLONGVMBINS() - start - 1;
-        }
-
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int k = 0; k < thirdvmstubs_.size(); k++) {
-            string vmsteSuffix = thirdvmstubs_.at(k)->getLastPartOfName();
-            vmsteSuffix = vmsteSuffix.substr(0, vmsteSuffix.find_last_of('n'));
-            if (stubpairs_.at(i)->getLastPartOfName() != vmsteSuffix)
-              continue;
-
-            for (unsigned int l = 0; l < thirdvmstubs_.at(k)->nVMStubsBinned(ibin); l++) {
-              if (countall >= settings_.maxStep("TRE"))
-                break;
-              countall++;
-
-              const VMStubTE &thirdvmstub = thirdvmstubs_.at(k)->getVMStubTEBinned(ibin, l);
-
-              assert(secondphibits_ != -1);
-              assert(thirdphibits_ != -1);
-
-              FPGAWord iphisecondbin = secondvmstub.finephi();
-              FPGAWord iphithirdbin = thirdvmstub.finephi();
-
-              unsigned int index = (iphisecondbin.value() << thirdphibits_) + iphithirdbin.value();
-
-              FPGAWord secondbend = secondvmstub.bend();
-              FPGAWord thirdbend = thirdvmstub.bend();
-
-              index = (index << secondbend.nbits()) + secondbend.value();
-              index = (index << thirdbend.nbits()) + thirdbend.value();
-
-              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
-                  (index >= table_.size() || !table_[index])) {
-                if (settings_.debugTracklet()) {
-                  edm::LogVerbatim("Tracklet")
-                      << "Stub triplet rejected because of stub pt cut bends : "
-                      << settings_.benddecode(secondvmstub.bend().value(), disk2_ + 5, secondvmstub.isPSmodule()) << " "
-                      << settings_.benddecode(thirdvmstub.bend().value(), layer3_ - 1, thirdvmstub.isPSmodule());
-                }
+          for (int ibin = start; ibin <= last; ibin++) {
+            for (unsigned int k = 0; k < thirdvmstubs_.size(); k++) {
+              string vmsteSuffix = thirdvmstubs_.at(k)->getLastPartOfName();
+              vmsteSuffix = vmsteSuffix.substr(0, vmsteSuffix.find_last_of('n'));
+              if (stubpairs_.at(i)->getLastPartOfName() != vmsteSuffix)
                 continue;
-              }
-              if (settings_.writeTripletTables()) {
-                if (index >= table_.size())
-                  table_.resize(index + 1, false);
-                table_[index] = true;
-
-                const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
-                const string &tedName = stubpairs_.at(i)->getTEDName(j);
-                if (!tmpSPTable_.count(tedName))
-                  tmpSPTable_[tedName];
-                if (spIndex >= tmpSPTable_.at(tedName).size())
-                  tmpSPTable_.at(tedName).resize(spIndex + 1);
-                tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
-              }
-
-              if (settings_.debugTracklet())
-                edm::LogVerbatim("Tracklet") << "Adding layer-disk pair in " << getName();
-              if (settings_.writeMonitorData("Seeds")) {
-                ofstream fout("seeds.txt", ofstream::app);
-                fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
-                fout.close();
-              }
-              stubtriplets_->addStubs(thirdvmstub.stub(),
-                                      (stubpairs_.at(i))->getVMStub1(j).stub(),
-                                      (stubpairs_.at(i))->getVMStub2(j).stub());
-              countpass++;
-            }
-          }
-        }
-      }
-
-      else if (layer2_ == 3 && disk3_ == 1) {
-        int lookupbits = (int)((firstvmstub.vmbits().value() >> 10) & 1023);
-
-        int newbin = (lookupbits & 127);
-        int bin = newbin / 8;
-
-        int start = (bin >> 1);
-        int last = start + (bin & 1);
-
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int k = 0; k < thirdvmstubs_.size(); k++) {
-            string vmsteSuffix = thirdvmstubs_.at(k)->getLastPartOfName();
-            vmsteSuffix = vmsteSuffix.substr(0, vmsteSuffix.find_last_of('n'));
-            if (stubpairs_.at(i)->getLastPartOfName() != vmsteSuffix)
-              continue;
-            for (unsigned int l = 0; l < thirdvmstubs_.at(k)->nVMStubsBinned(ibin); l++) {
-              if (countall >= settings_.maxStep("TRE"))
-                break;
-              countall++;
-
-              const VMStubTE &thirdvmstub = thirdvmstubs_.at(k)->getVMStubTEBinned(ibin, l);
-
-              assert(secondphibits_ != -1);
-              assert(thirdphibits_ != -1);
-
-              unsigned int nvmsecond;
-
-              nvmsecond = settings_.nallstubs(layer2_ - 1) * settings_.nvmte(1, iSeed_);
-              unsigned int nvmbitssecond = nbits(nvmsecond);
-
-              FPGAWord iphisecondbin = secondvmstub.stub()->iphivmFineBins(nvmbitssecond, secondphibits_);
-
-              //currentlty not using same number of bits as in the TED
-              //assert(iphisecondbin==(int)secondvmstub.finephi());
-              FPGAWord iphithirdbin = thirdvmstub.finephi();
-
-              unsigned int index = (iphisecondbin.value() << thirdphibits_) + iphithirdbin.value();
-
-              FPGAWord secondbend = secondvmstub.bend();
-              FPGAWord thirdbend = thirdvmstub.bend();
-
-              index = (index << secondbend.nbits()) + secondbend.value();
-              index = (index << thirdbend.nbits()) + thirdbend.value();
-
-              if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
-                  (index >= table_.size() || !table_[index])) {
+              for (unsigned int l = 0; l < thirdvmstubs_.at(k)->nVMStubsBinned(ibin); l++) {
                 if (settings_.debugTracklet()) {
-                  edm::LogVerbatim("Tracklet")
-                      << "Stub pair rejected because of stub pt cut bends : "
-                      << settings_.benddecode(secondvmstub.bend().value(), layer2_ - 1, secondvmstub.isPSmodule())
-                      << " " << settings_.benddecode(thirdvmstub.bend().value(), disk3_ + 5, thirdvmstub.isPSmodule());
+                  edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
                 }
+
+                if (countall >= settings_.maxStep("TRE"))
+                  break;
+                countall++;
+
+                const VMStubTE &thirdvmstub = thirdvmstubs_.at(k)->getVMStubTEBinned(ibin, l);
+
+                assert(secondphibits_ != -1);
+                assert(thirdphibits_ != -1);
+
+                unsigned int nvmsecond = settings_.nallstubs(layer2_ - 1) * settings_.nvmte(1, iSeed_);
+                unsigned int nvmbitssecond = nbits(nvmsecond);
+
+                FPGAWord iphisecondbin = secondvmstub.stub()->iphivmFineBins(nvmbitssecond, secondphibits_);
+
+                //currently not using same number of bits as in the TED
+                //assert(iphisecondbin==(int)secondvmstub.finephi());
+                FPGAWord iphithirdbin = thirdvmstub.finephi();
+
+                unsigned int index = (iphisecondbin.value() << thirdphibits_) + iphithirdbin.value();
+
+                FPGAWord secondbend = secondvmstub.bend();
+                FPGAWord thirdbend = thirdvmstub.bend();
+
+                index = (index << secondbend.nbits()) + secondbend.value();
+                index = (index << thirdbend.nbits()) + thirdbend.value();
+
+                if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                    (index >= table_.size() || !table_[index])) {
+                  if (settings_.debugTracklet()) {
+                    edm::LogVerbatim("Tracklet")
+                        << "Stub pair rejected because of stub pt cut bends : "
+                        << settings_.benddecode(secondvmstub.bend().value(), layer2_ - 1, secondvmstub.isPSmodule())
+                        << " "
+                        << settings_.benddecode(thirdvmstub.bend().value(), layer3_ - 1, thirdvmstub.isPSmodule());
+                  }
+
+                  //FIXME temporarily commented out until bend table fixed
+                  //if (!settings_.writeTripletTables())
+                  //  continue;
+                }
+                if (settings_.writeTripletTables()) {
+                  if (index >= table_.size())
+                    table_.resize(index + 1, false);
+                  table_[index] = true;
+
+                  const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
+                  const string &tedName = stubpairs_.at(i)->getTEDName(j);
+                  if (!tmpSPTable_.count(tedName))
+                    tmpSPTable_[tedName];
+                  if (spIndex >= tmpSPTable_.at(tedName).size())
+                    tmpSPTable_.at(tedName).resize(spIndex + 1);
+                  tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
+                }
+
+                if (settings_.debugTracklet())
+                  edm::LogVerbatim("Tracklet") << "Adding layer-layer pair in " << getName();
+                if (settings_.writeMonitorData("Seeds")) {
+                  ofstream fout("seeds.txt", ofstream::app);
+                  fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
+                  fout.close();
+                }
+                stubtriplets_->addStubs(thirdvmstub.stub(),
+                                        (stubpairs_.at(i))->getVMStub1(j).stub(),
+                                        (stubpairs_.at(i))->getVMStub2(j).stub());
+
+                countpass++;
+              }
+            }
+          }
+
+        }
+
+        else if (disk2_ == 2 && layer3_ == 2) {
+          int lookupbits = (int)((firstvmstub.vmbits().value() >> 10) & 1023);
+          int newbin = (lookupbits & 127);
+          int bin = newbin / 8;
+
+          int start = (bin >> 1);
+          int last = start + (bin & 1);
+
+          if (firstvmstub.stub()->disk().value() < 0) {  //TODO - negative disk should come from memory
+            start = settings_.NLONGVMBINS() - last - 1;
+            last = settings_.NLONGVMBINS() - start - 1;
+          }
+
+          for (int ibin = start; ibin <= last; ibin++) {
+            for (unsigned int k = 0; k < thirdvmstubs_.size(); k++) {
+              string vmsteSuffix = thirdvmstubs_.at(k)->getLastPartOfName();
+              vmsteSuffix = vmsteSuffix.substr(0, vmsteSuffix.find_last_of('n'));
+              if (stubpairs_.at(i)->getLastPartOfName() != vmsteSuffix)
                 continue;
-              }
-              if (settings_.writeTripletTables()) {
-                if (index >= table_.size())
-                  table_.resize(index + 1, false);
-                table_[index] = true;
 
-                const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
-                const string &tedName = stubpairs_.at(i)->getTEDName(j);
-                if (!tmpSPTable_.count(tedName))
-                  tmpSPTable_[tedName];
-                if (spIndex >= tmpSPTable_.at(tedName).size())
-                  tmpSPTable_.at(tedName).resize(spIndex + 1);
-                tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
-              }
+              for (unsigned int l = 0; l < thirdvmstubs_.at(k)->nVMStubsBinned(ibin); l++) {
+                if (countall >= settings_.maxStep("TRE"))
+                  break;
+                countall++;
 
-              if (settings_.debugTracklet())
-                edm::LogVerbatim("Tracklet") << "Adding layer-disk pair in " << getName();
-              if (settings_.writeMonitorData("Seeds")) {
-                ofstream fout("seeds.txt", ofstream::app);
-                fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
-                fout.close();
+                const VMStubTE &thirdvmstub = thirdvmstubs_.at(k)->getVMStubTEBinned(ibin, l);
+
+                assert(secondphibits_ != -1);
+                assert(thirdphibits_ != -1);
+
+                FPGAWord iphisecondbin = secondvmstub.finephi();
+                FPGAWord iphithirdbin = thirdvmstub.finephi();
+
+                unsigned int index = (iphisecondbin.value() << thirdphibits_) + iphithirdbin.value();
+
+                FPGAWord secondbend = secondvmstub.bend();
+                FPGAWord thirdbend = thirdvmstub.bend();
+
+                index = (index << secondbend.nbits()) + secondbend.value();
+                index = (index << thirdbend.nbits()) + thirdbend.value();
+
+                if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                    (index >= table_.size() || !table_[index])) {
+                  if (settings_.debugTracklet()) {
+                    edm::LogVerbatim("Tracklet")
+                        << "Stub triplet rejected because of stub pt cut bends : "
+                        << settings_.benddecode(secondvmstub.bend().value(), disk2_ + 5, secondvmstub.isPSmodule())
+                        << " "
+                        << settings_.benddecode(thirdvmstub.bend().value(), layer3_ - 1, thirdvmstub.isPSmodule());
+                  }
+                  continue;
+                }
+                if (settings_.writeTripletTables()) {
+                  if (index >= table_.size())
+                    table_.resize(index + 1, false);
+                  table_[index] = true;
+
+                  const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
+                  const string &tedName = stubpairs_.at(i)->getTEDName(j);
+                  if (!tmpSPTable_.count(tedName))
+                    tmpSPTable_[tedName];
+                  if (spIndex >= tmpSPTable_.at(tedName).size())
+                    tmpSPTable_.at(tedName).resize(spIndex + 1);
+                  tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
+                }
+
+                if (settings_.debugTracklet())
+                  edm::LogVerbatim("Tracklet") << "Adding layer-disk pair in " << getName();
+                if (settings_.writeMonitorData("Seeds")) {
+                  ofstream fout("seeds.txt", ofstream::app);
+                  fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
+                  fout.close();
+                }
+                stubtriplets_->addStubs(thirdvmstub.stub(),
+                                        (stubpairs_.at(i))->getVMStub1(j).stub(),
+                                        (stubpairs_.at(i))->getVMStub2(j).stub());
+                countpass++;
               }
-              stubtriplets_->addStubs(thirdvmstub.stub(),
-                                      (stubpairs_.at(i))->getVMStub1(j).stub(),
-                                      (stubpairs_.at(i))->getVMStub2(j).stub());
-              countpass++;
+            }
+          }
+        }
+
+        else if (layer2_ == 3 && disk3_ == 1) {
+          int lookupbits = (int)((firstvmstub.vmbits().value() >> 10) & 1023);
+
+          int newbin = (lookupbits & 127);
+          int bin = newbin / 8;
+
+          int start = (bin >> 1);
+          int last = start + (bin & 1);
+
+          for (int ibin = start; ibin <= last; ibin++) {
+            for (unsigned int k = 0; k < thirdvmstubs_.size(); k++) {
+              string vmsteSuffix = thirdvmstubs_.at(k)->getLastPartOfName();
+              vmsteSuffix = vmsteSuffix.substr(0, vmsteSuffix.find_last_of('n'));
+              if (stubpairs_.at(i)->getLastPartOfName() != vmsteSuffix)
+                continue;
+              for (unsigned int l = 0; l < thirdvmstubs_.at(k)->nVMStubsBinned(ibin); l++) {
+                if (countall >= settings_.maxStep("TRE"))
+                  break;
+                countall++;
+
+                const VMStubTE &thirdvmstub = thirdvmstubs_.at(k)->getVMStubTEBinned(ibin, l);
+
+                assert(secondphibits_ != -1);
+                assert(thirdphibits_ != -1);
+
+                unsigned int nvmsecond;
+
+                nvmsecond = settings_.nallstubs(layer2_ - 1) * settings_.nvmte(1, iSeed_);
+                unsigned int nvmbitssecond = nbits(nvmsecond);
+
+                FPGAWord iphisecondbin = secondvmstub.stub()->iphivmFineBins(nvmbitssecond, secondphibits_);
+
+                //currentlty not using same number of bits as in the TED
+                //assert(iphisecondbin==(int)secondvmstub.finephi());
+                FPGAWord iphithirdbin = thirdvmstub.finephi();
+
+                unsigned int index = (iphisecondbin.value() << thirdphibits_) + iphithirdbin.value();
+
+                FPGAWord secondbend = secondvmstub.bend();
+                FPGAWord thirdbend = thirdvmstub.bend();
+
+                index = (index << secondbend.nbits()) + secondbend.value();
+                index = (index << thirdbend.nbits()) + thirdbend.value();
+
+                if ((settings_.enableTripletTables() && !settings_.writeTripletTables()) &&
+                    (index >= table_.size() || !table_[index])) {
+                  if (settings_.debugTracklet()) {
+                    edm::LogVerbatim("Tracklet")
+                        << "Stub pair rejected because of stub pt cut bends : "
+                        << settings_.benddecode(secondvmstub.bend().value(), layer2_ - 1, secondvmstub.isPSmodule())
+                        << " "
+                        << settings_.benddecode(thirdvmstub.bend().value(), disk3_ + 5, thirdvmstub.isPSmodule());
+                  }
+                  continue;
+                }
+                if (settings_.writeTripletTables()) {
+                  if (index >= table_.size())
+                    table_.resize(index + 1, false);
+                  table_[index] = true;
+
+                  const unsigned spIndex = stubpairs_.at(i)->getIndex(j);
+                  const string &tedName = stubpairs_.at(i)->getTEDName(j);
+                  if (!tmpSPTable_.count(tedName))
+                    tmpSPTable_[tedName];
+                  if (spIndex >= tmpSPTable_.at(tedName).size())
+                    tmpSPTable_.at(tedName).resize(spIndex + 1);
+                  tmpSPTable_.at(tedName).at(spIndex).push_back(stubpairs_.at(i)->getName());
+                }
+
+                if (settings_.debugTracklet())
+                  edm::LogVerbatim("Tracklet") << "Adding layer-disk pair in " << getName();
+                if (settings_.writeMonitorData("Seeds")) {
+                  ofstream fout("seeds.txt", ofstream::app);
+                  fout << __FILE__ << ":" << __LINE__ << " " << name_ << " " << iSeed_ << endl;
+                  fout.close();
+                }
+                stubtriplets_->addStubs(thirdvmstub.stub(),
+                                        (stubpairs_.at(i))->getVMStub1(j).stub(),
+                                        (stubpairs_.at(i))->getVMStub2(j).stub());
+                countpass++;
+              }
             }
           }
         }
       }
     }
-  }
 
-  for (const auto &tedName : tmpSPTable_) {
-    for (unsigned spIndex = 0; spIndex < tedName.second.size(); spIndex++) {
-      if (tedName.second.at(spIndex).empty())
-        continue;
-      vector<string> entry(tedName.second.at(spIndex));
-      sort(entry.begin(), entry.end());
-      entry.erase(unique(entry.begin(), entry.end()), entry.end());
-      const string &spName = entry.at(0);
+    for (const auto &tedName : tmpSPTable_) {
+      for (unsigned spIndex = 0; spIndex < tedName.second.size(); spIndex++) {
+        if (tedName.second.at(spIndex).empty())
+          continue;
+        vector<string> entry(tedName.second.at(spIndex));
+        sort(entry.begin(), entry.end());
+        entry.erase(unique(entry.begin(), entry.end()), entry.end());
+        const string &spName = entry.at(0);
 
-      if (!spTable_.count(tedName.first))
-        spTable_[tedName.first];
-      if (spIndex >= spTable_.at(tedName.first).size())
-        spTable_.at(tedName.first).resize(spIndex + 1);
-      if (!spTable_.at(tedName.first).at(spIndex).count(spName))
-        spTable_.at(tedName.first).at(spIndex)[spName] = 0;
-      spTable_.at(tedName.first).at(spIndex)[spName]++;
+        if (!spTable_.count(tedName.first))
+          spTable_[tedName.first];
+        if (spIndex >= spTable_.at(tedName.first).size())
+          spTable_.at(tedName.first).resize(spIndex + 1);
+        if (!spTable_.at(tedName.first).at(spIndex).count(spName))
+          spTable_.at(tedName.first).at(spIndex)[spName] = 0;
+        spTable_.at(tedName.first).at(spIndex)[spName]++;
+      }
+    }
+
+    if (settings_.writeMonitorData("TRE")) {
+      globals_->ofstream("tripletengine.txt") << getName() << " " << countall << " " << countpass << endl;
     }
   }
 
-  if (settings_.writeMonitorData("TRE")) {
-    globals_->ofstream("tripletengine.txt") << getName() << " " << countall << " " << countpass << endl;
+  void TripletEngine::readTables() {
+    ifstream fin;
+    string tableName, word;
+    unsigned num;
+
+    string tablePath = settings_.tableTREFile();
+    unsigned int finddir = tablePath.find("table_TRE_");
+    tableName = tablePath.substr(0, finddir) + "table_" + name_ + ".txt";
+
+    fin.open(tableName, ifstream::in);
+    if (!fin) {
+      throw cms::Exception("BadConfig") << "TripletEngine::readTables, file " << tableName << " not known";
+    }
+    while (!fin.eof()) {
+      fin >> word;
+      num = atoi(word.c_str());
+      table_.push_back(num > 0 ? true : false);
+    }
+    fin.close();
   }
-}
 
-void TripletEngine::readTables() {
-  ifstream fin;
-  string tableName, word;
-  unsigned num;
+  void TripletEngine::writeTables() {
+    ofstream fout;
+    stringstream tableName;
 
-  string tablePath = settings_.tableTREFile();
-  unsigned int finddir = tablePath.find("table_TRE_");
-  tableName = tablePath.substr(0, finddir) + "table_" + name_ + ".txt";
-
-  fin.open(tableName, ifstream::in);
-  if (!fin) {
-    throw cms::Exception("BadConfig") << "TripletEngine::readTables, file " << tableName << " not known";
-  }
-  while (!fin.eof()) {
-    fin >> word;
-    num = atoi(word.c_str());
-    table_.push_back(num > 0 ? true : false);
-  }
-  fin.close();
-}
-
-void TripletEngine::writeTables() {
-  ofstream fout;
-  stringstream tableName;
-
-  tableName << "table/table_" << name_ << ".txt";
-
-  fout.open(tableName.str(), ofstream::out);
-  for (const auto entry : table_)
-    fout << entry << endl;
-  fout.close();
-
-  for (const auto &tedName : spTable_) {
-    tableName.str("");
-    tableName << "table/table_" << tedName.first << "_" << name_ << ".txt";
+    tableName << "table/table_" << name_ << ".txt";
 
     fout.open(tableName.str(), ofstream::out);
-    for (const auto &entry : tedName.second) {
-      for (const auto &spName : entry)
-        fout << spName.first << ":" << spName.second << " ";
-      fout << endl;
-    }
+    for (const auto entry : table_)
+      fout << entry << endl;
     fout.close();
-  }
-}
 
-}
+    for (const auto &tedName : spTable_) {
+      tableName.str("");
+      tableName << "table/table_" << tedName.first << "_" << name_ << ".txt";
+
+      fout.open(tableName.str(), ofstream::out);
+      for (const auto &entry : tedName.second) {
+        for (const auto &spName : entry)
+          fout << spName.first << ":" << spName.second << " ";
+        fout << endl;
+      }
+      fout.close();
+    }
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/VMProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMProjectionsMemory.cc
@@ -5,7 +5,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 VMProjectionsMemory::VMProjectionsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
   initLayerDisk(7, layer_, disk_);
@@ -49,4 +50,6 @@ void VMProjectionsMemory::writeVMPROJ(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/VMProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMProjectionsMemory.cc
@@ -8,48 +8,48 @@ using namespace std;
 
 namespace trklet {
 
-VMProjectionsMemory::VMProjectionsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
-  initLayerDisk(7, layer_, disk_);
-}
-
-void VMProjectionsMemory::addTracklet(Tracklet* tracklet, unsigned int allprojindex) {
-  std::pair<Tracklet*, unsigned int> tmp(tracklet, allprojindex);
-  //Check that order of TCID is correct
-  if (!tracklets_.empty()) {
-    assert(tracklets_[tracklets_.size() - 1].first->TCID() <= tracklet->TCID());
+  VMProjectionsMemory::VMProjectionsMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
+    initLayerDisk(7, layer_, disk_);
   }
-  tracklets_.push_back(tmp);
-}
 
-void VMProjectionsMemory::writeVMPROJ(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirVM = settings_.memPath() + "VMProjections/";
-
-  std::ostringstream oss;
-  oss << dirVM + "VMProjections_" << getName();
-  //get rid of duplicates
-  auto const& tmp = oss.str();
-  int len = tmp.size();
-  if (tmp[len - 2] == 'n' && tmp[len - 1] > '1' && tmp[len - 1] <= '9')
-    return;
-  oss << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirVM, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
-
-  for (unsigned int j = 0; j < tracklets_.size(); j++) {
-    string vmproj = (layer_ > 0) ? tracklets_[j].first->vmstrlayer(layer_, tracklets_[j].second)
-                                 : tracklets_[j].first->vmstrdisk(disk_, tracklets_[j].second);
-    out_ << hexstr(j) << " " << vmproj << " " << trklet::hexFormat(vmproj) << endl;
+  void VMProjectionsMemory::addTracklet(Tracklet* tracklet, unsigned int allprojindex) {
+    std::pair<Tracklet*, unsigned int> tmp(tracklet, allprojindex);
+    //Check that order of TCID is correct
+    if (!tracklets_.empty()) {
+      assert(tracklets_[tracklets_.size() - 1].first->TCID() <= tracklet->TCID());
+    }
+    tracklets_.push_back(tmp);
   }
-  out_.close();
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
+  void VMProjectionsMemory::writeVMPROJ(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirVM = settings_.memPath() + "VMProjections/";
 
-}
+    std::ostringstream oss;
+    oss << dirVM + "VMProjections_" << getName();
+    //get rid of duplicates
+    auto const& tmp = oss.str();
+    int len = tmp.size();
+    if (tmp[len - 2] == 'n' && tmp[len - 1] > '1' && tmp[len - 1] <= '9')
+      return;
+    oss << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
+    auto const& fname = oss.str();
+
+    openfile(out_, first, dirVM, fname, __FILE__, __LINE__);
+
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+
+    for (unsigned int j = 0; j < tracklets_.size(); j++) {
+      string vmproj = (layer_ > 0) ? tracklets_[j].first->vmstrlayer(layer_, tracklets_[j].second)
+                                   : tracklets_[j].first->vmstrdisk(disk_, tracklets_[j].second);
+      out_ << hexstr(j) << " " << vmproj << " " << trklet::hexFormat(vmproj) << endl;
+    }
+    out_.close();
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
@@ -14,375 +14,377 @@ using namespace std;
 
 namespace trklet {
 
-VMRouter::VMRouter(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global),
-      meTable_(settings),
-      diskTable_(settings),
-      innerTable_(settings),
-      innerOverlapTable_(settings),
-      innerThirdTable_(settings) {
-  layerdisk_ = initLayerDisk(4);
+  VMRouter::VMRouter(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global),
+        meTable_(settings),
+        diskTable_(settings),
+        innerTable_(settings),
+        innerOverlapTable_(settings),
+        innerThirdTable_(settings) {
+    layerdisk_ = initLayerDisk(4);
 
-  vmstubsMEPHI_.resize(settings_.nvmme(layerdisk_), nullptr);
+    vmstubsMEPHI_.resize(settings_.nvmme(layerdisk_), nullptr);
 
-  unsigned int region = name[9] - 'A';
-  assert(region < settings_.nallstubs(layerdisk_));
+    unsigned int region = name[9] - 'A';
+    assert(region < settings_.nallstubs(layerdisk_));
 
-  overlapbits_ = 7;
-  nextrabits_ = overlapbits_ - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_));
+    overlapbits_ = 7;
+    nextrabits_ = overlapbits_ - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_));
 
-  meTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::me, region);  //used for ME and outer TE barrel
+    meTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::me, region);  //used for ME and outer TE barrel
 
-  if (layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D2 || layerdisk_ == D4) {
-    diskTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::disk, region);  //outer disk used by D1, D2, and D4
-  }
-
-  if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3 ||
-      layerdisk_ == LayerDisk::L5 || layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D3) {
-    innerTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::inner, region);  //projection to next layer/disk
-  }
-
-  if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2) {
-    innerOverlapTable_.initVMRTable(
-        layerdisk_, TrackletLUT::VMRTableType::inneroverlap, region);  //projection to disk from layer
-  }
-
-  if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3 || layerdisk_ == LayerDisk::L5 ||
-      layerdisk_ == LayerDisk::D1) {
-    innerThirdTable_.initVMRTable(
-        layerdisk_, TrackletLUT::VMRTableType::innerthird, region);  //projection to third layer/disk
-  }
-
-  nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk_);
-  nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk_);
-}
-
-void VMRouter::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-
-  if (output.substr(0, 10) == "allstubout") {
-    AllStubsMemory* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    allstubs_.push_back(tmp);
-    return;
-  }
-
-  if (output.substr(0, 12) == "vmstuboutPHI" || output.substr(0, 14) == "vmstuboutMEPHI" ||
-      output.substr(0, 15) == "vmstuboutTEIPHI" || output.substr(0, 15) == "vmstuboutTEOPHI") {
-    char seedtype = memory->getName().substr(11, 1)[0];
-    unsigned int pos = 12;
-    int vmbin = memory->getName().substr(pos, 1)[0] - '0';
-    pos++;
-    if (pos < memory->getName().size()) {
-      if (memory->getName().substr(pos, 1)[0] != 'n') {
-        vmbin = vmbin * 10 + memory->getName().substr(pos, 1)[0] - '0';
-        pos++;
-      }
+    if (layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D2 || layerdisk_ == D4) {
+      diskTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::disk, region);  //outer disk used by D1, D2, and D4
     }
 
-    int iseed = -1;
-    unsigned int inner = 1;
-    if (memory->getName().substr(3, 2) == "TE") {
-      VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
+    if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3 ||
+        layerdisk_ == LayerDisk::L5 || layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D3) {
+      innerTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::inner, region);  //projection to next layer/disk
+    }
+
+    if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2) {
+      innerOverlapTable_.initVMRTable(
+          layerdisk_, TrackletLUT::VMRTableType::inneroverlap, region);  //projection to disk from layer
+    }
+
+    if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3 || layerdisk_ == LayerDisk::L5 ||
+        layerdisk_ == LayerDisk::D1) {
+      innerThirdTable_.initVMRTable(
+          layerdisk_, TrackletLUT::VMRTableType::innerthird, region);  //projection to third layer/disk
+    }
+
+    nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk_);
+    nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk_);
+  }
+
+  void VMRouter::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
+
+    if (output.substr(0, 10) == "allstubout") {
+      AllStubsMemory* tmp = dynamic_cast<AllStubsMemory*>(memory);
       assert(tmp != nullptr);
-      if (seedtype < 'I') {
-        if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2)
-          iseed = Seed::L1L2;
-        if (layerdisk_ == LayerDisk::L3 || layerdisk_ == LayerDisk::L4)
-          iseed = Seed::L3L4;
-        if (layerdisk_ == LayerDisk::L5 || layerdisk_ == LayerDisk::L6)
-          iseed = Seed::L5L6;
-        if (layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D2)
-          iseed = Seed::D1D2;
-        if (layerdisk_ == LayerDisk::D3 || layerdisk_ == LayerDisk::D4)
-          iseed = Seed::D3D4;
-        if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L3 || layerdisk_ == LayerDisk::L5 ||
-            layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D3)
-          inner = 0;
-      } else if (seedtype < 'M') {
-        if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3)
-          iseed = Seed::L2L3;
-        if (layerdisk_ == LayerDisk::L2)
-          inner = 0;
-      } else if (seedtype <= 'Z') {
-        if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::D1)
-          iseed = Seed::L1D1;
-        if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::D1)
-          iseed = Seed::L2D1;
-        if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2)
-          inner = 0;
-      } else if (seedtype < 'o' && seedtype >= 'a') {
-        if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3)
-          iseed = Seed::L2L3D1;
-        if (layerdisk_ == LayerDisk::L2)
-          inner = 0;
-      } else if (seedtype > 'o' && seedtype <= 'z') {
-        if (layerdisk_ == LayerDisk::L2)
-          iseed = Seed::D1D2L2;
-        if (layerdisk_ == LayerDisk::D1)
-          iseed = Seed::L2L3D1;
-        inner = 2;
-      } else {
-        throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
-      }
-      assert(iseed != -1);
-      int seedindex = -1;
-      for (unsigned int k = 0; k < vmstubsTEPHI_.size(); k++) {
-        if (vmstubsTEPHI_[k].seednumber == (unsigned int)iseed) {
-          seedindex = k;
-        }
-      }
-      if (seedindex == -1) {
-        seedindex = vmstubsTEPHI_.size();
-        vector<VMStubsTEMemory*> avectmp;
-        vector<vector<VMStubsTEMemory*> > vectmp(settings_.nvmte(inner, iseed), avectmp);
-        VMStubsTEPHI atmp(iseed, inner, vectmp);
-        vmstubsTEPHI_.push_back(atmp);
-      }
-      vmstubsTEPHI_[seedindex].vmstubmem[(vmbin - 1) & (settings_.nvmte(inner, iseed) - 1)].push_back(tmp);
-
-    } else if (memory->getName().substr(3, 2) == "ME") {
-      VMStubsMEMemory* tmp = dynamic_cast<VMStubsMEMemory*>(memory);
-      assert(tmp != nullptr);
-      vmstubsMEPHI_[(vmbin - 1) & (settings_.nvmme(layerdisk_) - 1)] = tmp;
-    } else {
-      throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " should never get here!";
+      allstubs_.push_back(tmp);
+      return;
     }
 
-    return;
-  }
-
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
-}
-
-void VMRouter::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input == "stubin") {
-    InputLinkMemory* tmp1 = dynamic_cast<InputLinkMemory*>(memory);
-    assert(tmp1 != nullptr);
-    if (tmp1 != nullptr) {
-      if (layerdisk_ >= N_LAYER && tmp1->getName().find("2S_") != string::npos) {
-        stubinputdisk2stmp_.push_back(tmp1);
-      } else {
-        stubinputtmp_.push_back(tmp1);
-      }
-    }
-    //This gymnastic is done to ensure that in the disks the PS stubs are processed before
-    //the 2S stubs. This is needed by the current HLS implemenation of the VM router.
-    stubinputs_ = stubinputtmp_;
-    for (auto& mem : stubinputdisk2stmp_) {
-      stubinputs_.push_back(mem);
-    }
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
-}
-
-void VMRouter::execute() {
-  unsigned int allStubCounter = 0;
-
-  //Loop over the input stubs
-  for (auto& stubinput : stubinputs_) {
-    for (unsigned int i = 0; i < stubinput->nStubs(); i++) {
-      if (allStubCounter >= settings_.maxStep("VMR"))
-        continue;
-      if (allStubCounter >= (1 << N_BITSMEMADDRESS))
-        continue;
-      Stub* stub = stubinput->getStub(i);
-
-      //Note - below information is not part of the stub, but rather from which input memory we are reading
-      bool negdisk = (stub->disk().value() < 0);
-
-      //use &127 to make sure we fit into the number of bits -
-      //though we should have protected against overflows above
-      FPGAWord allStubIndex(allStubCounter & ((1 << N_BITSMEMADDRESS) - 1), N_BITSMEMADDRESS, true, __LINE__, __FILE__);
-
-      //TODO - should not be needed - but need to migrate some other pieces of code before removing
-      stub->setAllStubIndex(allStubCounter);
-      //TODO - should not be needed - but need to migrate some other pieces of code before removing
-      stub->l1tstub()->setAllStubIndex(allStubCounter);
-
-      allStubCounter++;
-
-      //Fill allstubs memories - in HLS this is the same write to multiple memories
-      for (auto& allstub : allstubs_) {
-        allstub->addStub(stub);
-      }
-
-      //Fill all the ME VM memories
-
-      FPGAWord iphi = stub->phicorr();
-      unsigned int ivm =
-          iphi.bits(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_)),
-                    settings_.nbitsvmme(layerdisk_));
-      unsigned int extrabits = iphi.bits(iphi.nbits() - overlapbits_, nextrabits_);
-
-      unsigned int ivmPlus = ivm;
-
-      if (extrabits == ((1U << nextrabits_) - 1) && ivm != ((1U << settings_.nbitsvmme(layerdisk_)) - 1))
-        ivmPlus++;
-      unsigned int ivmMinus = ivm;
-      if (extrabits == 0 && ivm != 0)
-        ivmMinus--;
-
-      //Calculate the z and r position for the vmstub
-
-      //Take the top nbitszfinebintable_ bits of the z coordinate
-      int indexz = (((1 << (stub->z().nbits() - 1)) + stub->z().value()) >> (stub->z().nbits() - nbitszfinebintable_));
-      int indexr = -1;
-      if (layerdisk_ > (N_LAYER - 1)) {
-        if (negdisk) {
-          indexz = (1 << nbitszfinebintable_) - indexz;
-        }
-        indexr = stub->r().value();
-        if (stub->isPSmodule()) {
-          indexr = stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_);
-        }
-      } else {
-        //Take the top nbitsfinebintable_ bits of the z coordinate. The & is to handle the negative z values.
-        indexr = (((1 << (stub->r().nbits() - 1)) + stub->r().value()) >> (stub->r().nbits() - nbitsrfinebintable_));
-      }
-
-      assert(indexz >= 0);
-      assert(indexr >= 0);
-      assert(indexz < (1 << nbitszfinebintable_));
-      assert(indexr < (1 << nbitsrfinebintable_));
-
-      int melut = meTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-      assert(melut >= 0);
-
-      int vmbin = melut >> 3;
-      if (negdisk)
-        vmbin += 8;
-      int rzfine = melut & 7;
-
-      // pad disk PS bend word with a '0' in MSB so that all disk bends have 4 bits (for HLS compatibility)
-      int nbendbits = stub->bend().nbits();
-      if (layerdisk_ >= N_LAYER)
-        nbendbits = settings_.nbendbitsmedisk();
-
-      VMStubME vmstub(stub,
-                      stub->iphivmFineBins(settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_), 3),
-                      FPGAWord(rzfine, 3, true, __LINE__, __FILE__),
-                      FPGAWord(stub->bend().value(), nbendbits, true, __LINE__, __FILE__),
-                      allStubIndex);
-
-      if (!(settings_.reduced()))
-        assert(vmstubsMEPHI_[ivmPlus] != nullptr);
-      if (vmstubsMEPHI_[ivmPlus] != nullptr)
-        vmstubsMEPHI_[ivmPlus]->addStub(vmstub, vmbin);
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << getName() << " adding stub to " << vmstubsMEPHI_[ivmPlus]->getName()
-                                     << " ivmPlus" << ivmPlus << " bin=" << vmbin;
-      }
-
-      if (ivmMinus != ivmPlus && vmstubsMEPHI_[ivmMinus] != nullptr) {
-        vmstubsMEPHI_[ivmMinus]->addStub(vmstub, vmbin);
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << getName() << " adding stub to " << vmstubsMEPHI_[ivmMinus]->getName()
-                                       << " ivmMinus" << ivmMinus << " bin=" << vmbin;
+    if (output.substr(0, 12) == "vmstuboutPHI" || output.substr(0, 14) == "vmstuboutMEPHI" ||
+        output.substr(0, 15) == "vmstuboutTEIPHI" || output.substr(0, 15) == "vmstuboutTEOPHI") {
+      char seedtype = memory->getName().substr(11, 1)[0];
+      unsigned int pos = 12;
+      int vmbin = memory->getName().substr(pos, 1)[0] - '0';
+      pos++;
+      if (pos < memory->getName().size()) {
+        if (memory->getName().substr(pos, 1)[0] != 'n') {
+          vmbin = vmbin * 10 + memory->getName().substr(pos, 1)[0] - '0';
+          pos++;
         }
       }
 
-      //Fill the TE VM memories
-
-      for (auto& ivmstubTEPHI : vmstubsTEPHI_) {
-        unsigned int iseed = ivmstubTEPHI.seednumber;
-        unsigned int inner = ivmstubTEPHI.stubposition;
-        if ((iseed == Seed::D1D2 || iseed == Seed::D3D4 || iseed == Seed::L1D1 || iseed == Seed::L2D1) &&
-            (!stub->isPSmodule()))
-          continue;
-
-        unsigned int lutwidth = settings_.lutwidthtab(inner, iseed);
-        if (settings_.extended()) {
-          lutwidth = settings_.lutwidthtabextended(inner, iseed);
-        }
-
-        int lutval = -999;
-
-        if (inner > 0) {
-          if (layerdisk_ < N_LAYER) {
-            lutval = melut;
-          } else {
-            if (inner == 2 && iseed == Seed::L2L3D1) {
-              lutval = 0;
-              if (stub->r().value() < 10) {
-                lutval = 8 * (1 + (stub->r().value() >> 2));
-              } else {
-                if (stub->r().value() < settings_.rmindiskl3overlapvm() / settings_.kr()) {
-                  lutval = -1;
-                }
-              }
-            } else {
-              lutval = diskTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-            }
-          }
-          if (lutval == -1)
-            continue;
+      int iseed = -1;
+      unsigned int inner = 1;
+      if (memory->getName().substr(3, 2) == "TE") {
+        VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
+        assert(tmp != nullptr);
+        if (seedtype < 'I') {
+          if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2)
+            iseed = Seed::L1L2;
+          if (layerdisk_ == LayerDisk::L3 || layerdisk_ == LayerDisk::L4)
+            iseed = Seed::L3L4;
+          if (layerdisk_ == LayerDisk::L5 || layerdisk_ == LayerDisk::L6)
+            iseed = Seed::L5L6;
+          if (layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D2)
+            iseed = Seed::D1D2;
+          if (layerdisk_ == LayerDisk::D3 || layerdisk_ == LayerDisk::D4)
+            iseed = Seed::D3D4;
+          if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L3 || layerdisk_ == LayerDisk::L5 ||
+              layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D3)
+            inner = 0;
+        } else if (seedtype < 'M') {
+          if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3)
+            iseed = Seed::L2L3;
+          if (layerdisk_ == LayerDisk::L2)
+            inner = 0;
+        } else if (seedtype <= 'Z') {
+          if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::D1)
+            iseed = Seed::L1D1;
+          if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::D1)
+            iseed = Seed::L2D1;
+          if (layerdisk_ == LayerDisk::L1 || layerdisk_ == LayerDisk::L2)
+            inner = 0;
+        } else if (seedtype < 'o' && seedtype >= 'a') {
+          if (layerdisk_ == LayerDisk::L2 || layerdisk_ == LayerDisk::L3)
+            iseed = Seed::L2L3D1;
+          if (layerdisk_ == LayerDisk::L2)
+            inner = 0;
+        } else if (seedtype > 'o' && seedtype <= 'z') {
+          if (layerdisk_ == LayerDisk::L2)
+            iseed = Seed::D1D2L2;
+          if (layerdisk_ == LayerDisk::D1)
+            iseed = Seed::L2L3D1;
+          inner = 2;
         } else {
-          if (iseed < Seed::L1D1 || iseed > Seed::L2D1) {
-            lutval = innerTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-          } else {
-            lutval = innerOverlapTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-          }
-          if (lutval == -1)
-            continue;
-          if (settings_.extended() &&
-              (iseed == Seed::L3L4 || iseed == Seed::L5L6 || iseed == Seed::D1D2 || iseed == Seed::L2L3D1)) {
-            int lutval2 = innerThirdTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-            if (lutval2 != -1)
-              lutval += (lutval2 << 10);
+          throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
+        }
+        assert(iseed != -1);
+        int seedindex = -1;
+        for (unsigned int k = 0; k < vmstubsTEPHI_.size(); k++) {
+          if (vmstubsTEPHI_[k].seednumber == (unsigned int)iseed) {
+            seedindex = k;
           }
         }
+        if (seedindex == -1) {
+          seedindex = vmstubsTEPHI_.size();
+          vector<VMStubsTEMemory*> avectmp;
+          vector<vector<VMStubsTEMemory*> > vectmp(settings_.nvmte(inner, iseed), avectmp);
+          VMStubsTEPHI atmp(iseed, inner, vectmp);
+          vmstubsTEPHI_.push_back(atmp);
+        }
+        vmstubsTEPHI_[seedindex].vmstubmem[(vmbin - 1) & (settings_.nvmte(inner, iseed) - 1)].push_back(tmp);
 
-        assert(lutval >= 0);
+      } else if (memory->getName().substr(3, 2) == "ME") {
+        VMStubsMEMemory* tmp = dynamic_cast<VMStubsMEMemory*>(memory);
+        assert(tmp != nullptr);
+        vmstubsMEPHI_[(vmbin - 1) & (settings_.nvmme(layerdisk_) - 1)] = tmp;
+      } else {
+        throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " should never get here!";
+      }
 
-        FPGAWord binlookup(lutval, lutwidth, true, __LINE__, __FILE__);
+      return;
+    }
 
-        if (binlookup.value() < 0)
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
+  }
+
+  void VMRouter::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input == "stubin") {
+      InputLinkMemory* tmp1 = dynamic_cast<InputLinkMemory*>(memory);
+      assert(tmp1 != nullptr);
+      if (tmp1 != nullptr) {
+        if (layerdisk_ >= N_LAYER && tmp1->getName().find("2S_") != string::npos) {
+          stubinputdisk2stmp_.push_back(tmp1);
+        } else {
+          stubinputtmp_.push_back(tmp1);
+        }
+      }
+      //This gymnastic is done to ensure that in the disks the PS stubs are processed before
+      //the 2S stubs. This is needed by the current HLS implemenation of the VM router.
+      stubinputs_ = stubinputtmp_;
+      for (auto& mem : stubinputdisk2stmp_) {
+        stubinputs_.push_back(mem);
+      }
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
+  }
+
+  void VMRouter::execute() {
+    unsigned int allStubCounter = 0;
+
+    //Loop over the input stubs
+    for (auto& stubinput : stubinputs_) {
+      for (unsigned int i = 0; i < stubinput->nStubs(); i++) {
+        if (allStubCounter >= settings_.maxStep("VMR"))
           continue;
+        if (allStubCounter >= (1 << N_BITSMEMADDRESS))
+          continue;
+        Stub* stub = stubinput->getStub(i);
 
-        unsigned int ivmte =
-            iphi.bits(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmte(inner, iseed)),
-                      settings_.nbitsvmte(inner, iseed));
+        //Note - below information is not part of the stub, but rather from which input memory we are reading
+        bool negdisk = (stub->disk().value() < 0);
 
-        int bin = -1;
-        if (inner != 0) {
-          bin = binlookup.value() / 8;
-          unsigned int tmp = binlookup.value() & 7;  //three bits in outer layers - this could be coded cleaner...
-          binlookup.set(tmp, 3, true, __LINE__, __FILE__);
+        //use &127 to make sure we fit into the number of bits -
+        //though we should have protected against overflows above
+        FPGAWord allStubIndex(
+            allStubCounter & ((1 << N_BITSMEMADDRESS) - 1), N_BITSMEMADDRESS, true, __LINE__, __FILE__);
+
+        //TODO - should not be needed - but need to migrate some other pieces of code before removing
+        stub->setAllStubIndex(allStubCounter);
+        //TODO - should not be needed - but need to migrate some other pieces of code before removing
+        stub->l1tstub()->setAllStubIndex(allStubCounter);
+
+        allStubCounter++;
+
+        //Fill allstubs memories - in HLS this is the same write to multiple memories
+        for (auto& allstub : allstubs_) {
+          allstub->addStub(stub);
         }
 
-        FPGAWord finephi = stub->iphivmFineBins(settings_.nphireg(inner, iseed), settings_.nfinephi(inner, iseed));
+        //Fill all the ME VM memories
 
-        VMStubTE tmpstub(stub, finephi, stub->bend(), binlookup, allStubIndex);
+        FPGAWord iphi = stub->phicorr();
+        unsigned int ivm =
+            iphi.bits(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_)),
+                      settings_.nbitsvmme(layerdisk_));
+        unsigned int extrabits = iphi.bits(iphi.nbits() - overlapbits_, nextrabits_);
 
-        unsigned int nmem = ivmstubTEPHI.vmstubmem[ivmte].size();
+        unsigned int ivmPlus = ivm;
+
+        if (extrabits == ((1U << nextrabits_) - 1) && ivm != ((1U << settings_.nbitsvmme(layerdisk_)) - 1))
+          ivmPlus++;
+        unsigned int ivmMinus = ivm;
+        if (extrabits == 0 && ivm != 0)
+          ivmMinus--;
+
+        //Calculate the z and r position for the vmstub
+
+        //Take the top nbitszfinebintable_ bits of the z coordinate
+        int indexz =
+            (((1 << (stub->z().nbits() - 1)) + stub->z().value()) >> (stub->z().nbits() - nbitszfinebintable_));
+        int indexr = -1;
+        if (layerdisk_ > (N_LAYER - 1)) {
+          if (negdisk) {
+            indexz = (1 << nbitszfinebintable_) - indexz;
+          }
+          indexr = stub->r().value();
+          if (stub->isPSmodule()) {
+            indexr = stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_);
+          }
+        } else {
+          //Take the top nbitsfinebintable_ bits of the z coordinate. The & is to handle the negative z values.
+          indexr = (((1 << (stub->r().nbits() - 1)) + stub->r().value()) >> (stub->r().nbits() - nbitsrfinebintable_));
+        }
+
+        assert(indexz >= 0);
+        assert(indexr >= 0);
+        assert(indexz < (1 << nbitszfinebintable_));
+        assert(indexr < (1 << nbitsrfinebintable_));
+
+        int melut = meTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+        assert(melut >= 0);
+
+        int vmbin = melut >> 3;
+        if (negdisk)
+          vmbin += 8;
+        int rzfine = melut & 7;
+
+        // pad disk PS bend word with a '0' in MSB so that all disk bends have 4 bits (for HLS compatibility)
+        int nbendbits = stub->bend().nbits();
+        if (layerdisk_ >= N_LAYER)
+          nbendbits = settings_.nbendbitsmedisk();
+
+        VMStubME vmstub(stub,
+                        stub->iphivmFineBins(settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_), 3),
+                        FPGAWord(rzfine, 3, true, __LINE__, __FILE__),
+                        FPGAWord(stub->bend().value(), nbendbits, true, __LINE__, __FILE__),
+                        allStubIndex);
 
         if (!(settings_.reduced()))
-          assert(nmem > 0);
+          assert(vmstubsMEPHI_[ivmPlus] != nullptr);
+        if (vmstubsMEPHI_[ivmPlus] != nullptr)
+          vmstubsMEPHI_[ivmPlus]->addStub(vmstub, vmbin);
+        if (settings_.debugTracklet()) {
+          edm::LogVerbatim("Tracklet") << getName() << " adding stub to " << vmstubsMEPHI_[ivmPlus]->getName()
+                                       << " ivmPlus" << ivmPlus << " bin=" << vmbin;
+        }
 
-        for (unsigned int l = 0; l < nmem; l++) {
+        if (ivmMinus != ivmPlus && vmstubsMEPHI_[ivmMinus] != nullptr) {
+          vmstubsMEPHI_[ivmMinus]->addStub(vmstub, vmbin);
           if (settings_.debugTracklet()) {
-            edm::LogVerbatim("Tracklet") << getName() << " try adding stub to "
-                                         << ivmstubTEPHI.vmstubmem[ivmte][l]->getName() << " inner=" << inner
-                                         << " bin=" << bin;
+            edm::LogVerbatim("Tracklet") << getName() << " adding stub to " << vmstubsMEPHI_[ivmMinus]->getName()
+                                         << " ivmMinus" << ivmMinus << " bin=" << vmbin;
           }
-          if (inner == 0) {
-            ivmstubTEPHI.vmstubmem[ivmte][l]->addVMStub(tmpstub);
+        }
+
+        //Fill the TE VM memories
+
+        for (auto& ivmstubTEPHI : vmstubsTEPHI_) {
+          unsigned int iseed = ivmstubTEPHI.seednumber;
+          unsigned int inner = ivmstubTEPHI.stubposition;
+          if ((iseed == Seed::D1D2 || iseed == Seed::D3D4 || iseed == Seed::L1D1 || iseed == Seed::L2D1) &&
+              (!stub->isPSmodule()))
+            continue;
+
+          unsigned int lutwidth = settings_.lutwidthtab(inner, iseed);
+          if (settings_.extended()) {
+            lutwidth = settings_.lutwidthtabextended(inner, iseed);
+          }
+
+          int lutval = -999;
+
+          if (inner > 0) {
+            if (layerdisk_ < N_LAYER) {
+              lutval = melut;
+            } else {
+              if (inner == 2 && iseed == Seed::L2L3D1) {
+                lutval = 0;
+                if (stub->r().value() < 10) {
+                  lutval = 8 * (1 + (stub->r().value() >> 2));
+                } else {
+                  if (stub->r().value() < settings_.rmindiskl3overlapvm() / settings_.kr()) {
+                    lutval = -1;
+                  }
+                }
+              } else {
+                lutval = diskTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+              }
+            }
+            if (lutval == -1)
+              continue;
           } else {
-            ivmstubTEPHI.vmstubmem[ivmte][l]->addVMStub(tmpstub, bin);
+            if (iseed < Seed::L1D1 || iseed > Seed::L2D1) {
+              lutval = innerTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+            } else {
+              lutval = innerOverlapTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+            }
+            if (lutval == -1)
+              continue;
+            if (settings_.extended() &&
+                (iseed == Seed::L3L4 || iseed == Seed::L5L6 || iseed == Seed::D1D2 || iseed == Seed::L2L3D1)) {
+              int lutval2 = innerThirdTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+              if (lutval2 != -1)
+                lutval += (lutval2 << 10);
+            }
+          }
+
+          assert(lutval >= 0);
+
+          FPGAWord binlookup(lutval, lutwidth, true, __LINE__, __FILE__);
+
+          if (binlookup.value() < 0)
+            continue;
+
+          unsigned int ivmte =
+              iphi.bits(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmte(inner, iseed)),
+                        settings_.nbitsvmte(inner, iseed));
+
+          int bin = -1;
+          if (inner != 0) {
+            bin = binlookup.value() / 8;
+            unsigned int tmp = binlookup.value() & 7;  //three bits in outer layers - this could be coded cleaner...
+            binlookup.set(tmp, 3, true, __LINE__, __FILE__);
+          }
+
+          FPGAWord finephi = stub->iphivmFineBins(settings_.nphireg(inner, iseed), settings_.nfinephi(inner, iseed));
+
+          VMStubTE tmpstub(stub, finephi, stub->bend(), binlookup, allStubIndex);
+
+          unsigned int nmem = ivmstubTEPHI.vmstubmem[ivmte].size();
+
+          if (!(settings_.reduced()))
+            assert(nmem > 0);
+
+          for (unsigned int l = 0; l < nmem; l++) {
+            if (settings_.debugTracklet()) {
+              edm::LogVerbatim("Tracklet")
+                  << getName() << " try adding stub to " << ivmstubTEPHI.vmstubmem[ivmte][l]->getName()
+                  << " inner=" << inner << " bin=" << bin;
+            }
+            if (inner == 0) {
+              ivmstubTEPHI.vmstubmem[ivmte][l]->addVMStub(tmpstub);
+            } else {
+              ivmstubTEPHI.vmstubmem[ivmte][l]->addVMStub(tmpstub, bin);
+            }
           }
         }
       }
     }
   }
-}
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouter.cc
@@ -11,7 +11,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 VMRouter::VMRouter(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global),
@@ -382,4 +383,6 @@ void VMRouter::execute() {
       }
     }
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -12,7 +12,8 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 VMRouterCM::VMRouterCM(string name, Settings const& settings, Globals* global)
     : ProcessBase(name, settings, global), meTable_(settings), diskTable_(settings) {
@@ -315,4 +316,6 @@ void VMRouterCM::execute(unsigned int) {
       }
     }
   }
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -15,307 +15,309 @@ using namespace std;
 
 namespace trklet {
 
-VMRouterCM::VMRouterCM(string name, Settings const& settings, Globals* global)
-    : ProcessBase(name, settings, global), meTable_(settings), diskTable_(settings) {
-  layerdisk_ = initLayerDisk(4);
+  VMRouterCM::VMRouterCM(string name, Settings const& settings, Globals* global)
+      : ProcessBase(name, settings, global), meTable_(settings), diskTable_(settings) {
+    layerdisk_ = initLayerDisk(4);
 
-  unsigned int region = name[9] - 'A';
-  assert(region < settings_.nallstubs(layerdisk_));
+    unsigned int region = name[9] - 'A';
+    assert(region < settings_.nallstubs(layerdisk_));
 
-  vmstubsMEPHI_.resize(1, nullptr);
+    vmstubsMEPHI_.resize(1, nullptr);
 
-  overlapbits_ = 7;
-  nextrabits_ = overlapbits_ - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_));
+    overlapbits_ = 7;
+    nextrabits_ = overlapbits_ - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_));
 
-  meTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::me, region);  //used for ME and outer TE barrel
+    meTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::me, region);  //used for ME and outer TE barrel
 
-  if (layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D2 || layerdisk_ == LayerDisk::D4) {
-    diskTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::disk, region);  //outer disk used by D1, D2, and D4
+    if (layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D2 || layerdisk_ == LayerDisk::D4) {
+      diskTable_.initVMRTable(layerdisk_, TrackletLUT::VMRTableType::disk, region);  //outer disk used by D1, D2, and D4
+    }
+
+    nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk_);
+    nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk_);
+
+    nvmmebins_ = settings_.NLONGVMBINS() * ((layerdisk_ >= N_LAYER) ? 2 : 1);  //number of long z/r bins in VM
   }
 
-  nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk_);
-  nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk_);
+  void VMRouterCM::addOutput(MemoryBase* memory, string output) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
+                                   << output;
+    }
 
-  nvmmebins_ = settings_.NLONGVMBINS() * ((layerdisk_ >= N_LAYER) ? 2 : 1);  //number of long z/r bins in VM
-}
-
-void VMRouterCM::addOutput(MemoryBase* memory, string output) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding output to " << memory->getName() << " to output "
-                                 << output;
-  }
-
-  if (output == "allinnerstubout") {
-    AllInnerStubsMemory* tmp = dynamic_cast<AllInnerStubsMemory*>(memory);
-    assert(tmp != nullptr);
-    char memtype = memory->getName().back();
-    allinnerstubs_.emplace_back(memtype, tmp);
-    return;
-  }
-
-  if (output.substr(0, 10) == "allstubout") {
-    AllStubsMemory* tmp = dynamic_cast<AllStubsMemory*>(memory);
-    allstubs_.push_back(tmp);
-    return;
-  }
-
-  if (output.substr(0, 9) == "vmstubout") {
-    if (memory->getName().substr(3, 2) == "TE") {
-      VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
-      unsigned int iseed = output[output.size() - 1] - '0';
-      assert(iseed < N_SEED_PROMPT);
-
-      int seedindex = -1;
-      for (unsigned int k = 0; k < vmstubsTEPHI_.size(); k++) {
-        if (vmstubsTEPHI_[k].seednumber == iseed) {
-          seedindex = k;
-        }
-      }
-      if (seedindex == -1) {
-        seedindex = vmstubsTEPHI_.size();
-        vector<VMStubsTEMemory*> vectmp;
-        VMStubsTEPHICM atmp(iseed, vectmp);
-        vmstubsTEPHI_.push_back(atmp);
-      }
-      tmp->resize(settings_.NLONGVMBINS() * settings_.nvmte(1, iseed));
-      vmstubsTEPHI_[seedindex].vmstubmem.push_back(tmp);
-
-    } else if (memory->getName().substr(3, 2) == "ME") {
-      VMStubsMEMemory* tmp = dynamic_cast<VMStubsMEMemory*>(memory);
+    if (output == "allinnerstubout") {
+      AllInnerStubsMemory* tmp = dynamic_cast<AllInnerStubsMemory*>(memory);
       assert(tmp != nullptr);
-      tmp->resize(nvmmebins_ * settings_.nvmme(layerdisk_));
-      assert(vmstubsMEPHI_[0] == nullptr);
-      vmstubsMEPHI_[0] = tmp;
-    } else {
-      throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " memory: " << memory->getName()
-                                         << " => should never get here!";
+      char memtype = memory->getName().back();
+      allinnerstubs_.emplace_back(memtype, tmp);
+      return;
     }
 
-    return;
-  }
-
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
-}
-
-void VMRouterCM::addInput(MemoryBase* memory, string input) {
-  if (settings_.writetrace()) {
-    edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
-                                 << input;
-  }
-  if (input == "stubin") {
-    InputLinkMemory* tmp1 = dynamic_cast<InputLinkMemory*>(memory);
-    assert(tmp1 != nullptr);
-    if (tmp1 != nullptr) {
-      stubinputs_.push_back(tmp1);
+    if (output.substr(0, 10) == "allstubout") {
+      AllStubsMemory* tmp = dynamic_cast<AllStubsMemory*>(memory);
+      allstubs_.push_back(tmp);
+      return;
     }
-    return;
-  }
-  throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
-}
 
-void VMRouterCM::execute(unsigned int) {
-  unsigned int allStubCounter = 0;
+    if (output.substr(0, 9) == "vmstubout") {
+      if (memory->getName().substr(3, 2) == "TE") {
+        VMStubsTEMemory* tmp = dynamic_cast<VMStubsTEMemory*>(memory);
+        unsigned int iseed = output[output.size() - 1] - '0';
+        assert(iseed < N_SEED_PROMPT);
 
-  //bool print = getName() == "VMR_D1PHIB" && iSector == 3;
-  //print = false;
-
-  //Loop over the input stubs
-  for (auto& stubinput : stubinputs_) {
-    for (unsigned int i = 0; i < stubinput->nStubs(); i++) {
-      if (allStubCounter > settings_.maxStep("VMR"))
-        continue;
-      if (allStubCounter >= (1 << N_BITSMEMADDRESS))
-        continue;
-
-      Stub* stub = stubinput->getStub(i);
-
-      //Note - below information is not part of the stub, but rather from which input memory
-      //we are reading
-      bool negdisk = (stub->disk().value() < 0);
-
-      //use &127 to make sure we fit into the number of bits -
-      //though we should have protected against overflows above
-      FPGAWord allStubIndex(allStubCounter & ((1 << N_BITSMEMADDRESS) - 1), N_BITSMEMADDRESS, true, __LINE__, __FILE__);
-
-      //TODO - should not be needed - but need to migrate some other pieces of code before removing
-      stub->setAllStubIndex(allStubCounter);
-      //TODO - should not be needed - but need to migrate some other pieces of code before removing
-      stub->l1tstub()->setAllStubIndex(allStubCounter);
-
-      allStubCounter++;
-
-      for (auto& allstub : allstubs_) {
-        allstub->addStub(stub);
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << getName() << " adding stub to " << allstub->getName();
-        }
-      }
-
-      FPGAWord iphi = stub->phicorr();
-      unsigned int iphipos = iphi.bits(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + N_PHIBITS), N_PHIBITS);
-
-      unsigned int phicutmax = 4;
-      unsigned int phicutmin = 4;
-
-      if (layerdisk_ != 0) {
-        phicutmax = 6;
-        phicutmin = 2;
-      }
-
-      //Fill inner allstubs memories - in HLS this is the same write to multiple memories
-      for (auto& allstub : allinnerstubs_) {
-        char memtype = allstub.first;
-        if (memtype == 'R' && iphipos < phicutmax)
-          continue;
-        if (memtype == 'L' && iphipos >= phicutmin)
-          continue;
-        if (memtype == 'A' && iphipos < 4)
-          continue;
-        if (memtype == 'B' && iphipos >= 4)
-          continue;
-        if (memtype == 'E' && iphipos >= 4)
-          continue;
-        if (memtype == 'F' && iphipos < 4)
-          continue;
-        if (memtype == 'C' && iphipos >= 4)
-          continue;
-        if (memtype == 'D' && iphipos < 4)
-          continue;
-
-        int absz = std::abs(stub->z().value());
-        if (layerdisk_ == LayerDisk::L2 && absz < VMROUTERCUTZL2 / settings_.kz(layerdisk_))
-          continue;
-        if ((layerdisk_ == LayerDisk::L3 || layerdisk_ == LayerDisk::L5) &&
-            absz > VMROUTERCUTZL1L3L5 / settings_.kz(layerdisk_))
-          continue;
-        if ((layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D3) &&
-            stub->r().value() > VMROUTERCUTRD1D3 / settings_.kr())
-          continue;
-        if ((layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D3) && stub->r().value() < 2 * int(N_DSS_MOD))
-          continue;
-        if (layerdisk_ == LayerDisk::L1) {
-          if (memtype == 'M' || memtype == 'R' || memtype == 'L') {
-            if (absz < VMROUTERCUTZL1 / settings_.kz(layerdisk_))
-              continue;
-          } else {
-            if (absz > VMROUTERCUTZL1L3L5 / settings_.kz(layerdisk_))
-              continue;
+        int seedindex = -1;
+        for (unsigned int k = 0; k < vmstubsTEPHI_.size(); k++) {
+          if (vmstubsTEPHI_[k].seednumber == iseed) {
+            seedindex = k;
           }
         }
-
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << getName() << " adding stub to " << allstub.second->getName();
+        if (seedindex == -1) {
+          seedindex = vmstubsTEPHI_.size();
+          vector<VMStubsTEMemory*> vectmp;
+          VMStubsTEPHICM atmp(iseed, vectmp);
+          vmstubsTEPHI_.push_back(atmp);
         }
+        tmp->resize(settings_.NLONGVMBINS() * settings_.nvmte(1, iseed));
+        vmstubsTEPHI_[seedindex].vmstubmem.push_back(tmp);
 
-        allstub.second->addStub(stub);
-      }
-
-      //Fill all the ME VM memories
-      unsigned int ivm =
-          iphi.bits(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_)),
-                    settings_.nbitsvmme(layerdisk_));
-
-      //Calculate the z and r position for the vmstub
-
-      //Take the top nbitszfinebintable_ bits of the z coordinate
-      int indexz = (stub->z().value() >> (stub->z().nbits() - nbitszfinebintable_)) & ((1 << nbitszfinebintable_) - 1);
-      int indexr = -1;
-      if (layerdisk_ > (N_LAYER - 1)) {
-        if (negdisk) {
-          indexz = ((1 << nbitszfinebintable_) - 1) - indexz;
-        }
-        indexr = stub->r().value();
-        if (stub->isPSmodule()) {
-          indexr = stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_);
-        }
+      } else if (memory->getName().substr(3, 2) == "ME") {
+        VMStubsMEMemory* tmp = dynamic_cast<VMStubsMEMemory*>(memory);
+        assert(tmp != nullptr);
+        tmp->resize(nvmmebins_ * settings_.nvmme(layerdisk_));
+        assert(vmstubsMEPHI_[0] == nullptr);
+        vmstubsMEPHI_[0] = tmp;
       } else {
-        //Take the top nbitsfinebintable_ bits of the z coordinate. The & is to handle the negative z values.
-        indexr = (stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_)) & ((1 << nbitsrfinebintable_) - 1);
+        throw cms::Exception("LogicError")
+            << __FILE__ << " " << __LINE__ << " memory: " << memory->getName() << " => should never get here!";
       }
 
-      assert(indexz >= 0);
-      assert(indexr >= 0);
-      assert(indexz < (1 << nbitszfinebintable_));
-      assert(indexr < (1 << nbitsrfinebintable_));
+      return;
+    }
 
-      int melut = meTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find output : " << output;
+  }
 
-      assert(melut >= 0);
+  void VMRouterCM::addInput(MemoryBase* memory, string input) {
+    if (settings_.writetrace()) {
+      edm::LogVerbatim("Tracklet") << "In " << name_ << " adding input from " << memory->getName() << " to input "
+                                   << input;
+    }
+    if (input == "stubin") {
+      InputLinkMemory* tmp1 = dynamic_cast<InputLinkMemory*>(memory);
+      assert(tmp1 != nullptr);
+      if (tmp1 != nullptr) {
+        stubinputs_.push_back(tmp1);
+      }
+      return;
+    }
+    throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " Could not find input : " << input;
+  }
 
-      int vmbin = melut >> NFINERZBITS;
-      if (negdisk)
-        vmbin += (1 << NFINERZBITS);
-      int rzfine = melut & ((1 << NFINERZBITS) - 1);
+  void VMRouterCM::execute(unsigned int) {
+    unsigned int allStubCounter = 0;
 
-      // pad disk PS bend word with a '0' in MSB so that all disk bends have 4 bits (for HLS compatibility)
-      int nbendbits = stub->bend().nbits();
-      if (layerdisk_ >= N_LAYER)
-        nbendbits = settings_.nbendbitsmedisk();
+    //bool print = getName() == "VMR_D1PHIB" && iSector == 3;
+    //print = false;
 
-      VMStubME vmstub(
-          stub,
-          stub->iphivmFineBins(settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_), NFINERZBITS),
-          FPGAWord(rzfine, NFINERZBITS, true, __LINE__, __FILE__),
-          FPGAWord(stub->bend().value(), nbendbits, true, __LINE__, __FILE__),
-          allStubIndex);
+    //Loop over the input stubs
+    for (auto& stubinput : stubinputs_) {
+      for (unsigned int i = 0; i < stubinput->nStubs(); i++) {
+        if (allStubCounter > settings_.maxStep("VMR"))
+          continue;
+        if (allStubCounter >= (1 << N_BITSMEMADDRESS))
+          continue;
 
-      assert(vmstubsMEPHI_[0] != nullptr);
+        Stub* stub = stubinput->getStub(i);
 
-      vmstubsMEPHI_[0]->addStub(vmstub, ivm * nvmmebins_ + vmbin);
+        //Note - below information is not part of the stub, but rather from which input memory
+        //we are reading
+        bool negdisk = (stub->disk().value() < 0);
 
-      //Fill the TE VM memories
-      if (layerdisk_ >= N_LAYER && (!stub->isPSmodule()))
-        continue;
+        //use &127 to make sure we fit into the number of bits -
+        //though we should have protected against overflows above
+        FPGAWord allStubIndex(
+            allStubCounter & ((1 << N_BITSMEMADDRESS) - 1), N_BITSMEMADDRESS, true, __LINE__, __FILE__);
 
-      for (auto& ivmstubTEPHI : vmstubsTEPHI_) {
-        unsigned int iseed = ivmstubTEPHI.seednumber;
-        unsigned int lutwidth = settings_.lutwidthtab(1, iseed);
+        //TODO - should not be needed - but need to migrate some other pieces of code before removing
+        stub->setAllStubIndex(allStubCounter);
+        //TODO - should not be needed - but need to migrate some other pieces of code before removing
+        stub->l1tstub()->setAllStubIndex(allStubCounter);
 
-        int lutval = -999;
+        allStubCounter++;
 
-        if (layerdisk_ < N_LAYER) {
-          lutval = melut;
-        } else {
-          lutval = diskTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-          if (lutval == 0) {
-            continue;
+        for (auto& allstub : allstubs_) {
+          allstub->addStub(stub);
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << getName() << " adding stub to " << allstub->getName();
           }
         }
 
-        assert(lutval >= 0);
+        FPGAWord iphi = stub->phicorr();
+        unsigned int iphipos = iphi.bits(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + N_PHIBITS), N_PHIBITS);
 
-        FPGAWord binlookup(lutval, lutwidth, true, __LINE__, __FILE__);
+        unsigned int phicutmax = 4;
+        unsigned int phicutmin = 4;
 
-        if (binlookup.value() < 0)
+        if (layerdisk_ != 0) {
+          phicutmax = 6;
+          phicutmin = 2;
+        }
+
+        //Fill inner allstubs memories - in HLS this is the same write to multiple memories
+        for (auto& allstub : allinnerstubs_) {
+          char memtype = allstub.first;
+          if (memtype == 'R' && iphipos < phicutmax)
+            continue;
+          if (memtype == 'L' && iphipos >= phicutmin)
+            continue;
+          if (memtype == 'A' && iphipos < 4)
+            continue;
+          if (memtype == 'B' && iphipos >= 4)
+            continue;
+          if (memtype == 'E' && iphipos >= 4)
+            continue;
+          if (memtype == 'F' && iphipos < 4)
+            continue;
+          if (memtype == 'C' && iphipos >= 4)
+            continue;
+          if (memtype == 'D' && iphipos < 4)
+            continue;
+
+          int absz = std::abs(stub->z().value());
+          if (layerdisk_ == LayerDisk::L2 && absz < VMROUTERCUTZL2 / settings_.kz(layerdisk_))
+            continue;
+          if ((layerdisk_ == LayerDisk::L3 || layerdisk_ == LayerDisk::L5) &&
+              absz > VMROUTERCUTZL1L3L5 / settings_.kz(layerdisk_))
+            continue;
+          if ((layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D3) &&
+              stub->r().value() > VMROUTERCUTRD1D3 / settings_.kr())
+            continue;
+          if ((layerdisk_ == LayerDisk::D1 || layerdisk_ == LayerDisk::D3) && stub->r().value() < 2 * int(N_DSS_MOD))
+            continue;
+          if (layerdisk_ == LayerDisk::L1) {
+            if (memtype == 'M' || memtype == 'R' || memtype == 'L') {
+              if (absz < VMROUTERCUTZL1 / settings_.kz(layerdisk_))
+                continue;
+            } else {
+              if (absz > VMROUTERCUTZL1L3L5 / settings_.kz(layerdisk_))
+                continue;
+            }
+          }
+
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << getName() << " adding stub to " << allstub.second->getName();
+          }
+
+          allstub.second->addStub(stub);
+        }
+
+        //Fill all the ME VM memories
+        unsigned int ivm =
+            iphi.bits(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_)),
+                      settings_.nbitsvmme(layerdisk_));
+
+        //Calculate the z and r position for the vmstub
+
+        //Take the top nbitszfinebintable_ bits of the z coordinate
+        int indexz =
+            (stub->z().value() >> (stub->z().nbits() - nbitszfinebintable_)) & ((1 << nbitszfinebintable_) - 1);
+        int indexr = -1;
+        if (layerdisk_ > (N_LAYER - 1)) {
+          if (negdisk) {
+            indexz = ((1 << nbitszfinebintable_) - 1) - indexz;
+          }
+          indexr = stub->r().value();
+          if (stub->isPSmodule()) {
+            indexr = stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_);
+          }
+        } else {
+          //Take the top nbitsfinebintable_ bits of the z coordinate. The & is to handle the negative z values.
+          indexr = (stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_)) & ((1 << nbitsrfinebintable_) - 1);
+        }
+
+        assert(indexz >= 0);
+        assert(indexr >= 0);
+        assert(indexz < (1 << nbitszfinebintable_));
+        assert(indexr < (1 << nbitsrfinebintable_));
+
+        int melut = meTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+
+        assert(melut >= 0);
+
+        int vmbin = melut >> NFINERZBITS;
+        if (negdisk)
+          vmbin += (1 << NFINERZBITS);
+        int rzfine = melut & ((1 << NFINERZBITS) - 1);
+
+        // pad disk PS bend word with a '0' in MSB so that all disk bends have 4 bits (for HLS compatibility)
+        int nbendbits = stub->bend().nbits();
+        if (layerdisk_ >= N_LAYER)
+          nbendbits = settings_.nbendbitsmedisk();
+
+        VMStubME vmstub(
+            stub,
+            stub->iphivmFineBins(settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_), NFINERZBITS),
+            FPGAWord(rzfine, NFINERZBITS, true, __LINE__, __FILE__),
+            FPGAWord(stub->bend().value(), nbendbits, true, __LINE__, __FILE__),
+            allStubIndex);
+
+        assert(vmstubsMEPHI_[0] != nullptr);
+
+        vmstubsMEPHI_[0]->addStub(vmstub, ivm * nvmmebins_ + vmbin);
+
+        //Fill the TE VM memories
+        if (layerdisk_ >= N_LAYER && (!stub->isPSmodule()))
           continue;
 
-        unsigned int ivmte =
-            iphi.bits(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmte(1, iseed)),
-                      settings_.nbitsvmte(1, iseed));
+        for (auto& ivmstubTEPHI : vmstubsTEPHI_) {
+          unsigned int iseed = ivmstubTEPHI.seednumber;
+          unsigned int lutwidth = settings_.lutwidthtab(1, iseed);
 
-        int bin = binlookup.value() / 8;
-        unsigned int tmp = binlookup.value() & 7;  //three bits in outer layers - this could be coded cleaner...
-        binlookup.set(tmp, 3, true, __LINE__, __FILE__);
+          int lutval = -999;
 
-        FPGAWord finephi = stub->iphivmFineBins(settings_.nphireg(1, iseed), settings_.nfinephi(1, iseed));
-
-        VMStubTE tmpstub(stub, finephi, stub->bend(), binlookup, allStubIndex);
-
-        unsigned int nmem = ivmstubTEPHI.vmstubmem.size();
-        assert(nmem > 0);
-
-        for (unsigned int l = 0; l < nmem; l++) {
-          if (settings_.debugTracklet()) {
-            edm::LogVerbatim("Tracklet") << getName() << " try adding stub to " << ivmstubTEPHI.vmstubmem[l]->getName()
-                                         << " bin=" << bin << " ivmte " << ivmte << " finephi " << finephi.value()
-                                         << " regions bits " << settings_.nphireg(1, iseed) << " finephibits "
-                                         << settings_.nfinephi(1, iseed);
+          if (layerdisk_ < N_LAYER) {
+            lutval = melut;
+          } else {
+            lutval = diskTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+            if (lutval == 0) {
+              continue;
+            }
           }
-          ivmstubTEPHI.vmstubmem[l]->addVMStub(tmpstub, ivmte * settings_.NLONGVMBINS() + bin);
+
+          assert(lutval >= 0);
+
+          FPGAWord binlookup(lutval, lutwidth, true, __LINE__, __FILE__);
+
+          if (binlookup.value() < 0)
+            continue;
+
+          unsigned int ivmte =
+              iphi.bits(iphi.nbits() - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmte(1, iseed)),
+                        settings_.nbitsvmte(1, iseed));
+
+          int bin = binlookup.value() / 8;
+          unsigned int tmp = binlookup.value() & 7;  //three bits in outer layers - this could be coded cleaner...
+          binlookup.set(tmp, 3, true, __LINE__, __FILE__);
+
+          FPGAWord finephi = stub->iphivmFineBins(settings_.nphireg(1, iseed), settings_.nfinephi(1, iseed));
+
+          VMStubTE tmpstub(stub, finephi, stub->bend(), binlookup, allStubIndex);
+
+          unsigned int nmem = ivmstubTEPHI.vmstubmem.size();
+          assert(nmem > 0);
+
+          for (unsigned int l = 0; l < nmem; l++) {
+            if (settings_.debugTracklet()) {
+              edm::LogVerbatim("Tracklet")
+                  << getName() << " try adding stub to " << ivmstubTEPHI.vmstubmem[l]->getName() << " bin=" << bin
+                  << " ivmte " << ivmte << " finephi " << finephi.value() << " regions bits "
+                  << settings_.nphireg(1, iseed) << " finephibits " << settings_.nfinephi(1, iseed);
+            }
+            ivmstubTEPHI.vmstubmem[l]->addVMStub(tmpstub, ivmte * settings_.NLONGVMBINS() + bin);
+          }
         }
       }
     }
   }
-}
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/VMStubME.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubME.cc
@@ -4,24 +4,24 @@ using namespace std;
 
 namespace trklet {
 
-VMStubME::VMStubME(const Stub* stub, FPGAWord finephi, FPGAWord finerz, FPGAWord bend, FPGAWord allstubindex) {
-  stub_ = stub;
-  finephi_ = finephi;
-  finerz_ = finerz;
-  bend_ = bend;
-  allStubIndex_ = allstubindex;
-}
+  VMStubME::VMStubME(const Stub* stub, FPGAWord finephi, FPGAWord finerz, FPGAWord bend, FPGAWord allstubindex) {
+    stub_ = stub;
+    finephi_ = finephi;
+    finerz_ = finerz;
+    bend_ = bend;
+    allStubIndex_ = allstubindex;
+  }
 
-std::string VMStubME::str() const {
-  string stub = allStubIndex_.str();
-  stub += "|";
-  stub += bend_.str();
-  stub += "|";
-  stub += finephi_.str();
-  stub += "|";
-  stub += finerz_.str();
+  std::string VMStubME::str() const {
+    string stub = allStubIndex_.str();
+    stub += "|";
+    stub += bend_.str();
+    stub += "|";
+    stub += finephi_.str();
+    stub += "|";
+    stub += finerz_.str();
 
-  return stub;
-}
+    return stub;
+  }
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/VMStubME.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubME.cc
@@ -1,7 +1,8 @@
 #include "L1Trigger/TrackFindingTracklet/interface/VMStubME.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 VMStubME::VMStubME(const Stub* stub, FPGAWord finephi, FPGAWord finerz, FPGAWord bend, FPGAWord allstubindex) {
   stub_ = stub;
@@ -21,4 +22,6 @@ std::string VMStubME::str() const {
   stub += finerz_.str();
 
   return stub;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/VMStubTE.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubTE.cc
@@ -4,24 +4,24 @@ using namespace std;
 
 namespace trklet {
 
-VMStubTE::VMStubTE(const Stub* stub, FPGAWord finephi, FPGAWord bend, FPGAWord vmbits, FPGAWord allstubindex) {
-  stub_ = stub;
-  finephi_ = finephi;
-  bend_ = bend;
-  vmbits_ = vmbits;
-  allStubIndex_ = allstubindex;
-}
+  VMStubTE::VMStubTE(const Stub* stub, FPGAWord finephi, FPGAWord bend, FPGAWord vmbits, FPGAWord allstubindex) {
+    stub_ = stub;
+    finephi_ = finephi;
+    bend_ = bend;
+    vmbits_ = vmbits;
+    allStubIndex_ = allstubindex;
+  }
 
-std::string VMStubTE::str() const {
-  string stub = allStubIndex_.str();
-  stub += "|";
-  stub += bend_.str();
-  stub += "|";
-  stub += finephi_.str();
-  stub += "|";
-  stub += vmbits_.str();
+  std::string VMStubTE::str() const {
+    string stub = allStubIndex_.str();
+    stub += "|";
+    stub += bend_.str();
+    stub += "|";
+    stub += finephi_.str();
+    stub += "|";
+    stub += vmbits_.str();
 
-  return stub;
-}
+    return stub;
+  }
 
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/VMStubTE.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubTE.cc
@@ -1,7 +1,8 @@
 #include "L1Trigger/TrackFindingTracklet/interface/VMStubTE.h"
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 VMStubTE::VMStubTE(const Stub* stub, FPGAWord finephi, FPGAWord bend, FPGAWord vmbits, FPGAWord allstubindex) {
   stub_ = stub;
@@ -21,4 +22,6 @@ std::string VMStubTE::str() const {
   stub += vmbits_.str();
 
   return stub;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/VMStubsMEMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubsMEMemory.cc
@@ -7,52 +7,52 @@ using namespace std;
 
 namespace trklet {
 
-VMStubsMEMemory::VMStubsMEMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
-  unsigned int layerdisk = initLayerDisk(6);
-  if (layerdisk < N_LAYER) {
-    binnedstubs_.resize(settings_.NLONGVMBINS());
-  } else {
-    //For disks we have NLONGVMBITS on each disk
-    binnedstubs_.resize(2 * settings_.NLONGVMBINS());
-  }
-}
-
-void VMStubsMEMemory::writeStubs(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirVM = settings_.memPath() + "VMStubsME/";
-
-  std::ostringstream oss;
-  oss << dirVM << "VMStubs_" << getName();
-  //get rid of duplicates
-  auto const& tmp = oss.str();
-  int len = tmp.size();
-  if (tmp[len - 2] == 'n' && tmp[len - 1] > '1' && tmp[len - 1] <= '9')
-    return;
-  oss << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirVM, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
-
-  for (unsigned int i = 0; i < binnedstubs_.size(); i++) {
-    for (unsigned int j = 0; j < binnedstubs_[i].size(); j++) {
-      string stub = binnedstubs_[i][j].stubindex().str();
-      stub += "|" + binnedstubs_[i][j].bend().str();
-
-      FPGAWord finephipos = binnedstubs_[i][j].finephi();
-      stub += "|" + finephipos.str();
-      FPGAWord finepos = binnedstubs_[i][j].finerz();
-      stub += "|" + finepos.str();
-      out_ << hexstr(i) << " " << hexstr(j) << " " << stub << " " << trklet::hexFormat(stub) << endl;
+  VMStubsMEMemory::VMStubsMEMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
+    unsigned int layerdisk = initLayerDisk(6);
+    if (layerdisk < N_LAYER) {
+      binnedstubs_.resize(settings_.NLONGVMBINS());
+    } else {
+      //For disks we have NLONGVMBITS on each disk
+      binnedstubs_.resize(2 * settings_.NLONGVMBINS());
     }
   }
-  out_.close();
 
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
-}
+  void VMStubsMEMemory::writeStubs(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirVM = settings_.memPath() + "VMStubsME/";
 
-}
+    std::ostringstream oss;
+    oss << dirVM << "VMStubs_" << getName();
+    //get rid of duplicates
+    auto const& tmp = oss.str();
+    int len = tmp.size();
+    if (tmp[len - 2] == 'n' && tmp[len - 1] > '1' && tmp[len - 1] <= '9')
+      return;
+    oss << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
+    auto const& fname = oss.str();
+
+    openfile(out_, first, dirVM, fname, __FILE__, __LINE__);
+
+    out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+
+    for (unsigned int i = 0; i < binnedstubs_.size(); i++) {
+      for (unsigned int j = 0; j < binnedstubs_[i].size(); j++) {
+        string stub = binnedstubs_[i][j].stubindex().str();
+        stub += "|" + binnedstubs_[i][j].bend().str();
+
+        FPGAWord finephipos = binnedstubs_[i][j].finephi();
+        stub += "|" + finephipos.str();
+        FPGAWord finepos = binnedstubs_[i][j].finerz();
+        stub += "|" + finepos.str();
+        out_ << hexstr(i) << " " << hexstr(j) << " " << stub << " " << trklet::hexFormat(stub) << endl;
+      }
+    }
+    out_.close();
+
+    bx_++;
+    event_++;
+    if (bx_ > 7)
+      bx_ = 0;
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/VMStubsMEMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubsMEMemory.cc
@@ -4,7 +4,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 VMStubsMEMemory::VMStubsMEMemory(string name, Settings const& settings) : MemoryBase(name, settings) {
   unsigned int layerdisk = initLayerDisk(6);
@@ -52,4 +53,6 @@ void VMStubsMEMemory::writeStubs(bool first, unsigned int iSector) {
   event_++;
   if (bx_ > 7)
     bx_ = 0;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc
@@ -8,169 +8,106 @@ using namespace std;
 
 namespace trklet {
 
-VMStubsTEMemory::VMStubsTEMemory(string name, Settings const& settings)
-    : MemoryBase(name, settings), bendtable_(settings) {
-  //set the layer or disk that the memory is in
-  initLayerDisk(6, layer_, disk_);
+  VMStubsTEMemory::VMStubsTEMemory(string name, Settings const& settings)
+      : MemoryBase(name, settings), bendtable_(settings) {
+    //set the layer or disk that the memory is in
+    initLayerDisk(6, layer_, disk_);
 
-  layerdisk_ = initLayerDisk(6);
+    layerdisk_ = initLayerDisk(6);
 
-  //Pointer to other VMStub memory for creating stub pairs
-  other_ = nullptr;
+    //Pointer to other VMStub memory for creating stub pairs
+    other_ = nullptr;
 
-  //What type of seeding is this memory used for
-  initSpecialSeeding(11, overlap_, extra_, extended_);
+    //What type of seeding is this memory used for
+    initSpecialSeeding(11, overlap_, extra_, extended_);
 
-  string subname = name.substr(12, 2);
-  phibin_ = subname[0] - '0';
-  if (subname[1] != 'n') {
-    phibin_ = 10 * phibin_ + (subname[1] - '0');
-  }
-
-  isinner_ = (layer_ % 2 == 1 or disk_ % 2 == 1);
-  // special cases with overlap seeding
-  if (overlap_ and layer_ == 2)
-    isinner_ = true;
-  if (overlap_ and layer_ == 3)
-    isinner_ = false;
-  if (overlap_ and disk_ == 1)
-    isinner_ = false;
-
-  if (extra_ and layer_ == 2)
-    isinner_ = true;
-  if (extra_ and layer_ == 3)
-    isinner_ = false;
-  // more special cases for triplets
-  if (!overlap_ and extended_ and layer_ == 2)
-    isinner_ = true;
-  if (!overlap_ and extended_ and layer_ == 3)
-    isinner_ = false;
-  if (overlap_ and extended_ and layer_ == 2)
-    isinner_ = false;
-  if (overlap_ and extended_ and disk_ == 1)
-    isinner_ = false;
-
-  stubsbinnedvm_.resize(settings_.NLONGVMBINS());
-}
-
-bool VMStubsTEMemory::addVMStub(VMStubTE vmstub, int bin) {
-  //If the pt of the stub is consistent with the allowed pt of tracklets
-  //in that can be formed in this VM and the other VM used in the TE.
-
-  if (settings_.combined()) {
-    if (disk_ > 0) {
-      assert(vmstub.stub()->isPSmodule());
+    string subname = name.substr(12, 2);
+    phibin_ = subname[0] - '0';
+    if (subname[1] != 'n') {
+      phibin_ = 10 * phibin_ + (subname[1] - '0');
     }
-    bool negdisk = vmstub.stub()->disk().value() < 0.0;
-    if (negdisk)
-      bin += 4;
-    assert(bin < (int)stubsbinnedvm_.size());
-    if (stubsbinnedvm_[bin].size() < N_VMSTUBSMAX) {
-      stubsbinnedvm_[bin].push_back(vmstub);
-      stubsvm_.push_back(vmstub);
-    }
-    return true;
+
+    isinner_ = (layer_ % 2 == 1 or disk_ % 2 == 1);
+    // special cases with overlap seeding
+    if (overlap_ and layer_ == 2)
+      isinner_ = true;
+    if (overlap_ and layer_ == 3)
+      isinner_ = false;
+    if (overlap_ and disk_ == 1)
+      isinner_ = false;
+
+    if (extra_ and layer_ == 2)
+      isinner_ = true;
+    if (extra_ and layer_ == 3)
+      isinner_ = false;
+    // more special cases for triplets
+    if (!overlap_ and extended_ and layer_ == 2)
+      isinner_ = true;
+    if (!overlap_ and extended_ and layer_ == 3)
+      isinner_ = false;
+    if (overlap_ and extended_ and layer_ == 2)
+      isinner_ = false;
+    if (overlap_ and extended_ and disk_ == 1)
+      isinner_ = false;
+
+    stubsbinnedvm_.resize(settings_.NLONGVMBINS());
   }
 
-  bool pass = false;
-  if (settings_.extended() && bendtable_.size() == 0) {
-    pass = true;
-  } else {
-    pass = bendtable_.lookup(vmstub.bend().value());
-  }
+  bool VMStubsTEMemory::addVMStub(VMStubTE vmstub, int bin) {
+    //If the pt of the stub is consistent with the allowed pt of tracklets
+    //in that can be formed in this VM and the other VM used in the TE.
 
-  if (!pass) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << getName() << " Stub failed bend cut. bend = "
-                                   << settings_.benddecode(vmstub.bend().value(), layerdisk_, vmstub.isPSmodule());
-    return false;
-  }
-
-  bool negdisk = vmstub.stub()->disk().value() < 0.0;
-
-  if (overlap_) {
-    if (disk_ == 1) {
-      assert(bin < 4);
+    if (settings_.combined()) {
+      if (disk_ > 0) {
+        assert(vmstub.stub()->isPSmodule());
+      }
+      bool negdisk = vmstub.stub()->disk().value() < 0.0;
       if (negdisk)
         bin += 4;
-      if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
-        return false;
-      stubsbinnedvm_[bin].push_back(vmstub);
-      if (settings_.debugTracklet())
-        edm::LogVerbatim("Tracklet") << getName() << " Stub in disk = " << disk_ << "  in bin = " << bin;
-    } else if (layer_ == 2) {
-      if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
-        return false;
-      stubsbinnedvm_[bin].push_back(vmstub);
-    }
-  } else {
-    if (vmstub.stub()->layerdisk() < N_LAYER) {
-      if (!isinner_) {
-        if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
-          return false;
+      assert(bin < (int)stubsbinnedvm_.size());
+      if (stubsbinnedvm_[bin].size() < N_VMSTUBSMAX) {
         stubsbinnedvm_[bin].push_back(vmstub);
+        stubsvm_.push_back(vmstub);
       }
+      return true;
+    }
 
+    bool pass = false;
+    if (settings_.extended() && bendtable_.size() == 0) {
+      pass = true;
     } else {
-      if (disk_ % 2 == 0) {
-        assert(bin < 4);
-        if (negdisk)
-          bin += 4;
-        if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
-          return false;
-        stubsbinnedvm_[bin].push_back(vmstub);
-      }
+      pass = bendtable_.lookup(vmstub.bend().value());
     }
-  }
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "Adding stubs to " << getName();
-  if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
-    return false;
-  stubsvm_.push_back(vmstub);
-  return true;
-}
 
-// TODO - should migrate away from using this method for any binned memory
-bool VMStubsTEMemory::addVMStub(VMStubTE vmstub) {
-  FPGAWord binlookup = vmstub.vmbits();
+    if (!pass) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << getName() << " Stub failed bend cut. bend = "
+                                     << settings_.benddecode(vmstub.bend().value(), layerdisk_, vmstub.isPSmodule());
+      return false;
+    }
 
-  assert(binlookup.value() >= 0);
-  int bin = (binlookup.value() / 8);
+    bool negdisk = vmstub.stub()->disk().value() < 0.0;
 
-  //If the pt of the stub is consistent with the allowed pt of tracklets
-  //in that can be formed in this VM and the other VM used in the TE.
-
-  bool pass = false;
-  if (settings_.extended() && bendtable_.size() == 0) {
-    pass = true;
-  } else {
-    pass = bendtable_.lookup(vmstub.bend().value());
-  }
-
-  if (!pass) {
-    if (settings_.debugTracklet())
-      edm::LogVerbatim("Tracklet") << getName() << " Stub failed bend cut. bend = "
-                                   << settings_.benddecode(vmstub.bend().value(), layerdisk_, vmstub.isPSmodule());
-    return false;
-  }
-
-  bool negdisk = vmstub.stub()->disk().value() < 0.0;
-
-  if (!extended_) {
     if (overlap_) {
       if (disk_ == 1) {
         assert(bin < 4);
         if (negdisk)
           bin += 4;
+        if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
+          return false;
         stubsbinnedvm_[bin].push_back(vmstub);
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << getName() << " Stub with lookup = " << binlookup.value()
-                                       << " in disk = " << disk_ << "  in bin = " << bin;
-        }
+        if (settings_.debugTracklet())
+          edm::LogVerbatim("Tracklet") << getName() << " Stub in disk = " << disk_ << "  in bin = " << bin;
+      } else if (layer_ == 2) {
+        if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
+          return false;
+        stubsbinnedvm_[bin].push_back(vmstub);
       }
     } else {
       if (vmstub.stub()->layerdisk() < N_LAYER) {
         if (!isinner_) {
+          if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
+            return false;
           stubsbinnedvm_[bin].push_back(vmstub);
         }
 
@@ -179,99 +116,162 @@ bool VMStubsTEMemory::addVMStub(VMStubTE vmstub) {
           assert(bin < 4);
           if (negdisk)
             bin += 4;
+          if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
+            return false;
           stubsbinnedvm_[bin].push_back(vmstub);
         }
       }
     }
-  } else {  //extended
-    if (!isinner_) {
-      if (layer_ > 0) {
-        stubsbinnedvm_[bin].push_back(vmstub);
-      } else {
-        if (overlap_) {
-          assert(disk_ == 1);  // D1 from L2L3D1
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "Adding stubs to " << getName();
+    if (stubsbinnedvm_[bin].size() >= settings_.maxStubsPerBin())
+      return false;
+    stubsvm_.push_back(vmstub);
+    return true;
+  }
 
-          //bin 0 is PS, 1 through 3 is 2S
-          if (vmstub.stub()->isPSmodule()) {
-            bin = 0;
-          } else {
-            bin = vmstub.stub()->r().value();  // 0 to 9
-            bin = bin >> 2;                    // 0 to 2
-            bin += 1;
+  // TODO - should migrate away from using this method for any binned memory
+  bool VMStubsTEMemory::addVMStub(VMStubTE vmstub) {
+    FPGAWord binlookup = vmstub.vmbits();
+
+    assert(binlookup.value() >= 0);
+    int bin = (binlookup.value() / 8);
+
+    //If the pt of the stub is consistent with the allowed pt of tracklets
+    //in that can be formed in this VM and the other VM used in the TE.
+
+    bool pass = false;
+    if (settings_.extended() && bendtable_.size() == 0) {
+      pass = true;
+    } else {
+      pass = bendtable_.lookup(vmstub.bend().value());
+    }
+
+    if (!pass) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << getName() << " Stub failed bend cut. bend = "
+                                     << settings_.benddecode(vmstub.bend().value(), layerdisk_, vmstub.isPSmodule());
+      return false;
+    }
+
+    bool negdisk = vmstub.stub()->disk().value() < 0.0;
+
+    if (!extended_) {
+      if (overlap_) {
+        if (disk_ == 1) {
+          assert(bin < 4);
+          if (negdisk)
+            bin += 4;
+          stubsbinnedvm_[bin].push_back(vmstub);
+          if (settings_.debugTracklet()) {
+            edm::LogVerbatim("Tracklet") << getName() << " Stub with lookup = " << binlookup.value()
+                                         << " in disk = " << disk_ << "  in bin = " << bin;
           }
         }
-        assert(bin < 4);
-        if (negdisk)
-          bin += 4;
-        stubsbinnedvm_[bin].push_back(vmstub);
+      } else {
+        if (vmstub.stub()->layerdisk() < N_LAYER) {
+          if (!isinner_) {
+            stubsbinnedvm_[bin].push_back(vmstub);
+          }
+
+        } else {
+          if (disk_ % 2 == 0) {
+            assert(bin < 4);
+            if (negdisk)
+              bin += 4;
+            stubsbinnedvm_[bin].push_back(vmstub);
+          }
+        }
+      }
+    } else {  //extended
+      if (!isinner_) {
+        if (layer_ > 0) {
+          stubsbinnedvm_[bin].push_back(vmstub);
+        } else {
+          if (overlap_) {
+            assert(disk_ == 1);  // D1 from L2L3D1
+
+            //bin 0 is PS, 1 through 3 is 2S
+            if (vmstub.stub()->isPSmodule()) {
+              bin = 0;
+            } else {
+              bin = vmstub.stub()->r().value();  // 0 to 9
+              bin = bin >> 2;                    // 0 to 2
+              bin += 1;
+            }
+          }
+          assert(bin < 4);
+          if (negdisk)
+            bin += 4;
+          stubsbinnedvm_[bin].push_back(vmstub);
+        }
       }
     }
+
+    if (settings_.debugTracklet())
+      edm::LogVerbatim("Tracklet") << "Adding stubs to " << getName();
+    stubsvm_.push_back(vmstub);
+    return true;
   }
 
-  if (settings_.debugTracklet())
-    edm::LogVerbatim("Tracklet") << "Adding stubs to " << getName();
-  stubsvm_.push_back(vmstub);
-  return true;
-}
-
-void VMStubsTEMemory::clean() {
-  stubsvm_.clear();
-  for (auto& stubsbinnedvm : stubsbinnedvm_) {
-    stubsbinnedvm.clear();
-  }
-}
-
-void VMStubsTEMemory::writeStubs(bool first, unsigned int iSector) {
-  iSector_ = iSector;
-  const string dirVM = settings_.memPath() + "VMStubsTE/";
-  openFile(first, dirVM, "VMStubs_");
-
-  if (isinner_) {  // inner VM for TE purpose
-    for (unsigned int j = 0; j < stubsvm_.size(); j++) {
-      string stub = stubsvm_[j].str();
-      out_ << hexstr(j) << " " << stub << " " << trklet::hexFormat(stub) << endl;
+  void VMStubsTEMemory::clean() {
+    stubsvm_.clear();
+    for (auto& stubsbinnedvm : stubsbinnedvm_) {
+      stubsbinnedvm.clear();
     }
-  } else {  // outer VM for TE purpose
-    for (unsigned int i = 0; i < stubsbinnedvm_.size(); i++) {
-      for (unsigned int j = 0; j < stubsbinnedvm_[i].size(); j++) {
-        string stub = stubsbinnedvm_[i][j].str();
-        out_ << hexstr(i) << " " << hexstr(j) << " " << stub << " " << trklet::hexFormat(stub) << endl;
+  }
+
+  void VMStubsTEMemory::writeStubs(bool first, unsigned int iSector) {
+    iSector_ = iSector;
+    const string dirVM = settings_.memPath() + "VMStubsTE/";
+    openFile(first, dirVM, "VMStubs_");
+
+    if (isinner_) {  // inner VM for TE purpose
+      for (unsigned int j = 0; j < stubsvm_.size(); j++) {
+        string stub = stubsvm_[j].str();
+        out_ << hexstr(j) << " " << stub << " " << trklet::hexFormat(stub) << endl;
+      }
+    } else {  // outer VM for TE purpose
+      for (unsigned int i = 0; i < stubsbinnedvm_.size(); i++) {
+        for (unsigned int j = 0; j < stubsbinnedvm_[i].size(); j++) {
+          string stub = stubsbinnedvm_[i][j].str();
+          out_ << hexstr(i) << " " << hexstr(j) << " " << stub << " " << trklet::hexFormat(stub) << endl;
+        }
       }
     }
+
+    out_.close();
   }
 
-  out_.close();
-}
-
-void VMStubsTEMemory::getPhiRange(double& phimin, double& phimax, unsigned int iSeed, unsigned int inner) {
-  int nvm = -1;
-  if (overlap_) {
-    if (layer_ > 0) {
-      nvm = settings_.nallstubs(layer_ - 1) * settings_.nvmte(inner, iSeed);
-    }
-    if (disk_ > 0) {
-      nvm = settings_.nallstubs(disk_ + N_DISK) * settings_.nvmte(inner, iSeed);
-    }
-  } else {
-    if (layer_ > 0) {
-      nvm = settings_.nallstubs(layer_ - 1) * settings_.nvmte(inner, iSeed);
-      if (extra_) {
+  void VMStubsTEMemory::getPhiRange(double& phimin, double& phimax, unsigned int iSeed, unsigned int inner) {
+    int nvm = -1;
+    if (overlap_) {
+      if (layer_ > 0) {
         nvm = settings_.nallstubs(layer_ - 1) * settings_.nvmte(inner, iSeed);
       }
+      if (disk_ > 0) {
+        nvm = settings_.nallstubs(disk_ + N_DISK) * settings_.nvmte(inner, iSeed);
+      }
+    } else {
+      if (layer_ > 0) {
+        nvm = settings_.nallstubs(layer_ - 1) * settings_.nvmte(inner, iSeed);
+        if (extra_) {
+          nvm = settings_.nallstubs(layer_ - 1) * settings_.nvmte(inner, iSeed);
+        }
+      }
+      if (disk_ > 0) {
+        nvm = settings_.nallstubs(disk_ + N_DISK) * settings_.nvmte(inner, iSeed);
+      }
     }
-    if (disk_ > 0) {
-      nvm = settings_.nallstubs(disk_ + N_DISK) * settings_.nvmte(inner, iSeed);
-    }
+    assert(nvm > 0);
+    assert(nvm <= 32);
+    double dphi = settings_.dphisectorHG() / nvm;
+    phimax = phibin() * dphi;
+    phimin = phimax - dphi;
+
+    return;
   }
-  assert(nvm > 0);
-  assert(nvm <= 32);
-  double dphi = settings_.dphisectorHG() / nvm;
-  phimax = phibin() * dphi;
-  phimin = phimax - dphi;
 
-  return;
-}
+  void VMStubsTEMemory::setbendtable(const TrackletLUT& bendtable) { bendtable_ = bendtable; }
 
-void VMStubsTEMemory::setbendtable(const TrackletLUT& bendtable) { bendtable_ = bendtable; }
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc
@@ -5,7 +5,8 @@
 #include <filesystem>
 
 using namespace std;
-using namespace trklet;
+
+namespace trklet {
 
 VMStubsTEMemory::VMStubsTEMemory(string name, Settings const& settings)
     : MemoryBase(name, settings), bendtable_(settings) {
@@ -272,3 +273,5 @@ void VMStubsTEMemory::getPhiRange(double& phimin, double& phimax, unsigned int i
 }
 
 void VMStubsTEMemory::setbendtable(const TrackletLUT& bendtable) { bendtable_ = bendtable; }
+
+}

--- a/L1Trigger/TrackFindingTracklet/src/imath.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath.cc
@@ -13,339 +13,312 @@
 
 namespace trklet {
 
-std::string VarBase::itos(int i) { return std::to_string(i); }
+  std::string VarBase::itos(int i) { return std::to_string(i); }
 
-std::string VarBase::kstring() const {
-  char s[1024];
-  std::string t = "";
-  for (const auto &Kmap : Kmap_) {
-    sprintf(s, "^(%i)", Kmap.second);
-    std::string t0(s);
-    t = t + Kmap.first + t0;
+  std::string VarBase::kstring() const {
+    char s[1024];
+    std::string t = "";
+    for (const auto &Kmap : Kmap_) {
+      sprintf(s, "^(%i)", Kmap.second);
+      std::string t0(s);
+      t = t + Kmap.first + t0;
+    }
+    return t;
   }
-  return t;
-}
 
-void VarBase::analyze() {
-  if (!readytoanalyze_)
-    return;
+  void VarBase::analyze() {
+    if (!readytoanalyze_)
+      return;
 
-  double u = maxval_;
-  if (u < -minval_)
-    u = -minval_;
+    double u = maxval_;
+    if (u < -minval_)
+      u = -minval_;
 
-  int iu = log2(range() / u);
-  if (iu > 1) {
-    char slog[1024];
-    sprintf(slog,
-            "analyzing %s: range %g is much larger then %g. suggest cutting by a factor of 2^%i",
-            name_.c_str(),
-            range(),
-            u,
-            iu);
-    edm::LogVerbatim("Tracklet") << slog;
-  }
+    int iu = log2(range() / u);
+    if (iu > 1) {
+      char slog[1024];
+      sprintf(slog,
+              "analyzing %s: range %g is much larger then %g. suggest cutting by a factor of 2^%i",
+              name_.c_str(),
+              range(),
+              u,
+              iu);
+      edm::LogVerbatim("Tracklet") << slog;
+    }
 #ifdef IMATH_ROOT
-  char slog[100];
-  if (h_) {
-    double eff = h_->Integral() / h_->GetEntries();
-    if (eff < 0.99) {
-      sprintf(slog, "analyzing %s: range is too small, contains %f", name_.c_str(), eff);
-      edm::LogVerbatim("Tracklet") << slog;
-      h_->Print();
+    char slog[100];
+    if (h_) {
+      double eff = h_->Integral() / h_->GetEntries();
+      if (eff < 0.99) {
+        sprintf(slog, "analyzing %s: range is too small, contains %f", name_.c_str(), eff);
+        edm::LogVerbatim("Tracklet") << slog;
+        h_->Print();
+      }
+      globals_->h_file_->cd();
+      TCanvas *c = new TCanvas();
+      c->cd();
+      h_->Draw("colz");
+      h_->Write();
+    } else {
+      if (globals_->use_root) {
+        sprintf(slog, "analyzing %s: no histogram!\n", name_.c_str());
+        edm::LogVerbatim("Tracklet") << slog;
+      }
     }
-    globals_->h_file_->cd();
-    TCanvas *c = new TCanvas();
-    c->cd();
-    h_->Draw("colz");
-    h_->Write();
-  } else {
-    if (globals_->use_root) {
-      sprintf(slog, "analyzing %s: no histogram!\n", name_.c_str());
-      edm::LogVerbatim("Tracklet") << slog;
-    }
-  }
 #endif
 
-  if (p1_)
-    p1_->analyze();
-  if (p2_)
-    p2_->analyze();
-
-  readytoanalyze_ = false;
-}
-
-std::string VarBase::dump() {
-  char s[1024];
-  std::string u = kstring();
-  sprintf(
-      s,
-      "Name = %s \t Op = %s \t nbits = %i \n       ival = %li \t fval = %g \t K = %g Range = %f\n       units = %s\n",
-      name_.c_str(),
-      op_.c_str(),
-      nbits_,
-      ival_,
-      fval_,
-      K_,
-      range(),
-      u.c_str());
-  std::string t(s);
-  return t;
-}
-
-void VarBase::dump_msg() {
-  char s[2048];
-  std::string u = kstring();
-  sprintf(s,
-          "Name = %s \t Op = %s \t nbits = %i \n       ival = %li \t fval = %g \t K = %g Range = %f\n       units = "
-          "%s\n       step = %i, latency = %i\n",
-          name_.c_str(),
-          op_.c_str(),
-          nbits_,
-          ival_,
-          fval_,
-          K_,
-          range(),
-          u.c_str(),
-          step_,
-          latency_);
-  std::string t(s);
-  edm::LogVerbatim("Tracklet") << t;
-  if (p1_)
-    p1_->dump_msg();
-  if (p2_)
-    p2_->dump_msg();
-}
-
-void VarAdjustK::adjust(double Knew, double epsilon, bool do_assert, int nbits) {
-  //WARNING!!!
-  //THIS METHID CAN BE USED ONLY FOR THE FINAL ANSWER
-  //THE CHANGE IN CONSTANT CAN NOT BE PROPAGATED UP THE CALCULATION TREE
-
-  K_ = p1_->K();
-  Kmap_ = p1_->Kmap();
-  double r = Knew / K_;
-
-  lr_ = (r > 1) ? log2(r) + epsilon : log2(r);
-  K_ = K_ * pow(2, lr_);
-  if (do_assert)
-    assert(std::abs(Knew / K_ - 1) < epsilon);
-
-  if (nbits > 0)
-    nbits_ = nbits;
-  else
-    nbits_ = p1_->nbits() - lr_;
-
-  Kmap_["2"] = Kmap_["2"] + lr_;
-}
-
-void VarInv::initLUT(double offset) {
-  offset_ = offset;
-  double offsetI = lround(offset_ / p1_->K());
-  for (int i = 0; i < Nelements_; ++i) {
-    int i1 = addr_to_ival(i);
-    LUT[i] = gen_inv(offsetI + i1);
-  }
-}
-
-void VarBase::makeready() {
-  pipe_counter_ = 0;
-  pipe_delays_.clear();
-  readytoprint_ = true;
-  readytoanalyze_ = true;
-  usedasinput_ = false;
-  if (p1_)
-    p1_->makeready();
-  if (p2_)
-    p2_->makeready();
-  if (p3_)
-    p3_->makeready();
-}
-
-bool VarBase::has_delay(int i) {
-  //dumb sequential search
-  for (int pipe_delay : pipe_delays_)
-    if (pipe_delay == i)
-      return true;
-  return false;
-}
-
-std::string VarBase::pipe_delay(VarBase *v, int nbits, int delay) {
-  //have we been delayed by this much already?
-  if (v->has_delay(delay))
-    return "";
-  v->add_delay(delay);
-  std::string name = v->name();
-  std::string name_delayed = name + "_delay" + itos(delay);
-  std::string out = "wire signed [" + itos(nbits - 1) + ":0] " + name_delayed + ";\n";
-  out = out + pipe_delay_wire(v, name_delayed, nbits, delay);
-  return out;
-}
-std::string VarBase::pipe_delays(const int step) {
-  std::string out = "";
-  if (p1_)
-    out += p1_->pipe_delays(step);
-  if (p2_)
-    out += p2_->pipe_delays(step);
-  if (p3_)
-    out += p3_->pipe_delays(step);
-
-  int l = step - latency_ - step_;
-  return (out + pipe_delay(this, nbits(), l));
-}
-std::string VarBase::pipe_delay_wire(VarBase *v, std::string name_delayed, int nbits, int delay) {
-  std::string name = v->name();
-  std::string name_pipe = name + "_pipe" + itos(v->pipe_counter());
-  v->pipe_increment();
-  std::string out = "pipe_delay #(.STAGES(" + itos(delay) + "), .WIDTH(" + itos(nbits) + ")) " + name_pipe +
-                    "(.clk(clk), .val_in(" + name + "), .val_out(" + name_delayed + "));\n";
-  return out;
-}
-
-void VarBase::inputs(std::vector<VarBase *> *vd) {
-  if (op_ == "def" && !usedasinput_) {
-    usedasinput_ = true;
-    vd->push_back(this);
-  } else {
     if (p1_)
-      p1_->inputs(vd);
+      p1_->analyze();
     if (p2_)
-      p2_->inputs(vd);
-    if (p3_)
-      p3_->inputs(vd);
+      p2_->analyze();
+
+    readytoanalyze_ = false;
   }
-}
+
+  std::string VarBase::dump() {
+    char s[1024];
+    std::string u = kstring();
+    sprintf(
+        s,
+        "Name = %s \t Op = %s \t nbits = %i \n       ival = %li \t fval = %g \t K = %g Range = %f\n       units = %s\n",
+        name_.c_str(),
+        op_.c_str(),
+        nbits_,
+        ival_,
+        fval_,
+        K_,
+        range(),
+        u.c_str());
+    std::string t(s);
+    return t;
+  }
+
+  void VarBase::dump_msg() {
+    char s[2048];
+    std::string u = kstring();
+    sprintf(s,
+            "Name = %s \t Op = %s \t nbits = %i \n       ival = %li \t fval = %g \t K = %g Range = %f\n       units = "
+            "%s\n       step = %i, latency = %i\n",
+            name_.c_str(),
+            op_.c_str(),
+            nbits_,
+            ival_,
+            fval_,
+            K_,
+            range(),
+            u.c_str(),
+            step_,
+            latency_);
+    std::string t(s);
+    edm::LogVerbatim("Tracklet") << t;
+    if (p1_)
+      p1_->dump_msg();
+    if (p2_)
+      p2_->dump_msg();
+  }
+
+  void VarAdjustK::adjust(double Knew, double epsilon, bool do_assert, int nbits) {
+    //WARNING!!!
+    //THIS METHID CAN BE USED ONLY FOR THE FINAL ANSWER
+    //THE CHANGE IN CONSTANT CAN NOT BE PROPAGATED UP THE CALCULATION TREE
+
+    K_ = p1_->K();
+    Kmap_ = p1_->Kmap();
+    double r = Knew / K_;
+
+    lr_ = (r > 1) ? log2(r) + epsilon : log2(r);
+    K_ = K_ * pow(2, lr_);
+    if (do_assert)
+      assert(std::abs(Knew / K_ - 1) < epsilon);
+
+    if (nbits > 0)
+      nbits_ = nbits;
+    else
+      nbits_ = p1_->nbits() - lr_;
+
+    Kmap_["2"] = Kmap_["2"] + lr_;
+  }
+
+  void VarInv::initLUT(double offset) {
+    offset_ = offset;
+    double offsetI = lround(offset_ / p1_->K());
+    for (int i = 0; i < Nelements_; ++i) {
+      int i1 = addr_to_ival(i);
+      LUT[i] = gen_inv(offsetI + i1);
+    }
+  }
+
+  void VarBase::makeready() {
+    pipe_counter_ = 0;
+    pipe_delays_.clear();
+    readytoprint_ = true;
+    readytoanalyze_ = true;
+    usedasinput_ = false;
+    if (p1_)
+      p1_->makeready();
+    if (p2_)
+      p2_->makeready();
+    if (p3_)
+      p3_->makeready();
+  }
+
+  bool VarBase::has_delay(int i) {
+    //dumb sequential search
+    for (int pipe_delay : pipe_delays_)
+      if (pipe_delay == i)
+        return true;
+    return false;
+  }
+
+  std::string VarBase::pipe_delay(VarBase *v, int nbits, int delay) {
+    //have we been delayed by this much already?
+    if (v->has_delay(delay))
+      return "";
+    v->add_delay(delay);
+    std::string name = v->name();
+    std::string name_delayed = name + "_delay" + itos(delay);
+    std::string out = "wire signed [" + itos(nbits - 1) + ":0] " + name_delayed + ";\n";
+    out = out + pipe_delay_wire(v, name_delayed, nbits, delay);
+    return out;
+  }
+  std::string VarBase::pipe_delays(const int step) {
+    std::string out = "";
+    if (p1_)
+      out += p1_->pipe_delays(step);
+    if (p2_)
+      out += p2_->pipe_delays(step);
+    if (p3_)
+      out += p3_->pipe_delays(step);
+
+    int l = step - latency_ - step_;
+    return (out + pipe_delay(this, nbits(), l));
+  }
+  std::string VarBase::pipe_delay_wire(VarBase *v, std::string name_delayed, int nbits, int delay) {
+    std::string name = v->name();
+    std::string name_pipe = name + "_pipe" + itos(v->pipe_counter());
+    v->pipe_increment();
+    std::string out = "pipe_delay #(.STAGES(" + itos(delay) + "), .WIDTH(" + itos(nbits) + ")) " + name_pipe +
+                      "(.clk(clk), .val_in(" + name + "), .val_out(" + name_delayed + "));\n";
+    return out;
+  }
+
+  void VarBase::inputs(std::vector<VarBase *> *vd) {
+    if (op_ == "def" && !usedasinput_) {
+      usedasinput_ = true;
+      vd->push_back(this);
+    } else {
+      if (p1_)
+        p1_->inputs(vd);
+      if (p2_)
+        p2_->inputs(vd);
+      if (p3_)
+        p3_->inputs(vd);
+    }
+  }
 
 #ifdef IMATH_ROOT
-TTree *VarBase::addToTree(imathGlobals *globals, VarBase *v, char *s) {
-  if (globals->h_file_ == 0) {
-    globals->h_file_ = new TFile("imath.root", "RECREATE");
-    edm::LogVerbatim("Tracklet") << "recreating file imath.root";
-  }
-  globals->h_file_->cd();
-  TTree *tt = (TTree *)globals->h_file_->Get("tt");
-  if (tt == 0) {
-    tt = new TTree("tt", "");
-    edm::LogVerbatim("Tracklet") << "creating TTree tt";
-  }
-  std::string si = v->name() + "_i";
-  std::string sf = v->name() + "_f";
-  std::string sv = v->name();
-  if (s != 0) {
-    std::string prefix(s);
-    si = prefix + si;
-    sf = prefix + sf;
-    sv = prefix + sv;
-  }
-  if (!tt->GetBranchStatus(si.c_str())) {
-    tt->Branch(si.c_str(), (Long64_t *)&(v->ival_));
-    tt->Branch(sf.c_str(), &(v->fval_));
-    tt->Branch(sv.c_str(), &(v->val_));
-  }
+  TTree *VarBase::addToTree(imathGlobals *globals, VarBase *v, char *s) {
+    if (globals->h_file_ == 0) {
+      globals->h_file_ = new TFile("imath.root", "RECREATE");
+      edm::LogVerbatim("Tracklet") << "recreating file imath.root";
+    }
+    globals->h_file_->cd();
+    TTree *tt = (TTree *)globals->h_file_->Get("tt");
+    if (tt == 0) {
+      tt = new TTree("tt", "");
+      edm::LogVerbatim("Tracklet") << "creating TTree tt";
+    }
+    std::string si = v->name() + "_i";
+    std::string sf = v->name() + "_f";
+    std::string sv = v->name();
+    if (s != 0) {
+      std::string prefix(s);
+      si = prefix + si;
+      sf = prefix + sf;
+      sv = prefix + sv;
+    }
+    if (!tt->GetBranchStatus(si.c_str())) {
+      tt->Branch(si.c_str(), (Long64_t *)&(v->ival_));
+      tt->Branch(sf.c_str(), &(v->fval_));
+      tt->Branch(sv.c_str(), &(v->val_));
+    }
 
-  if (v->p1_)
-    addToTree(globals, v->p1_, s);
-  if (v->p2_)
-    addToTree(globals, v->p2_, s);
-  if (v->p3_)
-    addToTree(globals, v->p3_, s);
+    if (v->p1_)
+      addToTree(globals, v->p1_, s);
+    if (v->p2_)
+      addToTree(globals, v->p2_, s);
+    if (v->p3_)
+      addToTree(globals, v->p3_, s);
 
-  return tt;
-}
-TTree *VarBase::addToTree(imathGlobals *globals, double *v, char *s) {
-  if (globals->h_file_ == 0) {
-    globals->h_file_ = new TFile("imath.root", "RECREATE");
-    edm::LogVerbatim("Tracklet") << "recreating file imath.root";
+    return tt;
   }
-  globals->h_file_->cd();
-  TTree *tt = (TTree *)globals->h_file_->Get("tt");
-  if (tt == 0) {
-    tt = new TTree("tt", "");
-    edm::LogVerbatim("Tracklet") << "creating TTree tt";
+  TTree *VarBase::addToTree(imathGlobals *globals, double *v, char *s) {
+    if (globals->h_file_ == 0) {
+      globals->h_file_ = new TFile("imath.root", "RECREATE");
+      edm::LogVerbatim("Tracklet") << "recreating file imath.root";
+    }
+    globals->h_file_->cd();
+    TTree *tt = (TTree *)globals->h_file_->Get("tt");
+    if (tt == 0) {
+      tt = new TTree("tt", "");
+      edm::LogVerbatim("Tracklet") << "creating TTree tt";
+    }
+    tt->Branch(s, v);
+    return tt;
   }
-  tt->Branch(s, v);
-  return tt;
-}
-TTree *VarBase::addToTree(imathGlobals *globals, int *v, char *s) {
-  if (globals->h_file_ == 0) {
-    globals->h_file_ = new TFile("imath.root", "RECREATE");
-    edm::LogVerbatim("Tracklet") << "recreating file imath.root";
+  TTree *VarBase::addToTree(imathGlobals *globals, int *v, char *s) {
+    if (globals->h_file_ == 0) {
+      globals->h_file_ = new TFile("imath.root", "RECREATE");
+      edm::LogVerbatim("Tracklet") << "recreating file imath.root";
+    }
+    globals->h_file_->cd();
+    TTree *tt = (TTree *)globals->h_file_->Get("tt");
+    if (tt == 0) {
+      tt = new TTree("tt", "");
+      edm::LogVerbatim("Tracklet") << "creating TTree tt";
+    }
+    tt->Branch(s, v);
+    return tt;
   }
-  globals->h_file_->cd();
-  TTree *tt = (TTree *)globals->h_file_->Get("tt");
-  if (tt == 0) {
-    tt = new TTree("tt", "");
-    edm::LogVerbatim("Tracklet") << "creating TTree tt";
+  void VarBase::fillTree(imathGlobals *globals) {
+    if (globals->h_file_ == 0)
+      return;
+    globals->h_file_->cd();
+    TTree *tt = (TTree *)globals->h_file_->Get("tt");
+    if (tt == 0)
+      return;
+    tt->Fill();
   }
-  tt->Branch(s, v);
-  return tt;
-}
-void VarBase::fillTree(imathGlobals *globals) {
-  if (globals->h_file_ == 0)
-    return;
-  globals->h_file_->cd();
-  TTree *tt = (TTree *)globals->h_file_->Get("tt");
-  if (tt == 0)
-    return;
-  tt->Fill();
-}
-void VarBase::writeTree(imathGlobals *globals) {
-  if (globals->h_file_ == 0)
-    return;
-  globals->h_file_->cd();
-  TTree *tt = (TTree *)globals->h_file_->Get("tt");
-  if (tt == 0)
-    return;
-  tt->Write();
-}
+  void VarBase::writeTree(imathGlobals *globals) {
+    if (globals->h_file_ == 0)
+      return;
+    globals->h_file_->cd();
+    TTree *tt = (TTree *)globals->h_file_->Get("tt");
+    if (tt == 0)
+      return;
+    tt->Write();
+  }
 
 #endif
 
-void VarCut::local_passes(std::map<const VarBase *, std::vector<bool> > &passes,
-                          const std::map<const VarBase *, std::vector<bool> > *const previous_passes) const {
-  const int lower_cut = lower_cut_ / cut_var_->K();
-  const int upper_cut = upper_cut_ / cut_var_->K();
-  if (!previous_passes || (previous_passes && !previous_passes->count(cut_var_))) {
-    if (!passes.count(cut_var_))
-      passes[cut_var_];
-    passes.at(cut_var_).push_back(cut_var_->ival() > lower_cut && cut_var_->ival() < upper_cut);
-  }
-}
-
-bool VarBase::local_passes() const {
-  bool passes = false;
-  for (const auto &cut : cuts_) {
-    const VarCut *const cast_cut = (VarCut *)cut;
-    const int lower_cut = cast_cut->lower_cut() / K_;
-    const int upper_cut = cast_cut->upper_cut() / K_;
-    passes = passes || (ival_ > lower_cut && ival_ < upper_cut);
-    if (globals_->printCutInfo_) {
-      edm::LogVerbatim("Tracklet") << "  " << name_ << " "
-                                   << ((ival_ > lower_cut && ival_ < upper_cut) ? "PASSES" : "FAILS")
-                                   << " (required: " << lower_cut * K_ << " < " << ival_ * K_ << " < " << upper_cut * K_
-                                   << ")";
+  void VarCut::local_passes(std::map<const VarBase *, std::vector<bool> > &passes,
+                            const std::map<const VarBase *, std::vector<bool> > *const previous_passes) const {
+    const int lower_cut = lower_cut_ / cut_var_->K();
+    const int upper_cut = upper_cut_ / cut_var_->K();
+    if (!previous_passes || (previous_passes && !previous_passes->count(cut_var_))) {
+      if (!passes.count(cut_var_))
+        passes[cut_var_];
+      passes.at(cut_var_).push_back(cut_var_->ival() > lower_cut && cut_var_->ival() < upper_cut);
     }
   }
-  return passes;
-}
 
-void VarBase::passes(std::map<const VarBase *, std::vector<bool> > &passes,
-                     const std::map<const VarBase *, std::vector<bool> > *const previous_passes) const {
-  if (p1_)
-    p1_->passes(passes, previous_passes);
-  if (p2_)
-    p2_->passes(passes, previous_passes);
-  if (p3_)
-    p3_->passes(passes, previous_passes);
-
-  for (const auto &cut : cuts_) {
-    const VarCut *const cast_cut = (VarCut *)cut;
-    const int lower_cut = cast_cut->lower_cut() / K_;
-    const int upper_cut = cast_cut->upper_cut() / K_;
-    if (!previous_passes || (previous_passes && !previous_passes->count(this))) {
-      if (!passes.count(this))
-        passes[this];
-      passes.at(this).push_back(ival_ > lower_cut && ival_ < upper_cut);
+  bool VarBase::local_passes() const {
+    bool passes = false;
+    for (const auto &cut : cuts_) {
+      const VarCut *const cast_cut = (VarCut *)cut;
+      const int lower_cut = cast_cut->lower_cut() / K_;
+      const int upper_cut = cast_cut->upper_cut() / K_;
+      passes = passes || (ival_ > lower_cut && ival_ < upper_cut);
       if (globals_->printCutInfo_) {
         edm::LogVerbatim("Tracklet") << "  " << name_ << " "
                                      << ((ival_ > lower_cut && ival_ < upper_cut) ? "PASSES" : "FAILS")
@@ -353,89 +326,116 @@ void VarBase::passes(std::map<const VarBase *, std::vector<bool> > &passes,
                                      << upper_cut * K_ << ")";
       }
     }
-  }
-}
-
-void VarBase::add_cut(VarCut *cut, const bool call_set_cut_var) {
-  cuts_.push_back(cut);
-  if (call_set_cut_var)
-    cut->set_cut_var(this, false);
-}
-
-void VarCut::set_cut_var(VarBase *cut_var, const bool call_add_cut) {
-  cut_var_ = cut_var;
-  if (call_add_cut)
-    cut_var->add_cut(this, false);
-  if (parent_flag_)
-    parent_flag_->calculate_step();
-}
-
-void VarFlag::add_cut(VarBase *cut, const bool call_set_parent_flag) {
-  cuts_.push_back(cut);
-  if (cut->op() == "cut" && call_set_parent_flag) {
-    VarCut *const cast_cut = (VarCut *)cut;
-    cast_cut->set_parent_flag(this, false);
-  }
-  calculate_step();
-}
-
-void VarCut::set_parent_flag(VarFlag *parent_flag, const bool call_add_cut) {
-  parent_flag_ = parent_flag;
-  if (call_add_cut)
-    parent_flag->add_cut(this, false);
-}
-
-VarBase *VarBase::cut_var() {
-  if (op_ == "cut")
-    return cut_var_;
-  else
-    return this;
-}
-
-bool VarFlag::passes() {
-  if (globals_->printCutInfo_) {
-    edm::LogVerbatim("Tracklet") << "Checking if " << name_ << " passes...";
+    return passes;
   }
 
-  std::map<const VarBase *, std::vector<bool> > passes0, passes1;
-  for (const auto &cut : cuts_) {
-    if (cut->op() != "cut")
-      continue;
-    const VarCut *const cast_cut = (VarCut *)cut;
-    cast_cut->local_passes(passes0);
-  }
-  for (const auto &cut : cuts_) {
-    if (cut->op() != "cut")
-      cut->passes(passes1, &passes0);
-    else {
-      if (cut->cut_var()->p1())
-        cut->cut_var()->p1()->passes(passes1, &passes0);
-      if (cut->cut_var()->p2())
-        cut->cut_var()->p2()->passes(passes1, &passes0);
-      if (cut->cut_var()->p3())
-        cut->cut_var()->p3()->passes(passes1, &passes0);
+  void VarBase::passes(std::map<const VarBase *, std::vector<bool> > &passes,
+                       const std::map<const VarBase *, std::vector<bool> > *const previous_passes) const {
+    if (p1_)
+      p1_->passes(passes, previous_passes);
+    if (p2_)
+      p2_->passes(passes, previous_passes);
+    if (p3_)
+      p3_->passes(passes, previous_passes);
+
+    for (const auto &cut : cuts_) {
+      const VarCut *const cast_cut = (VarCut *)cut;
+      const int lower_cut = cast_cut->lower_cut() / K_;
+      const int upper_cut = cast_cut->upper_cut() / K_;
+      if (!previous_passes || (previous_passes && !previous_passes->count(this))) {
+        if (!passes.count(this))
+          passes[this];
+        passes.at(this).push_back(ival_ > lower_cut && ival_ < upper_cut);
+        if (globals_->printCutInfo_) {
+          edm::LogVerbatim("Tracklet") << "  " << name_ << " "
+                                       << ((ival_ > lower_cut && ival_ < upper_cut) ? "PASSES" : "FAILS")
+                                       << " (required: " << lower_cut * K_ << " < " << ival_ * K_ << " < "
+                                       << upper_cut * K_ << ")";
+        }
+      }
     }
   }
 
-  bool passes = true;
-  for (const auto &cut_var : passes0) {
-    bool local_passes = false;
-    for (const auto pass : cut_var.second)
-      local_passes = local_passes || pass;
-    passes = passes && local_passes;
-  }
-  for (const auto &cut_var : passes1) {
-    bool local_passes = false;
-    for (const auto pass : cut_var.second)
-      local_passes = local_passes || pass;
-    passes = passes && local_passes;
+  void VarBase::add_cut(VarCut *cut, const bool call_set_cut_var) {
+    cuts_.push_back(cut);
+    if (call_set_cut_var)
+      cut->set_cut_var(this, false);
   }
 
-  if (globals_->printCutInfo_) {
-    edm::LogVerbatim("Tracklet") << name_ << " " << (passes ? "PASSES" : "FAILS");
+  void VarCut::set_cut_var(VarBase *cut_var, const bool call_add_cut) {
+    cut_var_ = cut_var;
+    if (call_add_cut)
+      cut_var->add_cut(this, false);
+    if (parent_flag_)
+      parent_flag_->calculate_step();
   }
 
-  return passes;
-}
+  void VarFlag::add_cut(VarBase *cut, const bool call_set_parent_flag) {
+    cuts_.push_back(cut);
+    if (cut->op() == "cut" && call_set_parent_flag) {
+      VarCut *const cast_cut = (VarCut *)cut;
+      cast_cut->set_parent_flag(this, false);
+    }
+    calculate_step();
+  }
 
-}
+  void VarCut::set_parent_flag(VarFlag *parent_flag, const bool call_add_cut) {
+    parent_flag_ = parent_flag;
+    if (call_add_cut)
+      parent_flag->add_cut(this, false);
+  }
+
+  VarBase *VarBase::cut_var() {
+    if (op_ == "cut")
+      return cut_var_;
+    else
+      return this;
+  }
+
+  bool VarFlag::passes() {
+    if (globals_->printCutInfo_) {
+      edm::LogVerbatim("Tracklet") << "Checking if " << name_ << " passes...";
+    }
+
+    std::map<const VarBase *, std::vector<bool> > passes0, passes1;
+    for (const auto &cut : cuts_) {
+      if (cut->op() != "cut")
+        continue;
+      const VarCut *const cast_cut = (VarCut *)cut;
+      cast_cut->local_passes(passes0);
+    }
+    for (const auto &cut : cuts_) {
+      if (cut->op() != "cut")
+        cut->passes(passes1, &passes0);
+      else {
+        if (cut->cut_var()->p1())
+          cut->cut_var()->p1()->passes(passes1, &passes0);
+        if (cut->cut_var()->p2())
+          cut->cut_var()->p2()->passes(passes1, &passes0);
+        if (cut->cut_var()->p3())
+          cut->cut_var()->p3()->passes(passes1, &passes0);
+      }
+    }
+
+    bool passes = true;
+    for (const auto &cut_var : passes0) {
+      bool local_passes = false;
+      for (const auto pass : cut_var.second)
+        local_passes = local_passes || pass;
+      passes = passes && local_passes;
+    }
+    for (const auto &cut_var : passes1) {
+      bool local_passes = false;
+      for (const auto pass : cut_var.second)
+        local_passes = local_passes || pass;
+      passes = passes && local_passes;
+    }
+
+    if (globals_->printCutInfo_) {
+      edm::LogVerbatim("Tracklet") << name_ << " " << (passes ? "PASSES" : "FAILS");
+    }
+
+    return passes;
+  }
+
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/imath.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath.cc
@@ -11,7 +11,7 @@
 
 #include <cmath>
 
-using namespace trklet;
+namespace trklet {
 
 std::string VarBase::itos(int i) { return std::to_string(i); }
 
@@ -436,4 +436,6 @@ bool VarFlag::passes() {
   }
 
   return passes;
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/imath_HLS.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath_HLS.cc
@@ -1,6 +1,6 @@
 #include "L1Trigger/TrackFindingTracklet/interface/imath.h"
 
-using namespace trklet;
+namespace trklet {
 
 void VarInv::writeLUT(std::ofstream& fs, HLS) const {
   for (int i = 0; i < Nelements_ - 1; ++i)
@@ -401,4 +401,6 @@ void VarBase::design_print(const std::vector<VarBase*>& v, std::ofstream& fs, HL
   }
 
   fs << "}\n";
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/imath_HLS.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath_HLS.cc
@@ -2,405 +2,405 @@
 
 namespace trklet {
 
-void VarInv::writeLUT(std::ofstream& fs, HLS) const {
-  for (int i = 0; i < Nelements_ - 1; ++i)
-    fs << "0x" << std::hex << (LUT[i] & ((1 << nbits_) - 1)) << std::dec << ",\n";
-  fs << "0x" << std::hex << (LUT[Nelements_ - 1] & ((1 << nbits_) - 1)) << std::dec << "\n";
-}
-
-void VarBase::print_truncation(std::string& t, const std::string& o1, const int ps, HLS) const {
-  if (ps > 0) {
-    t += "const ap_int<" + itos(nbits_ + ps) + "> " + name_ + "_tmp = " + o1 + ";\n";
-    t += "const ap_int<" + itos(nbits_) + "> " + name_ + " = " + name_ + "_tmp >> " + itos(ps) + ";\n";
-  } else
-    t += "const ap_int<" + itos(nbits_) + "> " + name_ + " = " + o1 + ";\n";
-}
-
-//
-// print functions
-//
-
-void VarCut::print(std::map<const VarBase*, std::set<std::string> >& cut_strings,
-                   const int step,
-                   HLS,
-                   const std::map<const VarBase*, std::set<std::string> >* const previous_cut_strings) const {
-  assert(step > -1);
-  std::string name = cut_var_->name();
-
-  const int lower_cut = lower_cut_ / cut_var_->K();
-  const int upper_cut = upper_cut_ / cut_var_->K();
-  if (!previous_cut_strings || (previous_cut_strings && !previous_cut_strings->count(cut_var_))) {
-    if (!cut_strings.count(cut_var_))
-      cut_strings[cut_var_];
-    cut_strings.at(cut_var_).insert(name + " > " + itos(lower_cut) + " && " + name + " < " + itos(upper_cut));
-  }
-}
-
-void VarBase::print_cuts(std::map<const VarBase*, std::set<std::string> >& cut_strings,
-                         const int step,
-                         HLS,
-                         const std::map<const VarBase*, std::set<std::string> >* const previous_cut_strings) const {
-  if (p1_)
-    p1_->print_cuts(cut_strings, step, hls, previous_cut_strings);
-  if (p2_)
-    p2_->print_cuts(cut_strings, step, hls, previous_cut_strings);
-  if (p3_)
-    p3_->print_cuts(cut_strings, step, hls, previous_cut_strings);
-
-  std::string name = name_;
-
-  for (const auto& cut : cuts_) {
-    const VarCut* const cast_cut = (VarCut*)cut;
-    const int lower_cut = cast_cut->lower_cut() / K_;
-    const int upper_cut = cast_cut->upper_cut() / K_;
-    if (!previous_cut_strings || (previous_cut_strings && !previous_cut_strings->count(this))) {
-      if (!cut_strings.count(this))
-        cut_strings[this];
-      cut_strings.at(this).insert(name + " > " + itos(lower_cut) + " && " + name + " < " + itos(upper_cut));
-    }
-  }
-}
-
-void VarAdjustK::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-
-  std::string shift = "";
-  if (lr_ > 0)
-    shift = " >> " + itos(lr_);
-  else if (lr_ < 0)
-    shift = " << " + itos(-lr_);
-
-  std::string n1 = p1_->name();
-
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n";
-  fs << "const ap_int<" << nbits_ << "> " << name_ << " = " << n1 << shift << ";\n";
-}
-
-void VarAdjustKR::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-
-  std::string n1 = p1_->name();
-
-  std::string o1 = n1;
-  if (lr_ == 1)
-    o1 = "(" + o1 + "+1)>>1";
-  if (lr_ > 1)
-    o1 = "( (" + o1 + ">>" + itos(lr_ - 1) + ")+1)>>1";
-  if (lr_ < 0)
-    o1 = "ap_int<" + itos(nbits_) + ">(" + o1 + ")<<" + itos(-lr_);
-
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n";
-  fs << "const ap_int<" << nbits_ << "> " << name_ << " = " << o1 << ";\n";
-}
-
-void VarDef::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-
-  fs << "// units " << kstring() << "\t" << K_ << "\n";
-  fs << "const ap_int<" << nbits_ << "> " << name_ << " = " << name_ << "_wire;\n";
-}
-
-void VarParam::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n";
-  fs << "static const ap_int<" << nbits_ << "> " << name_ << " = " << ival_ << ";\n";
-}
-
-void VarAdd::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(p2_);
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string o1 = p1_->name();
-  if (shift1 > 0) {
-    o1 = "ap_int<" + itos(nbits_ + ps_) + ">(" + o1 + ")";
-    o1 += "<<" + itos(shift1);
-    o1 = "(" + o1 + ")";
+  void VarInv::writeLUT(std::ofstream& fs, HLS) const {
+    for (int i = 0; i < Nelements_ - 1; ++i)
+      fs << "0x" << std::hex << (LUT[i] & ((1 << nbits_) - 1)) << std::dec << ",\n";
+    fs << "0x" << std::hex << (LUT[Nelements_ - 1] & ((1 << nbits_) - 1)) << std::dec << "\n";
   }
 
-  std::string o2 = p2_->name();
-  if (shift2 > 0) {
-    o2 = "ap_int<" + itos(nbits_ + ps_) + ">(" + o2 + ")";
-    o2 += "<<" + itos(shift2);
-    o2 = "(" + o2 + ")";
+  void VarBase::print_truncation(std::string& t, const std::string& o1, const int ps, HLS) const {
+    if (ps > 0) {
+      t += "const ap_int<" + itos(nbits_ + ps) + "> " + name_ + "_tmp = " + o1 + ";\n";
+      t += "const ap_int<" + itos(nbits_) + "> " + name_ + " = " + name_ + "_tmp >> " + itos(ps) + ";\n";
+    } else
+      t += "const ap_int<" + itos(nbits_) + "> " + name_ + " = " + o1 + ";\n";
   }
 
-  o1 = o1 + " + " + o2;
+  //
+  // print functions
+  //
 
-  std::string t = "";
-  print_truncation(t, o1, ps_, hls);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
-}
+  void VarCut::print(std::map<const VarBase*, std::set<std::string> >& cut_strings,
+                     const int step,
+                     HLS,
+                     const std::map<const VarBase*, std::set<std::string> >* const previous_cut_strings) const {
+    assert(step > -1);
+    std::string name = cut_var_->name();
 
-void VarSubtract::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(p2_);
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string o1 = p1_->name();
-  if (shift1 > 0) {
-    o1 = "ap_int<" + itos(nbits_ + ps_) + ">(" + o1 + ")";
-    o1 += "<<" + itos(shift1);
-    o1 = "(" + o1 + ")";
-  }
-
-  std::string o2 = p2_->name();
-  if (shift2 > 0) {
-    o2 = "ap_int<" + itos(nbits_ + ps_) + ">(" + o2 + ")";
-    o2 += "<<" + itos(shift2);
-    o2 = "(" + o2 + ")";
-  }
-
-  o1 = o1 + " - " + o2;
-
-  std::string t = "";
-  print_truncation(t, o1, ps_, hls);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
-}
-
-void VarNounits::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-  std::string o1 = "(" + n1 + " * " + itos(cI_) + ")";
-
-  std::string t = "";
-  print_truncation(t, o1, ps_, hls);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
-}
-
-void VarTimesC::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-  std::string o1 = "(" + n1 + " * " + itos(cI_) + ")";
-
-  std::string t = "";
-  print_truncation(t, o1, ps_, hls);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
-}
-
-void VarNeg::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-
-  std::string t = "const ap_int<" + itos(nbits_) + "> " + name_ + " = -" + n1 + ";\n";
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
-}
-
-void VarShiftround::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-  std::string o1 = n1;
-  if (shift_ == 1)
-    o1 = "(" + o1 + "+1)>>1";
-  if (shift_ > 1)
-    o1 = "( (" + o1 + ">>" + itos(shift_ - 1) + ")+1)>>1";
-  if (shift_ < 0)
-    o1 = "ap_int<" + itos(nbits_) + ">(" + o1 + ")<<" + itos(-shift_);
-
-  std::string t = "const ap_int<" + itos(nbits_) + "> " + name_ + " = " + o1 + ";\n";
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
-}
-
-void VarShift::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-  std::string o1 = n1;
-  if (shift_ > 0)
-    o1 = o1 + ">>" + itos(shift_);
-  if (shift_ < 0)
-    o1 = "ap_int<" + itos(nbits_) + ">(" + o1 + ")<<" + itos(-shift_);
-
-  std::string t = "const ap_int<" + itos(nbits_) + "> " + name_ + " = " + o1 + ";\n";
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
-}
-
-void VarMult::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  assert(p1_);
-  std::string n1 = p1_->name();
-  assert(p2_);
-  std::string n2 = p2_->name();
-  std::string o1 = n1 + " * " + n2;
-
-  std::string t = "";
-  print_truncation(t, o1, ps_, hls);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
-}
-
-void VarInv::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-
-  fs << "static const ap_int<" << itos(nbits_) << "> LUT_" << name_ << "[" << Nelements_ << "] = {\n";
-  fs << "#include \"LUT_" << name_ << ".h\"\n";
-  fs << "};\n";
-
-  std::string n1 = p1_->name();
-  //first calculate address
-  std::string t1 = "addr_" + name_;
-  std::string t = "const ap_uint<" + itos(nbaddr_) + "> " + t1 + " = ";
-  if (shift_ > 0)
-    t = t + "(" + n1 + ">>" + itos(shift_) + ") & " + itos(mask_);
-  else
-    t = t + n1 + " & " + itos(mask_);
-  fs << t << "; // address for the LUT\n";
-
-  t = "const ap_int<" + itos(nbits_) + "> " + name_ + " = LUT_" + name_ + "[addr_" + name_ + "];\n";
-  fs << t;
-}
-
-void VarFlag::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-
-  fs << "const ap_int<1> " << name_ << " = (";
-  std::map<const VarBase*, std::set<std::string> > cut_strings0, cut_strings1;
-  for (const auto& cut : cuts_) {
-    if (cut->op() != "cut")
-      continue;
-    const VarCut* const cast_cut = (VarCut*)cut;
-    cast_cut->print(cut_strings0, step_, hls);
-  }
-  for (const auto& cut : cuts_) {
-    if (cut->op() != "cut")
-      cut->print_cuts(cut_strings1, step_, hls, &cut_strings0);
-    else {
-      if (cut->cut_var()->p1())
-        cut->cut_var()->p1()->print_cuts(cut_strings1, step_, hls, &cut_strings1);
-      if (cut->cut_var()->p2())
-        cut->cut_var()->p2()->print_cuts(cut_strings1, step_, hls, &cut_strings1);
-      if (cut->cut_var()->p3())
-        cut->cut_var()->p3()->print_cuts(cut_strings1, step_, hls, &cut_strings1);
+    const int lower_cut = lower_cut_ / cut_var_->K();
+    const int upper_cut = upper_cut_ / cut_var_->K();
+    if (!previous_cut_strings || (previous_cut_strings && !previous_cut_strings->count(cut_var_))) {
+      if (!cut_strings.count(cut_var_))
+        cut_strings[cut_var_];
+      cut_strings.at(cut_var_).insert(name + " > " + itos(lower_cut) + " && " + name + " < " + itos(upper_cut));
     }
   }
 
-  std::string separator = "";
-  for (const auto& cut_var : cut_strings0) {
-    separator += "((";
-    for (const auto& cut_string : cut_var.second) {
-      fs << separator << cut_string;
-      separator = ") || (";
+  void VarBase::print_cuts(std::map<const VarBase*, std::set<std::string> >& cut_strings,
+                           const int step,
+                           HLS,
+                           const std::map<const VarBase*, std::set<std::string> >* const previous_cut_strings) const {
+    if (p1_)
+      p1_->print_cuts(cut_strings, step, hls, previous_cut_strings);
+    if (p2_)
+      p2_->print_cuts(cut_strings, step, hls, previous_cut_strings);
+    if (p3_)
+      p3_->print_cuts(cut_strings, step, hls, previous_cut_strings);
+
+    std::string name = name_;
+
+    for (const auto& cut : cuts_) {
+      const VarCut* const cast_cut = (VarCut*)cut;
+      const int lower_cut = cast_cut->lower_cut() / K_;
+      const int upper_cut = cast_cut->upper_cut() / K_;
+      if (!previous_cut_strings || (previous_cut_strings && !previous_cut_strings->count(this))) {
+        if (!cut_strings.count(this))
+          cut_strings[this];
+        cut_strings.at(this).insert(name + " > " + itos(lower_cut) + " && " + name + " < " + itos(upper_cut));
+      }
     }
-    separator = ")) && ";
   }
-  for (const auto& cut_var : cut_strings1) {
-    separator += "((";
-    for (const auto& cut_string : cut_var.second) {
-      fs << separator << cut_string;
-      separator = ") || (";
+
+  void VarAdjustK::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+
+    std::string shift = "";
+    if (lr_ > 0)
+      shift = " >> " + itos(lr_);
+    else if (lr_ < 0)
+      shift = " << " + itos(-lr_);
+
+    std::string n1 = p1_->name();
+
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n";
+    fs << "const ap_int<" << nbits_ << "> " << name_ << " = " << n1 << shift << ";\n";
+  }
+
+  void VarAdjustKR::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+
+    std::string n1 = p1_->name();
+
+    std::string o1 = n1;
+    if (lr_ == 1)
+      o1 = "(" + o1 + "+1)>>1";
+    if (lr_ > 1)
+      o1 = "( (" + o1 + ">>" + itos(lr_ - 1) + ")+1)>>1";
+    if (lr_ < 0)
+      o1 = "ap_int<" + itos(nbits_) + ">(" + o1 + ")<<" + itos(-lr_);
+
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n";
+    fs << "const ap_int<" << nbits_ << "> " << name_ << " = " << o1 << ";\n";
+  }
+
+  void VarDef::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+
+    fs << "// units " << kstring() << "\t" << K_ << "\n";
+    fs << "const ap_int<" << nbits_ << "> " << name_ << " = " << name_ << "_wire;\n";
+  }
+
+  void VarParam::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n";
+    fs << "static const ap_int<" << nbits_ << "> " << name_ << " = " << ival_ << ";\n";
+  }
+
+  void VarAdd::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(p2_);
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string o1 = p1_->name();
+    if (shift1 > 0) {
+      o1 = "ap_int<" + itos(nbits_ + ps_) + ">(" + o1 + ")";
+      o1 += "<<" + itos(shift1);
+      o1 = "(" + o1 + ")";
     }
-    separator = ")) && ";
+
+    std::string o2 = p2_->name();
+    if (shift2 > 0) {
+      o2 = "ap_int<" + itos(nbits_ + ps_) + ">(" + o2 + ")";
+      o2 += "<<" + itos(shift2);
+      o2 = "(" + o2 + ")";
+    }
+
+    o1 = o1 + " + " + o2;
+
+    std::string t = "";
+    print_truncation(t, o1, ps_, hls);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
   }
 
-  fs << ")));";
-}
+  void VarSubtract::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(p2_);
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string o1 = p1_->name();
+    if (shift1 > 0) {
+      o1 = "ap_int<" + itos(nbits_ + ps_) + ">(" + o1 + ")";
+      o1 += "<<" + itos(shift1);
+      o1 = "(" + o1 + ")";
+    }
 
-void VarBase::print_step(int step, std::ofstream& fs, HLS) {
-  if (!readytoprint_)
-    return;
-  if (step > step_)
-    return;
-  if (p1_)
-    p1_->print_step(step, fs, hls);
-  if (p2_)
-    p2_->print_step(step, fs, hls);
-  if (p3_)
-    p3_->print_step(step, fs, hls);
-  if (step == step_) {
-    print(fs, hls, 0, 0, 0);
-    readytoprint_ = false;
+    std::string o2 = p2_->name();
+    if (shift2 > 0) {
+      o2 = "ap_int<" + itos(nbits_ + ps_) + ">(" + o2 + ")";
+      o2 += "<<" + itos(shift2);
+      o2 = "(" + o2 + ")";
+    }
+
+    o1 = o1 + " - " + o2;
+
+    std::string t = "";
+    print_truncation(t, o1, ps_, hls);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
   }
-}
 
-void VarBase::print_all(std::ofstream& fs, HLS) {
-  for (int i = 0; i <= step_; ++i) {
-    fs << "//\n// STEP " << i << "\n\n";
-    print_step(i, fs, hls);
+  void VarNounits::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
+    std::string o1 = "(" + n1 + " * " + itos(cI_) + ")";
+
+    std::string t = "";
+    print_truncation(t, o1, ps_, hls);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
   }
-}
 
-void VarBase::design_print(const std::vector<VarBase*>& v, std::ofstream& fs, HLS) {
-  //header of the module
+  void VarTimesC::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
+    std::string o1 = "(" + n1 + " * " + itos(cI_) + ")";
 
-  //inputs
-  std::vector<VarBase*> vd;
-  vd.clear();
-  int imax = v.size();
-  for (int i = 0; i < imax; ++i)
-    (v[i])->inputs(&vd);
+    std::string t = "";
+    print_truncation(t, o1, ps_, hls);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
+  }
 
-  //print header
-  fs << "#include \"ap_int.h\"\n\n";
-  fs << "void XXX (\n";
+  void VarNeg::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
 
-  imax = vd.size();
-  for (int i = 0; i < imax; ++i)
-    fs << "  const ap_int<" << (vd[i])->nbits() << "> " << (vd[i])->name() << "_wire,\n";
-  fs << "\n";
+    std::string t = "const ap_int<" + itos(nbits_) + "> " + name_ + " = -" + n1 + ";\n";
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
+  }
 
-  imax = v.size() - 1;
-  for (int i = 0; i < imax; ++i)
-    fs << "  ap_int<" << (v[i])->nbits() << "> * const " << (v[i])->name() << "_wire,\n";
-  if (imax >= 0)
-    fs << "  ap_int<" << (v[imax])->nbits() << "> * const " << (v[imax])->name() << "_wire\n";
-  fs << ")\n{\n";
-  fs << "#pragma HLS pipeline II=1\n";
-  fs << "#pragma HLS latency max=25\n";
+  void VarShiftround::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
+    std::string o1 = n1;
+    if (shift_ == 1)
+      o1 = "(" + o1 + "+1)>>1";
+    if (shift_ > 1)
+      o1 = "( (" + o1 + ">>" + itos(shift_ - 1) + ")+1)>>1";
+    if (shift_ < 0)
+      o1 = "ap_int<" + itos(nbits_) + ">(" + o1 + ")<<" + itos(-shift_);
 
-  //body of the module
-  imax = v.size();
-  for (int i = 0; i < imax; ++i) {
+    std::string t = "const ap_int<" + itos(nbits_) + "> " + name_ + " = " + o1 + ";\n";
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
+  }
+
+  void VarShift::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
+    std::string o1 = n1;
+    if (shift_ > 0)
+      o1 = o1 + ">>" + itos(shift_);
+    if (shift_ < 0)
+      o1 = "ap_int<" + itos(nbits_) + ">(" + o1 + ")<<" + itos(-shift_);
+
+    std::string t = "const ap_int<" + itos(nbits_) + "> " + name_ + " = " + o1 + ";\n";
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
+  }
+
+  void VarMult::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    assert(p1_);
+    std::string n1 = p1_->name();
+    assert(p2_);
+    std::string n2 = p2_->name();
+    std::string o1 = n1 + " * " + n2;
+
+    std::string t = "";
+    print_truncation(t, o1, ps_, hls);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
+  }
+
+  void VarInv::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+
+    fs << "static const ap_int<" << itos(nbits_) << "> LUT_" << name_ << "[" << Nelements_ << "] = {\n";
+    fs << "#include \"LUT_" << name_ << ".h\"\n";
+    fs << "};\n";
+
+    std::string n1 = p1_->name();
+    //first calculate address
+    std::string t1 = "addr_" + name_;
+    std::string t = "const ap_uint<" + itos(nbaddr_) + "> " + t1 + " = ";
+    if (shift_ > 0)
+      t = t + "(" + n1 + ">>" + itos(shift_) + ") & " + itos(mask_);
+    else
+      t = t + n1 + " & " + itos(mask_);
+    fs << t << "; // address for the LUT\n";
+
+    t = "const ap_int<" + itos(nbits_) + "> " + name_ + " = LUT_" + name_ + "[addr_" + name_ + "];\n";
+    fs << t;
+  }
+
+  void VarFlag::print(std::ofstream& fs, HLS, int l1, int l2, int l3) {
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+
+    fs << "const ap_int<1> " << name_ << " = (";
+    std::map<const VarBase*, std::set<std::string> > cut_strings0, cut_strings1;
+    for (const auto& cut : cuts_) {
+      if (cut->op() != "cut")
+        continue;
+      const VarCut* const cast_cut = (VarCut*)cut;
+      cast_cut->print(cut_strings0, step_, hls);
+    }
+    for (const auto& cut : cuts_) {
+      if (cut->op() != "cut")
+        cut->print_cuts(cut_strings1, step_, hls, &cut_strings0);
+      else {
+        if (cut->cut_var()->p1())
+          cut->cut_var()->p1()->print_cuts(cut_strings1, step_, hls, &cut_strings1);
+        if (cut->cut_var()->p2())
+          cut->cut_var()->p2()->print_cuts(cut_strings1, step_, hls, &cut_strings1);
+        if (cut->cut_var()->p3())
+          cut->cut_var()->p3()->print_cuts(cut_strings1, step_, hls, &cut_strings1);
+      }
+    }
+
+    std::string separator = "";
+    for (const auto& cut_var : cut_strings0) {
+      separator += "((";
+      for (const auto& cut_string : cut_var.second) {
+        fs << separator << cut_string;
+        separator = ") || (";
+      }
+      separator = ")) && ";
+    }
+    for (const auto& cut_var : cut_strings1) {
+      separator += "((";
+      for (const auto& cut_string : cut_var.second) {
+        fs << separator << cut_string;
+        separator = ") || (";
+      }
+      separator = ")) && ";
+    }
+
+    fs << ")));";
+  }
+
+  void VarBase::print_step(int step, std::ofstream& fs, HLS) {
+    if (!readytoprint_)
+      return;
+    if (step > step_)
+      return;
+    if (p1_)
+      p1_->print_step(step, fs, hls);
+    if (p2_)
+      p2_->print_step(step, fs, hls);
+    if (p3_)
+      p3_->print_step(step, fs, hls);
+    if (step == step_) {
+      print(fs, hls, 0, 0, 0);
+      readytoprint_ = false;
+    }
+  }
+
+  void VarBase::print_all(std::ofstream& fs, HLS) {
+    for (int i = 0; i <= step_; ++i) {
+      fs << "//\n// STEP " << i << "\n\n";
+      print_step(i, fs, hls);
+    }
+  }
+
+  void VarBase::design_print(const std::vector<VarBase*>& v, std::ofstream& fs, HLS) {
+    //header of the module
+
+    //inputs
+    std::vector<VarBase*> vd;
+    vd.clear();
+    int imax = v.size();
+    for (int i = 0; i < imax; ++i)
+      (v[i])->inputs(&vd);
+
+    //print header
+    fs << "#include \"ap_int.h\"\n\n";
+    fs << "void XXX (\n";
+
+    imax = vd.size();
+    for (int i = 0; i < imax; ++i)
+      fs << "  const ap_int<" << (vd[i])->nbits() << "> " << (vd[i])->name() << "_wire,\n";
+    fs << "\n";
+
+    imax = v.size() - 1;
+    for (int i = 0; i < imax; ++i)
+      fs << "  ap_int<" << (v[i])->nbits() << "> * const " << (v[i])->name() << "_wire,\n";
+    if (imax >= 0)
+      fs << "  ap_int<" << (v[imax])->nbits() << "> * const " << (v[imax])->name() << "_wire\n";
+    fs << ")\n{\n";
+    fs << "#pragma HLS pipeline II=1\n";
+    fs << "#pragma HLS latency max=25\n";
+
+    //body of the module
+    imax = v.size();
+    for (int i = 0; i < imax; ++i) {
+      fs << "\n//\n";
+      fs << "// calculating " << (v[i])->name() << "\n";
+      fs << "//\n";
+      (v[i])->print_all(fs, hls);
+    }
+    fs << "\n";
+
+    //trailer
+    fs << "\n";
     fs << "\n//\n";
-    fs << "// calculating " << (v[i])->name() << "\n";
+    fs << "// wiring the outputs \n";
     fs << "//\n";
-    (v[i])->print_all(fs, hls);
-  }
-  fs << "\n";
+    for (int i = 0; i < imax; ++i) {
+      std::string n = v[i]->name() + "_wire";
+      fs << "*" << n << " = " << (v[i])->name() << ";\n";
+    }
 
-  //trailer
-  fs << "\n";
-  fs << "\n//\n";
-  fs << "// wiring the outputs \n";
-  fs << "//\n";
-  for (int i = 0; i < imax; ++i) {
-    std::string n = v[i]->name() + "_wire";
-    fs << "*" << n << " = " << (v[i])->name() << ";\n";
+    fs << "}\n";
   }
 
-  fs << "}\n";
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/imath_Verilog.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath_Verilog.cc
@@ -2,535 +2,536 @@
 
 namespace trklet {
 
-void VarInv::writeLUT(std::ofstream& fs, Verilog) const {
-  for (int i = 0; i < Nelements_; ++i)
-    fs << std::hex << (LUT[i] & ((1 << nbits_) - 1)) << std::dec << "\n";
-}
-
-void VarBase::print_truncation(std::string& t, const std::string& o1, const int ps, Verilog) const {
-  if (ps > 0) {
-    t += "wire signed [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
-    t += "reg signed  [" + itos(nbits_ + ps - 1) + ":0]" + name_ + "_tmp;\n";
-    t += "always @(posedge clk) " + name_ + "_tmp <= " + o1 + ";\n";
-    t += "assign " + name_ + " = " + name_ + "_tmp[" + itos(nbits_ + ps - 1) + ":" + itos(ps) + "];\n";
-  } else {
-    t += "reg signed  [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
-    t += "always @(posedge clk) " + name_ + " <= " + o1 + ";\n";
-  }
-}
-
-//
-// print functions
-//
-
-void VarCut::print(std::map<const VarBase*, std::set<std::string> >& cut_strings,
-                   const int step,
-                   Verilog,
-                   const std::map<const VarBase*, std::set<std::string> >* const previous_cut_strings) const {
-  int l = step - cut_var_->latency() - cut_var_->step();
-  std::string name = cut_var_->name();
-  if (l > 0)
-    name += "_delay" + itos(l);
-
-  const int lower_cut = lower_cut_ / cut_var_->K();
-  const int upper_cut = upper_cut_ / cut_var_->K();
-  if (!previous_cut_strings || (previous_cut_strings && !previous_cut_strings->count(cut_var_))) {
-    if (!cut_strings.count(cut_var_))
-      cut_strings[cut_var_];
-    cut_strings.at(cut_var_).insert(name + " > " + itos(lower_cut) + " && " + name + " < " + itos(upper_cut));
-  }
-}
-
-void VarBase::print_cuts(std::map<const VarBase*, std::set<std::string> >& cut_strings,
-                         const int step,
-                         Verilog,
-                         const std::map<const VarBase*, std::set<std::string> >* const previous_cut_strings) const {
-  if (p1_)
-    p1_->print_cuts(cut_strings, step, verilog, previous_cut_strings);
-  if (p2_)
-    p2_->print_cuts(cut_strings, step, verilog, previous_cut_strings);
-  if (p3_)
-    p3_->print_cuts(cut_strings, step, verilog, previous_cut_strings);
-
-  int l = step - latency_ - step_;
-  std::string name = name_;
-  if (l > 0)
-    name += "_delay" + itos(l);
-
-  for (const auto& cut : cuts_) {
-    const VarCut* const cast_cut = (VarCut*)cut;
-    const int lower_cut = cast_cut->lower_cut() / K_;
-    const int upper_cut = cast_cut->upper_cut() / K_;
-    if (!previous_cut_strings || (previous_cut_strings && !previous_cut_strings->count(this))) {
-      if (!cut_strings.count(this))
-        cut_strings[this];
-      cut_strings.at(this).insert(name + " > " + itos(lower_cut) + " && " + name + " < " + itos(upper_cut));
-    }
-  }
-}
-
-void VarAdjustK::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l2 == 0);
-  assert(l3 == 0);
-
-  std::string shift = "";
-  if (lr_ > 0)
-    shift = " >>> " + itos(lr_);
-  else if (lr_ < 0)
-    shift = " << " + itos(-lr_);
-
-  std::string n1 = p1_->name();
-  if (l1 > 0)
-    n1 = n1 + "_delay" + itos(l1);
-
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n";
-  std::string t = "wire signed [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
-  t += "assign " + name_ + " = " + n1 + shift;
-  fs << t << "; \n";
-}
-
-void VarAdjustKR::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l2 == 0);
-  assert(l3 == 0);
-
-  std::string n1 = p1_->name();
-  if (l1 > 0)
-    n1 = n1 + "_delay" + itos(l1);
-
-  std::string o1 = n1;
-  if (lr_ == 1)
-    o1 = "(" + o1 + "+1)>>>1";
-  if (lr_ > 1)
-    o1 = "( (" + o1 + ">>>" + itos(lr_ - 1) + ")+1)>>>1";
-  if (lr_ < 0)
-    o1 = o1 + "<<" + itos(-lr_);
-
-  std::string t = "reg signed [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
-  t += "always @(posedge clk) " + name_ + " <= " + o1;
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
-}
-
-void VarDef::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-
-  std::string t = "reg signed  [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
-  t = t + "always @(posedge clk) " + name_ + " <= " + name_ + "_wire;\n";
-  fs << "// units " << kstring() << "\t" << K_ << "\n" << t;
-}
-
-void VarParam::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string t = "parameter " + name_ + " = ";
-  if (ival_ < 0)
-    t = t + "- " + itos(nbits_) + "\'sd" + itos(-ival_);
-  else
-    t = t + itos(nbits_) + "\'sd" + itos(ival_);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
-}
-
-void VarAdd::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(p2_);
-  assert(l3 == 0);
-  std::string o1 = p1_->name();
-  if (l1 > 0)
-    o1 += "_delay" + itos(l1);
-  if (shift1 > 0) {
-    o1 += "<<" + itos(shift1);
-    o1 = "(" + o1 + ")";
+  void VarInv::writeLUT(std::ofstream& fs, Verilog) const {
+    for (int i = 0; i < Nelements_; ++i)
+      fs << std::hex << (LUT[i] & ((1 << nbits_) - 1)) << std::dec << "\n";
   }
 
-  std::string o2 = p2_->name();
-  if (l2 > 0)
-    o2 += "_delay" + itos(l2);
-  if (shift2 > 0) {
-    o2 += "<<" + itos(shift2);
-    o2 = "(" + o2 + ")";
-  }
-
-  o1 = o1 + " + " + o2;
-
-  std::string t = "";
-  print_truncation(t, o1, ps_, verilog);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
-}
-
-void VarSubtract::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(p2_);
-  assert(l3 == 0);
-  std::string o1 = p1_->name();
-  if (l1 > 0)
-    o1 += "_delay" + itos(l1);
-  if (shift1 > 0) {
-    o1 += "<<" + itos(shift1);
-    o1 = "(" + o1 + ")";
-  }
-
-  std::string o2 = p2_->name();
-  if (l2 > 0)
-    o2 += "_delay" + itos(l2);
-  if (shift2 > 0) {
-    o2 += "<<" + itos(shift2);
-    o2 = "(" + o2 + ")";
-  }
-
-  o1 = o1 + " - " + o2;
-
-  std::string t = "";
-  print_truncation(t, o1, ps_, verilog);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
-}
-
-void VarNounits::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-  if (l1 > 0)
-    n1 = n1 + "_delay" + itos(l1);
-  std::string o1 = "(" + n1 + " * " + itos(cI_) + ")";
-
-  std::string t = "";
-  print_truncation(t, o1, ps_, verilog);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
-}
-
-void VarTimesC::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-  if (l1 > 0)
-    n1 = n1 + "_delay" + itos(l1);
-  std::string o1 = "(" + n1 + " * " + itos(cI_) + ")";
-
-  std::string t = "";
-  print_truncation(t, o1, ps_, verilog);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
-}
-
-void VarNeg::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-  if (l1 > 0)
-    n1 = n1 + "_delay" + itos(l1);
-
-  std::string t = "reg signed  [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
-  t += "always @(posedge clk) " + name_ + " <= - " + n1;
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
-}
-
-void VarShiftround::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-  if (l1 > 0)
-    n1 = n1 + "_delay" + itos(l1);
-  std::string o1 = n1;
-  if (shift_ == 1)
-    o1 = "(" + o1 + "+1)>>>1";
-  if (shift_ > 1)
-    o1 = "( (" + o1 + ">>>" + itos(shift_ - 1) + ")+1)>>>1";
-  if (shift_ < 0)
-    o1 = o1 + "<<" + itos(-shift_);
-
-  std::string t = "reg signed [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
-  t += "always @(posedge clk) " + name_ + " <= " + o1;
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
-}
-
-void VarShift::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-  if (l1 > 0)
-    n1 = n1 + "_delay" + itos(l1);
-  std::string o1 = n1;
-  if (shift_ > 0)
-    o1 = o1 + ">>>" + itos(shift_);
-  if (shift_ < 0)
-    o1 = o1 + "<<" + itos(-shift_);
-
-  std::string t = "wire signed [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
-  t += "assign " + name_ + " = " + o1;
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
-}
-
-void VarMult::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(l3 == 0);
-  assert(p1_);
-  std::string n1 = p1_->name();
-  if (l1 > 0)
-    n1 = n1 + "_delay" + itos(l1);
-  assert(p2_);
-  std::string n2 = p2_->name();
-  if (l2 > 0)
-    n2 = n2 + "_delay" + itos(l2);
-  std::string o1 = n1 + " * " + n2;
-
-  std::string t = "";
-  print_truncation(t, o1, ps_, verilog);
-  fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
-}
-
-void VarInv::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(l2 == 0);
-  assert(l3 == 0);
-  std::string n1 = p1_->name();
-  if (l1 > 0)
-    n1 = n1 + "_delay" + itos(l1);
-  //first calculate address
-  std::string t1 = "addr_" + name_;
-  std::string t = "wire [" + itos(nbaddr_ - 1) + ":0] " + t1 + ";\n";
-  t = t + "assign " + t1 + " = ";
-  if (shift_ > 0)
-    t = t + "(" + n1 + ">>>" + itos(shift_) + ") & " + itos(mask_);
-  else
-    t = t + n1 + " & " + itos(mask_);
-  fs << t << "; // address for the LUT\n";
-
-  t = "wire signed [" + itos(nbits_ - 1) + ":0] " + name_ + ";\n";
-  fs << t;
-
-  std::string t2 = "LUT_" + name_;
-
-  fs << "Memory #( \n";
-  fs << "         .RAM_WIDTH(" << nbits_ << "),            // Specify RAM data width \n";
-  fs << "         .RAM_DEPTH(" << Nelements_ << "),                     // Specify RAM depth (number of entries) \n";
-  fs << "         .RAM_PERFORMANCE(\"HIGH_PERFORMANCE\"), // \"HIGH_PERFORMANCE\" = 2 clks latency \n";
-  fs << "         .INIT_FILE() \n";
-  fs << "       ) " << t2 << " ( \n";
-  fs << "         .addra(" << itos(nbaddr_) << "\'b0),    // Write address bus, width determined from RAM_DEPTH  \n";
-  fs << "         .addrb(" << t1 << " ),                   // Read address bus, width determined from RAM_DEPTH  \n";
-  fs << "         .dina(" << itos(nbits_) << "\'b0),      // RAM input data, width determined from RAM_WIDTH   \n";
-  fs << "         .clka(clk),      // Write clock \n";
-  fs << "         .clkb(clk),      // Read clock  \n";
-  fs << "         .wea(1\'b0),        // Write enable  \n";
-  fs << "         .enb(1\'b1),        // Read Enable, for additional power savings, disable when not in use  \n";
-  fs << "         .rstb(reset),      // Output reset (does not affect memory contents)                      \n";
-  fs << "         .regceb(1\'b1),  // Output register enable                                                \n";
-  fs << "         .doutb(" << name_ << ")     // RAM output data,                                                \n";
-  fs << "     ); \n";
-}
-
-void VarDSPPostadd::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(p1_);
-  assert(p2_);
-  assert(p3_);
-  std::string n1 = p1_->name();
-  if (l1 > 0)
-    n1 = n1 + "_delay" + itos(l1);
-  std::string n2 = p2_->name();
-  if (l2 > 0)
-    n2 = n2 + "_delay" + itos(l2);
-  std::string n3 = p3_->name();
-  if (l3 > 0)
-    n3 = n3 + "_delay" + itos(l3);
-
-  if (shift3_ > 0)
-    n3 = n3 + "<<" + itos(shift3_);
-  if (shift3_ < 0)
-    n3 = n3 + ">>>" + itos(-shift3_);
-
-  std::string n4 = "";
-  if (ps_ > 0)
-    n4 = ">>>" + itos(ps_);
-
-  fs << name_ + " = DSP_postadd(" + n1 + ", " + n2 + ", " + n3 + ")" + n4 + ";";
-}
-
-void VarFlag::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
-  assert(l1 == 0);
-  assert(l2 == 0);
-  assert(l3 == 0);
-
-  fs << "wire " << name_ << ";" << std::endl;
-  fs << "assign " << name_ << " = (";
-  std::map<const VarBase*, std::set<std::string> > cut_strings0, cut_strings1;
-  for (const auto& cut : cuts_) {
-    if (cut->op() != "cut")
-      continue;
-    const VarCut* const cast_cut = (VarCut*)cut;
-    cast_cut->print(cut_strings0, step_, verilog);
-  }
-  for (const auto& cut : cuts_) {
-    if (cut->op() != "cut")
-      cut->print_cuts(cut_strings1, step_, verilog, &cut_strings0);
-    else {
-      if (cut->cut_var()->p1())
-        cut->cut_var()->p1()->print_cuts(cut_strings1, step_, verilog, &cut_strings1);
-      if (cut->cut_var()->p2())
-        cut->cut_var()->p2()->print_cuts(cut_strings1, step_, verilog, &cut_strings1);
-      if (cut->cut_var()->p3())
-        cut->cut_var()->p3()->print_cuts(cut_strings1, step_, verilog, &cut_strings1);
+  void VarBase::print_truncation(std::string& t, const std::string& o1, const int ps, Verilog) const {
+    if (ps > 0) {
+      t += "wire signed [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
+      t += "reg signed  [" + itos(nbits_ + ps - 1) + ":0]" + name_ + "_tmp;\n";
+      t += "always @(posedge clk) " + name_ + "_tmp <= " + o1 + ";\n";
+      t += "assign " + name_ + " = " + name_ + "_tmp[" + itos(nbits_ + ps - 1) + ":" + itos(ps) + "];\n";
+    } else {
+      t += "reg signed  [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
+      t += "always @(posedge clk) " + name_ + " <= " + o1 + ";\n";
     }
   }
 
-  std::string separator = "";
-  for (const auto& cut_var : cut_strings0) {
-    separator += "((";
-    for (const auto& cut_string : cut_var.second) {
-      fs << separator << cut_string;
-      separator = ") || (";
+  //
+  // print functions
+  //
+
+  void VarCut::print(std::map<const VarBase*, std::set<std::string> >& cut_strings,
+                     const int step,
+                     Verilog,
+                     const std::map<const VarBase*, std::set<std::string> >* const previous_cut_strings) const {
+    int l = step - cut_var_->latency() - cut_var_->step();
+    std::string name = cut_var_->name();
+    if (l > 0)
+      name += "_delay" + itos(l);
+
+    const int lower_cut = lower_cut_ / cut_var_->K();
+    const int upper_cut = upper_cut_ / cut_var_->K();
+    if (!previous_cut_strings || (previous_cut_strings && !previous_cut_strings->count(cut_var_))) {
+      if (!cut_strings.count(cut_var_))
+        cut_strings[cut_var_];
+      cut_strings.at(cut_var_).insert(name + " > " + itos(lower_cut) + " && " + name + " < " + itos(upper_cut));
     }
-    separator = ")) && ";
   }
-  for (const auto& cut_var : cut_strings1) {
-    separator += "((";
-    for (const auto& cut_string : cut_var.second) {
-      fs << separator << cut_string;
-      separator = ") || (";
+
+  void VarBase::print_cuts(std::map<const VarBase*, std::set<std::string> >& cut_strings,
+                           const int step,
+                           Verilog,
+                           const std::map<const VarBase*, std::set<std::string> >* const previous_cut_strings) const {
+    if (p1_)
+      p1_->print_cuts(cut_strings, step, verilog, previous_cut_strings);
+    if (p2_)
+      p2_->print_cuts(cut_strings, step, verilog, previous_cut_strings);
+    if (p3_)
+      p3_->print_cuts(cut_strings, step, verilog, previous_cut_strings);
+
+    int l = step - latency_ - step_;
+    std::string name = name_;
+    if (l > 0)
+      name += "_delay" + itos(l);
+
+    for (const auto& cut : cuts_) {
+      const VarCut* const cast_cut = (VarCut*)cut;
+      const int lower_cut = cast_cut->lower_cut() / K_;
+      const int upper_cut = cast_cut->upper_cut() / K_;
+      if (!previous_cut_strings || (previous_cut_strings && !previous_cut_strings->count(this))) {
+        if (!cut_strings.count(this))
+          cut_strings[this];
+        cut_strings.at(this).insert(name + " > " + itos(lower_cut) + " && " + name + " < " + itos(upper_cut));
+      }
     }
-    separator = ")) && ";
   }
 
-  fs << ")));";
-}
+  void VarAdjustK::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l2 == 0);
+    assert(l3 == 0);
 
-void VarBase::print_step(int step, std::ofstream& fs, Verilog) {
-  if (!readytoprint_)
-    return;
-  if (step > step_)
-    return;
-  int l1 = 0;
-  int l2 = 0;
-  int l3 = 0;
-  if (p1_) {
-    p1_->print_step(step, fs, verilog);
-    l1 = step_ - p1_->latency() - p1_->step();
-  }
-  if (p2_) {
-    p2_->print_step(step, fs, verilog);
-    l2 = step_ - p2_->latency() - p2_->step();
-  }
-  if (p3_) {
-    p3_->print_step(step, fs, verilog);
-    l3 = step_ - p3_->latency() - p3_->step();
-  }
-  if (step == step_) {
-    if (l1 < 0 || l2 < 0 || l3 < 0 || (l1 > 0 && l2 > 0 && l3 > 0)) {
-      char slog[100];
-      sprintf(slog, "%s::print_step(%i): something wrong with latencies! %i %i %i\n", name_.c_str(), step, l1, l2, l3);
-      edm::LogVerbatim("Tracklet") << slog;
-      dump_msg();
-      assert(0);
-    }
-    if (l1 > 0) {
-      if (p1_->op() != "const")
-        fs << pipe_delay(p1_, p1_->nbits(), l1);
-      else
-        l1 = 0;
-    }
-    if (l2 > 0) {
-      if (p2_->op() != "const")
-        fs << pipe_delay(p2_, p2_->nbits(), l2);
-      else
-        l2 = 0;
-    }
-    if (l3 > 0) {
-      if (p3_->op() != "const")
-        fs << pipe_delay(p3_, p3_->nbits(), l3);
-      else
-        l3 = 0;
-    }
+    std::string shift = "";
+    if (lr_ > 0)
+      shift = " >>> " + itos(lr_);
+    else if (lr_ < 0)
+      shift = " << " + itos(-lr_);
 
-    if (op_ == "flag") {
-      for (const auto& cut : cuts_)
-        fs << cut->cut_var()->pipe_delays(step_);
-    }
+    std::string n1 = p1_->name();
+    if (l1 > 0)
+      n1 = n1 + "_delay" + itos(l1);
 
-    print(fs, verilog, l1, l2, l3);
-    readytoprint_ = false;
-  }
-}
-
-void VarBase::print_all(std::ofstream& fs, Verilog) {
-  for (int i = 0; i <= step_; ++i) {
-    fs << "//\n// STEP " << i << "\n\n";
-    print_step(i, fs, verilog);
-  }
-}
-
-void VarBase::design_print(const std::vector<VarBase*>& v, std::ofstream& fs, Verilog) {
-  //step at which all the outputs should be valid
-  int maxstep = 0;
-
-  //header of the module
-
-  //inputs
-  std::vector<VarBase*> vd;
-  vd.clear();
-  int imax = v.size();
-  for (int i = 0; i < imax; ++i) {
-    (v[i])->inputs(&vd);
-    int step = v[i]->step() + v[i]->latency();
-    if (step > maxstep)
-      maxstep = step;
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n";
+    std::string t = "wire signed [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
+    t += "assign " + name_ + " = " + n1 + shift;
+    fs << t << "; \n";
   }
 
-  //print header
-  fs << "module \n";
-  fs << "(\n";
-  fs << "   input clk,\n";
-  fs << "   input reset,\n\n";
+  void VarAdjustKR::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l2 == 0);
+    assert(l3 == 0);
 
-  imax = vd.size();
-  for (int i = 0; i < imax; ++i)
-    fs << "   input [" << (vd[i])->nbits() - 1 << ":0] " << (vd[i])->name() << "_wire,\n";
-  fs << "\n";
+    std::string n1 = p1_->name();
+    if (l1 > 0)
+      n1 = n1 + "_delay" + itos(l1);
 
-  imax = v.size() - 1;
-  for (int i = 0; i < imax; ++i)
-    if (v[i]->nbits() > 1)
-      fs << "   output [" << (v[i])->nbits() - 1 << ":0] " << (v[i])->name() << "_wire,\n";
+    std::string o1 = n1;
+    if (lr_ == 1)
+      o1 = "(" + o1 + "+1)>>>1";
+    if (lr_ > 1)
+      o1 = "( (" + o1 + ">>>" + itos(lr_ - 1) + ")+1)>>>1";
+    if (lr_ < 0)
+      o1 = o1 + "<<" + itos(-lr_);
+
+    std::string t = "reg signed [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
+    t += "always @(posedge clk) " + name_ + " <= " + o1;
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
+  }
+
+  void VarDef::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+
+    std::string t = "reg signed  [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
+    t = t + "always @(posedge clk) " + name_ + " <= " + name_ + "_wire;\n";
+    fs << "// units " << kstring() << "\t" << K_ << "\n" << t;
+  }
+
+  void VarParam::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string t = "parameter " + name_ + " = ";
+    if (ival_ < 0)
+      t = t + "- " + itos(nbits_) + "\'sd" + itos(-ival_);
     else
-      fs << "   output " << (v[i])->name() << "_wire,\n";
-  if (imax >= 0) {
-    if (v[imax]->nbits() > 1)
-      fs << "   output [" << (v[imax])->nbits() - 1 << ":0] " << (v[imax])->name() << "_wire\n";
-    else
-      fs << "   output " << (v[imax])->name() << "_wire\n";
+      t = t + itos(nbits_) + "\'sd" + itos(ival_);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
   }
-  fs << ");\n\n";
 
-  //body of the module
-  imax = v.size();
-  for (int i = 0; i < imax; ++i) {
+  void VarAdd::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(p2_);
+    assert(l3 == 0);
+    std::string o1 = p1_->name();
+    if (l1 > 0)
+      o1 += "_delay" + itos(l1);
+    if (shift1 > 0) {
+      o1 += "<<" + itos(shift1);
+      o1 = "(" + o1 + ")";
+    }
+
+    std::string o2 = p2_->name();
+    if (l2 > 0)
+      o2 += "_delay" + itos(l2);
+    if (shift2 > 0) {
+      o2 += "<<" + itos(shift2);
+      o2 = "(" + o2 + ")";
+    }
+
+    o1 = o1 + " + " + o2;
+
+    std::string t = "";
+    print_truncation(t, o1, ps_, verilog);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
+  }
+
+  void VarSubtract::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(p2_);
+    assert(l3 == 0);
+    std::string o1 = p1_->name();
+    if (l1 > 0)
+      o1 += "_delay" + itos(l1);
+    if (shift1 > 0) {
+      o1 += "<<" + itos(shift1);
+      o1 = "(" + o1 + ")";
+    }
+
+    std::string o2 = p2_->name();
+    if (l2 > 0)
+      o2 += "_delay" + itos(l2);
+    if (shift2 > 0) {
+      o2 += "<<" + itos(shift2);
+      o2 = "(" + o2 + ")";
+    }
+
+    o1 = o1 + " - " + o2;
+
+    std::string t = "";
+    print_truncation(t, o1, ps_, verilog);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
+  }
+
+  void VarNounits::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
+    if (l1 > 0)
+      n1 = n1 + "_delay" + itos(l1);
+    std::string o1 = "(" + n1 + " * " + itos(cI_) + ")";
+
+    std::string t = "";
+    print_truncation(t, o1, ps_, verilog);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
+  }
+
+  void VarTimesC::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
+    if (l1 > 0)
+      n1 = n1 + "_delay" + itos(l1);
+    std::string o1 = "(" + n1 + " * " + itos(cI_) + ")";
+
+    std::string t = "";
+    print_truncation(t, o1, ps_, verilog);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
+  }
+
+  void VarNeg::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
+    if (l1 > 0)
+      n1 = n1 + "_delay" + itos(l1);
+
+    std::string t = "reg signed  [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
+    t += "always @(posedge clk) " + name_ + " <= - " + n1;
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
+  }
+
+  void VarShiftround::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
+    if (l1 > 0)
+      n1 = n1 + "_delay" + itos(l1);
+    std::string o1 = n1;
+    if (shift_ == 1)
+      o1 = "(" + o1 + "+1)>>>1";
+    if (shift_ > 1)
+      o1 = "( (" + o1 + ">>>" + itos(shift_ - 1) + ")+1)>>>1";
+    if (shift_ < 0)
+      o1 = o1 + "<<" + itos(-shift_);
+
+    std::string t = "reg signed [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
+    t += "always @(posedge clk) " + name_ + " <= " + o1;
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
+  }
+
+  void VarShift::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
+    if (l1 > 0)
+      n1 = n1 + "_delay" + itos(l1);
+    std::string o1 = n1;
+    if (shift_ > 0)
+      o1 = o1 + ">>>" + itos(shift_);
+    if (shift_ < 0)
+      o1 = o1 + "<<" + itos(-shift_);
+
+    std::string t = "wire signed [" + itos(nbits_ - 1) + ":0]" + name_ + ";\n";
+    t += "assign " + name_ + " = " + o1;
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t << ";\n";
+  }
+
+  void VarMult::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(l3 == 0);
+    assert(p1_);
+    std::string n1 = p1_->name();
+    if (l1 > 0)
+      n1 = n1 + "_delay" + itos(l1);
+    assert(p2_);
+    std::string n2 = p2_->name();
+    if (l2 > 0)
+      n2 = n2 + "_delay" + itos(l2);
+    std::string o1 = n1 + " * " + n2;
+
+    std::string t = "";
+    print_truncation(t, o1, ps_, verilog);
+    fs << "// " << nbits_ << " bits \t " << kstring() << "\t" << K_ << "\n" << t;
+  }
+
+  void VarInv::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(l2 == 0);
+    assert(l3 == 0);
+    std::string n1 = p1_->name();
+    if (l1 > 0)
+      n1 = n1 + "_delay" + itos(l1);
+    //first calculate address
+    std::string t1 = "addr_" + name_;
+    std::string t = "wire [" + itos(nbaddr_ - 1) + ":0] " + t1 + ";\n";
+    t = t + "assign " + t1 + " = ";
+    if (shift_ > 0)
+      t = t + "(" + n1 + ">>>" + itos(shift_) + ") & " + itos(mask_);
+    else
+      t = t + n1 + " & " + itos(mask_);
+    fs << t << "; // address for the LUT\n";
+
+    t = "wire signed [" + itos(nbits_ - 1) + ":0] " + name_ + ";\n";
+    fs << t;
+
+    std::string t2 = "LUT_" + name_;
+
+    fs << "Memory #( \n";
+    fs << "         .RAM_WIDTH(" << nbits_ << "),            // Specify RAM data width \n";
+    fs << "         .RAM_DEPTH(" << Nelements_ << "),                     // Specify RAM depth (number of entries) \n";
+    fs << "         .RAM_PERFORMANCE(\"HIGH_PERFORMANCE\"), // \"HIGH_PERFORMANCE\" = 2 clks latency \n";
+    fs << "         .INIT_FILE() \n";
+    fs << "       ) " << t2 << " ( \n";
+    fs << "         .addra(" << itos(nbaddr_) << "\'b0),    // Write address bus, width determined from RAM_DEPTH  \n";
+    fs << "         .addrb(" << t1 << " ),                   // Read address bus, width determined from RAM_DEPTH  \n";
+    fs << "         .dina(" << itos(nbits_) << "\'b0),      // RAM input data, width determined from RAM_WIDTH   \n";
+    fs << "         .clka(clk),      // Write clock \n";
+    fs << "         .clkb(clk),      // Read clock  \n";
+    fs << "         .wea(1\'b0),        // Write enable  \n";
+    fs << "         .enb(1\'b1),        // Read Enable, for additional power savings, disable when not in use  \n";
+    fs << "         .rstb(reset),      // Output reset (does not affect memory contents)                      \n";
+    fs << "         .regceb(1\'b1),  // Output register enable                                                \n";
+    fs << "         .doutb(" << name_ << ")     // RAM output data,                                                \n";
+    fs << "     ); \n";
+  }
+
+  void VarDSPPostadd::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(p1_);
+    assert(p2_);
+    assert(p3_);
+    std::string n1 = p1_->name();
+    if (l1 > 0)
+      n1 = n1 + "_delay" + itos(l1);
+    std::string n2 = p2_->name();
+    if (l2 > 0)
+      n2 = n2 + "_delay" + itos(l2);
+    std::string n3 = p3_->name();
+    if (l3 > 0)
+      n3 = n3 + "_delay" + itos(l3);
+
+    if (shift3_ > 0)
+      n3 = n3 + "<<" + itos(shift3_);
+    if (shift3_ < 0)
+      n3 = n3 + ">>>" + itos(-shift3_);
+
+    std::string n4 = "";
+    if (ps_ > 0)
+      n4 = ">>>" + itos(ps_);
+
+    fs << name_ + " = DSP_postadd(" + n1 + ", " + n2 + ", " + n3 + ")" + n4 + ";";
+  }
+
+  void VarFlag::print(std::ofstream& fs, Verilog, int l1, int l2, int l3) {
+    assert(l1 == 0);
+    assert(l2 == 0);
+    assert(l3 == 0);
+
+    fs << "wire " << name_ << ";" << std::endl;
+    fs << "assign " << name_ << " = (";
+    std::map<const VarBase*, std::set<std::string> > cut_strings0, cut_strings1;
+    for (const auto& cut : cuts_) {
+      if (cut->op() != "cut")
+        continue;
+      const VarCut* const cast_cut = (VarCut*)cut;
+      cast_cut->print(cut_strings0, step_, verilog);
+    }
+    for (const auto& cut : cuts_) {
+      if (cut->op() != "cut")
+        cut->print_cuts(cut_strings1, step_, verilog, &cut_strings0);
+      else {
+        if (cut->cut_var()->p1())
+          cut->cut_var()->p1()->print_cuts(cut_strings1, step_, verilog, &cut_strings1);
+        if (cut->cut_var()->p2())
+          cut->cut_var()->p2()->print_cuts(cut_strings1, step_, verilog, &cut_strings1);
+        if (cut->cut_var()->p3())
+          cut->cut_var()->p3()->print_cuts(cut_strings1, step_, verilog, &cut_strings1);
+      }
+    }
+
+    std::string separator = "";
+    for (const auto& cut_var : cut_strings0) {
+      separator += "((";
+      for (const auto& cut_string : cut_var.second) {
+        fs << separator << cut_string;
+        separator = ") || (";
+      }
+      separator = ")) && ";
+    }
+    for (const auto& cut_var : cut_strings1) {
+      separator += "((";
+      for (const auto& cut_string : cut_var.second) {
+        fs << separator << cut_string;
+        separator = ") || (";
+      }
+      separator = ")) && ";
+    }
+
+    fs << ")));";
+  }
+
+  void VarBase::print_step(int step, std::ofstream& fs, Verilog) {
+    if (!readytoprint_)
+      return;
+    if (step > step_)
+      return;
+    int l1 = 0;
+    int l2 = 0;
+    int l3 = 0;
+    if (p1_) {
+      p1_->print_step(step, fs, verilog);
+      l1 = step_ - p1_->latency() - p1_->step();
+    }
+    if (p2_) {
+      p2_->print_step(step, fs, verilog);
+      l2 = step_ - p2_->latency() - p2_->step();
+    }
+    if (p3_) {
+      p3_->print_step(step, fs, verilog);
+      l3 = step_ - p3_->latency() - p3_->step();
+    }
+    if (step == step_) {
+      if (l1 < 0 || l2 < 0 || l3 < 0 || (l1 > 0 && l2 > 0 && l3 > 0)) {
+        char slog[100];
+        sprintf(
+            slog, "%s::print_step(%i): something wrong with latencies! %i %i %i\n", name_.c_str(), step, l1, l2, l3);
+        edm::LogVerbatim("Tracklet") << slog;
+        dump_msg();
+        assert(0);
+      }
+      if (l1 > 0) {
+        if (p1_->op() != "const")
+          fs << pipe_delay(p1_, p1_->nbits(), l1);
+        else
+          l1 = 0;
+      }
+      if (l2 > 0) {
+        if (p2_->op() != "const")
+          fs << pipe_delay(p2_, p2_->nbits(), l2);
+        else
+          l2 = 0;
+      }
+      if (l3 > 0) {
+        if (p3_->op() != "const")
+          fs << pipe_delay(p3_, p3_->nbits(), l3);
+        else
+          l3 = 0;
+      }
+
+      if (op_ == "flag") {
+        for (const auto& cut : cuts_)
+          fs << cut->cut_var()->pipe_delays(step_);
+      }
+
+      print(fs, verilog, l1, l2, l3);
+      readytoprint_ = false;
+    }
+  }
+
+  void VarBase::print_all(std::ofstream& fs, Verilog) {
+    for (int i = 0; i <= step_; ++i) {
+      fs << "//\n// STEP " << i << "\n\n";
+      print_step(i, fs, verilog);
+    }
+  }
+
+  void VarBase::design_print(const std::vector<VarBase*>& v, std::ofstream& fs, Verilog) {
+    //step at which all the outputs should be valid
+    int maxstep = 0;
+
+    //header of the module
+
+    //inputs
+    std::vector<VarBase*> vd;
+    vd.clear();
+    int imax = v.size();
+    for (int i = 0; i < imax; ++i) {
+      (v[i])->inputs(&vd);
+      int step = v[i]->step() + v[i]->latency();
+      if (step > maxstep)
+        maxstep = step;
+    }
+
+    //print header
+    fs << "module \n";
+    fs << "(\n";
+    fs << "   input clk,\n";
+    fs << "   input reset,\n\n";
+
+    imax = vd.size();
+    for (int i = 0; i < imax; ++i)
+      fs << "   input [" << (vd[i])->nbits() - 1 << ":0] " << (vd[i])->name() << "_wire,\n";
+    fs << "\n";
+
+    imax = v.size() - 1;
+    for (int i = 0; i < imax; ++i)
+      if (v[i]->nbits() > 1)
+        fs << "   output [" << (v[i])->nbits() - 1 << ":0] " << (v[i])->name() << "_wire,\n";
+      else
+        fs << "   output " << (v[i])->name() << "_wire,\n";
+    if (imax >= 0) {
+      if (v[imax]->nbits() > 1)
+        fs << "   output [" << (v[imax])->nbits() - 1 << ":0] " << (v[imax])->name() << "_wire\n";
+      else
+        fs << "   output " << (v[imax])->name() << "_wire\n";
+    }
+    fs << ");\n\n";
+
+    //body of the module
+    imax = v.size();
+    for (int i = 0; i < imax; ++i) {
+      fs << "\n//\n";
+      fs << "// calculating " << (v[i])->name() << "\n";
+      fs << "//\n";
+      (v[i])->print_all(fs, verilog);
+    }
+    fs << "\n";
+
+    //trailer
+    fs << "\n";
     fs << "\n//\n";
-    fs << "// calculating " << (v[i])->name() << "\n";
+    fs << "// wiring the outputs \n";
+    fs << "// latency = " << maxstep << "\n";
     fs << "//\n";
-    (v[i])->print_all(fs, verilog);
-  }
-  fs << "\n";
+    for (int i = 0; i < imax; ++i) {
+      std::string n = v[i]->name() + "_wire";
+      int delay = maxstep - v[i]->step() - v[i]->latency();
+      if (delay == 0)
+        fs << "assign " << n << " = " << (v[i])->name() << ";\n";
+      else
+        fs << pipe_delay_wire(v[i], n, v[i]->nbits(), delay);
+    }
 
-  //trailer
-  fs << "\n";
-  fs << "\n//\n";
-  fs << "// wiring the outputs \n";
-  fs << "// latency = " << maxstep << "\n";
-  fs << "//\n";
-  for (int i = 0; i < imax; ++i) {
-    std::string n = v[i]->name() + "_wire";
-    int delay = maxstep - v[i]->step() - v[i]->latency();
-    if (delay == 0)
-      fs << "assign " << n << " = " << (v[i])->name() << ";\n";
-    else
-      fs << pipe_delay_wire(v[i], n, v[i]->nbits(), delay);
+    fs << "endmodule\n";
   }
 
-  fs << "endmodule\n";
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/imath_Verilog.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath_Verilog.cc
@@ -1,6 +1,6 @@
 #include "L1Trigger/TrackFindingTracklet/interface/imath.h"
 
-using namespace trklet;
+namespace trklet {
 
 void VarInv::writeLUT(std::ofstream& fs, Verilog) const {
   for (int i = 0; i < Nelements_; ++i)
@@ -531,4 +531,6 @@ void VarBase::design_print(const std::vector<VarBase*>& v, std::ofstream& fs, Ve
   }
 
   fs << "endmodule\n";
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/src/imath_calculate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath_calculate.cc
@@ -3,198 +3,199 @@
 
 namespace trklet {
 
-bool VarBase::calculate(int debug_level) {
-  bool ok1 = true;
-  bool ok2 = true;
-  bool ok3 = true;
+  bool VarBase::calculate(int debug_level) {
+    bool ok1 = true;
+    bool ok2 = true;
+    bool ok3 = true;
 
-  if (p1_)
-    ok1 = p1_->calculate(debug_level);
-  if (p2_)
-    ok2 = p2_->calculate(debug_level);
-  if (p3_)
-    ok3 = p3_->calculate(debug_level);
+    if (p1_)
+      ok1 = p1_->calculate(debug_level);
+    if (p2_)
+      ok2 = p2_->calculate(debug_level);
+    if (p3_)
+      ok3 = p3_->calculate(debug_level);
 
-  bool all_ok = debug_level && ok1 && ok2 && ok3;
-  long int ival_prev = ival_;
+    bool all_ok = debug_level && ok1 && ok2 && ok3;
+    long int ival_prev = ival_;
 
-  local_calculate();
+    local_calculate();
 
-  val_ = ival_ * K_;
+    val_ = ival_ * K_;
 
 #ifdef IMATH_ROOT
-  if (globals_->use_root) {
-    if (h_ == 0) {
-      globals_->h_file_->cd();
-      std::string hname = "h_" + name_;
-      h_ = (TH2F *)globals_->h_file_->Get(hname.c_str());
+    if (globals_->use_root) {
       if (h_ == 0) {
-        h_precision_ = 0.5 * h_nbins_ * K_;
-        std::string st = name_ + ";fval;fval-ival*K";
-        h_ = new TH2F(hname.c_str(), name_.c_str(), h_nbins_, -range(), range(), h_nbins_, -h_precision_, h_precision_);
-        if (debug_level == 3)
-          edm::LogVerbatim("Tracklet") << " booking histogram " << hname;
+        globals_->h_file_->cd();
+        std::string hname = "h_" + name_;
+        h_ = (TH2F *)globals_->h_file_->Get(hname.c_str());
+        if (h_ == 0) {
+          h_precision_ = 0.5 * h_nbins_ * K_;
+          std::string st = name_ + ";fval;fval-ival*K";
+          h_ = new TH2F(
+              hname.c_str(), name_.c_str(), h_nbins_, -range(), range(), h_nbins_, -h_precision_, h_precision_);
+          if (debug_level == 3)
+            edm::LogVerbatim("Tracklet") << " booking histogram " << hname;
+        }
       }
+      if (ival_ != ival_prev || op_ == "def" || op_ == "const")
+        h_->Fill(fval_, K_ * ival_ - fval_);
     }
-    if (ival_ != ival_prev || op_ == "def" || op_ == "const")
-      h_->Fill(fval_, K_ * ival_ - fval_);
-  }
 #endif
 
-  if (debug_level)
-    calcDebug(debug_level, ival_prev, all_ok);
+    if (debug_level)
+      calcDebug(debug_level, ival_prev, all_ok);
 
-  return all_ok;
-}
+    return all_ok;
+  }
 
-void VarBase::calcDebug(int debug_level, long int ival_prev, bool &all_ok) {
-  if (fval_ > maxval_)
-    maxval_ = fval_;
-  if (fval_ < minval_)
-    minval_ = fval_;
+  void VarBase::calcDebug(int debug_level, long int ival_prev, bool &all_ok) {
+    if (fval_ > maxval_)
+      maxval_ = fval_;
+    if (fval_ < minval_)
+      minval_ = fval_;
 
-  bool todump = false;
-  int nmax = sizeof(long int) * 8;
-  int ns = nmax - nbits_;
-  long int itest = ival_;
-  itest = l1t::bitShift(itest, ns);
-  itest = itest >> ns;
-  if (itest != ival_) {
-    if (debug_level == 3 || (ival_ != ival_prev && all_ok)) {
-      edm::LogVerbatim("Tracklet") << "imath: truncated value mismatch!! " << ival_ << " != " << itest;
-      todump = true;
+    bool todump = false;
+    int nmax = sizeof(long int) * 8;
+    int ns = nmax - nbits_;
+    long int itest = ival_;
+    itest = l1t::bitShift(itest, ns);
+    itest = itest >> ns;
+    if (itest != ival_) {
+      if (debug_level == 3 || (ival_ != ival_prev && all_ok)) {
+        edm::LogVerbatim("Tracklet") << "imath: truncated value mismatch!! " << ival_ << " != " << itest;
+        todump = true;
+      }
+      all_ok = false;
     }
-    all_ok = false;
-  }
 
-  float ftest = val_;
-  float tolerance = 0.1 * std::abs(fval_);
-  if (tolerance < 2 * K_)
-    tolerance = 2 * K_;
-  if (std::abs(ftest - fval_) > tolerance) {
-    if (debug_level == 3 || (ival_ != ival_prev && (all_ok && (op_ != "inv" || debug_level >= 2)))) {
-      edm::LogVerbatim("Tracklet") << "imath: **GROSS** value mismatch!! " << fval_ << " != " << ftest;
-      if (op_ == "inv")
-        edm::LogVerbatim("Tracklet") << p1_->dump() << "\n-----------------------------------";
-      todump = true;
+    float ftest = val_;
+    float tolerance = 0.1 * std::abs(fval_);
+    if (tolerance < 2 * K_)
+      tolerance = 2 * K_;
+    if (std::abs(ftest - fval_) > tolerance) {
+      if (debug_level == 3 || (ival_ != ival_prev && (all_ok && (op_ != "inv" || debug_level >= 2)))) {
+        edm::LogVerbatim("Tracklet") << "imath: **GROSS** value mismatch!! " << fval_ << " != " << ftest;
+        if (op_ == "inv")
+          edm::LogVerbatim("Tracklet") << p1_->dump() << "\n-----------------------------------";
+        todump = true;
+      }
+      all_ok = false;
     }
-    all_ok = false;
+    if (todump)
+      edm::LogVerbatim("Tracklet") << dump();
   }
-  if (todump)
-    edm::LogVerbatim("Tracklet") << dump();
-}
 
-void VarFlag::calculate_step() {
-  int max_step = 0;
-  for (const auto &cut : cuts_) {
-    if (!cut->cut_var())
-      continue;
-    if (cut->cut_var()->latency() + cut->cut_var()->step() > max_step)
-      max_step = cut->cut_var()->latency() + cut->cut_var()->step();
+  void VarFlag::calculate_step() {
+    int max_step = 0;
+    for (const auto &cut : cuts_) {
+      if (!cut->cut_var())
+        continue;
+      if (cut->cut_var()->latency() + cut->cut_var()->step() > max_step)
+        max_step = cut->cut_var()->latency() + cut->cut_var()->step();
+    }
+    step_ = max_step;
   }
-  step_ = max_step;
-}
 
-//
-//  local calculations
-//
+  //
+  //  local calculations
+  //
 
-void VarAdjustK::local_calculate() {
-  fval_ = p1_->fval();
-  ival_ = p1_->ival();
-  if (lr_ > 0)
-    ival_ = ival_ >> lr_;
-  else if (lr_ < 0)
-    ival_ = l1t::bitShift(ival_, (-lr_));
-}
+  void VarAdjustK::local_calculate() {
+    fval_ = p1_->fval();
+    ival_ = p1_->ival();
+    if (lr_ > 0)
+      ival_ = ival_ >> lr_;
+    else if (lr_ < 0)
+      ival_ = l1t::bitShift(ival_, (-lr_));
+  }
 
-void VarAdjustKR::local_calculate() {
-  fval_ = p1_->fval();
-  ival_ = p1_->ival();
-  if (lr_ > 0)
-    ival_ = ((ival_ >> (lr_ - 1)) + 1) >> 1;  //rounding
-  else if (lr_ < 0)
-    ival_ = l1t::bitShift(ival_, (-lr_));
-}
+  void VarAdjustKR::local_calculate() {
+    fval_ = p1_->fval();
+    ival_ = p1_->ival();
+    if (lr_ > 0)
+      ival_ = ((ival_ >> (lr_ - 1)) + 1) >> 1;  //rounding
+    else if (lr_ < 0)
+      ival_ = l1t::bitShift(ival_, (-lr_));
+  }
 
-void VarAdd::local_calculate() {
-  fval_ = p1_->fval() + p2_->fval();
-  long int i1 = p1_->ival();
-  long int i2 = p2_->ival();
-  if (shift1 > 0)
-    i1 = l1t::bitShift(i1, shift1);
-  if (shift2 > 0)
-    i2 = l1t::bitShift(i2, shift2);
-  ival_ = i1 + i2;
-  if (ps_ > 0)
+  void VarAdd::local_calculate() {
+    fval_ = p1_->fval() + p2_->fval();
+    long int i1 = p1_->ival();
+    long int i2 = p2_->ival();
+    if (shift1 > 0)
+      i1 = l1t::bitShift(i1, shift1);
+    if (shift2 > 0)
+      i2 = l1t::bitShift(i2, shift2);
+    ival_ = i1 + i2;
+    if (ps_ > 0)
+      ival_ = ival_ >> ps_;
+  }
+
+  void VarSubtract::local_calculate() {
+    fval_ = p1_->fval() - p2_->fval();
+    long int i1 = p1_->ival();
+    long int i2 = p2_->ival();
+    if (shift1 > 0)
+      i1 = l1t::bitShift(i1, shift1);
+    if (shift2 > 0)
+      i2 = l1t::bitShift(i2, shift2);
+    ival_ = i1 - i2;
+    if (ps_ > 0)
+      ival_ = ival_ >> ps_;
+  }
+
+  void VarNounits::local_calculate() {
+    fval_ = p1_->fval();
+    ival_ = (p1_->ival() * cI_) >> ps_;
+  }
+
+  void VarTimesC::local_calculate() {
+    fval_ = p1_->fval() * cF_;
+    ival_ = (p1_->ival() * cI_) >> ps_;
+  }
+
+  void VarNeg::local_calculate() {
+    fval_ = -p1_->fval();
+    ival_ = -p1_->ival();
+  }
+
+  void VarShift::local_calculate() {
+    fval_ = p1_->fval() * pow(2, -shift_);
+    ival_ = p1_->ival();
+    if (shift_ > 0)
+      ival_ = ival_ >> shift_;
+    if (shift_ < 0)
+      ival_ = l1t::bitShift(ival_, (-shift_));
+  }
+
+  void VarShiftround::local_calculate() {
+    fval_ = p1_->fval() * pow(2, -shift_);
+    ival_ = p1_->ival();
+    if (shift_ > 0)
+      ival_ = ((ival_ >> (shift_ - 1)) + 1) >> 1;
+    if (shift_ < 0)
+      ival_ = l1t::bitShift(ival_, (-shift_));
+  }
+
+  void VarMult::local_calculate() {
+    fval_ = p1_->fval() * p2_->fval();
+    ival_ = (p1_->ival() * p2_->ival()) >> ps_;
+  }
+
+  void VarDSPPostadd::local_calculate() {
+    fval_ = p1_->fval() * p2_->fval() + p3_->fval();
+    ival_ = p3_->ival();
+    if (shift3_ > 0)
+      ival_ = l1t::bitShift(ival_, shift3_);
+    if (shift3_ < 0)
+      ival_ = ival_ >> (-shift3_);
+    ival_ += p1_->ival() * p2_->ival();
     ival_ = ival_ >> ps_;
-}
+  }
 
-void VarSubtract::local_calculate() {
-  fval_ = p1_->fval() - p2_->fval();
-  long int i1 = p1_->ival();
-  long int i2 = p2_->ival();
-  if (shift1 > 0)
-    i1 = l1t::bitShift(i1, shift1);
-  if (shift2 > 0)
-    i2 = l1t::bitShift(i2, shift2);
-  ival_ = i1 - i2;
-  if (ps_ > 0)
-    ival_ = ival_ >> ps_;
-}
+  void VarInv::local_calculate() {
+    fval_ = 1. / (offset_ + p1_->fval());
+    ival_ = LUT[ival_to_addr(p1_->ival())];
+  }
 
-void VarNounits::local_calculate() {
-  fval_ = p1_->fval();
-  ival_ = (p1_->ival() * cI_) >> ps_;
-}
-
-void VarTimesC::local_calculate() {
-  fval_ = p1_->fval() * cF_;
-  ival_ = (p1_->ival() * cI_) >> ps_;
-}
-
-void VarNeg::local_calculate() {
-  fval_ = -p1_->fval();
-  ival_ = -p1_->ival();
-}
-
-void VarShift::local_calculate() {
-  fval_ = p1_->fval() * pow(2, -shift_);
-  ival_ = p1_->ival();
-  if (shift_ > 0)
-    ival_ = ival_ >> shift_;
-  if (shift_ < 0)
-    ival_ = l1t::bitShift(ival_, (-shift_));
-}
-
-void VarShiftround::local_calculate() {
-  fval_ = p1_->fval() * pow(2, -shift_);
-  ival_ = p1_->ival();
-  if (shift_ > 0)
-    ival_ = ((ival_ >> (shift_ - 1)) + 1) >> 1;
-  if (shift_ < 0)
-    ival_ = l1t::bitShift(ival_, (-shift_));
-}
-
-void VarMult::local_calculate() {
-  fval_ = p1_->fval() * p2_->fval();
-  ival_ = (p1_->ival() * p2_->ival()) >> ps_;
-}
-
-void VarDSPPostadd::local_calculate() {
-  fval_ = p1_->fval() * p2_->fval() + p3_->fval();
-  ival_ = p3_->ival();
-  if (shift3_ > 0)
-    ival_ = l1t::bitShift(ival_, shift3_);
-  if (shift3_ < 0)
-    ival_ = ival_ >> (-shift3_);
-  ival_ += p1_->ival() * p2_->ival();
-  ival_ = ival_ >> ps_;
-}
-
-void VarInv::local_calculate() {
-  fval_ = 1. / (offset_ + p1_->fval());
-  ival_ = LUT[ival_to_addr(p1_->ival())];
-}
-
-}
+}  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/imath_calculate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/imath_calculate.cc
@@ -1,7 +1,7 @@
 #include "L1Trigger/TrackFindingTracklet/interface/imath.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-using namespace trklet;
+namespace trklet {
 
 bool VarBase::calculate(int debug_level) {
   bool ok1 = true;
@@ -195,4 +195,6 @@ void VarDSPPostadd::local_calculate() {
 void VarInv::local_calculate() {
   fval_ = 1. / (offset_ + p1_->fval());
   ival_ = LUT[ival_to_addr(p1_->ival())];
+}
+
 }

--- a/L1Trigger/TrackFindingTracklet/test/BuildFile.xml
+++ b/L1Trigger/TrackFindingTracklet/test/BuildFile.xml
@@ -1,43 +1,19 @@
-<environment>
-  <library   file="*.cc" name="TrackFindingTrackletTests">
-    <flags   EDM_PLUGIN="1"/>
-    <flags   SKIP_FILES="fpga.cc"/>
-    <flags   CXXFLAGS="-DUSEHYBRID"/>
-    <use   name="clhep"/>
-    <use   name="root"/>
-    <use   name="heppdt"/>
-    <use   name="CommonTools/UtilAlgos"/>
-    <use   name="CondFormats/Alignment"/>
-    <use   name="CondFormats/DataRecord"/>
-    <use   name="CondFormats/L1TObjects"/>
-    <use   name="DataFormats/Common"/>
-    <use   name="DataFormats/HepMCCandidate"/>
-    <use   name="DataFormats/L1TrackTrigger"/>
-    <use   name="DataFormats/L1Trigger"/>
-    <use   name="DataFormats/Phase2TrackerDigi"/>
-    <use   name="DataFormats/TrackerRecHit2D"/>
-    <use   name="FWCore/Framework"/>
-    <use   name="FWCore/MessageLogger"/>
-    <use   name="FWCore/PluginManager"/>
-    <use   name="FWCore/ParameterSet"/>
-    <use   name="FWCore/ServiceRegistry"/>
-    <use   name="Geometry/CommonDetUnit"/>
-    <use   name="Geometry/Records"/>
-    <use   name="Geometry/TrackerGeometryBuilder"/>
-    <use   name="Geometry/TrackerNumberingBuilder"/>
-    <use   name="PhysicsTools/CandUtils"/>
-    <use   name="PhysicsTools/UtilAlgos"/>
-    <use   name="SimTracker/TrackerHitAssociation"/>
-    <use   name="RecoLocalTracker/SiPixelRecHits"/>
-    <use   name="RecoTracker/TkSeedGenerator"/>
-    <use   name="SimTracker/TrackTriggerAssociation"/>
-    <use   name="SimDataFormats/Vertex"/>
-    <use   name="SimDataFormats/TrackingHit"/>
-    <use   name="SimDataFormats/CrossingFrame"/>
-    <use   name="SimDataFormats/TrackingAnalysis"/>
-    <use   name="TrackingTools/TrackAssociator"/>
-    <use   name="TrackingTools/TrajectoryState"/>
-    <use name="L1Trigger/TrackerTFP"/>
-    <use name="L1Trigger/TrackFindingTracklet"/>
-  </library>
-</environment>
+<library   file="*.cc" name="TrackFindingTrackletTests">
+  <flags   EDM_PLUGIN="1"/>
+  <flags   SKIP_FILES="fpga.cc"/>
+  <flags   CXXFLAGS="-DUSEHYBRID"/>
+  <use name="heppdt"/>
+  <use name="CommonTools/UtilAlgos"/>
+  <use name="CondFormats/Alignment"/>
+  <use name="DataFormats/Common"/>
+  <use name="FWCore/ServiceRegistry"/>
+  <use name="PhysicsTools/UtilAlgos"/>
+  <use name="SimTracker/TrackerHitAssociation"/>
+  <use name="RecoLocalTracker/SiPixelRecHits"/>
+  <use name="SimDataFormats/Vertex"/>
+  <use name="SimDataFormats/TrackingHit"/>
+  <use name="SimDataFormats/CrossingFrame"/>
+  <use name="TrackingTools/TrackAssociator"/>
+  <use name="TrackingTools/TrajectoryState"/>
+  <use name="L1Trigger/TrackFindingTracklet"/>
+</library>


### PR DESCRIPTION
The TMTT & TrackerTFP .cc files wrap the class implementations in a namespace. e.g. https://github.com/cms-L1TK/cmssw/blob/L1TK-dev-12_6_0_pre5/L1Trigger/TrackFindingTMTT/src/InputData.cc#L23 , whereas the Tracklet ones do not, instead just using "using namespace" https://github.com/cms-L1TK/cmssw/blob/L1TK-dev-12_6_0_pre5/L1Trigger/TrackFindingTracklet/src/MatchEngine.cc#L16 .  The Tracklet method is not recommended -- see https://google.github.io/styleguide/cppguide.html#Namespaces and https://stackoverflow.com/questions/8681714/correct-way-to-define-c-namespace-methods-in-cpp-file , and is not used elsewhere in CMSSW. e.g. https://cmssdt.cern.ch/lxr/source/FWCore/Common/src/TriggerNames.cc . This PR therefore corrects it. 

Warning: this changes the indentation of all the Tracklet .cc files, explaining why so many lines of code change. But there is little ongoing work at the moment, so this shouldn't give clashes. It is also the first PR here that has not gone into central CMSSW yet, so it may be possible to push it by itself to central CMSSW after merge.

This cleanup is helpful in the future emulation code, since all namespaces are treated the same way.

The PR also includes some small cleanups of the BuildFile.xml's.