### PR TITLE
Run combined modules by default

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1028,11 +1028,12 @@ namespace trklet {
     bool reduced_{false};        // use reduced (Summer Chain) config
     bool inventStubs_{true};     // invent seeding stub coordinates based on tracklet traj
 
-    // Use combined TP (TE+TC) and MP (PR+ME+MC) configuration (with prompt tracking)
-    bool combined_{false};
-    // N.B. To use combined modules with extended tracking, edit
-    // Tracklet_cfi.py to refer to *_hourglassExtendedCombined.dat,
-    // but leave combined_=false.
+    // Use combined TP (TE+TC) & MP (PR+ME+MC) config (with prompt tracking)
+    bool combined_{true};
+    // N.B. For extended tracking, this combined_ is overridden by python cfg
+    // to false, but combined modules are nonetheless used by default.
+    // If you don't want them, edit l1tTTTracksFromTrackletEmulation_cfi.py
+    // to refer to *_hourglassExtended.dat .
 
     std::string skimfile_{""};  //if not empty events will be written out in ascii format to this file
 

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -282,6 +282,10 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   settings_.setExtended(extended_);
   settings_.setReduced(reduced_);
   settings_.setNHelixPar(nHelixPar_);
+  // combined_ must be false for extended tracking, regardless of whether
+  // combined modules are used or not.
+  if (extended_)
+    settings_.setCombined(false);
 
   settings_.setFitPatternFile(fitPatternFile.fullPath());
   settings_.setProcessingModulesFile(processingModulesFile.fullPath());

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -154,7 +154,9 @@ private:
   bool readMoreMcTruth_;
 
   /// File path for configuration files
+#ifndef USEHYBRID  
   edm::FileInPath fitPatternFile;
+#endif
   edm::FileInPath memoryModulesFile;
   edm::FileInPath processingModulesFile;
   edm::FileInPath wiresFile;
@@ -255,7 +257,6 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
 
   asciiEventOutName_ = iConfig.getUntrackedParameter<string>("asciiFileName", "");
 
-  fitPatternFile = iConfig.getParameter<edm::FileInPath>("fitPatternFile");
   processingModulesFile = iConfig.getParameter<edm::FileInPath>("processingModulesFile");
   memoryModulesFile = iConfig.getParameter<edm::FileInPath>("memoryModulesFile");
   wiresFile = iConfig.getParameter<edm::FileInPath>("wiresFile");
@@ -287,7 +288,10 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   if (extended_)
     settings_.setCombined(false);
 
+#ifndef USEHYBRID  
+  fitPatternFile = iConfig.getParameter<edm::FileInPath>("fitPatternFile");
   settings_.setFitPatternFile(fitPatternFile.fullPath());
+#endif
   settings_.setProcessingModulesFile(processingModulesFile.fullPath());
   settings_.setMemoryModulesFile(memoryModulesFile.fullPath());
   settings_.setWiresFile(wiresFile.fullPath());
@@ -313,7 +317,10 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   }
 
   if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") << "fit pattern :     " << fitPatternFile.fullPath()
+    edm::LogVerbatim("Tracklet") 
+#ifndef USEHYBRID  
+                                 << "fit pattern :     " << fitPatternFile.fullPath()
+#endif
                                  << "\n process modules : " << processingModulesFile.fullPath()
                                  << "\n memory modules :  " << memoryModulesFile.fullPath()
                                  << "\n wires          :  " << wiresFile.fullPath();

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -154,7 +154,7 @@ private:
   bool readMoreMcTruth_;
 
   /// File path for configuration files
-#ifndef USEHYBRID  
+#ifndef USEHYBRID
   edm::FileInPath fitPatternFile;
 #endif
   edm::FileInPath memoryModulesFile;
@@ -288,7 +288,7 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   if (extended_)
     settings_.setCombined(false);
 
-#ifndef USEHYBRID  
+#ifndef USEHYBRID
   fitPatternFile = iConfig.getParameter<edm::FileInPath>("fitPatternFile");
   settings_.setFitPatternFile(fitPatternFile.fullPath());
 #endif
@@ -317,13 +317,12 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
   }
 
   if (settings_.debugTracklet()) {
-    edm::LogVerbatim("Tracklet") 
-#ifndef USEHYBRID  
-                                 << "fit pattern :     " << fitPatternFile.fullPath()
+    edm::LogVerbatim("Tracklet")
+#ifndef USEHYBRID
+        << "fit pattern :     " << fitPatternFile.fullPath()
 #endif
-                                 << "\n process modules : " << processingModulesFile.fullPath()
-                                 << "\n memory modules :  " << memoryModulesFile.fullPath()
-                                 << "\n wires          :  " << wiresFile.fullPath();
+        << "\n process modules : " << processingModulesFile.fullPath()
+        << "\n memory modules :  " << memoryModulesFile.fullPath() << "\n wires          :  " << wiresFile.fullPath();
     if (extended_) {
       edm::LogVerbatim("Tracklet") << "table_TED    :  " << tableTEDFile.fullPath()
                                    << "\n table_TRE    :  " << tableTREFile.fullPath();

--- a/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
@@ -27,3 +27,7 @@ def reducedConfig(process):
   process.l1tTTTracksFromTrackletEmulation.memoryModulesFile = 'L1Trigger/TrackFindingTracklet/data/reduced_memorymodules.dat'
   process.l1tTTTracksFromTrackletEmulation.processingModulesFile = 'L1Trigger/TrackFindingTracklet/data/reduced_processingmodules.dat'
   process.l1tTTTracksFromTrackletEmulation.wiresFile = 'L1Trigger/TrackFindingTracklet/data/reduced_wires.dat'
+
+# configures pure tracklet algorithm (as opposed to Hybrid algorithm)
+def trackletConfig(process):
+    process.l1tTTTracksFromTrackletEmulation.fitPatternFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/fitpattern.txt') 

--- a/L1Trigger/TrackFindingTracklet/python/l1tTTTracksFromTrackletEmulation_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/l1tTTTracksFromTrackletEmulation_cfi.py
@@ -15,11 +15,13 @@ l1tTTTracksFromTrackletEmulation = cms.EDProducer("L1FPGATrackProducer",
                                                Extended = cms.bool(False),
                                                Reduced = cms.bool(False),
                                                Hnpar = cms.uint32(4),
+                                               # This file not used with Hybrid algo.
                                                # (if running on CRAB use "../../fitpattern.txt" etc instead)
                                                fitPatternFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/fitpattern.txt'),
-                                               memoryModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/memorymodules_hourglassExtended.dat'),
-                                               processingModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/processingmodules_hourglassExtended.dat'),
-                                               wiresFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/wires_hourglassExtended.dat'),
+                                              # These 3 files only used for extended or reduced mode.
+                                               memoryModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/memorymodules_hourglassExtendedCombined.dat'),
+                                               processingModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/processingmodules_hourglassExtendedCombined.dat'),
+                                               wiresFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/wires_hourglassExtendedCombined.dat'),
                                                # Quality Flag and Quality params
                                                TrackQuality = cms.bool(True),
                                                TrackQualityPSet = cms.PSet(TrackQualityParams),

--- a/L1Trigger/TrackFindingTracklet/python/l1tTTTracksFromTrackletEmulation_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/l1tTTTracksFromTrackletEmulation_cfi.py
@@ -15,10 +15,7 @@ l1tTTTracksFromTrackletEmulation = cms.EDProducer("L1FPGATrackProducer",
                                                Extended = cms.bool(False),
                                                Reduced = cms.bool(False),
                                                Hnpar = cms.uint32(4),
-                                               # This file not used with Hybrid algo.
-                                               # (if running on CRAB use "../../fitpattern.txt" etc instead)
-                                               fitPatternFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/fitpattern.txt'),
-                                              # These 3 files only used for extended or reduced mode.
+                                               # These 3 files only used for extended or reduced mode.
                                                memoryModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/memorymodules_hourglassExtendedCombined.dat'),
                                                processingModulesFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/processingmodules_hourglassExtendedCombined.dat'),
                                                wiresFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/wires_hourglassExtendedCombined.dat'),

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -136,7 +136,8 @@ void FitTrack::trackFitKF(Tracklet* tracklet,
     }
   }
 }
-#endif
+
+#else // Code for pure Tracklet algo.
 
 void FitTrack::trackFitChisq(Tracklet* tracklet, std::vector<const Stub*>&, std::vector<std::pair<int, int>>&) {
   if (globals_->trackDerTable() == nullptr) {
@@ -787,6 +788,8 @@ void FitTrack::trackFitChisq(Tracklet* tracklet, std::vector<const Stub*>&, std:
                        0,
                        0);
 }
+
+#endif
 
 void FitTrack::trackFitFake(Tracklet* tracklet, std::vector<const Stub*>&, std::vector<std::pair<int, int>>&) {
   tracklet->setFitPars(tracklet->rinvapprox(),

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -137,7 +137,7 @@ void FitTrack::trackFitKF(Tracklet* tracklet,
   }
 }
 
-#else // Code for pure Tracklet algo.
+#else  // Code for pure Tracklet algo.
 
 void FitTrack::trackFitChisq(Tracklet* tracklet, std::vector<const Stub*>&, std::vector<std::pair<int, int>>&) {
   if (globals_->trackDerTable() == nullptr) {

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -13,9 +13,11 @@
 #include "L1Trigger/TrackFindingTracklet/interface/HybridFit.h"
 #endif
 
+#include "DataFormats/Math/interface/deltaPhi.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+#include "TString.h"
 #include <unordered_set>
 #include <algorithm>
 
@@ -618,6 +620,7 @@ std::pair<int, int> PurgeDuplicate::findLayerDisk(const Stub* st) const {
 }
 
 std::string PurgeDuplicate::l1tinfo(const L1TStub* l1stub, std::string str = "") const {
+  // Uses ROOT::TString
   std::string thestr = Form("\t %s stub info:  r/z/phi:\t%f\t%f\t%f\t%d\t%f\t%d",
                             str.c_str(),
                             l1stub->r(),

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -196,6 +196,8 @@ elif (L1TRKALGO == 'TRACKLET'):
     print("\n To run the Tracklet-only algorithm, ensure you have commented out 'CXXFLAGS=-DUSEHYBRID' in BuildFile.xml & recompiled! \n")
     process.TTTracksEmulation = cms.Path(process.L1THybridTracks)
     process.TTTracksEmulationWithTruth = cms.Path(process.L1THybridTracksWithAssociators)
+    from L1Trigger.TrackFindingTracklet.Customize_cff import *
+    trackletConfig( process )
     NHELIXPAR = 4
     L1TRK_NAME  = "l1tTTTracksFromTrackletEmulation"
     L1TRK_LABEL = "Level1TTTracks"


### PR DESCRIPTION
#### PR description:

Made combined modules the default for both prompt and extended tracking.

(Also moved references to fitpattern.txt file out of Hybrid algo, where they are not needed. These references remain available to the pure Tracklet algo via "#ifndef USEHYBRID" statements in the C++ and via function trackletConfig() in Customize_cff.py).

(Also fixed compilation errors in the pure tracklet L1 track algo. But @aryd / @skinnari should note that this algo crashes when doing the track fit, because of a variable outside  the allowed digi range. This problem has existed for some time. I'm unable to fix it).

## Performance of PROMPT tracking on ttbar+200PU (for Pt > 2)

#### Non-combined modules:
efficiency = 95.04 +- 0.14%
tracks/event = 167.99

#### Combined modules:
efficiency = 94.27 +- 0.15%
tracks/event = 166.61

## Performance of EXTENDED tracking on ttbar+200PU (for Pt > 2)

#### Non-combined modules:
efficiency = 96.55 +- 0.12%
tracks/event = 269.95

#### Combined modules:
efficiency = 96.55 +- 0.12%
tracks/event =  276.97

So there is a 0.8% efficiency loss (due to MP truncation) for PROMPT tracking, which is not present for EXTENDED tracking (probably because the latter is not a full emulation).



