### PR TITLE
Dally rinv bins comment

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1047,14 +1047,10 @@ namespace trklet {
     double stripLength_2S_{5.0250};
 
     //Following values are used for duplicate removal
+    //Rinv bins were optimised to ensure a similar number of tracks in each bin prior to DR
     //Rinv bin edges for 6 bins.
     std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
     //Phi bin edges for 2 bins.
-    //The bin edges for rinv were chosen using the output tracks without duplicate removal for a large number of events
-    //The rinv of the output tracks was calculated, put into an array, and then sorted in increasing order
-    //The length of the rinv array was floor divided by the number of bins, the resulting number and its multiples were used as indices for the rinv array
-    //The bin edges were the rinv of the tracks at those indices
-    //This was to ensure all bins had approximately the same number of tracks
     std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
     double rinvOverlapSize_{0.0004};

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1050,6 +1050,11 @@ namespace trklet {
     //Rinv bin edges for 6 bins.
     std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
     //Phi bin edges for 2 bins.
+    //The bin edges for rinv were chosen using the output tracks without duplicate removal for a large number of events
+    //The rinv of the output tracks was calculated, put into an array, and then sorted in increasing order
+    //The length of the rinv array was floor divided by the number of bins, the resulting number and its multiples were used as indices for the rinv array 
+    //The bin edges were the rinv of the tracks at those indices
+    //This was to ensure all bins had approximately the same number of tracks
     std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
     double rinvOverlapSize_{0.0004};

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1052,7 +1052,7 @@ namespace trklet {
     //Phi bin edges for 2 bins.
     //The bin edges for rinv were chosen using the output tracks without duplicate removal for a large number of events
     //The rinv of the output tracks was calculated, put into an array, and then sorted in increasing order
-    //The length of the rinv array was floor divided by the number of bins, the resulting number and its multiples were used as indices for the rinv array 
+    //The length of the rinv array was floor divided by the number of bins, the resulting number and its multiples were used as indices for the rinv array
     //The bin edges were the rinv of the tracks at those indices
     //This was to ensure all bins had approximately the same number of tracks
     std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};


### PR DESCRIPTION
This pull requests adds some more comments explaining why the rinv bin edges in L1Trigger/TrackFindingTracklet/interface/Settings.h were chosen as such. See here https://github.com/cms-sw/cmssw/pull/42663#discussion_r1344066992. 
