### PR TITLE
MP fix new tracklet with projections

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/MatchProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MatchProcessor.h
@@ -96,8 +96,8 @@ namespace trklet {
     int best_ideltaz_barrel;
     int best_ideltaphi_disk;
     int best_ideltar_disk;
-    Tracklet* curr_tracklet;
-    Tracklet* next_tracklet;
+    std::string curr_tracklet;
+    std::string next_tracklet;
 
     CircularBuffer<ProjectionTemp> inputProjBuffer_;
   };

--- a/L1Trigger/TrackFindingTracklet/interface/MatchProcessor.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MatchProcessor.h
@@ -38,6 +38,7 @@ namespace trklet {
   private:
     unsigned int layerdisk_;
     bool barrel_;
+    bool first_;
 
     unsigned int phiregion_;
 
@@ -96,8 +97,8 @@ namespace trklet {
     int best_ideltaz_barrel;
     int best_ideltaphi_disk;
     int best_ideltar_disk;
-    std::string curr_tracklet;
-    std::string next_tracklet;
+    Tracklet* curr_tracklet;
+    Tracklet* next_tracklet;
 
     CircularBuffer<ProjectionTemp> inputProjBuffer_;
   };

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -116,8 +116,8 @@ MatchProcessor::MatchProcessor(string name, Settings const& settings, Globals* g
   best_ideltaz_barrel = 0xFFFF;
   best_ideltaphi_disk = 0xFFFF;
   best_ideltar_disk = 0xFFFF;
-  curr_tracklet = nullptr;
-  next_tracklet = nullptr;
+  curr_tracklet = "";
+  next_tracklet = "";
 }
 
 void MatchProcessor::addOutput(MemoryBase* memory, string output) {
@@ -538,10 +538,10 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
 
     int seedindex = tracklet->getISeed();
     curr_tracklet = next_tracklet;
-    next_tracklet = tracklet;
+    next_tracklet = trklet::hexFormat(tracklet->trackletprojstr(layerdisk_+1));
 
     // Do we have a new tracklet?
-    bool newtracklet = (istep == 0 || tracklet != curr_tracklet);
+    bool newtracklet = (istep == 0 || next_tracklet.compare(curr_tracklet));
     if (istep == 0)
       best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
     // If so, replace the "best" values with the cut tables
@@ -740,9 +740,9 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
     }
 
     curr_tracklet = next_tracklet;
-    next_tracklet = tracklet;
+    next_tracklet = trklet::hexFormat(tracklet->trackletprojstrD(disk));
     // Do we have a new tracklet?
-    bool newtracklet = (istep == 0 || tracklet != curr_tracklet);
+    bool newtracklet = (istep == 0 || next_tracklet.compare(curr_tracklet));
     // If so, replace the "best" values with the cut tables
     if (newtracklet) {
       best_ideltaphi_disk = idrphicut;

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -538,7 +538,7 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
 
     int seedindex = tracklet->getISeed();
     curr_tracklet = next_tracklet;
-    next_tracklet = trklet::hexFormat(tracklet->trackletprojstr(layerdisk_+1));
+    next_tracklet = trklet::hexFormat(tracklet->trackletprojstr(layerdisk_ + 1));
 
     // Do we have a new tracklet?
     bool newtracklet = (istep == 0 || next_tracklet.compare(curr_tracklet));

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -116,8 +116,9 @@ MatchProcessor::MatchProcessor(string name, Settings const& settings, Globals* g
   best_ideltaz_barrel = 0xFFFF;
   best_ideltaphi_disk = 0xFFFF;
   best_ideltar_disk = 0xFFFF;
-  curr_tracklet = "";
-  next_tracklet = "";
+  curr_tracklet = nullptr;
+  next_tracklet = nullptr;
+  first_ = false;
 }
 
 void MatchProcessor::addOutput(MemoryBase* memory, string output) {
@@ -538,10 +539,11 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
 
     int seedindex = tracklet->getISeed();
     curr_tracklet = next_tracklet;
-    next_tracklet = trklet::hexFormat(tracklet->trackletprojstr(layerdisk_ + 1));
+    next_tracklet = tracklet;
 
     // Do we have a new tracklet?
-    bool newtracklet = (istep == 0 || next_tracklet.compare(curr_tracklet));
+    bool newtracklet = (!first_ || next_tracklet != curr_tracklet);
+    first_ = newtracklet ? true : first_;
     if (istep == 0)
       best_ideltar_disk = (1 << (fpgastub->r().nbits() - 1));  // Set to the maximum possible
     // If so, replace the "best" values with the cut tables
@@ -740,9 +742,10 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
     }
 
     curr_tracklet = next_tracklet;
-    next_tracklet = trklet::hexFormat(tracklet->trackletprojstrD(disk));
+    next_tracklet = tracklet;
     // Do we have a new tracklet?
-    bool newtracklet = (istep == 0 || next_tracklet.compare(curr_tracklet));
+    bool newtracklet = (!first_ || next_tracklet != curr_tracklet);
+    first_ = newtracklet ? true : first_;
     // If so, replace the "best" values with the cut tables
     if (newtracklet) {
       best_ideltaphi_disk = idrphicut;


### PR DESCRIPTION
#### PR description:
This PR fixes a disagreement between the HLS and emulation. Currently, the emulation resets the best match values only when a new `tracklet` is found. This means tracklets with multiple projections can have issues, e.g.:
```
D2 PHIB
tracklet: 0x4933f000
proj: 0x7106acaa7f8a3c2  passes
proj: 0x01129bb27e8883d  failes
```
The PR looks instead uses the current and previous `projection`. It currently uses the string value, as this was easy to access. If this is inefficient, we could look into comparing the member values.

#### PR validation:

Full agreement with HLS in the barrel and disks for `PHIB` and `PHIC`

```
                      Tracklet  SUMMARY
number of stubs     per TFP = 363.0212 +- 8.0716
number of tracks    per TFP =  70.6402 +- 1.5618
current tracking efficiency =   0.9284 +- 0.0122
max     tracking efficiency =   0.9306 +- 0.0120
                  fake rate =   0.1789
             duplicate rate =   0.589
```
