### PR TITLE
Added PS/2S logic to MEU

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/MatchEngineUnit.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MatchEngineUnit.h
@@ -99,6 +99,9 @@ namespace trklet {
 
     unsigned int layerdisk_;
 
+    //The minimum radius for 2s disks in projection bins
+    unsigned int ir2smin_;
+
     //Save state at the start of istep
     bool almostfullsave_;
 

--- a/L1Trigger/TrackFindingTracklet/interface/MatchEngineUnit.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MatchEngineUnit.h
@@ -80,7 +80,7 @@ namespace trklet {
     VMStubsMEMemory* vmstubsmemory_;
 
     unsigned int nrzbins_;
-    unsigned int rzbin_;
+    unsigned int rzbin_, rzbin__, rzbin___, rzbin__t;
     unsigned int phibin_;
     int shift_;
 

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -89,6 +89,7 @@ void MatchEngineUnit::step() {
   }
 
   vmstub__ = vmstubsmemory_->getVMStubMEBin(slot, istub_);
+  rzbin__ = rzbin_ + use_[iuse_].first;
 
   isPSseed__ = isPSseed_;
   projrinv__ = projrinv_;
@@ -107,9 +108,22 @@ void MatchEngineUnit::step() {
 
 void MatchEngineUnit::processPipeline() {
   if (good___) {
-    bool isPSmodule = vmstub___.isPSmodule();
     int stubfinerz = vmstub___.finerz().value();
     int stubfinephi = vmstub___.finephi().value();
+    bool isPSmodule = false;
+
+    if (barrel_) {
+      isPSmodule = layerdisk_ < N_PSLAYER;
+    } else {
+      const int absz = (1 << settings_.MEBinsBits()) - 1;
+      std::cout << "absz=" << absz << std::endl;
+      if (layerdisk_ < N_LAYER + 2) {
+        isPSmodule = ((rzbin___ & absz) < 3) || ((rzbin___ & absz) == 3 && stubfinerz <= 3);
+      } else {
+        isPSmodule = ((rzbin___ & absz) < 3) || ((rzbin___ & absz) == 3 && stubfinerz <= 2);
+      }
+    }
+    assert(isPSmodule == vmstub___.isPSmodule());
 
     int deltaphi = stubfinephi - projfinephi___;
 
@@ -162,6 +176,7 @@ void MatchEngineUnit::processPipeline() {
   isPSseed___ = isPSseed__t;
   good___ = good__t;
   vmstub___ = vmstub__t;
+  rzbin___ = rzbin__t;
 
   proj__t = proj__;
   projfinephi__t = projfinephi__;
@@ -170,6 +185,7 @@ void MatchEngineUnit::processPipeline() {
   isPSseed__t = isPSseed__;
   good__t = good__;
   vmstub__t = vmstub__;
+  rzbin__t = rzbin__;
 }
 
 void MatchEngineUnit::reset() {

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -116,7 +116,6 @@ void MatchEngineUnit::processPipeline() {
       isPSmodule = layerdisk_ < N_PSLAYER;
     } else {
       const int absz = (1 << settings_.MEBinsBits()) - 1;
-      std::cout << "absz=" << absz << std::endl;
       if (layerdisk_ < N_LAYER + 2) {
         isPSmodule = ((rzbin___ & absz) < 3) || ((rzbin___ & absz) == 3 && stubfinerz <= 3);
       } else {

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -84,7 +84,7 @@ if GEOMETRY == "D76":
 elif GEOMETRY == "D88":
 
   # Read specified .root file:
-  inputMC = ["/store/relval/CMSSW_12_6_0_pre4/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_125X_mcRun4_realistic_v2_2026D88PU200-v1/2590000/00b3d04b-4c7b-4506-8d82-9538fb21ee19.root"]
+  inputMC = ["/store/mc/CMSSW_12_6_0/RelValTTbar_14TeV/GEN-SIM-DIGI-RAW/PU_125X_mcRun4_realistic_v5_2026D88PU200RV183v2-v1/30000/0959f326-3f52-48d8-9fcf-65fc41de4e27.root"]
 
 else:
 


### PR DESCRIPTION
#### PR description:

This PR adds the disk PS/2S logic to the MatchEngineUnit. This does not change the output files, as the MEU was previously looking up the correct answers. However, this makes the logic match the HLS.
The `rzbin` variable is now pipelined to match the `vmstub`, and it is adjusted to account when a projection is consistent with two disks.