### PR TITLE
Fix typo in MEU index calculation

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -141,7 +141,7 @@ void MatchEngineUnit::processPipeline() {
     int diskps = (!barrel_) && isPSmodule;
 
     //here we always use the larger number of bits for the bend
-    unsigned int index = (diskps << (N_BENDBITS_2S + NRINVBITS)) + (projrinv___ << nbits) + vmstub___.bend().value();
+    unsigned int index = (diskps << (N_BENDBITS_2S + NRINVBITS)) + (projrinv____ << nbits) + vmstub____.bend().value();
 
     //Check if stub z position consistent
     int idrz = stubfinerz - projfinerz____;


### PR DESCRIPTION
#### PR description:

This PR fixes a typo in the variables used to calculate the stub index inside the MEU. I've tested with 44 events and see full agreement with the HLS output.

#### PR validation:
```
                      Tracklet  SUMMARY
number of stubs     per TFP = 407.0505 +- 6.1832
number of tracks    per TFP =  75.3081 +- 1.1423
current tracking efficiency =   0.9548 +- 0.0069
max     tracking efficiency =   0.9581 +- 0.0066
                  fake rate =   0.1772
             duplicate rate =   0.6025
=============================================================
                        TBout SUMMARY
number of stubs       per TFP = 407.0505 +- 6.1832
number of tracks      per TFP =  75.3081 +- 1.1423
number of lost tracks per TFP =   0.0000 +- 0.0000
     max  tracking efficiency =   0.9581 +- 0.0066
     lost tracking efficiency =   0.0000 +- 0.0000
                    fake rate =   0.1772
               duplicate rate =   0.6025
=============================================================
                        DRin  SUMMARY
number of stubs       per TFP = 398.5076 +- 6.1446
number of tracks      per TFP =  73.6641 +- 1.1337
number of lost tracks per TFP =   0.0051 +- 0.0036
  current tracking efficiency =   0.9515 +- 0.0071
  max     tracking efficiency =   0.9559 +- 0.0068
     lost tracking efficiency =   0.0000 +- 0.0000
                    fake rate =   0.1772
               duplicate rate =   0.5980
=============================================================
                         DR  SUMMARY
number of stubs       per TFP = 123.4571 +- 1.8858
number of tracks      per TFP =  23.8561 +- 0.3787
number of lost tracks per TFP =   0.0000 +- 0.0000
  current tracking efficiency =   0.9130 +- 0.0094
  max     tracking efficiency =   0.9493 +- 0.0073
     lost tracking efficiency =   0.0000 +- 0.0000
                    fake rate =   0.2369
               duplicate rate =   0.0723
=============================================================
                        KFin  SUMMARY
number of stubs       per TFP = 123.4571 +- 1.8858
number of tracks      per TFP =  23.8561 +- 0.3787
number of lost tracks per TFP =   0.0000 +- 0.0000
  current tracking efficiency =   0.9130 +- 0.0094
  max     tracking efficiency =   0.9493 +- 0.0073
     lost tracking efficiency =   0.0000 +- 0.0000
                    fake rate =   0.2369
               duplicate rate =   0.0723
=============================================================
                         KF  SUMMARY
number of stubs       per TFP = 115.0682 +- 1.7936
number of tracks      per TFP =  23.8561 +- 0.3787
number of lost tracks per TFP =   2.4066 +- 0.1286
          tracking efficiency =   0.9427 +- 0.0077
     lost tracking efficiency =   0.0000 +- 0.0000
                    fake rate =   0.2445
               duplicate rate =   0.0706
    state assessment fraction =   0.7151
=============================================================
                        KFout SUMMARY
number of tracks      per TFP =  23.8561 +- 0.3787
number of lost tracks per TFP =   0.0000 +- 0.0000
          tracking efficiency =   0.9449 +- 0.0076
     lost tracking efficiency =   0.0000 +- 0.0000
                    fake rate =   0.2418
               duplicate rate =   0.0712
=============================================================
```