### PR TITLE
Fixed L1TrackNtupleMaker crash

### DIFF
--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -936,6 +936,12 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_phi = iterL1Track->momentum().phi();
       float tmp_trk_z0 = iterL1Track->z0();  //cm
       float tmp_trk_tanL = iterL1Track->tanL();
+      bool usingNewKF = hphSetup->useNewKF();
+      if (usingNewKF) {
+        // Skip crazy tracks to avoid crash (as NewKF applies no cuts to kill them).
+        constexpr float crazy_z0_cut = 30.; // Cut to kill any crazy tracks found by New KF (which applies no cuts)
+        if (fabs(tmp_trk_z0) > crazy_z0_cut) continue;
+      }
 
       int tmp_trk_hitpattern = 0;
       tmp_trk_hitpattern = (int)iterL1Track->hitPattern();

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -939,8 +939,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       bool usingNewKF = hphSetup->useNewKF();
       if (usingNewKF) {
         // Skip crazy tracks to avoid crash (as NewKF applies no cuts to kill them).
-        constexpr float crazy_z0_cut = 30.; // Cut to kill any crazy tracks found by New KF (which applies no cuts)
-        if (fabs(tmp_trk_z0) > crazy_z0_cut) continue;
+        constexpr float crazy_z0_cut = 30.;  // Cut to kill any crazy tracks found by New KF (which applies no cuts)
+        if (fabs(tmp_trk_z0) > crazy_z0_cut)
+          continue;
       }
 
       int tmp_trk_hitpattern = 0;

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -186,6 +186,8 @@ elif (L1TRKALGO == 'HYBRID_NEWKF' or L1TRKALGO == 'HYBRID_REDUCED'):
         fwConfig( process )
     if (L1TRKALGO == 'HYBRID_REDUCED'):
         reducedConfig( process )
+    # Needed by L1TrackNtupleMaker
+    process.HitPatternHelperSetup.useNewKF = True
 
 # LEGACY ALGORITHM (EXPERTS ONLY): TRACKLET
 elif (L1TRKALGO == 'TRACKLET'):

--- a/L1Trigger/TrackerTFP/src/DataFormats.cc
+++ b/L1Trigger/TrackerTFP/src/DataFormats.cc
@@ -70,6 +70,7 @@ namespace trackerTFP {
     numStreamsTracks_[+Process::kfin] = numStreams_[+Process::kf];
     numStreamsTracks_[+Process::kf] = numStreams_[+Process::kf];
     // Print digi data format of all variables of any specified algo step
+    // (Look at DataFormat.h::tracks_ to see variable names).
     //for (const Variable v : tracks_[+Process::kf]) {
     //  const DataFormat& f = format(v, Process::kf);
     //  cout <<" KF "<< f.base() << " " << f.range() << " " << f.width() << endl;


### PR DESCRIPTION
#### PR description:

#### PR description:

Fixes L1TrackNtupleMaker crash that as reported in https://github.com/cms-L1TK/cmssw/issues/218 occurs when running L1TrackNtupleMaker_cfg.py in HYBRID_NEWKF mode. 

Fix consists of adding 30cm abs(z0) cut to L1TrackNTupleMaker to kill crazy tracks from KF. And setting cfg param HitPatternHelperSetup.useNewKF = True when using the New KF.
