### PR TITLE
MP fix keep/cut logic order

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -580,11 +580,6 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
 
     bool imatch = (std::abs(ideltaphi) <= best_ideltaphi_barrel && (ideltaz << dzshift_ < best_ideltaz_barrel) &&
                    (ideltaz << dzshift_ >= -best_ideltaz_barrel));
-    // Update the "best" values
-    if (imatch) {
-      best_ideltaphi_barrel = std::abs(ideltaphi);
-      best_ideltaz_barrel = std::abs(ideltaz << dzshift_);
-    }
 
     if (settings_.debugTracklet()) {
       edm::LogVerbatim("Tracklet") << getName() << " imatch = " << imatch << " ideltaphi cut " << ideltaphi << " "
@@ -607,6 +602,11 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
         keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
         imatch = keep;
       }
+    }
+    // Update the "best" values
+    if (imatch) {
+      best_ideltaphi_barrel = std::abs(ideltaphi);
+      best_ideltaz_barrel = std::abs(ideltaz << dzshift_);
     }
 
     if (imatch) {
@@ -764,11 +764,6 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
 
     bool match = (std::abs(drphi) < drphicut) && (std::abs(deltar) < drcut);
     bool imatch = (std::abs(ideltaphi * irstub) < best_ideltaphi_disk) && (std::abs(ideltar) < best_ideltar_disk);
-    // Update the "best" values
-    if (imatch) {
-      best_ideltaphi_disk = std::abs(ideltaphi) * irstub;
-      best_ideltar_disk = std::abs(ideltar);
-    }
 
     if (settings_.debugTracklet()) {
       edm::LogVerbatim("Tracklet") << "imatch match disk: " << imatch << " " << match << " " << std::abs(ideltaphi)
@@ -785,6 +780,11 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
         keep = abs(ideltaphi) < abs(res.fpgaphiresid().value());
         imatch = keep;
       }
+    }
+    // Update the "best" values
+    if (imatch) {
+      best_ideltaphi_disk = std::abs(ideltaphi) * irstub;
+      best_ideltar_disk = std::abs(ideltar);
     }
 
     if (imatch) {


### PR DESCRIPTION
#### PR description:

This PR fixes a bug in the MP logic. When `DoMultipleMatches` is set to `False`, the MC section decides whether additional matches to the same projection are worth keeping. The logic for updating the best cut values came _before_ this decision, so worse full matches could sometimes replace a cut value if that particular value was better. 

#### PR validation:

This PR gives full agreement with HLS from L1PHIA to L6PHID (debugging the rest now)