### PR TITLE
[backport] Moved ntuple python to cfi file

### DIFF
--- a/L1Trigger/TrackFindingTracklet/python/L1TrackNtupleMaker_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/L1TrackNtupleMaker_cfi.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+# Configuration for Ntuple maker for analyzing L1 track performance.
+# The parameters specified here are suitable for  Hybrid prompt track collections
+
+L1TrackNtupleMaker = cms.EDAnalyzer('L1TrackNtupleMaker',
+      # MyProcess is the (unsigned) PDGID corresponding to the process which is run
+      # e.g. single electron/positron = 11
+      #      single pion+/pion- = 211
+      #      single muon+/muon- = 13
+      #      pions in jets = 6
+      #      taus = 15
+      #      all TPs = 1 (pp collisions)
+       MyProcess = cms.int32(1),
+       DebugMode = cms.bool(False),      # printout lots of debug statements
+       SaveAllTracks = cms.bool(True),   # save *all* L1 tracks, not just truth matched to primary particle
+       SaveStubs = cms.bool(False),      # save some info for *all* stubs
+       L1Tk_nPar = cms.int32(4), # use 4 or 5-parameter L1 tracking?
+       L1Tk_minNStub = cms.int32(4),     # L1 tracks with >= 4 stubs
+       TP_minNStub = cms.int32(4),       # require TP to have >= X number of stubs associated with it
+       TP_minNStubLayer = cms.int32(4),  # require TP to have stubs in >= X layers/disks
+       TP_minPt = cms.double(1.9),       # only save TPs with pt > X GeV
+       TP_maxEta = cms.double(2.5),      # only save TPs with |eta| < X
+       TP_maxZ0 = cms.double(30.0),      # only save TPs with |z0| < X cm
+       L1TrackInputTag = cms.InputTag("l1tTTTracksFromTrackletEmulation",  "Level1TTTracks"),         # TTTrack input
+       MCTruthTrackInputTag = cms.InputTag( "TTTrackAssociatorFromPixelDigis",  "Level1TTTracks"),  # MCTruth input
+       # other input collections
+       L1StubInputTag = cms.InputTag("TTStubsFromPhase2TrackerDigis","StubAccepted"),
+       MCTruthClusterInputTag = cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"),
+       MCTruthStubInputTag = cms.InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"),
+       TrackingParticleInputTag = cms.InputTag("mix", "MergedTrackTruth"),
+       TrackingVertexInputTag = cms.InputTag("mix", "MergedTrackTruth"),
+       # tracking in jets (--> requires AK4 genjet collection present!)
+       TrackingInJets = cms.bool(False),
+       GenJetInputTag = cms.InputTag("ak4GenJets", "")
+)

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -221,40 +221,14 @@ else:
     print("ERROR: Unknown L1TRKALGO option")
     exit(1)
 
-############################################################
-# Define the track ntuple process, MyProcess is the (unsigned) PDGID corresponding to the process which is run
-# e.g. single electron/positron = 11
-#      single pion+/pion- = 211
-#      single muon+/muon- = 13
-#      pions in jets = 6
-#      taus = 15
-#      all TPs = 1
-############################################################
 
-process.L1TrackNtuple = cms.EDAnalyzer('L1TrackNtupleMaker',
-                                       MyProcess = cms.int32(1),
-                                       DebugMode = cms.bool(False),      # printout lots of debug statements
-                                       SaveAllTracks = cms.bool(True),   # save *all* L1 tracks, not just truth matched to primary particle
-                                       SaveStubs = cms.bool(False),      # save some info for *all* stubs
-                                       L1Tk_nPar = cms.int32(NHELIXPAR), # use 4 or 5-parameter L1 tracking?
-                                       L1Tk_minNStub = cms.int32(4),     # L1 tracks with >= 4 stubs
-                                       TP_minNStub = cms.int32(4),       # require TP to have >= X number of stubs associated with it
-                                       TP_minNStubLayer = cms.int32(4),  # require TP to have stubs in >= X layers/disks
-                                       TP_minPt = cms.double(1.9),       # only save TPs with pt > X GeV
-                                       TP_maxEta = cms.double(2.5),      # only save TPs with |eta| < X
-                                       TP_maxZ0 = cms.double(30.0),      # only save TPs with |z0| < X cm
-                                       L1TrackInputTag = cms.InputTag(L1TRK_NAME, L1TRK_LABEL),         # TTTrack input
-                                       MCTruthTrackInputTag = cms.InputTag(L1TRUTH_NAME, L1TRK_LABEL),  # MCTruth input
-                                       # other input collections
-                                       L1StubInputTag = cms.InputTag("TTStubsFromPhase2TrackerDigis","StubAccepted"),
-                                       MCTruthClusterInputTag = cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"),
-                                       MCTruthStubInputTag = cms.InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"),
-                                       TrackingParticleInputTag = cms.InputTag("mix", "MergedTrackTruth"),
-                                       TrackingVertexInputTag = cms.InputTag("mix", "MergedTrackTruth"),
-                                       # tracking in jets (--> requires AK4 genjet collection present!)
-                                       TrackingInJets = cms.bool(False),
-                                       GenJetInputTag = cms.InputTag("ak4GenJets", "")
-                                       )
+# Define L1 track ntuple maker
+from L1Trigger.TrackFindingTracklet.L1TrackNtupleMaker_cfi import *
+process.L1TrackNtuple = L1TrackNtupleMaker.clone(
+   L1Tk_nPar = NHELIXPAR, # use 4 or 5-parameter L1 tracking?
+   L1TrackInputTag = (L1TRK_NAME, L1TRK_LABEL),         # TTTrack input
+   MCTruthTrackInputTag = (L1TRUTH_NAME, L1TRK_LABEL),  # MCTruth input
+)
 
 process.ana = cms.Path(process.L1TrackNtuple)
 


### PR DESCRIPTION
#### PR description:

Backport of https://github.com/cms-L1TK/cmssw/pull/260 to this branch, which is now used by the Future Software emulation.
Needed by [this merge request](https://gitlab.cern.ch/ejclemen/cmssw_trackfinding_hlsframework/-/merge_requests/62#fe0da19469008a2bfa6f91032a99aab5c3ae59a3) for the Future Software emulation.