### PR TITLE
DR: fix displaced track bug & disable binning

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1053,18 +1053,18 @@ namespace trklet {
     //Following values are used for duplicate removal
     //Rinv bins were optimised to ensure a similar number of tracks in each bin prior to DR
     //Rinv bin edges for 6 bins.
-    std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
-    //std::vector<double> rinvBins_{-rinvcut(), rinvcut()};
+    //std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
+    std::vector<double> rinvBins_{-rinvcut(), rinvcut()};
     //Phi bin edges for 2 bins.
-    std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
-    //std::vector<double> phiBins_{0, dphisectorHG()};
+    //std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
+    std::vector<double> phiBins_{0, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
     double rinvOverlapSize_{0.0004};
     //Overlap size for the overlap phi bins in DR
     double phiOverlapSize_{M_PI / 360};
     //The maximum number of tracks that are compared to all the other tracks per rinv bin
-    int numTracksComparedPerBin_{32};
-    //int numTracksComparedPerBin_{999};
+    //int numTracksComparedPerBin_{32};
+    int numTracksComparedPerBin_{9999};
 
     double sensorSpacing_2S_{0.18};
   };

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1048,23 +1048,23 @@ namespace trklet {
     double stripLength_PS_{0.1467};
     double stripLength_2S_{5.0250};
 
-    // The DR binning below temporarily disabled, as breaks displaced tracking.
+    // The DR binning below disabled, as doesn't match latest FW.
 
     //Following values are used for duplicate removal
     //Rinv bins were optimised to ensure a similar number of tracks in each bin prior to DR
     //Rinv bin edges for 6 bins.
-    //std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
-    std::vector<double> rinvBins_{-rinvcut(), rinvcut()};
+    std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
+    //std::vector<double> rinvBins_{-rinvcut(), rinvcut()};
     //Phi bin edges for 2 bins.
-    //std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
-    std::vector<double> phiBins_{0, dphisectorHG()};
+    std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
+    //std::vector<double> phiBins_{0, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
     double rinvOverlapSize_{0.0004};
     //Overlap size for the overlap phi bins in DR
     double phiOverlapSize_{M_PI / 360};
     //The maximum number of tracks that are compared to all the other tracks per rinv bin
-    //int numTracksComparedPerBin_{32};
-    int numTracksComparedPerBin_{999};
+    int numTracksComparedPerBin_{32};
+    //int numTracksComparedPerBin_{999};
 
     double sensorSpacing_2S_{0.18};
   };

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1048,18 +1048,23 @@ namespace trklet {
     double stripLength_PS_{0.1467};
     double stripLength_2S_{5.0250};
 
+    // The DR binning below temporarily disabled, as breaks displaced tracking.
+
     //Following values are used for duplicate removal
     //Rinv bins were optimised to ensure a similar number of tracks in each bin prior to DR
     //Rinv bin edges for 6 bins.
-    std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
+    //std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
+    std::vector<double> rinvBins_{-rinvcut(), rinvcut()};
     //Phi bin edges for 2 bins.
-    std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
+    //std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
+    std::vector<double> phiBins_{0, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
     double rinvOverlapSize_{0.0004};
     //Overlap size for the overlap phi bins in DR
     double phiOverlapSize_{M_PI / 360};
     //The maximum number of tracks that are compared to all the other tracks per rinv bin
-    int numTracksComparedPerBin_{32};
+    //int numTracksComparedPerBin_{32};
+    int numTracksComparedPerBin_{999};
 
     double sensorSpacing_2S_{0.18};
   };

--- a/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
@@ -221,7 +221,7 @@ namespace trklet {
 
     unsigned int PSseed() const { return ((layer() == 1) || (layer() == 2) || (disk() != 0)) ? 1 : 0; }
 
-    // Seed type: 
+    // Seed type:
     //  L1L2=0,L2L3=1,L3L4=2,L5L6=3,D1D2=4,D3D4=5,L1D1=6,L2D1=7
     unsigned int seedIndex() const { return seedIndex_; }
 

--- a/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
@@ -221,6 +221,8 @@ namespace trklet {
 
     unsigned int PSseed() const { return ((layer() == 1) || (layer() == 2) || (disk() != 0)) ? 1 : 0; }
 
+    // Seed type: 
+    //  L1L2=0,L2L3=1,L3L4=2,L5L6=3,D1D2=4,D3D4=5,L1D1=6,L2D1=7
     unsigned int seedIndex() const { return seedIndex_; }
 
   private:

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -163,7 +163,8 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               } else if (settings_.extended()) {
                 seedRank.push_back(9);
               } else {
-                throw cms::Exception("LogError") << __FILE__ << " " << __LINE__ << " Seed type " << curSeed << " not found in list, and settings->extended() not set.";
+                throw cms::Exception("LogError") << __FILE__ << " " << __LINE__ << " Seed type " << curSeed
+                                                 << " not found in list, and settings->extended() not set.";
               }
 
               if (stublist.size() != stubidslist.size())

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -156,12 +156,15 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
               // Best Rank:           L1L2 > L3L4 > D3D4 > D1D2 > L2L3 > L2D1 > L5L6 > L1D1
               // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
-              unsigned int curSeed = aTrack->seedIndex();
-              std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
-              if (settings_.extended())
-                seedRank.push_back(9);
-              else
+              const unsigned int curSeed = aTrack->seedIndex();
+              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
+              if (curSeed < ranks.size()) {
                 seedRank.push_back(ranks[curSeed]);
+              } else if (settings_.extended()) {
+                seedRank.push_back(9);
+              } else {
+                throw cms::Exception("LogError") << __FILE__ << " " << __LINE__ << " Seed type " << curSeed << " not found in list, and settings->extended() not set.";
+              }
 
               if (stublist.size() != stubidslist.size())
                 throw cms::Exception("LogicError")


### PR DESCRIPTION
#### PR description:

Fixed bug in the calculation of variable seedRank in PurgeDuplicate.cc , which was incorrect for displaced tracklets, and damaged the tracking performance.

Temporarily disable binning in DR, since it may be messing up displaced tracking.

These issues are also causing problems with attempts to switch to using "combined" tracking modules by default, as reported in https://github.com/cms-L1TK/cmssw/pull/265 .