### PR TITLE
TrackFit phi region

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -728,6 +728,13 @@ std::string Tracklet::trackfitstr() const {
 
     oss += "1|";  // valid bit
     oss += tmp.str() + "|";
+    if (settings_.combined()) {
+      if (seedIndex() == Seed::L1D1 || seedIndex() == Seed::L2D1) {
+        oss += outerFPGAStub()->phiregionstr() + "|";
+      } else {
+        oss += innerFPGAStub()->phiregionstr() + "|";
+      }
+    }
     oss += innerFPGAStub()->stubindex().str() + "|";
     oss += outerFPGAStub()->stubindex().str() + "|";
     oss += fpgapars_.rinv().str() + "|";

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -731,8 +731,10 @@ std::string Tracklet::trackfitstr() const {
     if (settings_.combined()) {
       if (seedIndex() == Seed::L1D1 || seedIndex() == Seed::L2D1) {
         oss += outerFPGAStub()->phiregionstr() + "|";
+        oss += innerFPGAStub()->phiregionstr() + "|";
       } else {
         oss += innerFPGAStub()->phiregionstr() + "|";
+        oss += outerFPGAStub()->phiregionstr() + "|";
       }
     }
     oss += innerFPGAStub()->stubindex().str() + "|";


### PR DESCRIPTION
#### PR description:

This PR adds six bits to the TrackFitMemory output, which represent the phi regions of the two seed stubs. It's similar to what PR #233 did for TrackletParametersMemory, but now for TrackFitMemory, and for both seed stubs.

#### PR validation:

I generated test vectors with these changes, and the added bits are now present.

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

N/A