### PR TITLE
Suppress warning about "Hybrid tracking disabled"

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -58,8 +58,10 @@ namespace trklet {
     Settings() {
       //Comment out to run tracklet-only algorithm
 #ifdef CMSSW_GIT_HASH
-#ifndef USEHYBRID
+#ifndef CMS_DICT_IMPL // Don't print message if genreflex being run.
+#ifndef USEHYBRID 
 #pragma message "USEHYBRID is undefined, so Hybrid L1 tracking disabled."
+#endif
 #endif
 #endif
     }

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -58,8 +58,8 @@ namespace trklet {
     Settings() {
       //Comment out to run tracklet-only algorithm
 #ifdef CMSSW_GIT_HASH
-#ifndef CMS_DICT_IMPL // Don't print message if genreflex being run.
-#ifndef USEHYBRID 
+#ifndef CMS_DICT_IMPL  // Don't print message if genreflex being run.
+#ifndef USEHYBRID
 #pragma message "USEHYBRID is undefined, so Hybrid L1 tracking disabled."
 #endif
 #endif


### PR DESCRIPTION
Even if the pragma USEHYBRID is defined, Setting.h still prints out the following message during scram compilation:
"USEHYBRID is undefined, so Hybrid L1 tracking disabled"
This occurs when scram runs the "genreflex" command, which scram doesn't pass the user defined pragmas to. I've supressed this by only printing out this message if pragma CMS_DICT_IMPL is not defined, since scram defines it when running genreflex.