### PR TITLE
Removed unnecessary "trklet::" statements

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/IMATH_TrackletCalculator.h
+++ b/L1Trigger/TrackFindingTracklet/interface/IMATH_TrackletCalculator.h
@@ -147,9 +147,9 @@ namespace trklet {
     VarParam plus2{globals_, "plus2", 2., 10};
     VarParam minus1{globals_, "minus1", -1., 10};
 
-    VarParam r1mean{globals_, "r1mean", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarParam r2mean{globals_, "r2mean", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarParam r12mean{globals_, "r12mean", "Kr", 2 * settings_.rmax(trklet::N_DISK - 1), settings_.kr()};
+    VarParam r1mean{globals_, "r1mean", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarParam r2mean{globals_, "r2mean", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarParam r12mean{globals_, "r12mean", "Kr", 2 * settings_.rmax(N_DISK - 1), settings_.kr()};
 
     //inputs
     VarDef r1{globals_, "r1", "Kr", settings_.drmax(), settings_.kr()};
@@ -161,22 +161,22 @@ namespace trklet {
     VarDef phi1{globals_, "phi1", "Kphi", settings_.dphisector() / 0.75, settings_.kphi1()};
     VarDef phi2{globals_, "phi2", "Kphi", settings_.dphisector() / 0.75, settings_.kphi1()};
 
-    VarDef rproj0{globals_, "rproj0", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarDef rproj1{globals_, "rproj1", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarDef rproj2{globals_, "rproj2", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarDef rproj3{globals_, "rproj3", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
+    VarDef rproj0{globals_, "rproj0", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarDef rproj1{globals_, "rproj1", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarDef rproj2{globals_, "rproj2", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarDef rproj3{globals_, "rproj3", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
 
-    VarDef zproj0{globals_, "zproj0", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
-    VarDef zproj1{globals_, "zproj1", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
-    VarDef zproj2{globals_, "zproj2", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
-    VarDef zproj3{globals_, "zproj3", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
-    VarDef zproj4{globals_, "zproj4", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
+    VarDef zproj0{globals_, "zproj0", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
+    VarDef zproj1{globals_, "zproj1", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
+    VarDef zproj2{globals_, "zproj2", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
+    VarDef zproj3{globals_, "zproj3", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
+    VarDef zproj4{globals_, "zproj4", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
 
     //calculations
 
     //tracklet
-    VarAdd r1abs{globals_, "r1abs", &r1, &r1mean, settings_.rmax(trklet::N_LAYER - 1)};
-    VarAdd r2abs{globals_, "r2abs", &r2, &r2mean, settings_.rmax(trklet::N_LAYER - 1)};
+    VarAdd r1abs{globals_, "r1abs", &r1, &r1mean, settings_.rmax(N_LAYER - 1)};
+    VarAdd r2abs{globals_, "r2abs", &r2, &r2mean, settings_.rmax(N_LAYER - 1)};
 
     VarSubtract dr{globals_, "dr", &r2, &r1};
 

--- a/L1Trigger/TrackFindingTracklet/interface/IMATH_TrackletCalculatorDisk.h
+++ b/L1Trigger/TrackFindingTracklet/interface/IMATH_TrackletCalculatorDisk.h
@@ -136,31 +136,31 @@ namespace trklet {
     VarParam plus1{globals_, "plus1", 1., 10};
     VarParam minus1{globals_, "minus1", -1, 10};
 
-    VarParam z1mean{globals_, "z1mean", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
-    VarParam z2mean{globals_, "z2mean", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
+    VarParam z1mean{globals_, "z1mean", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
+    VarParam z2mean{globals_, "z2mean", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
 
     //inputs
-    VarDef r1{globals_, "r1", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarDef r2{globals_, "r2", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
+    VarDef r1{globals_, "r1", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarDef r2{globals_, "r2", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
     VarDef z1{globals_, "z1", "Kz", settings_.dzmax(), settings_.kz()};
     VarDef z2{globals_, "z2", "Kz", settings_.dzmax(), settings_.kz()};
 
     VarDef phi1{globals_, "phi1", "Kphi", settings_.dphisector() / 0.75, settings_.kphi1()};
     VarDef phi2{globals_, "phi2", "Kphi", settings_.dphisector() / 0.75, settings_.kphi1()};
 
-    VarDef rproj0{globals_, "rproj0", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarDef rproj1{globals_, "rproj1", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarDef rproj2{globals_, "rproj2", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
+    VarDef rproj0{globals_, "rproj0", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarDef rproj1{globals_, "rproj1", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarDef rproj2{globals_, "rproj2", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
 
-    VarDef zproj0{globals_, "zproj0", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
-    VarDef zproj1{globals_, "zproj1", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
-    VarDef zproj2{globals_, "zproj2", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
+    VarDef zproj0{globals_, "zproj0", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
+    VarDef zproj1{globals_, "zproj1", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
+    VarDef zproj2{globals_, "zproj2", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
 
     //calculations
 
     //tracklet
-    VarAdd z1abs{globals_, "z1abs", &z1, &z1mean, settings_.zmax(trklet::N_DISK - 1)};
-    VarAdd z2abs{globals_, "z2abs", &z2, &z2mean, settings_.zmax(trklet::N_DISK - 1)};
+    VarAdd z1abs{globals_, "z1abs", &z1, &z1mean, settings_.zmax(N_DISK - 1)};
+    VarAdd z2abs{globals_, "z2abs", &z2, &z2mean, settings_.zmax(N_DISK - 1)};
 
     VarSubtract dr{globals_, "dr", &r2, &r1, dr_max};
 

--- a/L1Trigger/TrackFindingTracklet/interface/IMATH_TrackletCalculatorOverlap.h
+++ b/L1Trigger/TrackFindingTracklet/interface/IMATH_TrackletCalculatorOverlap.h
@@ -141,32 +141,32 @@ namespace trklet {
     VarParam minus1{globals_, "minus1", -1, 10};
     //
     //
-    VarParam r1mean{globals_, "r1mean", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarParam z2mean{globals_, "z2mean", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
+    VarParam r1mean{globals_, "r1mean", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarParam z2mean{globals_, "z2mean", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
 
     //inputs
     VarDef r1{globals_, "r1", "Kr", settings_.drmax(), settings_.kr()};
-    VarDef r2{globals_, "r2", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
+    VarDef r2{globals_, "r2", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
     VarDef z1{globals_, "z1", "Kz", settings_.zlength(), settings_.kz()};
     VarDef z2{globals_, "z2", "Kz", settings_.dzmax(), settings_.kz()};
 
     VarDef phi1{globals_, "phi1", "Kphi", settings_.dphisector() / 0.75, settings_.kphi1()};
     VarDef phi2{globals_, "phi2", "Kphi", settings_.dphisector() / 0.75, settings_.kphi1()};
 
-    VarDef rproj0{globals_, "rproj0", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarDef rproj1{globals_, "rproj1", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
-    VarDef rproj2{globals_, "rproj2", "Kr", settings_.rmax(trklet::N_LAYER - 1), settings_.kr()};
+    VarDef rproj0{globals_, "rproj0", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarDef rproj1{globals_, "rproj1", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
+    VarDef rproj2{globals_, "rproj2", "Kr", settings_.rmax(N_LAYER - 1), settings_.kr()};
 
-    VarDef zproj0{globals_, "zproj0", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
-    VarDef zproj1{globals_, "zproj1", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
-    VarDef zproj2{globals_, "zproj2", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
-    VarDef zproj3{globals_, "zproj3", "Kz", settings_.zmax(trklet::N_DISK - 1), settings_.kz()};
+    VarDef zproj0{globals_, "zproj0", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
+    VarDef zproj1{globals_, "zproj1", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
+    VarDef zproj2{globals_, "zproj2", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
+    VarDef zproj3{globals_, "zproj3", "Kz", settings_.zmax(N_DISK - 1), settings_.kz()};
 
     //calculations
 
     //tracklet
-    VarAdd r1abs{globals_, "r1abs", &r1, &r1mean, settings_.rmax(trklet::N_LAYER - 1)};
-    VarAdd z2abs{globals_, "z2abs", &z2, &z2mean, settings_.zmax(trklet::N_DISK - 1)};
+    VarAdd r1abs{globals_, "r1abs", &r1, &r1mean, settings_.rmax(N_LAYER - 1)};
+    VarAdd z2abs{globals_, "z2abs", &z2, &z2mean, settings_.zmax(N_DISK - 1)};
 
     VarSubtract dr{globals_, "dr", &r2, &r1abs, dr_max};
 


### PR DESCRIPTION
#### PR description:

Removed unnecessary trklet:: statements from variables in IMATH header files. (Not needed, as all IMATH code is part of trklet namespace). Reduces line length. Trivial change.

(Reduction in line length may help with future idea for cleaning up configuration params).