### PR TITLE
Fix TQ input variables

### DIFF
--- a/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py
@@ -7,7 +7,7 @@ TrackQualityParams = cms.PSet(qualityAlgorithm = cms.string("GBDT_cpp"), #None, 
                               # git clone https://github.com/cms-data/L1Trigger-TrackTrigger.git L1Trigger/TrackTrigger/data
                               ONNXInputName = cms.string("feature_input"),
                               #Vector of strings of training features, in the order that the model was trained with
-                              featureNames = cms.vstring(["eta", "z0", "bendchi2_bin", "nstub", 
+                              featureNames = cms.vstring(["tanl", "z0_scaled", "bendchi2_bin", "nstub",
                                                           "nlaymiss_interior", "chi2rphi_bin", "chi2rz_bin"]),
                               # Parameters for cut based classifier, optimized for L1 Track MET
                               # (Table 3.7  The Phase-2 Upgrade of the CMS Level-1 Trigger http://cds.cern.ch/record/2714892) 

--- a/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
@@ -74,19 +74,23 @@ std::vector<float> L1TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDig
 
   // get other variables directly from TTTrack
   float tmp_trk_z0 = aTrack.z0();
+  float tmp_trk_z0_scaled = tmp_trk_z0/abs(aTrack.minZ0);
   float tmp_trk_phi = aTrack.phi();
   float tmp_trk_eta = aTrack.eta();
+  float tmp_trk_tanl = aTrack.tanL();
 
   // -------- fill the feature map ---------
 
   feature_map["nstub"] = float(tmp_trk_nstub);
   feature_map["z0"] = tmp_trk_z0;
+  feature_map["z0_scaled"] = tmp_trk_z0_scaled;
   feature_map["phi"] = tmp_trk_phi;
   feature_map["eta"] = tmp_trk_eta;
   feature_map["nlaymiss_interior"] = float(tmp_trk_nlaymiss_interior);
   feature_map["bendchi2_bin"] = tmp_trk_bendchi2_bin;
   feature_map["chi2rphi_bin"] = tmp_trk_chi2rphi_bin;
   feature_map["chi2rz_bin"] = tmp_trk_chi2rz_bin;
+  feature_map["tanl"] = tmp_trk_tanl;
 
   // fill tensor with track params
   transformedFeatures.reserve(featureNames.size());


### PR DESCRIPTION
#### PR description:

The [input variables](https://github.com/cms-L1TK/cmssw/blob/e0a9a38fc780948f44366211a9a042d6627332dd/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc#L288) for the latest track quality classifier (emulated version, runs with newKF emulation) changed. However, the variables set for the [simulation version](https://github.com/cms-L1TK/cmssw/blob/L1TK-dev-12_6_0_pre5/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py#L10) of the code did not get updated to reflect this change in the classifier. This PR updates the variables to the proper ones.

The changes in the variables are a consequence of the emulation. In emulation tanl is more readily available than eta and z0 is scaled by a non-base 2 value which makes it more costly to change back. Therefore, the bdt uses tanl and a scaled version of the z0 that are both easier to obtain.

#### PR validation:

I checked that the outputs from the MVA variable calculated by the cmssw code matched the output from the python version  of the classifier that was used for the training of the bdt. The results here show perfect matching between the cmssw and python version of the classifier:
![Screen Shot 2023-07-10 at 4 33 24 PM](https://github.com/cms-L1TK/cmssw/assets/15660721/6bfb21f1-5f57-4fc9-abf8-8a9b1f4e58ef)

