### PR TITLE
Combined Module Eff Bug Fix

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -141,7 +141,7 @@ void MatchEngineUnit::processPipeline() {
     int diskps = (!barrel_) && isPSmodule;
 
     //here we always use the larger number of bits for the bend
-    unsigned int index = (diskps << (nbits + NRINVBITS)) + (projrinv___ << nbits) + vmstub___.bend().value();
+    unsigned int index = (diskps << (N_BENDBITS_2S + NRINVBITS)) + (projrinv___ << nbits) + vmstub___.bend().value();
 
     //Check if stub z position consistent
     int idrz = stubfinerz - projfinerz___;


### PR DESCRIPTION
#### PR description:

Changing one line which caused a bug in which combined module efficiency was significantly decreased in high eta/endcap region. 

More specifically, this is the link to the line that I changed back to what it was before: https://github.com/cms-L1TK/cmssw/commit/23a8a8cfaf3086866b503032b56d93578de8fcc1#diff-0c7cf803e613a94ff5b22deb42f152136d1c91cb933f889070380ae102f02094R125

See attached presentation for how the combined modules were affected.
[Combined Module Bug.pdf](https://github.com/cms-L1TK/cmssw/files/12894827/Combined.Module.Bug.pdf)

#### PR validation:
No tests were done (I was told they were not needed for a simple change like this)