### PR TITLE
Displaced Tracking Combined Module Bug Fix (TPD bug)

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -230,6 +230,8 @@ void TrackletProcessorDisplaced::addInput(MemoryBase* memory, string input) {
 }
 
 void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, double phimax) {
+  unsigned int countall = 0;
+  unsigned int countsel = 0;
   // unsigned int nThirdStubs = 0;
   // unsigned int nOuterStubs = 0;
   count_ = 0;
@@ -358,6 +360,7 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                 continue;
               }
 
+
               if ((layer2_ == 4 && layer3_ == 2) || (layer2_ == 6 && layer3_ == 4)) {
                 constexpr int vmbitshift = 10;
                 constexpr int andlookupbits_ = 1023;
@@ -385,7 +388,10 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                         edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub\n";
                       }
 
+                      countall++;
+
                       const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
+
 
                       const Stub* innerFPGAStub = firstallstub;
                       const Stub* middleFPGAStub = secondvmstub.stub();
@@ -408,8 +414,15 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                             << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
                       }
 
-                      if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
-                          outerFPGAStub->layerdisk() >= N_LAYER) {
+                      if (innerFPGAStub->layerdisk() < N_LAYER && middleFPGAStub->layerdisk() < N_LAYER &&
+                          outerFPGAStub->layerdisk() < N_LAYER) {
+                        bool accept =
+                            LLLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+
+                        if (accept)
+                          countsel++;
+                      } else if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
+                                 outerFPGAStub->layerdisk() >= N_LAYER) {
                         throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
                       }
 
@@ -495,7 +508,10 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                         edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
                       }
 
+                      countall++;
+
                       const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
+
 
                       const Stub* innerFPGAStub = firstallstub;
                       const Stub* middleFPGAStub = secondvmstub.stub();
@@ -517,6 +533,12 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                         edm::LogVerbatim("Tracklet")
                             << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
                       }
+
+                      bool accept =
+                          LLDSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+
+                      if (accept)
+                        countsel++;
 
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
@@ -565,6 +587,7 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
             }
 
             for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
+
               const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
               int rbin = (secondvmstub.vmbits().value() & 7);
               if (start != ibin)
@@ -601,7 +624,10 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                         edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
                       }
 
+                      countall++;
+
                       const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
+
 
                       const Stub* innerFPGAStub = firstallstub;
                       const Stub* middleFPGAStub = secondvmstub.stub();
@@ -624,6 +650,12 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                             << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
                       }
 
+                      bool accept =
+                          DDLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+
+                      if (accept)
+                        countsel++;
+
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
@@ -636,5 +668,9 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
         }
       }
     }
+  }
+
+  if (settings_.writeMonitorData("TPD")) {
+    globals_->ofstream("trackletprocessordisplaced.txt") << getName() << " " << countall << " " << countsel << endl;
   }
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -360,7 +360,6 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                 continue;
               }
 
-
               if ((layer2_ == 4 && layer3_ == 2) || (layer2_ == 6 && layer3_ == 4)) {
                 constexpr int vmbitshift = 10;
                 constexpr int andlookupbits_ = 1023;
@@ -391,7 +390,6 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       countall++;
 
                       const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
-
 
                       const Stub* innerFPGAStub = firstallstub;
                       const Stub* middleFPGAStub = secondvmstub.stub();
@@ -512,7 +510,6 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
 
                       const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
 
-
                       const Stub* innerFPGAStub = firstallstub;
                       const Stub* middleFPGAStub = secondvmstub.stub();
                       const Stub* outerFPGAStub = thirdvmstub.stub();
@@ -587,7 +584,6 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
             }
 
             for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
-
               const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
               int rbin = (secondvmstub.vmbits().value() & 7);
               if (start != ibin)
@@ -627,7 +623,6 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       countall++;
 
                       const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
-
 
                       const Stub* innerFPGAStub = firstallstub;
                       const Stub* middleFPGAStub = secondvmstub.stub();


### PR DESCRIPTION
#### PR description:

This PR fixes a bug in TrackletProcessorDisplaced.cc that caused efficiency to be extremely low. The bug was introduced when the CMS build crew fixed CLANG warnings, but in doing so removed displaced seeding. 

The changes that introduced the bug are seen here: https://github.com/cms-L1TK/cmssw/commit/818beb0788d5303218ba3430b5a595c3b30e40c7#diff-3becd5e0ce57b58a0103b161658ca69686e19efc936c48255292aa3c1ebd388e

This PR restores the deleted code and fixes the CLANG warnings which were caused by unused variables by outputting some counters to a file if settings_.writeMonitorData("TPD") is true. The counters can be useful for debugging.

Information on the restored efficiency can be found here:
[Displaced Combined Bug Fix.pdf](https://github.com/cms-L1TK/cmssw/files/13322868/Displaced.Combined.Bug.Fix.pdf)

It is restored fully back to that of uncombined modules for displaced tracking.


#### PR validation:

scram b -j code-format was used to make some format fixes.


