### PR TITLE
Fix to set nbits_ for the VMRME/TE files (#196)

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -1100,10 +1100,12 @@ void TrackletLUT::initVMRTable(unsigned int layerdisk, VMRTableType type, int re
 
   if (settings_.combined()) {
     if (type == VMRTableType::me) {
+      nbits_ = 2 * settings_.NLONGVMBITS();
       positive_ = false;
       name_ = "VMRME_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
     }
     if (type == VMRTableType::disk) {
+      nbits_ = 2 * settings_.NLONGVMBITS();
       positive_ = false;
       name_ = "VMRTE_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
     }


### PR DESCRIPTION
A mistake was introduced earlier where nbits_ was not set when writing the VMR ME/TE LUTs for the combined modules. This cased a crash (segv) when trying to write the LUTs when running the combined modules. (Fix from Anders Ryd).

This is being added to the PR to central CMSSW.