### PR TITLE
Add missing bits to store the phi region for the inner stub in the combined module trackletparameters

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Stub.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Stub.h
@@ -54,6 +54,7 @@ namespace trklet {
 
     unsigned int phiregionaddress() const;
     std::string phiregionaddressstr() const;
+    std::string phiregionstr() const;
 
     void setAllStubIndex(int nstub);  //should migrate away from using this method
 

--- a/L1Trigger/TrackFindingTracklet/src/Stub.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Stub.cc
@@ -122,6 +122,12 @@ std::string Stub::phiregionaddressstr() const {
   return phiregion.str() + stubindex_.str();
 }
 
+std::string Stub::phiregionstr() const {
+  int iphi = (phicorr_.value() >> (phicorr_.nbits() - settings_.nbitsallstubs(layerdisk())));
+  FPGAWord phiregion(iphi, 3, true, __LINE__, __FILE__);
+  return phiregion.str();
+}
+
 void Stub::setAllStubIndex(int nstub) {
   if (nstub >= (1 << N_BITSMEMADDRESS)) {
     if (settings_.debugTracklet())

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -194,7 +194,15 @@ std::string Tracklet::trackletparstr() {
                       std::to_string(fpgapars_.t().value() * settings_.ktpars());
     return oss;
   } else {
-    std::string str = innerFPGAStub_->stubindex().str() + "|";
+    std::string str = "";
+    if (settings_.combined()) {
+      if (seedIndex() == Seed::L1D1 || seedIndex() == Seed::L2D1) {
+        str += outerFPGAStub_->phiregionstr() + "|";
+      } else {
+        str += innerFPGAStub_->phiregionstr() + "|";
+      }
+    }
+    str += innerFPGAStub_->stubindex().str() + "|";
     if (middleFPGAStub_) {
       str += middleFPGAStub_->stubindex().str() + "|";
     }


### PR DESCRIPTION

#### PR description:

This PR is a simple change to add three bits to store the phi region to identify which AllStub memory is used in a combined module seed.

#### PR validation:

I have run this code in CMSSW and produced the test vectors for HLS. I have updated the HLS code to handle these additional bits and checked that the code is working. (PR for HLS is not quite ready yet, some cleanup still needed.)

