### PR TITLE
Overlap Phi Bins for Duplicate Removal 

### DIFF
--- a/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
+++ b/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
@@ -333,11 +333,27 @@ namespace tmtt {
 
     // Is the fitted track trajectory within the same (eta,phi) sector of the HT used to find it?
     bool consistentSector() const {
+      if (settings_->hybrid()) { 
+        float phiCentre = 2. * M_PI * iPhiSec() / settings_->numPhiSectors();
+        float sectorHalfWidth = M_PI / settings_->numPhiSectors();
+        bool insidePhi =
+            (reco::reduceRange(std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), phiCentre))) < sectorHalfWidth);
+        return insidePhi;
+      } else {
+        bool insidePhi = 
+            (std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), secTmp_->phiCentre())) < secTmp_->sectorHalfWidth());
+        bool insideEta = 
+            (this->zAtChosenR() > secTmp_->zAtChosenR_Min() && this->zAtChosenR() < secTmp_->zAtChosenR_Max());
+        return (insidePhi && insideEta);
+      }
+    } 
+
+
+    bool hybridConsistentSector() const {
+      std::cout << "The sector of this track is " << iPhiSec() << std::endl;
       bool insidePhi =
-          (std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), secTmp_->phiCentre())) < secTmp_->sectorHalfWidth());
-      bool insideEta =
-          (this->zAtChosenR() > secTmp_->zAtChosenR_Min() && this->zAtChosenR() < secTmp_->zAtChosenR_Max());
-      return (insidePhi && insideEta);
+          (std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), 2. * M_PI * iPhiSec() / float(settings_->numPhiSectors()))) < M_PI / settings_->numPhiSectors());
+      return (insidePhi);
     }
 
     // Digitize track and degrade helix parameter resolution according to effect of digitisation.

--- a/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
+++ b/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
@@ -333,27 +333,19 @@ namespace tmtt {
 
     // Is the fitted track trajectory within the same (eta,phi) sector of the HT used to find it?
     bool consistentSector() const {
-      if (settings_->hybrid()) { 
+      if (settings_->hybrid()) {
         float phiCentre = 2. * M_PI * iPhiSec() / settings_->numPhiSectors();
         float sectorHalfWidth = M_PI / settings_->numPhiSectors();
         bool insidePhi =
             (reco::reduceRange(std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), phiCentre))) < sectorHalfWidth);
         return insidePhi;
       } else {
-        bool insidePhi = 
-            (std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), secTmp_->phiCentre())) < secTmp_->sectorHalfWidth());
-        bool insideEta = 
+        bool insidePhi = (std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), secTmp_->phiCentre())) <
+                          secTmp_->sectorHalfWidth());
+        bool insideEta =
             (this->zAtChosenR() > secTmp_->zAtChosenR_Min() && this->zAtChosenR() < secTmp_->zAtChosenR_Max());
         return (insidePhi && insideEta);
       }
-    } 
-
-
-    bool hybridConsistentSector() const {
-      std::cout << "The sector of this track is " << iPhiSec() << std::endl;
-      bool insidePhi =
-          (std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), 2. * M_PI * iPhiSec() / float(settings_->numPhiSectors()))) < M_PI / settings_->numPhiSectors());
-      return (insidePhi);
     }
 
     // Digitize track and degrade helix parameter resolution according to effect of digitisation.

--- a/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
+++ b/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
@@ -336,8 +336,7 @@ namespace tmtt {
       if (settings_->hybrid()) {
         float phiCentre = 2. * M_PI * iPhiSec() / settings_->numPhiSectors();
         float sectorHalfWidth = M_PI / settings_->numPhiSectors();
-        bool insidePhi =
-            (reco::reduceRange(std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), phiCentre))) < sectorHalfWidth);
+        bool insidePhi = (std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), phiCentre)) < sectorHalfWidth);
         return insidePhi;
       } else {
         bool insidePhi = (std::abs(reco::deltaPhi(this->phiAtChosenR(done_bcon_), secTmp_->phiCentre())) <

--- a/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
+++ b/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
@@ -50,8 +50,12 @@ namespace trklet {
                                                     const std::vector<const Stub*>&) const;
     // return the regular rinvbins which contain the input tracklet
     unsigned int findVarRInvBin(const Tracklet* trk) const;
+    // return the regular phibins which contain the input tracklet
+    unsigned int findPhiBin(const Tracklet* trk) const;
     // return the overlap rinvbins which contain the input tracklet
     std::vector<unsigned int> findOverlapRInvBins(const Tracklet* trk) const;
+    // return the overlap phi bins which contain the input tracklet
+    std::vector<unsigned int> findOverlapPhiBins(const Tracklet* trk) const;
     // sort the tracklets into the correct bin by comparing the overlap rinv bin(s) the tracklets are in to the current bin
     bool isTrackInBin(const std::vector<unsigned int>& vec, unsigned int num) const;
 

--- a/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
+++ b/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
@@ -33,7 +33,7 @@ namespace trklet {
     void addOutput(MemoryBase* memory, std::string output) override;
     void addInput(MemoryBase* memory, std::string input) override;
 
-    void execute(std::vector<Track>& outputtracks_, unsigned int iSector);
+    void execute(std::vector<Track>& outputtracks, unsigned int iSector);
 
   private:
     double getPhiRes(Tracklet* curTracklet, const Stub* curStub) const;

--- a/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
+++ b/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
@@ -48,12 +48,12 @@ namespace trklet {
     std::vector<const Stub*> getInventedSeedingStub(unsigned int,
                                                     const Tracklet*,
                                                     const std::vector<const Stub*>&) const;
-    // return the regular rinvbins which contain the input tracklet
-    unsigned int findVarRInvBin(const Tracklet* trk) const;
-    // return the regular phibins which contain the input tracklet
+    // return the regular rinv bins which contain the input tracklet
+    unsigned int findRinvBin(const Tracklet* trk) const;
+    // return the regular phi bins which contain the input tracklet
     unsigned int findPhiBin(const Tracklet* trk) const;
-    // return the overlap rinvbins which contain the input tracklet
-    std::vector<unsigned int> findOverlapRInvBins(const Tracklet* trk) const;
+    // return the overlap rinv bins which contain the input tracklet
+    std::vector<unsigned int> findOverlapRinvBins(const Tracklet* trk) const;
     // return the overlap phi bins which contain the input tracklet
     std::vector<unsigned int> findOverlapPhiBins(const Tracklet* trk) const;
     // sort the tracklets into the correct bin by comparing the overlap rinv bin(s) the tracklets are in to the current bin

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -298,7 +298,7 @@ namespace trklet {
     unsigned int numTracksComparedPerBin() const { return numTracksComparedPerBin_; }
     //Returns the rinv bin edges you need for duplicate removal bins
     const std::vector<double> varRInvBins() const { return varRInvBins_; }
-    //Returns the phi bin edges you need for duplicate removal bins 
+    //Returns the phi bin edges you need for duplicate removal bins
     const std::vector<double> phiBins() const { return phiBins_; }
 
     std::string skimfile() const { return skimfile_; }
@@ -1048,11 +1048,11 @@ namespace trklet {
     //Variable bin edges for 6 bins.
     std::vector<double> varRInvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
     //Phi bin edges for 2 bins.
-    std::vector<double> phiBins_{0, dphisectorHG()/2, dphisectorHG()};
+    std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
     double overlapSize_{0.0004};
     //Overlap size for the overlap phi bins in DR
-    double phiOverlapSize_{M_PI/360};
+    double phiOverlapSize_{M_PI / 360};
     //The maximum number of tracks that are compared to all the other tracks per rinv bin
     int numTracksComparedPerBin_{32};
 

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -290,12 +290,16 @@ namespace trklet {
     void setStripLength_2S(double stripLength_2S) { stripLength_2S_ = stripLength_2S; }
 
     //Following functions are used for duplicate removal
-    //Function which gets the value corresponding to the overlap size for the overlap rinv bins in DR
+    //Function which returns the value corresponding to the overlap size for the overlap rinv bins in DR
     double overlapSize() const { return overlapSize_; }
-    //Function which gets the value corresponding to the number of tracks that are compared to all the other tracks per rinv bin
+    //Function which returns the value corresponding to the overlap size for the overlap phi bins in DR
+    double phiOverlapSize() const { return phiOverlapSize_; }
+    //Function which returns the value corresponding to the number of tracks that are compared to all the other tracks per rinv bin
     unsigned int numTracksComparedPerBin() const { return numTracksComparedPerBin_; }
-    //Grabs the bin edges you need for duplicate removal bins
+    //Returns the rinv bin edges you need for duplicate removal bins
     const std::vector<double> varRInvBins() const { return varRInvBins_; }
+    //Returns the phi bin edges you need for duplicate removal bins 
+    const std::vector<double> phiBins() const { return phiBins_; }
 
     std::string skimfile() const { return skimfile_; }
     void setSkimfile(std::string skimfile) { skimfile_ = skimfile; }
@@ -1043,10 +1047,14 @@ namespace trklet {
     //Following values are used for duplicate removal
     //Variable bin edges for 6 bins.
     std::vector<double> varRInvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
+    //Phi bin edges for 2 bins.
+    std::vector<double> phiBins_{0, dphisectorHG()/2, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
     double overlapSize_{0.0004};
+    //Overlap size for the overlap phi bins in DR
+    double phiOverlapSize_{M_PI/360};
     //The maximum number of tracks that are compared to all the other tracks per rinv bin
-    int numTracksComparedPerBin_{64};
+    int numTracksComparedPerBin_{32};
 
     double sensorSpacing_2S_{0.18};
   };

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -297,9 +297,9 @@ namespace trklet {
     //Function which returns the value corresponding to the number of tracks that are compared to all the other tracks per rinv bin
     unsigned int numTracksComparedPerBin() const { return numTracksComparedPerBin_; }
     //Returns the rinv bin edges you need for duplicate removal bins
-    const std::vector<double> rinvBins() const { return rinvBins_; }
+    const std::vector<double>& rinvBins() const { return rinvBins_; }
     //Returns the phi bin edges you need for duplicate removal bins
-    const std::vector<double> phiBins() const { return phiBins_; }
+    const std::vector<double>& phiBins() const { return phiBins_; }
 
     std::string skimfile() const { return skimfile_; }
     void setSkimfile(std::string skimfile) { skimfile_ = skimfile; }

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -291,13 +291,13 @@ namespace trklet {
 
     //Following functions are used for duplicate removal
     //Function which returns the value corresponding to the overlap size for the overlap rinv bins in DR
-    double overlapSize() const { return overlapSize_; }
+    double rinvOverlapSize() const { return rinvOverlapSize_; }
     //Function which returns the value corresponding to the overlap size for the overlap phi bins in DR
     double phiOverlapSize() const { return phiOverlapSize_; }
     //Function which returns the value corresponding to the number of tracks that are compared to all the other tracks per rinv bin
     unsigned int numTracksComparedPerBin() const { return numTracksComparedPerBin_; }
     //Returns the rinv bin edges you need for duplicate removal bins
-    const std::vector<double> varRInvBins() const { return varRInvBins_; }
+    const std::vector<double> rinvBins() const { return rinvBins_; }
     //Returns the phi bin edges you need for duplicate removal bins
     const std::vector<double> phiBins() const { return phiBins_; }
 
@@ -1045,14 +1045,15 @@ namespace trklet {
     double stripLength_2S_{5.0250};
 
     //Following values are used for duplicate removal
-    //Variable bin edges for 6 bins.
-    std::vector<double> varRInvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
+    //Variable rinv bin edges for 6 bins.
+    std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
     //Phi bin edges for 2 bins.
     std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
-    double overlapSize_{0.0004};
+    double rinvOverlapSize_{0.0004};
     //Overlap size for the overlap phi bins in DR
     double phiOverlapSize_{M_PI / 360};
+    //double phiOverlapSize_{0};
     //The maximum number of tracks that are compared to all the other tracks per rinv bin
     int numTracksComparedPerBin_{32};
 

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1045,7 +1045,7 @@ namespace trklet {
     double stripLength_2S_{5.0250};
 
     //Following values are used for duplicate removal
-    //Variable rinv bin edges for 6 bins.
+    //Rinv bin edges for 6 bins.
     std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
     //Phi bin edges for 2 bins.
     std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
@@ -1053,7 +1053,6 @@ namespace trklet {
     double rinvOverlapSize_{0.0004};
     //Overlap size for the overlap phi bins in DR
     double phiOverlapSize_{M_PI / 360};
-    //double phiOverlapSize_{0};
     //The maximum number of tracks that are compared to all the other tracks per rinv bin
     int numTracksComparedPerBin_{32};
 

--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -187,70 +187,76 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
   tmtt::L1fittedTrack fittedTrk = fitterKF.fit(l1track3d);
 
   if (fittedTrk.accepted()) {
-    tmtt::KFTrackletTrack trk = fittedTrk.returnKFTrackletTrack();
+    if (fittedTrk.consistentSector()) {  
+      tmtt::KFTrackletTrack trk = fittedTrk.returnKFTrackletTrack();
 
-    if (settings_.printDebugKF())
-      edm::LogVerbatim("L1track") << "Done with Kalman fit. Pars: pt = " << trk.pt()
-                                  << ", 1/2R = " << settings_.bfield() * 3 * trk.qOverPt() / 2000
-                                  << ", phi0 = " << trk.phi0() << ", eta = " << trk.eta() << ", z0 = " << trk.z0()
-                                  << ", chi2 = " << trk.chi2() << ", accepted = " << trk.accepted();
+      if (settings_.printDebugKF())
+        edm::LogVerbatim("L1track") << "Done with Kalman fit. Pars: pt = " << trk.pt()
+          << ", 1/2R = " << settings_.bfield() * 3 * trk.qOverPt() / 2000
+          << ", phi0 = " << trk.phi0() << ", eta = " << trk.eta() << ", z0 = " << trk.z0()
+          << ", chi2 = " << trk.chi2() << ", accepted = " << trk.accepted();
 
-    double d0, chi2rphi, phi0, qoverpt = -999;
-    if (trk.done_bcon()) {
-      d0 = trk.d0_bcon();
-      chi2rphi = trk.chi2rphi_bcon();
-      phi0 = trk.phi0_bcon();
-      qoverpt = trk.qOverPt_bcon();
+      double d0, chi2rphi, phi0, qoverpt = -999;
+      if (trk.done_bcon()) {
+        d0 = trk.d0_bcon();
+        chi2rphi = trk.chi2rphi_bcon();
+        phi0 = trk.phi0_bcon();
+        qoverpt = trk.qOverPt_bcon();
+      } else {
+        d0 = trk.d0();
+        chi2rphi = trk.chi2rphi();
+        phi0 = trk.phi0();
+        qoverpt = trk.qOverPt();
+      }
+
+      // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
+      double phi0fit = reco::reduceRange(phi0 - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
+      double rinvfit = 0.01 * settings_.c() * settings_.bfield() * qoverpt;
+
+      int irinvfit = floor(rinvfit / settings_.krinvpars());
+      int iphi0fit = floor(phi0fit / settings_.kphi0pars());
+      int itanlfit = floor(trk.tanLambda() / settings_.ktpars());
+      int iz0fit = floor(trk.z0() / settings_.kz0pars());
+      int id0fit = floor(d0 / settings_.kd0pars());
+      int ichi2rphifit = chi2rphi / 16;
+      int ichi2rzfit = trk.chi2rz() / 16;
+
+      const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
+      vector<const L1TStub*> l1stubsFromFit;
+      for (const tmtt::Stub* s : stubsFromFit) {
+        unsigned int IDf = s->index();
+        const L1TStub* l1s = L1StubIndices.at(IDf);
+        l1stubsFromFit.push_back(l1s);
+      }
+
+      tracklet->setFitPars(rinvfit,
+          phi0fit,
+          d0,
+          trk.tanLambda(),
+          trk.z0(),
+          chi2rphi,
+          trk.chi2rz(),
+          rinvfit,
+          phi0fit,
+          d0,
+          trk.tanLambda(),
+          trk.z0(),
+          chi2rphi,
+          trk.chi2rz(),
+          irinvfit,
+          iphi0fit,
+          id0fit,
+          itanlfit,
+          iz0fit,
+          ichi2rphifit,
+          ichi2rzfit,
+          trk.hitPattern(),
+          l1stubsFromFit);
     } else {
-      d0 = trk.d0();
-      chi2rphi = trk.chi2rphi();
-      phi0 = trk.phi0();
-      qoverpt = trk.qOverPt();
+      if (settings_.printDebugKF()) {
+        edm::LogVerbatim("L1track") << "FitTrack:KF rejected track";
+      }
     }
-
-    // Tracklet wants phi0 with respect to lower edge of sector, not global phi0.
-    double phi0fit = reco::reduceRange(phi0 - iSector_ * 2 * M_PI / N_SECTOR + 0.5 * settings_.dphisectorHG());
-    double rinvfit = 0.01 * settings_.c() * settings_.bfield() * qoverpt;
-
-    int irinvfit = floor(rinvfit / settings_.krinvpars());
-    int iphi0fit = floor(phi0fit / settings_.kphi0pars());
-    int itanlfit = floor(trk.tanLambda() / settings_.ktpars());
-    int iz0fit = floor(trk.z0() / settings_.kz0pars());
-    int id0fit = floor(d0 / settings_.kd0pars());
-    int ichi2rphifit = chi2rphi / 16;
-    int ichi2rzfit = trk.chi2rz() / 16;
-
-    const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
-    vector<const L1TStub*> l1stubsFromFit;
-    for (const tmtt::Stub* s : stubsFromFit) {
-      unsigned int IDf = s->index();
-      const L1TStub* l1s = L1StubIndices.at(IDf);
-      l1stubsFromFit.push_back(l1s);
-    }
-
-    tracklet->setFitPars(rinvfit,
-                         phi0fit,
-                         d0,
-                         trk.tanLambda(),
-                         trk.z0(),
-                         chi2rphi,
-                         trk.chi2rz(),
-                         rinvfit,
-                         phi0fit,
-                         d0,
-                         trk.tanLambda(),
-                         trk.z0(),
-                         chi2rphi,
-                         trk.chi2rz(),
-                         irinvfit,
-                         iphi0fit,
-                         id0fit,
-                         itanlfit,
-                         iz0fit,
-                         ichi2rphifit,
-                         ichi2rzfit,
-                         trk.hitPattern(),
-                         l1stubsFromFit);
   } else {
     if (settings_.printDebugKF()) {
       edm::LogVerbatim("L1track") << "FitTrack:KF rejected track";

--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -187,14 +187,14 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
   tmtt::L1fittedTrack fittedTrk = fitterKF.fit(l1track3d);
 
   if (fittedTrk.accepted()) {
-    if (fittedTrk.consistentSector()) {  
+    if (fittedTrk.consistentSector()) {
       tmtt::KFTrackletTrack trk = fittedTrk.returnKFTrackletTrack();
 
       if (settings_.printDebugKF())
         edm::LogVerbatim("L1track") << "Done with Kalman fit. Pars: pt = " << trk.pt()
-          << ", 1/2R = " << settings_.bfield() * 3 * trk.qOverPt() / 2000
-          << ", phi0 = " << trk.phi0() << ", eta = " << trk.eta() << ", z0 = " << trk.z0()
-          << ", chi2 = " << trk.chi2() << ", accepted = " << trk.accepted();
+                                    << ", 1/2R = " << settings_.bfield() * 3 * trk.qOverPt() / 2000
+                                    << ", phi0 = " << trk.phi0() << ", eta = " << trk.eta() << ", z0 = " << trk.z0()
+                                    << ", chi2 = " << trk.chi2() << ", accepted = " << trk.accepted();
 
       double d0, chi2rphi, phi0, qoverpt = -999;
       if (trk.done_bcon()) {
@@ -230,28 +230,28 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
       }
 
       tracklet->setFitPars(rinvfit,
-          phi0fit,
-          d0,
-          trk.tanLambda(),
-          trk.z0(),
-          chi2rphi,
-          trk.chi2rz(),
-          rinvfit,
-          phi0fit,
-          d0,
-          trk.tanLambda(),
-          trk.z0(),
-          chi2rphi,
-          trk.chi2rz(),
-          irinvfit,
-          iphi0fit,
-          id0fit,
-          itanlfit,
-          iz0fit,
-          ichi2rphifit,
-          ichi2rzfit,
-          trk.hitPattern(),
-          l1stubsFromFit);
+                           phi0fit,
+                           d0,
+                           trk.tanLambda(),
+                           trk.z0(),
+                           chi2rphi,
+                           trk.chi2rz(),
+                           rinvfit,
+                           phi0fit,
+                           d0,
+                           trk.tanLambda(),
+                           trk.z0(),
+                           chi2rphi,
+                           trk.chi2rz(),
+                           irinvfit,
+                           iphi0fit,
+                           id0fit,
+                           itanlfit,
+                           iz0fit,
+                           ichi2rphifit,
+                           ichi2rzfit,
+                           trk.hitPattern(),
+                           l1stubsFromFit);
     } else {
       if (settings_.printDebugKF()) {
         edm::LogVerbatim("L1track") << "FitTrack:KF rejected track";

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -126,279 +126,286 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
     std::vector<int> prefTrackFit;  // Stores the track seed that corresponds to the associated track in prefTracks
 
     for (unsigned int bin = 0; bin < settings_.varRInvBins().size() - 1; bin++) {
-      // Get vectors from TrackFit and save them
-      // inputtracklets: Tracklet objects from the FitTrack (not actually fit yet)
-      // inputstublists: L1Stubs for that track
-      // inputstubidslists: Stub stubIDs for that 3rack
-      // mergedstubidslists: the same as inputstubidslists, but will be used during duplicate removal
-      for (unsigned int i = 0; i < inputtrackfits_.size(); i++) {
-        if (inputtrackfits_[i]->nStublists() == 0)
-          continue;
-        if (inputtrackfits_[i]->nStublists() != inputtrackfits_[i]->nTracks())
-          throw "Number of stublists and tracks don't match up!";
-        for (unsigned int j = 0; j < inputtrackfits_[i]->nStublists(); j++) {
-          if (isTrackInBin(findOverlapRInvBins(inputtrackfits_[i]->getTrack(j)), bin)) {
-            if (inputtracklets_.size() >= settings_.maxStep("DR"))
+      for (unsigned int phiBin = 0; phiBin < settings_.phiBins().size() - 1; phiBin++) {
+        // Get vectors from TrackFit and save them
+        // inputtracklets: Tracklet objects from the FitTrack (not actually fit yet)
+        // inputstublists: L1Stubs for that track
+        // inputstubidslists: Stub stubIDs for that 3rack
+        // mergedstubidslists: the same as inputstubidslists, but will be used during duplicate removal
+        for (unsigned int i = 0; i < inputtrackfits_.size(); i++) {
+          if (inputtrackfits_[i]->nStublists() == 0)
+            continue;
+          if (inputtrackfits_[i]->nStublists() != inputtrackfits_[i]->nTracks())
+            throw "Number of stublists and tracks don't match up!";
+          for (unsigned int j = 0; j < inputtrackfits_[i]->nStublists(); j++) {
+            if (isTrackInBin(findOverlapRInvBins(inputtrackfits_[i]->getTrack(j)), bin)) {
+              if (!isTrackInBin(findOverlapPhiBins(inputtrackfits_[i]->getTrack(j)), phiBin)) 
+              //if (phiBin != findPhiBin(inputtrackfits_[i]->getTrack(j)))
+                continue;
+              if (inputtracklets_.size() >= settings_.maxStep("DR"))
+                continue;
+              Tracklet* aTrack = inputtrackfits_[i]->getTrack(j);
+              inputtracklets_.push_back(inputtrackfits_[i]->getTrack(j));
+              std::vector<const Stub*> stublist = inputtrackfits_[i]->getStublist(j);
+              inputstublists_.push_back(stublist);
+              std::vector<std::pair<int, int>> stubidslist = inputtrackfits_[i]->getStubidslist(j);
+              inputstubidslists_.push_back(stubidslist);
+              mergedstubidslists_.push_back(stubidslist);
+
+
+              // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7
+              // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
+              // Best Rank:           L1L2 > L3L4 > D3D4 > D1D2 > L2L3 > L2D1 > L5L6 > L1D1
+              // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
+              unsigned int curSeed = aTrack->seedIndex();
+              std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
+              if (settings_.extended())
+                seedRank.push_back(9);
+              else
+                seedRank.push_back(ranks[curSeed]);
+
+              if (stublist.size() != stubidslist.size())
+                throw "Number of stubs and stubids don't match up!";
+
+              trackInfo.emplace_back(i, false);
+              trackBinInfo.emplace_back(false);
+            } else
               continue;
-            Tracklet* aTrack = inputtrackfits_[i]->getTrack(j);
-            inputtracklets_.push_back(inputtrackfits_[i]->getTrack(j));
-            std::vector<const Stub*> stublist = inputtrackfits_[i]->getStublist(j);
-            inputstublists_.push_back(stublist);
-            std::vector<std::pair<int, int>> stubidslist = inputtrackfits_[i]->getStubidslist(j);
-            inputstubidslists_.push_back(stubidslist);
-            mergedstubidslists_.push_back(stubidslist);
-
-            // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7
-            // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
-            // Best Rank:           L1L2 > L3L4 > D3D4 > D1D2 > L2L3 > L2D1 > L5L6 > L1D1
-            // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
-            unsigned int curSeed = aTrack->seedIndex();
-            std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
-            if (settings_.extended())
-              seedRank.push_back(9);
-            else
-              seedRank.push_back(ranks[curSeed]);
-
-            if (stublist.size() != stubidslist.size())
-              throw "Number of stubs and stubids don't match up!";
-
-            trackInfo.emplace_back(i, false);
-            trackBinInfo.emplace_back(false);
-          } else
-            continue;
+          }
         }
-      }
 
-      if (inputtracklets_.empty())
-        continue;
-      unsigned int numStublists = inputstublists_.size();
+        if (inputtracklets_.empty())
+          continue;
+        unsigned int numStublists = inputstublists_.size();
 
-      if (settings_.inventStubs()) {
+        if (settings_.inventStubs()) {
+          for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
+            inputstublists_[itrk] = getInventedSeedingStub(iSector, inputtracklets_[itrk], inputstublists_[itrk]);
+          }
+        }
+
+        // Initialize all-false 2D array of tracks being duplicates to other tracks
+        bool dupMap[numStublists][numStublists];  // Ends up symmetric
         for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-          inputstublists_[itrk] = getInventedSeedingStub(iSector, inputtracklets_[itrk], inputstublists_[itrk]);
+          for (unsigned int jtrk = 0; jtrk < numStublists; jtrk++) {
+            dupMap[itrk][jtrk] = false;
+          }
         }
-      }
 
-      // Initialize all-false 2D array of tracks being duplicates to other tracks
-      bool dupMap[numStublists][numStublists];  // Ends up symmetric
-      for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-        for (unsigned int jtrk = 0; jtrk < numStublists; jtrk++) {
-          dupMap[itrk][jtrk] = false;
+        // Used to check if a track is in two bins, is not a duplicate in either bin, so is sent out twice
+        bool noMerge[numStublists];
+        for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
+          noMerge[itrk] = false;
         }
-      }
 
-      // Used to check if a track is in two bins, is not a duplicate in either bin, so is sent out twice
-      bool noMerge[numStublists];
-      for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-        noMerge[itrk] = false;
-      }
+        // Find duplicates; Fill dupMap by looping over all pairs of "tracks"
+        // numStublists-1 since last track has no other to compare to
+        for (unsigned int itrk = 0; itrk < numStublists - 1; itrk++) {
+          for (unsigned int jtrk = itrk + 1; jtrk < numStublists; jtrk++) {
+            if (itrk >= settings_.numTracksComparedPerBin())
+              continue;
+            // Get primary track stubids = (layer, unique stub index within layer)
+            const std::vector<std::pair<int, int>>& stubsTrk1 = inputstubidslists_[itrk];
 
-      // Find duplicates; Fill dupMap by looping over all pairs of "tracks"
-      // numStublists-1 since last track has no other to compare to
-      for (unsigned int itrk = 0; itrk < numStublists - 1; itrk++) {
-        for (unsigned int jtrk = itrk + 1; jtrk < numStublists; jtrk++) {
-          if (itrk >= settings_.numTracksComparedPerBin())
-            continue;
-          // Get primary track stubids = (layer, unique stub index within layer)
-          const std::vector<std::pair<int, int>>& stubsTrk1 = inputstubidslists_[itrk];
+            // Get and count secondary track stubids
+            const std::vector<std::pair<int, int>>& stubsTrk2 = inputstubidslists_[jtrk];
 
-          // Get and count secondary track stubids
-          const std::vector<std::pair<int, int>>& stubsTrk2 = inputstubidslists_[jtrk];
-
-          // Count number of layers that share stubs, and the number of UR that each track hits
-          unsigned int nShareLay = 0;
-          unsigned int nLayStubTrk1 = 0;
-          unsigned int nLayStubTrk2 = 0;
-          if (settings_.mergeComparison() == "CompareAll") {
-            bool layerArr[16];
-            for (auto& i : layerArr) {
-              i = false;
-            };
-            for (const auto& st1 : stubsTrk1) {
-              for (const auto& st2 : stubsTrk2) {
-                if (st1.first == st2.first && st1.second == st2.second) {  // tracks share stub
-                  // Converts layer/disk encoded in st1->first to an index in the layer array
-                  int i = st1.first;  // layer/disk
-                  bool barrel = (i > 0 && i < 10);
-                  bool endcapA = (i > 10);
-                  bool endcapB = (i < 0);
-                  int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
-                  if (!layerArr[lay]) {
-                    nShareLay++;
-                    layerArr[lay] = true;
+            // Count number of layers that share stubs, and the number of UR that each track hits
+            unsigned int nShareLay = 0;
+            unsigned int nLayStubTrk1 = 0;
+            unsigned int nLayStubTrk2 = 0;
+            if (settings_.mergeComparison() == "CompareAll") {
+              bool layerArr[16];
+              for (auto& i : layerArr) {
+                i = false;
+              };
+              for (const auto& st1 : stubsTrk1) {
+                for (const auto& st2 : stubsTrk2) {
+                  if (st1.first == st2.first && st1.second == st2.second) {  // tracks share stub
+                    // Converts layer/disk encoded in st1->first to an index in the layer array
+                    int i = st1.first;  // layer/disk
+                    bool barrel = (i > 0 && i < 10);
+                    bool endcapA = (i > 10);
+                    bool endcapB = (i < 0);
+                    int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
+                    if (!layerArr[lay]) {
+                      nShareLay++;
+                      layerArr[lay] = true;
+                    }
                   }
                 }
               }
-            }
-          } else if (settings_.mergeComparison() == "CompareBest") {
-            std::vector<const Stub*> fullStubslistsTrk1 = inputstublists_[itrk];
-            std::vector<const Stub*> fullStubslistsTrk2 = inputstublists_[jtrk];
+            } else if (settings_.mergeComparison() == "CompareBest") {
+              std::vector<const Stub*> fullStubslistsTrk1 = inputstublists_[itrk];
+              std::vector<const Stub*> fullStubslistsTrk2 = inputstublists_[jtrk];
 
-            // Arrays to store the index of the best stub in each layer
-            int layStubidsTrk1[16];
-            int layStubidsTrk2[16];
-            for (int i = 0; i < 16; i++) {
-              layStubidsTrk1[i] = -1;
-              layStubidsTrk2[i] = -1;
-            }
-            // For each stub on the first track, find the stub with the best residual and store its index in the layStubidsTrk1 array
-            for (unsigned int stcount = 0; stcount < stubsTrk1.size(); stcount++) {
-              int i = stubsTrk1[stcount].first;  // layer/disk
-              bool barrel = (i > 0 && i < 10);
-              bool endcapA = (i > 10);
-              bool endcapB = (i < 0);
-              int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
-              double nres = getPhiRes(inputtracklets_[itrk], fullStubslistsTrk1[stcount]);
-              double ores = 0;
-              if (layStubidsTrk1[lay] != -1)
-                ores = getPhiRes(inputtracklets_[itrk], fullStubslistsTrk1[layStubidsTrk1[lay]]);
-              if (layStubidsTrk1[lay] == -1 || nres < ores) {
-                layStubidsTrk1[lay] = stcount;
+              // Arrays to store the index of the best stub in each layer
+              int layStubidsTrk1[16];
+              int layStubidsTrk2[16];
+              for (int i = 0; i < 16; i++) {
+                layStubidsTrk1[i] = -1;
+                layStubidsTrk2[i] = -1;
               }
-            }
-            // For each stub on the second track, find the stub with the best residual and store its index in the layStubidsTrk1 array
-            for (unsigned int stcount = 0; stcount < stubsTrk2.size(); stcount++) {
-              int i = stubsTrk2[stcount].first;  // layer/disk
-              bool barrel = (i > 0 && i < 10);
-              bool endcapA = (i > 10);
-              bool endcapB = (i < 0);
-              int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
-              double nres = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[stcount]);
-              double ores = 0;
-              if (layStubidsTrk2[lay] != -1)
-                ores = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[layStubidsTrk2[lay]]);
-              if (layStubidsTrk2[lay] == -1 || nres < ores) {
-                layStubidsTrk2[lay] = stcount;
-              }
-            }
-            // For all 16 layers (6 layers and 10 disks), count the number of layers who's best stub on both tracks are the same
-            for (int i = 0; i < 16; i++) {
-              int t1i = layStubidsTrk1[i];
-              int t2i = layStubidsTrk2[i];
-              if (t1i != -1 && t2i != -1 && stubsTrk1[t1i].first == stubsTrk2[t2i].first &&
-                  stubsTrk1[t1i].second == stubsTrk2[t2i].second)
-                nShareLay++;
-            }
-            // Calculate the number of layers hit by each track, so that this number can be used in calculating the number of independent
-            // stubs on a track (not enabled/used by default)
-            for (int i = 0; i < 16; i++) {
-              if (layStubidsTrk1[i] != -1)
-                nLayStubTrk1++;
-              if (layStubidsTrk2[i] != -1)
-                nLayStubTrk2++;
-            }
-          }
-
-          // Fill duplicate map
-          if (nShareLay >= settings_.minIndStubs()) {  // For number of shared stub merge condition
-            dupMap[itrk][jtrk] = true;
-            dupMap[jtrk][itrk] = true;
-          }
-        }
-      }
-
-      // Check to see if the track is a duplicate
-      for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-        for (unsigned int jtrk = 0; jtrk < numStublists; jtrk++) {
-          if (dupMap[itrk][jtrk]) {
-            noMerge[itrk] = true;
-          }
-        }
-      }
-
-      // If the track isn't a duplicate, and if it's in more than one bin, and it is not in the proper varrinvbin, then mark it so it won't be sent to output
-      for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
-        if (noMerge[itrk] == false) {
-          if ((findOverlapRInvBins(inputtracklets_[itrk]).size() > 1) &&
-              (findVarRInvBin(inputtracklets_[itrk]) != bin)) {
-            trackInfo[itrk].second = true;
-          }
-        }
-      }
-      // Merge duplicate tracks
-      for (unsigned int itrk = 0; itrk < numStublists - 1; itrk++) {
-        for (unsigned int jtrk = itrk + 1; jtrk < numStublists; jtrk++) {
-          // Merge a track with its first duplicate found.
-          if (dupMap[itrk][jtrk]) {
-            // Set preferred track based on seed rank
-            int preftrk;
-            int rejetrk;
-            if (seedRank[itrk] < seedRank[jtrk]) {
-              preftrk = itrk;
-              rejetrk = jtrk;
-            } else {
-              preftrk = jtrk;
-              rejetrk = itrk;
-            }
-
-            // If the preffered track is in more than one bin, but not in the proper varrinvbin, then mark as true
-            if ((findOverlapRInvBins(inputtracklets_[preftrk]).size() > 1) &&
-                (findVarRInvBin(inputtracklets_[preftrk]) != bin)) {
-              trackBinInfo[preftrk] = true;
-              trackBinInfo[rejetrk] = true;
-            } else {
-              // Get a merged stub list
-              std::vector<const Stub*> newStubList;
-              std::vector<const Stub*> stubsTrk1 = inputstublists_[preftrk];
-              std::vector<const Stub*> stubsTrk2 = inputstublists_[rejetrk];
-              std::vector<unsigned int> stubsTrk1indices;
-              std::vector<unsigned int> stubsTrk2indices;
-              for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
-                stubsTrk1indices.push_back(stubsTrk1[stub1it]->l1tstub()->uniqueIndex());
-              }
-              for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
-                stubsTrk2indices.push_back(stubsTrk2[stub2it]->l1tstub()->uniqueIndex());
-              }
-              newStubList = stubsTrk1;
-              for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
-                if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) ==
-                    stubsTrk1indices.end()) {
-                  newStubList.push_back(stubsTrk2[stub2it]);
+              // For each stub on the first track, find the stub with the best residual and store its index in the layStubidsTrk1 array
+              for (unsigned int stcount = 0; stcount < stubsTrk1.size(); stcount++) {
+                int i = stubsTrk1[stcount].first;  // layer/disk
+                bool barrel = (i > 0 && i < 10);
+                bool endcapA = (i > 10);
+                bool endcapB = (i < 0);
+                int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
+                double nres = getPhiRes(inputtracklets_[itrk], fullStubslistsTrk1[stcount]);
+                double ores = 0;
+                if (layStubidsTrk1[lay] != -1)
+                  ores = getPhiRes(inputtracklets_[itrk], fullStubslistsTrk1[layStubidsTrk1[lay]]);
+                if (layStubidsTrk1[lay] == -1 || nres < ores) {
+                  layStubidsTrk1[lay] = stcount;
                 }
               }
-              //   Overwrite stublist of preferred track with merged list
-              inputstublists_[preftrk] = newStubList;
-
-              std::vector<std::pair<int, int>> newStubidsList;
-              std::vector<std::pair<int, int>> stubidsTrk1 = mergedstubidslists_[preftrk];
-              std::vector<std::pair<int, int>> stubidsTrk2 = mergedstubidslists_[rejetrk];
-              newStubidsList = stubidsTrk1;
-
-              for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
-                if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) ==
-                    stubsTrk1indices.end()) {
-                  newStubidsList.push_back(stubidsTrk2[stub2it]);
+              // For each stub on the second track, find the stub with the best residual and store its index in the layStubidsTrk1 array
+              for (unsigned int stcount = 0; stcount < stubsTrk2.size(); stcount++) {
+                int i = stubsTrk2[stcount].first;  // layer/disk
+                bool barrel = (i > 0 && i < 10);
+                bool endcapA = (i > 10);
+                bool endcapB = (i < 0);
+                int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
+                double nres = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[stcount]);
+                double ores = 0;
+                if (layStubidsTrk2[lay] != -1)
+                  ores = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[layStubidsTrk2[lay]]);
+                if (layStubidsTrk2[lay] == -1 || nres < ores) {
+                  layStubidsTrk2[lay] = stcount;
                 }
               }
-              // Overwrite stubidslist of preferred track with merged list
-              mergedstubidslists_[preftrk] = newStubidsList;
+              // For all 16 layers (6 layers and 10 disks), count the number of layers who's best stub on both tracks are the same
+              for (int i = 0; i < 16; i++) {
+                int t1i = layStubidsTrk1[i];
+                int t2i = layStubidsTrk2[i];
+                if (t1i != -1 && t2i != -1 && stubsTrk1[t1i].first == stubsTrk2[t2i].first &&
+                    stubsTrk1[t1i].second == stubsTrk2[t2i].second)
+                  nShareLay++;
+              }
+              // Calculate the number of layers hit by each track, so that this number can be used in calculating the number of independent
+              // stubs on a track (not enabled/used by default)
+              for (int i = 0; i < 16; i++) {
+                if (layStubidsTrk1[i] != -1)
+                  nLayStubTrk1++;
+                if (layStubidsTrk2[i] != -1)
+                  nLayStubTrk2++;
+              }
+            }
 
-              // Mark that rejected track has been merged into another track
-              trackInfo[rejetrk].second = true;
+            // Fill duplicate map
+            if (nShareLay >= settings_.minIndStubs()) {  // For number of shared stub merge condition
+              dupMap[itrk][jtrk] = true;
+              dupMap[jtrk][itrk] = true;
             }
           }
         }
-      }
 
-      for (unsigned int ktrk = 0; ktrk < numStublists; ktrk++) {
-        if ((trackInfo[ktrk].second != true) && (trackBinInfo[ktrk] != true)) {
-          prefTracks.push_back(ktrk);
-          prefTrackFit.push_back(trackInfo[ktrk].first);
-          inputtrackletsall.push_back(inputtracklets_[ktrk]);
-          inputstublistsall.push_back(inputstublists_[ktrk]);
-          inputstubidslistsall.push_back(inputstubidslists_[ktrk]);
-          mergedstubidslistsall.push_back(mergedstubidslists_[ktrk]);
+        // Check to see if the track is a duplicate
+        for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
+          for (unsigned int jtrk = 0; jtrk < numStublists; jtrk++) {
+            if (dupMap[itrk][jtrk]) {
+              noMerge[itrk] = true;
+            }
+          }
         }
-      }
 
-      // Need to clear all the vectors which will be used in the next bin
-      seedRank.clear();
-      trackInfo.clear();
-      trackBinInfo.clear();
-      inputtracklets_.clear();
-      inputstublists_.clear();
-      inputstubidslists_.clear();
-      mergedstubidslists_.clear();
+        // If the track isn't a duplicate, and if it's in more than one bin, and it is not in the proper varrinvbin, then mark it so it won't be sent to output
+        for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
+          if (noMerge[itrk] == false) {
+            if (((findOverlapRInvBins(inputtracklets_[itrk]).size() > 1) && (findVarRInvBin(inputtracklets_[itrk]) != bin)) 
+                || ((findOverlapPhiBins(inputtracklets_[itrk]).size() > 1) && findPhiBin(inputtracklets_[itrk]) != phiBin)) {
+              trackInfo[itrk].second = true;
+            }
+          }
+        }
+        // Merge duplicate tracks
+        for (unsigned int itrk = 0; itrk < numStublists - 1; itrk++) {
+          for (unsigned int jtrk = itrk + 1; jtrk < numStublists; jtrk++) {
+            // Merge a track with its first duplicate found.
+            if (dupMap[itrk][jtrk]) {
+              // Set preferred track based on seed rank
+              int preftrk;
+              int rejetrk;
+              if (seedRank[itrk] < seedRank[jtrk]) {
+                preftrk = itrk;
+                rejetrk = jtrk;
+              } else {
+                preftrk = jtrk;
+                rejetrk = itrk;
+              }
+
+              // If the preffered track is in more than one bin, but not in the proper varrinvbin, then mark as true
+              if (((findOverlapRInvBins(inputtracklets_[preftrk]).size() > 1) && (findVarRInvBin(inputtracklets_[preftrk]) != bin)) 
+                  || ((findOverlapPhiBins(inputtracklets_[preftrk]).size() > 1) && (findPhiBin(inputtracklets_[preftrk]) != phiBin))) {
+                trackBinInfo[preftrk] = true;
+                trackBinInfo[rejetrk] = true;
+              } else {
+                // Get a merged stub list
+                std::vector<const Stub*> newStubList;
+                std::vector<const Stub*> stubsTrk1 = inputstublists_[preftrk];
+                std::vector<const Stub*> stubsTrk2 = inputstublists_[rejetrk];
+                std::vector<unsigned int> stubsTrk1indices;
+                std::vector<unsigned int> stubsTrk2indices;
+                for (unsigned int stub1it = 0; stub1it < stubsTrk1.size(); stub1it++) {
+                  stubsTrk1indices.push_back(stubsTrk1[stub1it]->l1tstub()->uniqueIndex());
+                }
+                for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
+                  stubsTrk2indices.push_back(stubsTrk2[stub2it]->l1tstub()->uniqueIndex());
+                }
+                newStubList = stubsTrk1;
+                for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
+                  if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) ==
+                      stubsTrk1indices.end()) {
+                    newStubList.push_back(stubsTrk2[stub2it]);
+                  }
+                }
+                //   Overwrite stublist of preferred track with merged list
+                inputstublists_[preftrk] = newStubList;
+
+                std::vector<std::pair<int, int>> newStubidsList;
+                std::vector<std::pair<int, int>> stubidsTrk1 = mergedstubidslists_[preftrk];
+                std::vector<std::pair<int, int>> stubidsTrk2 = mergedstubidslists_[rejetrk];
+                newStubidsList = stubidsTrk1;
+
+                for (unsigned int stub2it = 0; stub2it < stubsTrk2.size(); stub2it++) {
+                  if (find(stubsTrk1indices.begin(), stubsTrk1indices.end(), stubsTrk2indices[stub2it]) ==
+                      stubsTrk1indices.end()) {
+                    newStubidsList.push_back(stubidsTrk2[stub2it]);
+                  }
+                }
+                // Overwrite stubidslist of preferred track with merged list
+                mergedstubidslists_[preftrk] = newStubidsList;
+
+                // Mark that rejected track has been merged into another track
+                trackInfo[rejetrk].second = true;
+              }
+            }
+          }
+        }
+
+        for (unsigned int ktrk = 0; ktrk < numStublists; ktrk++) {
+          if ((trackInfo[ktrk].second != true) && (trackBinInfo[ktrk] != true)) {
+            prefTracks.push_back(ktrk);
+            prefTrackFit.push_back(trackInfo[ktrk].first);
+            inputtrackletsall.push_back(inputtracklets_[ktrk]);
+            inputstublistsall.push_back(inputstublists_[ktrk]);
+            inputstubidslistsall.push_back(inputstubidslists_[ktrk]);
+            mergedstubidslistsall.push_back(mergedstubidslists_[ktrk]);
+          }
+        }
+
+
+        // Need to clear all the vectors which will be used in the next bin
+        seedRank.clear();
+        trackInfo.clear();
+        trackBinInfo.clear();
+        inputtracklets_.clear();
+        inputstublists_.clear();
+        inputstubidslists_.clear();
+        mergedstubidslists_.clear();
+      }
     }
 
     // Make the final track objects, fit with KF, and send to output
@@ -763,6 +770,26 @@ unsigned int PurgeDuplicate::findVarRInvBin(const Tracklet* trk) const {
     return rIndx - 1;
 }
 
+// Tells us the phi bin to which a track would belong
+unsigned int PurgeDuplicate::findPhiBin(const Tracklet* trk) const {
+  std::vector<double> phiBins = settings_.phiBins();
+  
+  //Get phi of track
+  double phi = trk->phi0();
+
+  //Check between what 2 values in phbins phi is between
+  auto bins = std::upper_bound(phiBins.begin(), phiBins.end(), phi);
+
+  //return integer for bin index
+  unsigned int phiIndx = std::distance(phiBins.begin(), bins);
+  if (phiIndx == std::distance(phiBins.end(), bins))
+    return phiBins.size() - 2;
+  else if (bins == phiBins.begin())
+    return std::distance(phiBins.begin(), bins);
+  else
+    return phiIndx - 1;
+}
+
 // Tells us the overlap bin(s) to which a track belongs
 std::vector<unsigned int> PurgeDuplicate::findOverlapRInvBins(const Tracklet* trk) const {
   double rInv = trk->rinv();
@@ -771,6 +798,20 @@ std::vector<unsigned int> PurgeDuplicate::findOverlapRInvBins(const Tracklet* tr
   std::vector<unsigned int> chosenBins;
   for (long unsigned int i = 0; i < varRInvBins.size() - 1; i++) {
     if ((rInv < varRInvBins[i + 1] + overlapSize) && (rInv > varRInvBins[i] - overlapSize)) {
+      chosenBins.push_back(i);
+    }
+  }
+  return chosenBins;
+}
+
+// Tells us the overlap bin(s) to which a track belongs
+std::vector<unsigned int> PurgeDuplicate::findOverlapPhiBins(const Tracklet* trk) const {
+  double phi = trk->phi0();
+  const double phiOverlapSize = settings_.phiOverlapSize();
+  const std::vector<double>& phiBins = settings_.phiBins();
+  std::vector<unsigned int> chosenBins;
+  for (long unsigned int i = 0; i < phiBins.size() - 1; i++) {
+    if ((phi < phiBins[i + 1] + phiOverlapSize) && (phi > phiBins[i] - phiOverlapSize)) {
       chosenBins.push_back(i);
     }
   }

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -139,8 +139,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
             throw "Number of stublists and tracks don't match up!";
           for (unsigned int j = 0; j < inputtrackfits_[i]->nStublists(); j++) {
             if (isTrackInBin(findOverlapRInvBins(inputtrackfits_[i]->getTrack(j)), bin)) {
-              if (!isTrackInBin(findOverlapPhiBins(inputtrackfits_[i]->getTrack(j)), phiBin)) 
-              //if (phiBin != findPhiBin(inputtrackfits_[i]->getTrack(j)))
+              if (!isTrackInBin(findOverlapPhiBins(inputtrackfits_[i]->getTrack(j)), phiBin))
                 continue;
               if (inputtracklets_.size() >= settings_.maxStep("DR"))
                 continue;
@@ -151,7 +150,6 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
               std::vector<std::pair<int, int>> stubidslist = inputtrackfits_[i]->getStubidslist(j);
               inputstubidslists_.push_back(stubidslist);
               mergedstubidslists_.push_back(stubidslist);
-
 
               // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7
               // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
@@ -314,8 +312,10 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
         // If the track isn't a duplicate, and if it's in more than one bin, and it is not in the proper varrinvbin, then mark it so it won't be sent to output
         for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
           if (noMerge[itrk] == false) {
-            if (((findOverlapRInvBins(inputtracklets_[itrk]).size() > 1) && (findVarRInvBin(inputtracklets_[itrk]) != bin)) 
-                || ((findOverlapPhiBins(inputtracklets_[itrk]).size() > 1) && findPhiBin(inputtracklets_[itrk]) != phiBin)) {
+            if (((findOverlapRInvBins(inputtracklets_[itrk]).size() > 1) &&
+                 (findVarRInvBin(inputtracklets_[itrk]) != bin)) ||
+                ((findOverlapPhiBins(inputtracklets_[itrk]).size() > 1) &&
+                 findPhiBin(inputtracklets_[itrk]) != phiBin)) {
               trackInfo[itrk].second = true;
             }
           }
@@ -337,8 +337,10 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
               }
 
               // If the preffered track is in more than one bin, but not in the proper varrinvbin, then mark as true
-              if (((findOverlapRInvBins(inputtracklets_[preftrk]).size() > 1) && (findVarRInvBin(inputtracklets_[preftrk]) != bin)) 
-                  || ((findOverlapPhiBins(inputtracklets_[preftrk]).size() > 1) && (findPhiBin(inputtracklets_[preftrk]) != phiBin))) {
+              if (((findOverlapRInvBins(inputtracklets_[preftrk]).size() > 1) &&
+                   (findVarRInvBin(inputtracklets_[preftrk]) != bin)) ||
+                  ((findOverlapPhiBins(inputtracklets_[preftrk]).size() > 1) &&
+                   (findPhiBin(inputtracklets_[preftrk]) != phiBin))) {
                 trackBinInfo[preftrk] = true;
                 trackBinInfo[rejetrk] = true;
               } else {
@@ -395,7 +397,6 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
             mergedstubidslistsall.push_back(mergedstubidslists_[ktrk]);
           }
         }
-
 
         // Need to clear all the vectors which will be used in the next bin
         seedRank.clear();
@@ -773,7 +774,7 @@ unsigned int PurgeDuplicate::findVarRInvBin(const Tracklet* trk) const {
 // Tells us the phi bin to which a track would belong
 unsigned int PurgeDuplicate::findPhiBin(const Tracklet* trk) const {
   std::vector<double> phiBins = settings_.phiBins();
-  
+
   //Get phi of track
   double phi = trk->phi0();
 

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -797,8 +797,10 @@ unsigned int PurgeDuplicate::findPhiBin(const Tracklet* trk) const {
 // Tells us the overlap rinv bin(s) to which a track belongs
 std::vector<unsigned int> PurgeDuplicate::findOverlapRinvBins(const Tracklet* trk) const {
   double rinv = trk->rinv();
+
   const double rinvOverlapSize = settings_.rinvOverlapSize();
   const std::vector<double>& rinvBins = settings_.rinvBins();
+
   std::vector<unsigned int> chosenBins;
   for (long unsigned int i = 0; i < rinvBins.size() - 1; i++) {
     if ((rinv < rinvBins[i + 1] + rinvOverlapSize) && (rinv > rinvBins[i] - rinvOverlapSize)) {
@@ -814,8 +816,10 @@ std::vector<unsigned int> PurgeDuplicate::findOverlapPhiBins(const Tracklet* trk
   double rcrit = settings_.rcrit();
   double rinv = trk->rinv();
   double phi = phi0 - asin(0.5 * rinv * rcrit);
+
   const double phiOverlapSize = settings_.phiOverlapSize();
   const std::vector<double>& phiBins = settings_.phiBins();
+
   std::vector<unsigned int> chosenBins;
   for (long unsigned int i = 0; i < phiBins.size() - 1; i++) {
     if ((phi < phiBins[i + 1] + phiOverlapSize) && (phi > phiBins[i] - phiOverlapSize)) {

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -78,7 +78,7 @@ void PurgeDuplicate::addInput(MemoryBase* memory, std::string input) {
   throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input: " << input;
 }
 
-void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSector) {
+void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSector) {
   inputtracklets_.clear();
   inputtracks_.clear();
 
@@ -429,7 +429,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
         // Add all tracks to standalone root file output
         outtrack->setStubIDpremerge(inputstubidslistsall[itrk]);
         outtrack->setStubIDprefit(mergedstubidslistsall[itrk]);
-        outputtracks_.push_back(*outtrack);
+        outputtracks.push_back(*outtrack);
       }
     }
   }
@@ -558,7 +558,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
           outputtracklets_[i]->addTrack(inputtrackfits_[i]->getTrack(j));
         }
         //For root file:
-        outputtracks_.push_back(*inputtrackfits_[i]->getTrack(j)->getTrack());
+        outputtracks.push_back(*inputtrackfits_[i]->getTrack(j)->getTrack());
       }
     }
   }
@@ -659,7 +659,7 @@ std::vector<double> PurgeDuplicate::getInventedCoords(unsigned int iSector,
     stub_r = 2 / tracklet_rinv * std::sin((stub_z - tracklet->z0()) * tracklet_rinv / 2 / tracklet->t());
   }
 
-  std::vector invented_coords{stub_r, stub_z, stub_phi};
+  std::vector<double> invented_coords{stub_r, stub_z, stub_phi};
   return invented_coords;
 }
 
@@ -710,7 +710,7 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
     stub_r = st->l1tstub()->r();
   }
 
-  std::vector invented_coords{stub_r, stub_z, stub_phi};
+  std::vector<double> invented_coords{stub_r, stub_z, stub_phi};
   return invented_coords;
 }
 

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -110,7 +110,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
   if (settings_.removalType() == "merge") {
     // Track seed & duplicate flag
     std::vector<std::pair<int, bool>> trackInfo;
-    // Flag for tracks in multiple bins that get merged but are not in the correct variable bin
+    // Flag for tracks in multiple bins that get merged but are not in the correct bin
     std::vector<bool> trackBinInfo;
     // Vector to store the relative rank of the track candidate for merging, based on seed type
     std::vector<int> seedRank;
@@ -125,7 +125,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
     std::vector<unsigned int> prefTracks;  // Stores all the tracks that are sent to the KF from each bin
     std::vector<int> prefTrackFit;  // Stores the track seed that corresponds to the associated track in prefTracks
 
-    for (unsigned int bin = 0; bin < settings_.varRInvBins().size() - 1; bin++) {
+    for (unsigned int bin = 0; bin < settings_.rinvBins().size() - 1; bin++) {
       for (unsigned int phiBin = 0; phiBin < settings_.phiBins().size() - 1; phiBin++) {
         // Get vectors from TrackFit and save them
         // inputtracklets: Tracklet objects from the FitTrack (not actually fit yet)
@@ -138,7 +138,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
           if (inputtrackfits_[i]->nStublists() != inputtrackfits_[i]->nTracks())
             throw "Number of stublists and tracks don't match up!";
           for (unsigned int j = 0; j < inputtrackfits_[i]->nStublists(); j++) {
-            if (isTrackInBin(findOverlapRInvBins(inputtrackfits_[i]->getTrack(j)), bin)) {
+            if (isTrackInBin(findOverlapRinvBins(inputtrackfits_[i]->getTrack(j)), bin)) {
               if (!isTrackInBin(findOverlapPhiBins(inputtrackfits_[i]->getTrack(j)), phiBin))
                 continue;
               if (inputtracklets_.size() >= settings_.maxStep("DR"))
@@ -309,11 +309,11 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
           }
         }
 
-        // If the track isn't a duplicate, and if it's in more than one bin, and it is not in the proper varrinvbin, then mark it so it won't be sent to output
+        // If the track isn't a duplicate, and if it's in more than one bin, and it is not in the proper rinv bin, then mark it so it won't be sent to output
         for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
           if (noMerge[itrk] == false) {
-            if (((findOverlapRInvBins(inputtracklets_[itrk]).size() > 1) &&
-                 (findVarRInvBin(inputtracklets_[itrk]) != bin)) ||
+            if (((findOverlapRinvBins(inputtracklets_[itrk]).size() > 1) &&
+                 (findRinvBin(inputtracklets_[itrk]) != bin)) ||
                 ((findOverlapPhiBins(inputtracklets_[itrk]).size() > 1) &&
                  findPhiBin(inputtracklets_[itrk]) != phiBin)) {
               trackInfo[itrk].second = true;
@@ -336,9 +336,9 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
                 rejetrk = itrk;
               }
 
-              // If the preffered track is in more than one bin, but not in the proper varrinvbin, then mark as true
-              if (((findOverlapRInvBins(inputtracklets_[preftrk]).size() > 1) &&
-                   (findVarRInvBin(inputtracklets_[preftrk]) != bin)) ||
+              // If the preffered track is in more than one bin, but not in the proper rinv bin, then mark as true
+              if (((findOverlapRinvBins(inputtracklets_[preftrk]).size() > 1) &&
+                   (findRinvBin(inputtracklets_[preftrk]) != bin)) ||
                   ((findOverlapPhiBins(inputtracklets_[preftrk]).size() > 1) &&
                    (findPhiBin(inputtracklets_[preftrk]) != phiBin))) {
                 trackBinInfo[preftrk] = true;
@@ -752,21 +752,21 @@ std::vector<const Stub*> PurgeDuplicate::getInventedSeedingStub(
 }
 
 // Tells us the variable bin to which a track would belong
-unsigned int PurgeDuplicate::findVarRInvBin(const Tracklet* trk) const {
-  std::vector<double> rInvBins = settings_.varRInvBins();
+unsigned int PurgeDuplicate::findRinvBin(const Tracklet* trk) const {
+  std::vector<double> rinvBins = settings_.rinvBins();
 
   //Get rinverse of track
-  double rInv = trk->rinv();
+  double rinv = trk->rinv();
 
   //Check between what 2 values in rinvbins rinv is between
-  auto bins = std::upper_bound(rInvBins.begin(), rInvBins.end(), rInv);
+  auto bins = std::upper_bound(rinvBins.begin(), rinvBins.end(), rinv);
 
   //return integer for bin index
-  unsigned int rIndx = std::distance(rInvBins.begin(), bins);
-  if (rIndx == std::distance(rInvBins.end(), bins))
-    return rInvBins.size() - 2;
-  else if (bins == rInvBins.begin())
-    return std::distance(rInvBins.begin(), bins);
+  unsigned int rIndx = std::distance(rinvBins.begin(), bins);
+  if (rIndx == std::distance(rinvBins.end(), bins))
+    return rinvBins.size() - 2;
+  else if (bins == rinvBins.begin())
+    return std::distance(rinvBins.begin(), bins);
   else
     return rIndx - 1;
 }
@@ -775,9 +775,12 @@ unsigned int PurgeDuplicate::findVarRInvBin(const Tracklet* trk) const {
 unsigned int PurgeDuplicate::findPhiBin(const Tracklet* trk) const {
   std::vector<double> phiBins = settings_.phiBins();
 
-  //Get phi of track
-  double phi = trk->phi0();
-
+  //Get phi of track at rcrit
+  double phi0 = trk->phi0();
+  double rcrit = settings_.rcrit();
+  double rinv = trk->rinv();
+  double phi = phi0 - asin(0.5 * rinv * rcrit);
+  
   //Check between what 2 values in phbins phi is between
   auto bins = std::upper_bound(phiBins.begin(), phiBins.end(), phi);
 
@@ -792,13 +795,13 @@ unsigned int PurgeDuplicate::findPhiBin(const Tracklet* trk) const {
 }
 
 // Tells us the overlap bin(s) to which a track belongs
-std::vector<unsigned int> PurgeDuplicate::findOverlapRInvBins(const Tracklet* trk) const {
-  double rInv = trk->rinv();
-  const double overlapSize = settings_.overlapSize();
-  const std::vector<double>& varRInvBins = settings_.varRInvBins();
+std::vector<unsigned int> PurgeDuplicate::findOverlapRinvBins(const Tracklet* trk) const {
+  double rinv = trk->rinv();
+  const double rinvOverlapSize = settings_.rinvOverlapSize();
+  const std::vector<double>& rinvBins = settings_.rinvBins();
   std::vector<unsigned int> chosenBins;
-  for (long unsigned int i = 0; i < varRInvBins.size() - 1; i++) {
-    if ((rInv < varRInvBins[i + 1] + overlapSize) && (rInv > varRInvBins[i] - overlapSize)) {
+  for (long unsigned int i = 0; i < rinvBins.size() - 1; i++) {
+    if ((rinv < rinvBins[i + 1] + rinvOverlapSize) && (rinv > rinvBins[i] - rinvOverlapSize)) {
       chosenBins.push_back(i);
     }
   }
@@ -807,7 +810,10 @@ std::vector<unsigned int> PurgeDuplicate::findOverlapRInvBins(const Tracklet* tr
 
 // Tells us the overlap bin(s) to which a track belongs
 std::vector<unsigned int> PurgeDuplicate::findOverlapPhiBins(const Tracklet* trk) const {
-  double phi = trk->phi0();
+  double phi0 = trk->phi0();
+  double rcrit = settings_.rcrit();
+  double rinv = trk->rinv();
+  double phi = phi0 - asin(0.5 * rinv * rcrit);
   const double phiOverlapSize = settings_.phiOverlapSize();
   const std::vector<double>& phiBins = settings_.phiBins();
   std::vector<unsigned int> chosenBins;

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -309,7 +309,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
           }
         }
 
-        // If the track isn't a duplicate, and if it's in more than one bin, and it is not in the proper rinv bin, then mark it so it won't be sent to output
+        // If the track isn't a duplicate, and if it's in more than one bin, and it is not in the proper rinv or phi bin, then mark it so it won't be sent to output
         for (unsigned int itrk = 0; itrk < numStublists; itrk++) {
           if (noMerge[itrk] == false) {
             if (((findOverlapRinvBins(inputtracklets_[itrk]).size() > 1) &&
@@ -336,7 +336,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks_, unsigned int iSe
                 rejetrk = itrk;
               }
 
-              // If the preffered track is in more than one bin, but not in the proper rinv bin, then mark as true
+              // If the preffered track is in more than one bin, but not in the proper rinv or phi bin, then mark as true
               if (((findOverlapRinvBins(inputtracklets_[preftrk]).size() > 1) &&
                    (findRinvBin(inputtracklets_[preftrk]) != bin)) ||
                   ((findOverlapPhiBins(inputtracklets_[preftrk]).size() > 1) &&
@@ -780,8 +780,8 @@ unsigned int PurgeDuplicate::findPhiBin(const Tracklet* trk) const {
   double rcrit = settings_.rcrit();
   double rinv = trk->rinv();
   double phi = phi0 - asin(0.5 * rinv * rcrit);
-  
-  //Check between what 2 values in phbins phi is between
+
+  //Check between what 2 values in phibins phi is between
   auto bins = std::upper_bound(phiBins.begin(), phiBins.end(), phi);
 
   //return integer for bin index
@@ -794,7 +794,7 @@ unsigned int PurgeDuplicate::findPhiBin(const Tracklet* trk) const {
     return phiIndx - 1;
 }
 
-// Tells us the overlap bin(s) to which a track belongs
+// Tells us the overlap rinv bin(s) to which a track belongs
 std::vector<unsigned int> PurgeDuplicate::findOverlapRinvBins(const Tracklet* trk) const {
   double rinv = trk->rinv();
   const double rinvOverlapSize = settings_.rinvOverlapSize();
@@ -808,7 +808,7 @@ std::vector<unsigned int> PurgeDuplicate::findOverlapRinvBins(const Tracklet* tr
   return chosenBins;
 }
 
-// Tells us the overlap bin(s) to which a track belongs
+// Tells us the overlap phi bin(s) to which a track belongs
 std::vector<unsigned int> PurgeDuplicate::findOverlapPhiBins(const Tracklet* trk) const {
   double phi0 = trk->phi0();
   double rcrit = settings_.rcrit();

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -179,7 +179,6 @@ void TrackletEventProcessor::event(SLHCEvent& ev,
   globals_->event() = &ev;
 
   tracks_.clear();
-
   eventnum_++;
   bool first = (eventnum_ == 1);
 


### PR DESCRIPTION
With this PR, phi bins would be added to duplicate removal to increase performance. 

With this PR, the duplicate fraction is reduced to 0.466% and has efficiencies 
```
efficiency for |eta| < 1.0 = 95.315 +- 0.188948
efficiency for 1.0 < |eta| < 1.75 = 95.0322 +- 0.263025
efficiency for 1.75 < |eta| < 2.4 = 94.9885 +- 0.369216
combined efficiency for |eta| < 2.4 = 95.1805 +- 0.141768 = 21724/22824

efficiency for pt > 2 = 95.1805 +- 0.141768
efficiency for 2 < pt < 8.0 = 95.3649 +- 0.160332
efficiency for pt > 8.0 = 94.6172 +- 0.300798
efficiency for pt > 40.0 = 91.7431 +- 1.31811

# TP/event (pt > 2) = 152.514
# TP/event (pt > 3.0) = 50.786
# TP/event (pt > 10.0) = 4.586
# tracks/event (no pt cut)= 179.731
# tracks/event (pt > 2) = 165.781
# tracks/event (pt > 3.0) = 57.551
# tracks/event (pt > 10.0) = 5.906
```

Before this PR, the duplicate fraction was 0.741%, and the efficiencies were
```
efficiency for |eta| < 1.0 = 95.1366 +- 0.194801
efficiency for 1.0 < |eta| < 1.75 = 95.5566 +- 0.256393
efficiency for 1.75 < |eta| < 2.4 = 95.0683 +- 0.361436
combined efficiency for |eta| < 2.4 = 95.2475 +- 0.142663 = 21184/22241

efficiency for pt > 2 = 95.2475 +- 0.142663
efficiency for 2 < pt < 8.0 = 95.4162 +- 0.161779
efficiency for pt > 8.0 = 94.7378 +- 0.30025
efficiency for pt > 40.0 = 93.2668 +- 1.25141

# TP/event (pt > 2) = 152.045
# TP/event (pt > 3.0) = 50.605
# TP/event (pt > 10.0) = 4.638
# tracks/event (no pt cut)= 180.974
# tracks/event (pt > 2) = 167.362
# tracks/event (pt > 3.0) = 58.763
# tracks/event (pt > 10.0) = 6.026
```