### PR TITLE
Fill MVA1 when using newKF

### DIFF
--- a/L1Trigger/TrackFindingTracklet/python/l1tTTTracksFromTrackletEmulation_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/l1tTTTracksFromTrackletEmulation_cfi.py
@@ -21,7 +21,7 @@ l1tTTTracksFromTrackletEmulation = cms.EDProducer("L1FPGATrackProducer",
                                                processingModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/processingmodules_hourglassExtended.dat'),
                                                wiresFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/wires_hourglassExtended.dat'),
                                                # Quality Flag and Quality params
-                                               TrackQuality = cms.bool(True),
+                                               TrackQuality = cms.bool(False),
                                                TrackQualityPSet = cms.PSet(TrackQualityParams),
                                                Fakefit = cms.bool(False), # True causes Tracklet reco to output TTTracks before DR & KF
                                                StoreTrackBuilderOutput = cms.bool(False), # if True EDProducts for TrackBuilder tracks and stubs will be filled

--- a/L1Trigger/TrackerTFP/interface/DataFormats.h
+++ b/L1Trigger/TrackerTFP/interface/DataFormats.h
@@ -14,6 +14,7 @@ and in undigitized format in an std::tuple. (This saves CPU)
 #include "L1Trigger/TrackerTFP/interface/DataFormatsRcd.h"
 #include "L1Trigger/TrackTrigger/interface/Setup.h"
 #include "DataFormats/L1TrackTrigger/interface/TTBV.h"
+#include "L1Trigger/TrackTrigger/interface/L1TrackQuality.h"
 
 #include <vector>
 #include <cmath>
@@ -472,6 +473,8 @@ namespace trackerTFP {
     ~DataFormats() {}
     // bool indicating if hybrid or tmtt being used
     bool hybrid() const { return iConfig_.getParameter<bool>("UseHybrid"); }
+    // L1TrackQuality model parameters
+    edm::ParameterSet TQPset() const { return iConfig_.getParameter<edm::ParameterSet>("TrackQualityPSet"); }
     // converts bits to ntuple of variables
     template <typename... Ts>
     void convertStub(Process p, const tt::Frame& bv, std::tuple<Ts...>& data) const;

--- a/L1Trigger/TrackerTFP/python/ProducerES_cfi.py
+++ b/L1Trigger/TrackerTFP/python/ProducerES_cfi.py
@@ -1,8 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+from L1Trigger.TrackTrigger.TrackQualityParams_cfi import *
 
 TrackTriggerDataFormats_params = cms.PSet (
 
   UseHybrid = cms.bool( True ),
+
+  TrackQualityPSet = cms.PSet(TrackQualityParams),
 
   ZHoughTransform = cms.PSet (
 

--- a/L1Trigger/TrackerTFP/src/DataFormats.cc
+++ b/L1Trigger/TrackerTFP/src/DataFormats.cc
@@ -517,6 +517,10 @@ namespace trackerTFP {
     ttTrack.setTrackSeedType(frame_.first->trackSeedType());
     ttTrack.setStubPtConsistency(StubPtConsistency::getConsistency(
         ttTrack, setup()->trackerGeometry(), setup()->trackerTopology(), bField, nPar));
+
+    std::unique_ptr<L1TrackQuality> trackQualityModel_ = std::make_unique<L1TrackQuality>(dataFormats_->TQPset());
+    trackQualityModel_->setL1TrackQuality(ttTrack);
+
     return ttTrack;
   }
 


### PR DESCRIPTION
#### PR description:

When using the new KF, TTTracks are converted from the KFTracks [here](https://github.com/cms-L1TK/cmssw/blob/cf9087e16493a7b4002cce06537f99d3a9c79912/L1Trigger/TrackerTFP/src/DataFormats.cc#L485). The trk_MVA1 variable is set to 0 however, and so this PR runs the track quality code to fill this variable.

#### PR validation:

The L1TrackNtupleMaker ntuple is now filled with non-zero trk_MVA1 variables.
