### PR TITLE
nbits_ was not set in TrackletLUT.cc for all tables. This is fixed now.

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -1397,15 +1397,15 @@ int TrackletLUT::getphiCorrValue(
 
 // Write LUT table.
 void TrackletLUT::writeTable() const {
+  if (name_.empty()) {
+    return;
+  }
+
   if (nbits_ == 0) {
     throw cms::Exception("LogicError") << "Error in " << __FILE__ << " nbits_ == 0 ";
   }
 
   if (!settings_.writeTable()) {
-    return;
-  }
-
-  if (name_.empty()) {
     return;
   }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -9,7 +9,8 @@
 using namespace std;
 using namespace trklet;
 
-TrackletLUT::TrackletLUT(const Settings& settings) : settings_(settings), setup_(settings.setup()), nbits_(0), positive_(true) {}
+TrackletLUT::TrackletLUT(const Settings& settings)
+    : settings_(settings), setup_(settings.setup()), nbits_(0), positive_(true) {}
 
 std::vector<const tt::SensorModule*> TrackletLUT::getSensorModules(
     unsigned int layerdisk, bool isPS, std::array<double, 2> tan_range, unsigned int nzbins, unsigned int zbin) {
@@ -1142,7 +1143,7 @@ void TrackletLUT::initVMRTable(unsigned int layerdisk, VMRTableType type, int re
       //This if a hack where the same memory is used in both ME and TE modules
       if (layerdisk == LayerDisk::L2 || layerdisk == LayerDisk::L3 || layerdisk == LayerDisk::L4 ||
           layerdisk == LayerDisk::L6) {
-	nbits_ = 6;
+        nbits_ = 6;
         positive_ = false;
         name_ = "VMTableOuter" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
         writeTable();
@@ -1453,10 +1454,10 @@ void TrackletLUT::writeTable() const {
 }
 
 int TrackletLUT::lookup(unsigned int index) const {
-  if (index >= table_.size() ){
-    throw cms::Exception("LogicError") << "Error in " << __FILE__ << " index >= size " 
-				       << index << " " << table_.size() << " in " << name_;
-  } 
+  if (index >= table_.size()) {
+    throw cms::Exception("LogicError") << "Error in " << __FILE__ << " index >= size " << index << " " << table_.size()
+                                       << " in " << name_;
+  }
   assert(index < table_.size());
   return table_[index];
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -9,7 +9,7 @@
 using namespace std;
 using namespace trklet;
 
-TrackletLUT::TrackletLUT(const Settings& settings) : settings_(settings), setup_(settings.setup()) {}
+TrackletLUT::TrackletLUT(const Settings& settings) : settings_(settings), setup_(settings.setup()), nbits_(0), positive_(true) {}
 
 std::vector<const tt::SensorModule*> TrackletLUT::getSensorModules(
     unsigned int layerdisk, bool isPS, std::array<double, 2> tan_range, unsigned int nzbins, unsigned int zbin) {
@@ -235,33 +235,43 @@ void TrackletLUT::initmatchcut(unsigned int layerdisk, MatchType type, unsigned 
   name_ = settings_.combined() ? "MP_" : "MC_";
 
   if (type == barrelphi) {
+    nbits_ = 10;
     name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_phicut.tab";
   }
   if (type == barrelz) {
+    nbits_ = 9;
     name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_zcut.tab";
   }
   if (type == diskPSphi) {
+    nbits_ = 19;
     name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_PSphicut.tab";
   }
   if (type == disk2Sphi) {
+    nbits_ = 19;
     name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_2Sphicut.tab";
   }
   if (type == disk2Sr) {
+    nbits_ = 7;
     name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_2Srcut.tab";
   }
   if (type == diskPSr) {
+    nbits_ = 2;
     name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_PSrcut.tab";
   }
   if (type == alphainner) {
+    nbits_ = 8;
     name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_alphainner.tab";
   }
   if (type == alphaouter) {
+    nbits_ = 8;
     name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_alphaouter.tab";
   }
   if (type == rSSinner) {
+    nbits_ = 15;
     name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_rDSSinner.tab";
   }
   if (type == rSSouter) {
+    nbits_ = 15;
     name_ += TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_rDSSouter.tab";
   }
 
@@ -473,6 +483,7 @@ void TrackletLUT::initTPlut(bool fillInner,
   nbits_ = 8;
 
   positive_ = false;
+  nbits_ = 1;
   char cTP = 'A' + iTP;
 
   name_ = "TP_" + TrackletConfigBuilder::LayerName(layerdisk1) + TrackletConfigBuilder::LayerName(layerdisk2) + cTP;
@@ -535,6 +546,7 @@ void TrackletLUT::initTPregionlut(unsigned int iSeed,
   }
 
   positive_ = false;
+  nbits_ = 8;
   char cTP = 'A' + iTP;
 
   name_ = "TP_" + TrackletConfigBuilder::LayerName(layerdisk1) + TrackletConfigBuilder::LayerName(layerdisk2) + cTP +
@@ -766,6 +778,7 @@ void TrackletLUT::initteptlut(bool fillInner,
   }
 
   positive_ = false;
+  nbits_ = 1;
 
   if (fillTEMem) {
     if (fillInner) {
@@ -830,6 +843,7 @@ void TrackletLUT::initProjectionBend(double k_phider,
   }
 
   positive_ = false;
+  nbits_ = 5;
   name_ = settings_.combined() ? "MP_" : "PR_";
   name_ += "ProjectionBend_" + TrackletConfigBuilder::LayerName(N_LAYER + idisk) + ".tab";
 
@@ -973,6 +987,7 @@ void TrackletLUT::initBendMatch(unsigned int layerdisk) {
   }
 
   positive_ = false;
+  nbits_ = 1;
 
   name_ = "METable_" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
 
@@ -1127,6 +1142,7 @@ void TrackletLUT::initVMRTable(unsigned int layerdisk, VMRTableType type, int re
       //This if a hack where the same memory is used in both ME and TE modules
       if (layerdisk == LayerDisk::L2 || layerdisk == LayerDisk::L3 || layerdisk == LayerDisk::L4 ||
           layerdisk == LayerDisk::L6) {
+	nbits_ = 6;
         positive_ = false;
         name_ = "VMTableOuter" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
         writeTable();
@@ -1135,23 +1151,27 @@ void TrackletLUT::initVMRTable(unsigned int layerdisk, VMRTableType type, int re
       assert(region >= 0);
       char cregion = 'A' + region;
       name_ = "VMR_" + TrackletConfigBuilder::LayerName(layerdisk) + "PHI" + cregion + "_finebin.tab";
+      nbits_ = 6;
       positive_ = false;
     }
 
     if (type == VMRTableType::inner) {
       positive_ = false;
+      nbits_ = 10;
       name_ = "VMTableInner" + TrackletConfigBuilder::LayerName(layerdisk) +
               TrackletConfigBuilder::LayerName(layerdisk + 1) + ".tab";
     }
 
     if (type == VMRTableType::inneroverlap) {
       positive_ = false;
+      nbits_ = 10;
       name_ = "VMTableInner" + TrackletConfigBuilder::LayerName(layerdisk) + TrackletConfigBuilder::LayerName(N_LAYER) +
               ".tab";
     }
 
     if (type == VMRTableType::disk) {
       positive_ = false;
+      nbits_ = 10;
       name_ = "VMTableOuter" + TrackletConfigBuilder::LayerName(layerdisk) + ".tab";
     }
   }
@@ -1412,6 +1432,10 @@ void TrackletLUT::writeTable() const {
 
   out = openfile(settings_.tablePath(), name, __FILE__, __LINE__);
 
+  if (nbits_ == 0) {
+    throw cms::Exception("LogicError") << "Error in " << __FILE__ << " nbits_ == 0 ";
+  }
+
   int width = (nbits_ + 3) / 4;
 
   for (unsigned int i = 0; i < table_.size(); i++) {
@@ -1429,6 +1453,10 @@ void TrackletLUT::writeTable() const {
 }
 
 int TrackletLUT::lookup(unsigned int index) const {
+  if (index >= table_.size() ){
+    throw cms::Exception("LogicError") << "Error in " << __FILE__ << " index >= size " 
+				       << index << " " << table_.size() << " in " << name_;
+  } 
   assert(index < table_.size());
   return table_[index];
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletLUT.cc
@@ -1397,6 +1397,10 @@ int TrackletLUT::getphiCorrValue(
 
 // Write LUT table.
 void TrackletLUT::writeTable() const {
+  if (nbits_ == 0) {
+    throw cms::Exception("LogicError") << "Error in " << __FILE__ << " nbits_ == 0 ";
+  }
+
   if (!settings_.writeTable()) {
     return;
   }
@@ -1432,10 +1436,6 @@ void TrackletLUT::writeTable() const {
   name[name_.size() - 1] = 't';
 
   out = openfile(settings_.tablePath(), name, __FILE__, __LINE__);
-
-  if (nbits_ == 0) {
-    throw cms::Exception("LogicError") << "Error in " << __FILE__ << " nbits_ == 0 ";
-  }
 
   int width = (nbits_ + 3) / 4;
 


### PR DESCRIPTION
#### PR description:

In TrackletLUT.cc the variable nbits_ was not set for all different LUTs and this caused a failure when trying to write out the LUTs to files. nbits_ is now set and code has been added to catch if nbits_ is not set and generate a meaning full error.

#### PR validation:

This code has been tested to verify that the writing of the LUTs work OK.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
