### PR TITLE
Fix inventStubs bug in duplicate removal

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -679,7 +679,7 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
 
   // TMP: for displaced tracking, exclude one of the 3 seeding stubs
   // to be discussed
-  if ((seed == L2L3L4 && stubLayer == 4) || (seed == L4L5L6 && stubLayer == 5) || 
+  if ((seed == L2L3L4 && stubLayer == 4) || (seed == L4L5L6 && stubLayer == 5) ||
       (seed == L2L3D1 && abs(stubDisk) == 1) || (seed == D1D2L2 && abs(stubDisk) == 1)) {
     stub_phi = st->l1tstub()->phi();
     stub_z = st->l1tstub()->z();

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -679,8 +679,8 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
 
   // TMP: for displaced tracking, exclude one of the 3 seeding stubs
   // to be discussed
-  if ((seed == L2L3L4 && stubLayer == 4) || (seed == L4L5L6 && stubLayer == 5) || (seed == L2L3D1 && abs(stubDisk) == 1) ||
-      (seed == D1D2L2 && abs(stubDisk) == 1)) {
+  if ((seed == L2L3L4 && stubLayer == 4) || (seed == L4L5L6 && stubLayer == 5) || 
+      (seed == L2L3D1 && abs(stubDisk) == 1) || (seed == D1D2L2 && abs(stubDisk) == 1)) {
     stub_phi = st->l1tstub()->phi();
     stub_z = st->l1tstub()->z();
     stub_r = st->l1tstub()->r();

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -679,7 +679,7 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
 
   // TMP: for displaced tracking, exclude one of the 3 seeding stubs
   // to be discussed
-  if ((seed == L2L3L4 && stubLayer == 4) || (seed == L4L5L6 && stubLayer == 5) || (seed == L2L3D1 && stubLayer == 3) ||
+  if ((seed == L2L3L4 && stubLayer == 4) || (seed == L4L5L6 && stubLayer == 5) || (seed == L2L3D1 && abs(stubDisk) == 1) ||
       (seed == D1D2L2 && abs(stubDisk) == 1)) {
     stub_phi = st->l1tstub()->phi();
     stub_z = st->l1tstub()->z();

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorDisplaced.cc
@@ -1211,6 +1211,9 @@ bool TrackletCalculatorDisplaced::LLDSeeding(const Stub* innerFPGAStub,
   int take3 = 0;  //L2L3D1
   unsigned ndisks = 1;
 
+  // N.B. The names r1, r2, r3 reflect the fact that confusingly,
+  // innerStub is actually the one furthest from the beamline ...
+
   double r3 = innerStub->r();
   double z3 = innerStub->z();
   double phi3 = innerStub->phi();


### PR DESCRIPTION
When using L2L3D1 seeds, it is only L2L3 that are used to determined the r-z helix params, not L2D1 as the code currently assumes. This PR fixes this.

When run on ttbar+200PU, remaking the stubs using the CMSSW 13 stub window sizes, it reduces the track rate per event from 323 to 284. 

When run on ttbar+200PU, using the existing stubs made with CMSSW 14 stub window sizes, it reduces the track rate per event from 294 to 268. 

The efficiency on displaced muon MC is very slightly higher.

P.S. One can query if https://github.com/cms-L1TK/cmssw/blob/ianFixInventStubs/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc#L743 should be calling getInventedCoordsExtended() for the prompt seed types (0-7) that form part of the extended tracking. Though I think getInventedCoordsExtended() and getInventedCoords() should give the same results for these.
