### PR TITLE
Change assert to an if statement so that we can run with reduced conf…

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -258,9 +258,9 @@ void VMRouterCM::execute(unsigned int) {
           FPGAWord(stub->bend().value(), nbendbits, true, __LINE__, __FILE__),
           allStubIndex);
 
-      assert(vmstubsMEPHI_[0] != nullptr);
-
-      vmstubsMEPHI_[0]->addStub(vmstub, ivm * nvmmebins_ + vmbin);
+      if (vmstubsMEPHI_[0] != nullptr) {
+        vmstubsMEPHI_[0]->addStub(vmstub, ivm * nvmmebins_ + vmbin);
+      }
 
       //Fill the TE VM memories
       if (layerdisk_ >= N_LAYER && (!stub->isPSmodule()))


### PR DESCRIPTION
…igurations where not all stubs are routed

#### PR description:

Trivial change to replace an assert in VMRouterCM with an if statement. If we are running on a complete configuration all stubs will be routed to some VM memory. But in a reduced configuration this is not the case and the assert is not replaced with an if statement.

#### PR validation:

This code has been tested to generate all the combined module reduced configurations as well as running the full configuration.



