### PR TITLE
add bit into AllStubInner for TP Disks

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Stub.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Stub.h
@@ -43,7 +43,12 @@ namespace trklet {
       unsigned int nbitsfinephi = 8;
       FPGAWord finephi(
           phicorr_.bits(phicorr_.nbits() - nbitsfinephi, nbitsfinephi), nbitsfinephi, true, __LINE__, __FILE__);
-      return str() + "|" + stubindex_.str() + "|" + finephi.str();
+      if (layer_.value() == -1) {
+          return str() + "|" + negdisk_.str() + "|" + stubindex_.str() + "|" + finephi.str();      
+      }
+      else {
+          return str() + "|" + stubindex_.str() + "|" + finephi.str();
+      }
     }
 
     FPGAWord allStubIndex() const { return stubindex_; }
@@ -59,6 +64,7 @@ namespace trklet {
 
     const FPGAWord& r() const { return r_; }
     const FPGAWord& z() const { return z_; }
+    const FPGAWord& negdisk() const { return negdisk_; }
     const FPGAWord& phi() const { return phi_; }
     const FPGAWord& phicorr() const { return phicorr_; }
     const FPGAWord& alpha() const { return alpha_; }
@@ -87,6 +93,7 @@ namespace trklet {
     FPGAWord disk_;
     FPGAWord r_;
     FPGAWord z_;
+    FPGAWord negdisk_;
     FPGAWord phi_;
     FPGAWord alpha_;
 

--- a/L1Trigger/TrackFindingTracklet/src/Stub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Stub.cc
@@ -77,6 +77,8 @@ Stub::Stub(L1TStub& stub, Settings const& settings, Globals& globals) : settings
       alpha_.set(newalpha, nalphabits, false, __LINE__, __FILE__);
       nrbits = 4;
     }
+    int negdisk = (disk<0) ? 1 : 0;
+    negdisk_.set(negdisk, 1, true, __LINE__, __FILE__);
   } else {
     disk_.set(0, 4, false, __LINE__, __FILE__);
     layer_.set(layerdisk_, 3, true, __LINE__, __FILE__);

--- a/L1Trigger/TrackFindingTracklet/src/Stub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Stub.cc
@@ -77,7 +77,7 @@ Stub::Stub(L1TStub& stub, Settings const& settings, Globals& globals) : settings
       alpha_.set(newalpha, nalphabits, false, __LINE__, __FILE__);
       nrbits = 4;
     }
-    int negdisk = (disk<0) ? 1 : 0;
+    int negdisk = (disk < 0) ? 1 : 0;
     negdisk_.set(negdisk, 1, true, __LINE__, __FILE__);
   } else {
     disk_.set(0, 4, false, __LINE__, __FILE__);


### PR DESCRIPTION
#### PR description:

PR records an extra bit into disk allStubInner memories test vectors. This bit is used by the TP in HLS to differentiate the postive and negative disks.

corresponds to firmware_hls PR [(280)](https://github.com/cms-L1TK/firmware-hls/pull/280)


edit: I see now that I need to do a PR from a cms-l1tk branch instead of from a personal fork for the CI check - I think I need some permission to do so? will remake once I can get that up

[new pr](https://github.com/cms-L1TK/cmssw/pull/230)