### PR TITLE
MP fix disk deltar

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -122,7 +122,7 @@ void MatchEngineUnit::processPipeline() {
     int diskps = (!barrel_) && isPSmodule;
 
     //here we always use the larger number of bits for the bend
-    unsigned int index = (diskps << (N_BENDBITS_2S + NRINVBITS)) + (projrinv___ << nbits) + vmstub___.bend().value();
+    unsigned int index = (diskps << (nbits + NRINVBITS)) + (projrinv___ << nbits) + vmstub___.bend().value();
 
     //Check if stub z position consistent
     int idrz = stubfinerz - projfinerz___;

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -608,6 +608,7 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
         imatch = keep;
       }
     }
+
     if (imatch) {
       tracklet->addMatch(layerdisk_,
                          ideltaphi,
@@ -670,7 +671,8 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
       }
     }
 
-    int ideltar = (irstub>>1) - ir;
+    constexpr int diff_bits = 1;
+    int ideltar = (irstub >> diff_bits) - ir;
 
     if (!stub->isPSmodule()) {
       int ialpha = fpgastub->alpha().value();

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -583,7 +583,7 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
     // Update the "best" values
     if (imatch) {
       best_ideltaphi_barrel = std::abs(ideltaphi);
-      best_ideltaz_barrel = std::abs(ideltaz);
+      best_ideltaz_barrel = std::abs(ideltaz << dzshift_);
     }
 
     if (settings_.debugTracklet()) {
@@ -671,7 +671,7 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
       }
     }
 
-    int ideltar = (irstub * settings_.kr()) / settings_.krprojshiftdisk() - ir;
+    int ideltar = (irstub>>1) - ir;
 
     if (!stub->isPSmodule()) {
       int ialpha = fpgastub->alpha().value();

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -352,7 +352,7 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
 
         unsigned int iphi = (fpgaphi.value() >> (fpgaphi.nbits() - nvmbits_)) & (nvmbins_ - 1);
 
-        int nextrabits = 2;
+        constexpr int nextrabits = 2;
         int overlapbits = nvmbits_ + nextrabits;
 
         unsigned int extrabits = fpgaphi.bits(fpgaphi.nbits() - overlapbits - nextrabits, nextrabits);
@@ -435,7 +435,7 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
         VMStubsMEMemory* stubmem = vmstubs_[0];
         bool usefirstMinus = stubmem->nStubsBin(ivmMinus * nbins + slot) != 0;
         bool usesecondMinus = (second && (stubmem->nStubsBin(ivmMinus * nbins + slot + 1) != 0));
-        bool usefirstPlus = ivmPlus != ivmMinus && stubmem->nStubsBin(ivmPlus * nbins + slot) != 0;
+        bool usefirstPlus = ivmPlus != ivmMinus && (stubmem->nStubsBin(ivmPlus * nbins + slot) != 0);
         bool usesecondPlus = ivmPlus != ivmMinus && (second && (stubmem->nStubsBin(ivmPlus * nbins + slot + 1) != 0));
 
         good_ = usefirstPlus || usesecondPlus || usefirstMinus || usesecondMinus;
@@ -608,7 +608,6 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
         imatch = keep;
       }
     }
-
     if (imatch) {
       tracklet->addMatch(layerdisk_,
                          ideltaphi,


### PR DESCRIPTION
#### PR description:

This PR fixes agreement in the disks between the emulation and the HLS implementation. The calculation for the `ideltar` value is updated (shifting by one to account for the different number of bits in the stubs and projections). The `best_ideltaz_barrel` calculation is also updated.

This PR will bring the emulation in agreement with the HLS PR https://github.com/cms-L1TK/firmware-hls/pull/242 (still a work in progress).

Temporary test vectors:
https://cernbox.cern.ch/remote.php/dav/public-files/KMwIFrlRqnQTtGc/MemPrints_byates_100_1260.tar.gz

#### PR validation:

The HLS implementation of the MP disks is still a work in progress, but so far D1 has full agreement for 99/100 events (event 96 has 9 missing FMs in the HLS, likely due to truncation)