### PR TITLE
Seed stub IDs

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
@@ -58,11 +58,11 @@ namespace trklet {
 
     bool stubtruthmatch(const L1TStub* stub);
 
-    const Stub* innerFPGAStub() { return innerFPGAStub_; }
+    const Stub* innerFPGAStub() const { return innerFPGAStub_; }
 
-    const Stub* middleFPGAStub() { return middleFPGAStub_; }
+    const Stub* middleFPGAStub() const { return middleFPGAStub_; }
 
-    const Stub* outerFPGAStub() { return outerFPGAStub_; }
+    const Stub* outerFPGAStub() const { return outerFPGAStub_; }
 
     std::string addressstr();
 

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -720,6 +720,8 @@ std::string Tracklet::trackfitstr() const {
 
     oss += "1|";  // valid bit
     oss += tmp.str() + "|";
+    oss += innerFPGAStub()->stubindex().str() + "|";
+    oss += outerFPGAStub()->stubindex().str() + "|";
     oss += fpgapars_.rinv().str() + "|";
     oss += fpgapars_.phi0().str() + "|";
     oss += fpgapars_.z0().str() + "|";


### PR DESCRIPTION
#### PR description:

This PR adds the seed stub IDs to the TrackBuilder output, for use by the TrackMerger.

#### PR validation:

I ran the code with writeMem_ = true, and saw the seed stub IDs correctly output in the resulting test vectors.