### PR TITLE
Bin TQ MVA output

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -374,7 +374,7 @@ double TTTrack<T>::chi2ZRed() const {
 
 template <typename T>
 double TTTrack<T>::trkMVA1() const {
-  return theTrkMVA1_;
+  return 1. / (1. + exp(-theTrkMVA1_));
 }
 
 template <typename T>
@@ -443,7 +443,6 @@ void TTTrack<T>::setTrackWordBits() {
   }
 
   unsigned int valid = true;
-  double mvaQuality = -1 * log(1 / theTrkMVA1_ - 1); //inverse logistic sigmoid
   unsigned int mvaOther = 0;
 
   // missing conversion of global phi to difference from sector center phi
@@ -457,7 +456,7 @@ void TTTrack<T>::setTrackWordBits() {
                  0,
                  theStubPtConsistency_,
                  theHitPattern_,
-                 mvaQuality,
+                 theTrkMVA1_,
                  mvaOther,
                  thePhiSector_);
   } else {
@@ -469,7 +468,7 @@ void TTTrack<T>::setTrackWordBits() {
                  chi2ZRed(),
                  chi2BendRed(),
                  theHitPattern_,
-                 mvaQuality,
+                 theTrkMVA1_,
                  mvaOther,
                  thePhiSector_);
   }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -45,7 +45,7 @@ private:
   double theChi2_Z_;
   unsigned int theNumFitPars_;
   unsigned int theHitPattern_;
-  double theTrkMVA1_;
+  double theTrkMVA1Pre_;
   double theTrkMVA2_;
   double theTrkMVA3_;
   int theTrackSeedType_;
@@ -65,7 +65,7 @@ public:
           double az0,
           double ad0,
           double aChi2,
-          double trkMVA1,
+          double trkMVA1Pre,
           double trkMVA2,
           double trkMVA3,
           unsigned int aHitpattern,
@@ -79,7 +79,7 @@ public:
           double ad0,
           double aChi2xyfit,
           double aChi2zfit,
-          double trkMVA1,
+          double trkMVA1Pre,
           double trkMVA2,
           double trkMVA3,
           unsigned int aHitpattern,
@@ -125,7 +125,8 @@ public:
 
   /// MVA Track quality variables
   double trkMVA1() const;
-  void settrkMVA1(double atrkMVA1);
+  double trkMVA1Pre() const;
+  void settrkMVA1Pre(double atrkMVA1Pre);
   double trkMVA2() const;
   void settrkMVA2(double atrkMVA2);
   double trkMVA3() const;
@@ -195,7 +196,7 @@ TTTrack<T>::TTTrack() {
   theZ0_ = 0.;
   theTanL_ = 0;
   thePhi_ = 0;
-  theTrkMVA1_ = 0;
+  theTrkMVA1Pre_ = 0;
   theTrkMVA2_ = 0;
   theTrkMVA3_ = 0;
   thePhiSector_ = 0;
@@ -216,7 +217,7 @@ TTTrack<T>::TTTrack(double aRinv,
                     double az0,
                     double ad0,
                     double aChi2,
-                    double trkMVA1,
+                    double trkMVA1Pre,
                     double trkMVA2,
                     double trkMVA3,
                     unsigned int aHitPattern,
@@ -235,7 +236,7 @@ TTTrack<T>::TTTrack(double aRinv,
   theEtaSector_ = 0;      // must be set externally
   theTrackSeedType_ = 0;  // must be set externally
   theChi2_ = aChi2;
-  theTrkMVA1_ = trkMVA1;
+  theTrkMVA1Pre_ = trkMVA1Pre;
   theTrkMVA2_ = trkMVA2;
   theTrkMVA3_ = trkMVA3;
   theStubPtConsistency_ = 0.0;  // must be set externally
@@ -255,7 +256,7 @@ TTTrack<T>::TTTrack(double aRinv,
                     double ad0,
                     double aChi2XY,
                     double aChi2Z,
-                    double trkMVA1,
+                    double trkMVA1Pre,
                     double trkMVA2,
                     double trkMVA3,
                     unsigned int aHitPattern,
@@ -267,7 +268,7 @@ TTTrack<T>::TTTrack(double aRinv,
               az0,
               ad0,
               aChi2XY + aChi2Z,  // add chi2 values
-              trkMVA1,
+              trkMVA1Pre,
               trkMVA2,
               trkMVA3,
               aHitPattern,
@@ -372,14 +373,21 @@ double TTTrack<T>::chi2ZRed() const {
   return theChi2_Z_ / (theStubRefs.size() - 2.);
 }
 
+/// prompt track quality MVA pre-logistic sigmoid
+template <typename T>
+double TTTrack<T>::trkMVA1Pre() const {
+  return theTrkMVA1Pre_;
+}
+
+/// prompt track quality MVA post-logistic sigmoid
 template <typename T>
 double TTTrack<T>::trkMVA1() const {
-  return 1. / (1. + exp(-theTrkMVA1_));
+  return 1. / (1. + exp(-theTrkMVA1Pre_));
 }
 
 template <typename T>
-void TTTrack<T>::settrkMVA1(double atrkMVA1) {
-  theTrkMVA1_ = atrkMVA1;
+void TTTrack<T>::settrkMVA1Pre(double atrkMVA1Pre) {
+  theTrkMVA1Pre_ = atrkMVA1Pre;
   return;
 }
 
@@ -456,7 +464,7 @@ void TTTrack<T>::setTrackWordBits() {
                  0,
                  theStubPtConsistency_,
                  theHitPattern_,
-                 theTrkMVA1_,
+                 theTrkMVA1Pre_,
                  mvaOther,
                  thePhiSector_);
   } else {
@@ -468,7 +476,7 @@ void TTTrack<T>::setTrackWordBits() {
                  chi2ZRed(),
                  chi2BendRed(),
                  theHitPattern_,
-                 theTrkMVA1_,
+                 theTrkMVA1Pre_,
                  mvaOther,
                  thePhiSector_);
   }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -443,7 +443,7 @@ void TTTrack<T>::setTrackWordBits() {
   }
 
   unsigned int valid = true;
-  unsigned int mvaQuality = 0;
+  double mvaQuality = -1 * log(1 / theTrkMVA1_ - 1); //inverse logistic sigmoid
   unsigned int mvaOther = 0;
 
   // missing conversion of global phi to difference from sector center phi

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -45,7 +45,7 @@ private:
   double theChi2_Z_;
   unsigned int theNumFitPars_;
   unsigned int theHitPattern_;
-  double theTrkMVA1Pre_;
+  double theTrkMVA1_;
   double theTrkMVA2_;
   double theTrkMVA3_;
   int theTrackSeedType_;
@@ -65,7 +65,7 @@ public:
           double az0,
           double ad0,
           double aChi2,
-          double trkMVA1Pre,
+          double trkMVA1,
           double trkMVA2,
           double trkMVA3,
           unsigned int aHitpattern,
@@ -79,7 +79,7 @@ public:
           double ad0,
           double aChi2xyfit,
           double aChi2zfit,
-          double trkMVA1Pre,
+          double trkMVA1,
           double trkMVA2,
           double trkMVA3,
           unsigned int aHitpattern,
@@ -125,8 +125,7 @@ public:
 
   /// MVA Track quality variables
   double trkMVA1() const;
-  double trkMVA1Pre() const;
-  void settrkMVA1Pre(double atrkMVA1Pre);
+  void settrkMVA1(double atrkMVA1);
   double trkMVA2() const;
   void settrkMVA2(double atrkMVA2);
   double trkMVA3() const;
@@ -196,7 +195,7 @@ TTTrack<T>::TTTrack() {
   theZ0_ = 0.;
   theTanL_ = 0;
   thePhi_ = 0;
-  theTrkMVA1Pre_ = 0;
+  theTrkMVA1_ = 0;
   theTrkMVA2_ = 0;
   theTrkMVA3_ = 0;
   thePhiSector_ = 0;
@@ -217,7 +216,7 @@ TTTrack<T>::TTTrack(double aRinv,
                     double az0,
                     double ad0,
                     double aChi2,
-                    double trkMVA1Pre,
+                    double trkMVA1,
                     double trkMVA2,
                     double trkMVA3,
                     unsigned int aHitPattern,
@@ -236,7 +235,7 @@ TTTrack<T>::TTTrack(double aRinv,
   theEtaSector_ = 0;      // must be set externally
   theTrackSeedType_ = 0;  // must be set externally
   theChi2_ = aChi2;
-  theTrkMVA1Pre_ = trkMVA1Pre;
+  theTrkMVA1_ = trkMVA1;
   theTrkMVA2_ = trkMVA2;
   theTrkMVA3_ = trkMVA3;
   theStubPtConsistency_ = 0.0;  // must be set externally
@@ -256,7 +255,7 @@ TTTrack<T>::TTTrack(double aRinv,
                     double ad0,
                     double aChi2XY,
                     double aChi2Z,
-                    double trkMVA1Pre,
+                    double trkMVA1,
                     double trkMVA2,
                     double trkMVA3,
                     unsigned int aHitPattern,
@@ -268,7 +267,7 @@ TTTrack<T>::TTTrack(double aRinv,
               az0,
               ad0,
               aChi2XY + aChi2Z,  // add chi2 values
-              trkMVA1Pre,
+              trkMVA1,
               trkMVA2,
               trkMVA3,
               aHitPattern,
@@ -373,21 +372,15 @@ double TTTrack<T>::chi2ZRed() const {
   return theChi2_Z_ / (theStubRefs.size() - 2.);
 }
 
-/// prompt track quality MVA pre-logistic sigmoid
-template <typename T>
-double TTTrack<T>::trkMVA1Pre() const {
-  return theTrkMVA1Pre_;
-}
-
-/// prompt track quality MVA post-logistic sigmoid
+/// prompt track quality MVA
 template <typename T>
 double TTTrack<T>::trkMVA1() const {
-  return 1. / (1. + exp(-theTrkMVA1Pre_));
+  return theTrkMVA1_;
 }
 
 template <typename T>
-void TTTrack<T>::settrkMVA1Pre(double atrkMVA1Pre) {
-  theTrkMVA1Pre_ = atrkMVA1Pre;
+void TTTrack<T>::settrkMVA1(double atrkMVA1) {
+  theTrkMVA1_ = atrkMVA1;
   return;
 }
 
@@ -464,7 +457,7 @@ void TTTrack<T>::setTrackWordBits() {
                  0,
                  theStubPtConsistency_,
                  theHitPattern_,
-                 theTrkMVA1Pre_,
+                 theTrkMVA1_,
                  mvaOther,
                  thePhiSector_);
   } else {
@@ -476,7 +469,7 @@ void TTTrack<T>::setTrackWordBits() {
                  chi2ZRed(),
                  chi2BendRed(),
                  theHitPattern_,
-                 theTrkMVA1Pre_,
+                 theTrkMVA1_,
                  mvaOther,
                  thePhiSector_);
   }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -105,7 +105,7 @@ public:
       {0.0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
 
   // Bin edges for TQ MVA (without logistic sigmoid applied),
-  // corresponds to {0, 0.1, 0.2, 0.4, 0.6, 0.8, 0.9, 0.95} on (0,1) range
+  // corresponds to {0, 0.1, 0.2, 0.4, 0.6, 0.8, 0.9, 0.95} on (0,1) range with 2 decimal precision
   static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVABins = {
       {-480, -2.197, -1.386, -0.405, 0.405, 1.386, 2.197, 2.944}};
 
@@ -229,7 +229,7 @@ public:
   double getBendChi2() const { return bendChi2Bins[getBendChi2Bits()]; }
   unsigned int getHitPattern() const { return getHitPatternBits(); }
   unsigned int getNStubs() const { return countSetBits(getHitPatternBits()); }
-  unsigned int getMVAQuality() const { return tqMVABins[getMVAQualityBits()]; }
+  double getMVAQuality() const { return std::round(100. / (1. + exp(-tqMVABins[getMVAQualityBits()]))) / 100.; }
   unsigned int getMVAOther() const { return getMVAOtherBits(); }
 
   // ----------member functions (setters) ------------

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -104,9 +104,9 @@ public:
   static constexpr std::array<double, 1 << TrackBitWidths::kBendChi2Size> bendChi2Bins = {
       {0.0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
 
-  // Bin edges for TQ MVA (without logistic sigmoid applied),
+  // Bin edges for TQ MVA, pre-logistic sigmoid,
   // corresponds to {0, 0.1, 0.2, 0.4, 0.6, 0.8, 0.9, 0.95} on (0,1) range with 2 decimal precision
-  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVABins = {
+  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVAPreBins = {
       {-480, -2.197, -1.386, -0.405, 0.405, 1.386, 2.197, 2.944}};
 
   // Sector constants
@@ -146,7 +146,7 @@ public:
                     double chi2RZ,
                     double bendChi2,
                     unsigned int hitPattern,
-                    double mvaQuality,
+                    double mvaQualityPre,
                     unsigned int mvaOther,
                     unsigned int sector);
   TTTrack_TrackWord(unsigned int valid,
@@ -159,7 +159,7 @@ public:
                     unsigned int chi2RZ,
                     unsigned int bendChi2,
                     unsigned int hitPattern,
-                    unsigned int mvaQuality,
+                    unsigned int mvaQualityPre,
                     unsigned int mvaOther);
 
   // ----------copy constructor ----------------------
@@ -229,7 +229,9 @@ public:
   double getBendChi2() const { return bendChi2Bins[getBendChi2Bits()]; }
   unsigned int getHitPattern() const { return getHitPatternBits(); }
   unsigned int getNStubs() const { return countSetBits(getHitPatternBits()); }
-  double getMVAQuality() const { return std::round(100. / (1. + exp(-tqMVABins[getMVAQualityBits()]))) / 100.; }
+  double getMVAQualityPre() const { return tqMVAPreBins[getMVAQualityBits()]; }
+  // convert to MVA post-logistic sigmoid to 2 decimals, returns 0-1 range bins
+  double getMVAQuality() const { return std::round(100. / (1. + exp(-tqMVAPreBins[getMVAQualityBits()]))) / 100.; }
   unsigned int getMVAOther() const { return getMVAOtherBits(); }
 
   // ----------member functions (setters) ------------
@@ -241,7 +243,7 @@ public:
                     double chi2RZ,
                     double bendChi2,
                     unsigned int hitPattern,
-                    double mvaQuality,
+                    double mvaQualityPre,
                     unsigned int mvaOther,
                     unsigned int sector);
 
@@ -255,7 +257,7 @@ public:
                     unsigned int chi2RZ,
                     unsigned int bendChi2,
                     unsigned int hitPattern,
-                    unsigned int mvaQuality,
+                    unsigned int mvaQualityPre,
                     unsigned int mvaOther);
 
   void setTrackWord(ap_uint<TrackBitWidths::kValidSize> valid,
@@ -268,7 +270,7 @@ public:
                     ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
                     ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
                     ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
-                    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
+                    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQualityPre,
                     ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther);
 
   // ----------member functions (testers) ------------

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -231,18 +231,6 @@ public:
   double getMVAQuality() const { return tqMVABins[getMVAQualityBits()]; }
   double getMVAOther() const { return getMVAOtherBits(); }
 
-  // Get pre-sigmoid TQ MVA bins
-  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> getTqMVAPreSigBins() {
-    return {{-480,
-             invSigmoid(tqMVABins[1]),
-             invSigmoid(tqMVABins[2]),
-             invSigmoid(tqMVABins[3]),
-             invSigmoid(tqMVABins[4]),
-             invSigmoid(tqMVABins[5]),
-             invSigmoid(tqMVABins[6]),
-             invSigmoid(tqMVABins[7])}};
-  }
-
   // ----------member functions (setters) ------------
   void setTrackWord(unsigned int valid,
                     const GlobalVector& momentum,
@@ -345,8 +333,6 @@ public:
     // Convert to floating point value
     return (double(digitizedValue) + offset) * lsb;
   }
-
-  static constexpr double invSigmoid(double value) { return -log(1. / value - 1.); }
 
   // ----------member data ---------------------------
   tkword_bs_t trackWord_;

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -104,10 +104,9 @@ public:
   static constexpr std::array<double, 1 << TrackBitWidths::kBendChi2Size> bendChi2Bins = {
       {0.0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
 
-  // Bin edges for TQ MVA, pre-logistic sigmoid,
-  // corresponds to {0, 0.1, 0.2, 0.4, 0.6, 0.8, 0.9, 0.95} on (0,1) range with 2 decimal precision
-  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVAPreBins = {
-      {-480, -2.197, -1.386, -0.405, 0.405, 1.386, 2.197, 2.944}};
+  // Bin edges for TQ MVA
+  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVABins = {
+      {0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.750, 0.875}};
 
   // Sector constants
   static constexpr unsigned int nSectors = 9;
@@ -146,8 +145,8 @@ public:
                     double chi2RZ,
                     double bendChi2,
                     unsigned int hitPattern,
-                    double mvaQualityPre,
-                    unsigned int mvaOther,
+                    double mvaQuality,
+                    double mvaOther,
                     unsigned int sector);
   TTTrack_TrackWord(unsigned int valid,
                     unsigned int rInv,
@@ -159,7 +158,7 @@ public:
                     unsigned int chi2RZ,
                     unsigned int bendChi2,
                     unsigned int hitPattern,
-                    unsigned int mvaQualityPre,
+                    unsigned int mvaQuality,
                     unsigned int mvaOther);
 
   // ----------copy constructor ----------------------
@@ -229,10 +228,8 @@ public:
   double getBendChi2() const { return bendChi2Bins[getBendChi2Bits()]; }
   unsigned int getHitPattern() const { return getHitPatternBits(); }
   unsigned int getNStubs() const { return countSetBits(getHitPatternBits()); }
-  double getMVAQualityPre() const { return tqMVAPreBins[getMVAQualityBits()]; }
-  // convert to MVA post-logistic sigmoid to 2 decimals, returns 0-1 range bins
-  double getMVAQuality() const { return std::round(100. / (1. + exp(-tqMVAPreBins[getMVAQualityBits()]))) / 100.; }
-  unsigned int getMVAOther() const { return getMVAOtherBits(); }
+  double getMVAQuality() const { return tqMVABins[getMVAQualityBits()]; }
+  double getMVAOther() const { return getMVAOtherBits(); }
 
   // ----------member functions (setters) ------------
   void setTrackWord(unsigned int valid,
@@ -243,8 +240,8 @@ public:
                     double chi2RZ,
                     double bendChi2,
                     unsigned int hitPattern,
-                    double mvaQualityPre,
-                    unsigned int mvaOther,
+                    double mvaQuality,
+                    double mvaOther,
                     unsigned int sector);
 
   void setTrackWord(unsigned int valid,
@@ -257,7 +254,7 @@ public:
                     unsigned int chi2RZ,
                     unsigned int bendChi2,
                     unsigned int hitPattern,
-                    unsigned int mvaQualityPre,
+                    unsigned int mvaQuality,
                     unsigned int mvaOther);
 
   void setTrackWord(ap_uint<TrackBitWidths::kValidSize> valid,
@@ -270,7 +267,7 @@ public:
                     ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
                     ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
                     ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
-                    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQualityPre,
+                    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
                     ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther);
 
   // ----------member functions (testers) ------------

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -231,6 +231,18 @@ public:
   double getMVAQuality() const { return tqMVABins[getMVAQualityBits()]; }
   double getMVAOther() const { return getMVAOtherBits(); }
 
+  // Get pre-sigmoid TQ MVA bins
+  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> getTqMVAPreSigBins() {
+    return {{-480,
+             invSigmoid(tqMVABins[1]),
+             invSigmoid(tqMVABins[2]),
+             invSigmoid(tqMVABins[3]),
+             invSigmoid(tqMVABins[4]),
+             invSigmoid(tqMVABins[5]),
+             invSigmoid(tqMVABins[6]),
+             invSigmoid(tqMVABins[7])}};
+  }
+
   // ----------member functions (setters) ------------
   void setTrackWord(unsigned int valid,
                     const GlobalVector& momentum,
@@ -333,6 +345,8 @@ public:
     // Convert to floating point value
     return (double(digitizedValue) + offset) * lsb;
   }
+
+  static constexpr double invSigmoid(double value) { return -log(1. / value - 1.); }
 
   // ----------member data ---------------------------
   tkword_bs_t trackWord_;

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -104,6 +104,11 @@ public:
   static constexpr std::array<double, 1 << TrackBitWidths::kBendChi2Size> bendChi2Bins = {
       {0.0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
 
+  // Bin edges for TQ MVA (without logistic sigmoid applied),
+  // corresponds to {0, 0.1, 0.2, 0.4, 0.6, 0.8, 0.9, 0.95} on (0,1) range
+  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVABins = {
+      {-480, -2.197, -1.386, -0.405, 0.405, 1.386, 2.197, 2.944}};
+
   // Sector constants
   static constexpr unsigned int nSectors = 9;
   static constexpr double sectorWidth = (2. * M_PI) / nSectors;
@@ -141,7 +146,7 @@ public:
                     double chi2RZ,
                     double bendChi2,
                     unsigned int hitPattern,
-                    unsigned int mvaQuality,
+                    double mvaQuality,
                     unsigned int mvaOther,
                     unsigned int sector);
   TTTrack_TrackWord(unsigned int valid,
@@ -224,7 +229,7 @@ public:
   double getBendChi2() const { return bendChi2Bins[getBendChi2Bits()]; }
   unsigned int getHitPattern() const { return getHitPatternBits(); }
   unsigned int getNStubs() const { return countSetBits(getHitPatternBits()); }
-  unsigned int getMVAQuality() const { return getMVAQualityBits(); }
+  unsigned int getMVAQuality() const { return tqMVABins[getMVAQualityBits()]; }
   unsigned int getMVAOther() const { return getMVAOtherBits(); }
 
   // ----------member functions (setters) ------------
@@ -236,7 +241,7 @@ public:
                     double chi2RZ,
                     double bendChi2,
                     unsigned int hitPattern,
-                    unsigned int mvaQuality,
+                    double mvaQuality,
                     unsigned int mvaOther,
                     unsigned int sector);
 

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -35,10 +35,10 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      double chi2RZ,
                                      double bendChi2,
                                      unsigned int hitPattern,
-                                     double mvaQuality,
+                                     double mvaQualityPre,
                                      unsigned int mvaOther,
                                      unsigned int sector) {
-  setTrackWord(valid, momentum, POCA, rInv, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther, sector);
+  setTrackWord(valid, momentum, POCA, rInv, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQualityPre, mvaOther, sector);
 }
 
 TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
@@ -51,9 +51,9 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      unsigned int chi2RZ,
                                      unsigned int bendChi2,
                                      unsigned int hitPattern,
-                                     unsigned int mvaQuality,
+                                     unsigned int mvaQualityPre,
                                      unsigned int mvaOther) {
-  setTrackWord(valid, rInv, phi0, tanl, z0, d0, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther);
+  setTrackWord(valid, rInv, phi0, tanl, z0, d0, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQualityPre, mvaOther);
 }
 
 // A setter for the floating point values
@@ -65,7 +65,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
                                      double chi2RZ,
                                      double bendChi2,
                                      unsigned int hitPattern,
-                                     double mvaQuality,
+                                     double mvaQualityPre,
                                      unsigned int mvaOther,
                                      unsigned int sector) {
   // first, derive quantities to be packed
@@ -85,7 +85,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   chi2rz_t chi2RZ_ = getBin(chi2RZ, chi2RZBins);
   bendChi2_t bendChi2_ = getBin(bendChi2, bendChi2Bins);
   hit_t hitPattern_ = hitPattern;
-  qualityMVA_t mvaQuality_ = getBin(mvaQuality, tqMVABins);
+  qualityMVA_t mvaQuality_ = getBin(mvaQualityPre, tqMVAPreBins);
   otherMVA_t mvaOther_ = mvaOther;
 
   // pack the track word
@@ -105,7 +105,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
                                      unsigned int chi2RZ,
                                      unsigned int bendChi2,
                                      unsigned int hitPattern,
-                                     unsigned int mvaQuality,
+                                     unsigned int mvaQualityPre,
                                      unsigned int mvaOther) {
   // bin and convert to integers
   valid_t valid_ = valid;
@@ -118,7 +118,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   chi2rz_t chi2RZ_ = chi2RZ;
   bendChi2_t bendChi2_ = bendChi2;
   hit_t hitPattern_ = hitPattern;
-  qualityMVA_t mvaQuality_ = mvaQuality;
+  qualityMVA_t mvaQuality_ = mvaQualityPre;
   otherMVA_t mvaOther_ = mvaOther;
 
   // pack the track word
@@ -140,7 +140,7 @@ void TTTrack_TrackWord::setTrackWord(
     ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
     ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
     ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
-    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
+    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQualityPre,
     ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther) {
   // pack the track word
   unsigned int offset = 0;
@@ -149,7 +149,7 @@ void TTTrack_TrackWord::setTrackWord(
   }
   offset += TrackBitWidths::kMVAOtherSize;
   for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualitySize); b++) {
-    trackWord_.set(b, mvaQuality[b - offset]);
+    trackWord_.set(b, mvaQualityPre[b - offset]);
   }
   offset += TrackBitWidths::kMVAQualitySize;
   for (unsigned int b = offset; b < (offset + TrackBitWidths::kHitPatternSize); b++) {

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -35,7 +35,7 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      double chi2RZ,
                                      double bendChi2,
                                      unsigned int hitPattern,
-                                     unsigned int mvaQuality,
+                                     double mvaQuality,
                                      unsigned int mvaOther,
                                      unsigned int sector) {
   setTrackWord(valid, momentum, POCA, rInv, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther, sector);
@@ -65,7 +65,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
                                      double chi2RZ,
                                      double bendChi2,
                                      unsigned int hitPattern,
-                                     unsigned int mvaQuality,
+                                     double mvaQuality,
                                      unsigned int mvaOther,
                                      unsigned int sector) {
   // first, derive quantities to be packed
@@ -85,7 +85,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   chi2rz_t chi2RZ_ = getBin(chi2RZ, chi2RZBins);
   bendChi2_t bendChi2_ = getBin(bendChi2, bendChi2Bins);
   hit_t hitPattern_ = hitPattern;
-  qualityMVA_t mvaQuality_ = mvaQuality;
+  qualityMVA_t mvaQuality_ = getBin(mvaQuality, tqMVABins);
   otherMVA_t mvaOther_ = mvaOther;
 
   // pack the track word

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -35,10 +35,10 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      double chi2RZ,
                                      double bendChi2,
                                      unsigned int hitPattern,
-                                     double mvaQualityPre,
-                                     unsigned int mvaOther,
+                                     double mvaQuality,
+                                     double mvaOther,
                                      unsigned int sector) {
-  setTrackWord(valid, momentum, POCA, rInv, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQualityPre, mvaOther, sector);
+  setTrackWord(valid, momentum, POCA, rInv, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther, sector);
 }
 
 TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
@@ -51,9 +51,9 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      unsigned int chi2RZ,
                                      unsigned int bendChi2,
                                      unsigned int hitPattern,
-                                     unsigned int mvaQualityPre,
+                                     unsigned int mvaQuality,
                                      unsigned int mvaOther) {
-  setTrackWord(valid, rInv, phi0, tanl, z0, d0, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQualityPre, mvaOther);
+  setTrackWord(valid, rInv, phi0, tanl, z0, d0, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther);
 }
 
 // A setter for the floating point values
@@ -65,8 +65,8 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
                                      double chi2RZ,
                                      double bendChi2,
                                      unsigned int hitPattern,
-                                     double mvaQualityPre,
-                                     unsigned int mvaOther,
+                                     double mvaQuality,
+                                     double mvaOther,
                                      unsigned int sector) {
   // first, derive quantities to be packed
   float rPhi = localPhi(momentum.phi(), sector);  // this needs to be phi relative to the center of the sector
@@ -85,7 +85,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   chi2rz_t chi2RZ_ = getBin(chi2RZ, chi2RZBins);
   bendChi2_t bendChi2_ = getBin(bendChi2, bendChi2Bins);
   hit_t hitPattern_ = hitPattern;
-  qualityMVA_t mvaQuality_ = getBin(mvaQualityPre, tqMVAPreBins);
+  qualityMVA_t mvaQuality_ = getBin(mvaQuality, tqMVABins);
   otherMVA_t mvaOther_ = mvaOther;
 
   // pack the track word
@@ -105,7 +105,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
                                      unsigned int chi2RZ,
                                      unsigned int bendChi2,
                                      unsigned int hitPattern,
-                                     unsigned int mvaQualityPre,
+                                     unsigned int mvaQuality,
                                      unsigned int mvaOther) {
   // bin and convert to integers
   valid_t valid_ = valid;
@@ -118,7 +118,7 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   chi2rz_t chi2RZ_ = chi2RZ;
   bendChi2_t bendChi2_ = bendChi2;
   hit_t hitPattern_ = hitPattern;
-  qualityMVA_t mvaQuality_ = mvaQualityPre;
+  qualityMVA_t mvaQuality_ = mvaQuality;
   otherMVA_t mvaOther_ = mvaOther;
 
   // pack the track word
@@ -140,7 +140,7 @@ void TTTrack_TrackWord::setTrackWord(
     ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
     ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
     ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
-    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQualityPre,
+    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
     ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther) {
   // pack the track word
   unsigned int offset = 0;
@@ -149,7 +149,7 @@ void TTTrack_TrackWord::setTrackWord(
   }
   offset += TrackBitWidths::kMVAOtherSize;
   for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualitySize); b++) {
-    trackWord_.set(b, mvaQualityPre[b - offset]);
+    trackWord_.set(b, mvaQuality[b - offset]);
   }
   offset += TrackBitWidths::kMVAQualitySize;
   for (unsigned int b = offset; b < (offset + TrackBitWidths::kHitPatternSize); b++) {

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -749,6 +749,9 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     aTrack.setStubPtConsistency(
         StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar()));
 
+    // set track word before TQ MVA calculated which uses track word variables
+    aTrack.setTrackWordBits();
+
     if (trackQuality_) {
       trackQualityModel_->setL1TrackQuality(aTrack);
     }
@@ -761,7 +764,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     // test track word
     //aTrack.testTrackWordBits();
 
-    // set TTTrack word
+    // set track word again to set MVA variable from TTTrack into track word
     aTrack.setTrackWordBits();
 
     L1TkTracksForOutput->push_back(aTrack);

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -749,9 +749,6 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     aTrack.setStubPtConsistency(
         StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar()));
 
-    // set TTTrack word
-    aTrack.setTrackWordBits();
-
     if (trackQuality_) {
       trackQualityModel_->setL1TrackQuality(aTrack);
     }
@@ -763,6 +760,9 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
     // test track word
     //aTrack.testTrackWordBits();
+
+    // set TTTrack word
+    aTrack.setTrackWordBits();
 
     L1TkTracksForOutput->push_back(aTrack);
   }

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
@@ -198,7 +198,7 @@ namespace trklet {
       StreamsTrack outputStreamsTracks(setup_->numRegions() * setup_->tfpNumChannel());
 
       // Setup containers for track quality
-      float tempTQMVAPre = 0.0;
+      float tempTQMVAPreSig = 0.0;
       // Due to ap_fixed implementation in CMSSW this 10,5 must be specified at compile time, TODO make this a changeable parameter
       std::vector<ap_fixed<10, 5>> trackQuality_inputs = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
@@ -293,10 +293,10 @@ namespace trklet {
               digitise(TTTrack_TrackWord::chi2RZBins, tempchi2rz, (double)setup_->kfoutchi2rzConv())};
 
           // Run BDT emulation and package output into 3 bits
-
-          tempTQMVAPre = trackQualityModel_->runEmulatedTQ(trackQuality_inputs);
-          tempTQMVAPre = std::trunc(tempTQMVAPre * ap_fixed_rescale);
-          TTBV tqMVA(digitise(TTTrack_TrackWord::tqMVAPreBins, tempTQMVAPre, 1.0),
+          // output needs sigmoid transformation applied
+          tempTQMVAPreSig = trackQualityModel_->runEmulatedTQ(trackQuality_inputs);
+          tempTQMVAPreSig = std::trunc(tempTQMVAPreSig * ap_fixed_rescale);
+          TTBV tqMVA(digitise(TTTrack_TrackWord::tqMVABins, 1. / (1. + exp(-tempTQMVAPreSig)), 1.0),
                      TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize,
                      false);
 

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
@@ -198,7 +198,7 @@ namespace trklet {
       StreamsTrack outputStreamsTracks(setup_->numRegions() * setup_->tfpNumChannel());
 
       // Setup containers for track quality
-      float tempTQMVA = 0.0;
+      float tempTQMVAPre = 0.0;
       // Due to ap_fixed implementation in CMSSW this 10,5 must be specified at compile time, TODO make this a changeable parameter
       std::vector<ap_fixed<10, 5>> trackQuality_inputs = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
 
@@ -294,9 +294,9 @@ namespace trklet {
 
           // Run BDT emulation and package output into 3 bits
 
-          tempTQMVA = trackQualityModel_->runEmulatedTQ(trackQuality_inputs);
-          tempTQMVA = std::trunc(tempTQMVA * ap_fixed_rescale);
-          TTBV tqMVA(digitise(TTTrack_TrackWord::tqMVABins, tempTQMVA, 1.0), TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize, false);
+          tempTQMVAPre = trackQualityModel_->runEmulatedTQ(trackQuality_inputs);
+          tempTQMVAPre = std::trunc(tempTQMVAPre * ap_fixed_rescale);
+          TTBV tqMVA(digitise(TTTrack_TrackWord::tqMVAPreBins, tempTQMVAPre, 1.0), TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize, false);
 
           // Build 32 bit partial tracks for outputting in 64 bit packets
           //                  12 +  3       +  7         +  3    +  6

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
@@ -296,7 +296,9 @@ namespace trklet {
 
           tempTQMVAPre = trackQualityModel_->runEmulatedTQ(trackQuality_inputs);
           tempTQMVAPre = std::trunc(tempTQMVAPre * ap_fixed_rescale);
-          TTBV tqMVA(digitise(TTTrack_TrackWord::tqMVAPreBins, tempTQMVAPre, 1.0), TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize, false);
+          TTBV tqMVA(digitise(TTTrack_TrackWord::tqMVAPreBins, tempTQMVAPre, 1.0),
+                     TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize,
+                     false);
 
           // Build 32 bit partial tracks for outputting in 64 bit packets
           //                  12 +  3       +  7         +  3    +  6

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
@@ -68,7 +68,6 @@ namespace trklet {
     vector<double> dZBins_;
 
     std::unique_ptr<L1TrackQuality> trackQualityModel_;
-    vector<int> tqBins_;
     double tqTanlScale_;
     double tqZ0Scale_;
     static constexpr double ap_fixed_rescale = 32.0;
@@ -111,7 +110,6 @@ namespace trklet {
 
     trackQualityModel_ = std::make_unique<L1TrackQuality>(iConfig.getParameter<edm::ParameterSet>("TrackQualityPSet"));
     edm::ParameterSet trackQualityPSset = iConfig.getParameter<edm::ParameterSet>("TrackQualityPSet");
-    tqBins_ = trackQualityPSset.getParameter<vector<int>>("tqemu_bins");
     tqTanlScale_ = trackQualityPSset.getParameter<double>("tqemu_TanlScale");
     tqZ0Scale_ = trackQualityPSset.getParameter<double>("tqemu_Z0Scale");
   }
@@ -298,7 +296,7 @@ namespace trklet {
 
           tempTQMVA = trackQualityModel_->runEmulatedTQ(trackQuality_inputs);
           tempTQMVA = std::trunc(tempTQMVA * ap_fixed_rescale);
-          TTBV tqMVA(digitise(tqBins_, tempTQMVA, 1.0), TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize, false);
+          TTBV tqMVA(digitise(TTTrack_TrackWord::tqMVABins, tempTQMVA, 1.0), TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize, false);
 
           // Build 32 bit partial tracks for outputting in 64 bit packets
           //                  12 +  3       +  7         +  3    +  6

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
@@ -77,13 +77,14 @@ namespace trklet {
 
     int partialTrackWordBits_;
 
-    // Helper function to convert floating chi2 to chi2 bin
+    // Helper function to convert floating value to bin
     template <typename T>
     unsigned int digitise(const T& bins, double value, double factor) {
       unsigned int bin = 0;
       for (unsigned int i = 0; i < bins.size() - 1; i++) {
         if (value * factor > bins[i] && value * factor <= bins[i + 1])
-          bin = i;
+          break;
+        bin++;
       }
       return bin;
     }
@@ -295,8 +296,7 @@ namespace trklet {
           // Run BDT emulation and package output into 3 bits
           // output needs sigmoid transformation applied
           tempTQMVAPreSig = trackQualityModel_->runEmulatedTQ(trackQuality_inputs);
-          tempTQMVAPreSig = std::trunc(tempTQMVAPreSig * ap_fixed_rescale);
-          TTBV tqMVA(digitise(TTTrack_TrackWord::tqMVABins, 1. / (1. + exp(-tempTQMVAPreSig)), 1.0),
+          TTBV tqMVA(digitise(TTTrack_TrackWord::getTqMVAPreSigBins(), tempTQMVAPreSig, 1.0),
                      TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize,
                      false);
 

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
@@ -296,7 +296,7 @@ namespace trklet {
           // Run BDT emulation and package output into 3 bits
           // output needs sigmoid transformation applied
           tempTQMVAPreSig = trackQualityModel_->runEmulatedTQ(trackQuality_inputs);
-          TTBV tqMVA(digitise(TTTrack_TrackWord::getTqMVAPreSigBins(), tempTQMVAPreSig, 1.0),
+          TTBV tqMVA(digitise(L1TrackQuality::getTqMVAPreSigBins(), tempTQMVAPreSig, 1.0),
                      TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize,
                      false);
 

--- a/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
+++ b/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
@@ -50,6 +50,19 @@ public:
 
   void setBonusFeatures(std::vector<float> bonusFeatures);
 
+  // TQ MVA bin conversions
+  static constexpr double invSigmoid(double value) { return -log(1. / value - 1.); }
+  static constexpr std::array<double, 1 << TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize> getTqMVAPreSigBins() {
+    return {{-15.,
+             invSigmoid(TTTrack_TrackWord::tqMVABins[1]),
+             invSigmoid(TTTrack_TrackWord::tqMVABins[2]),
+             invSigmoid(TTTrack_TrackWord::tqMVABins[3]),
+             invSigmoid(TTTrack_TrackWord::tqMVABins[4]),
+             invSigmoid(TTTrack_TrackWord::tqMVABins[5]),
+             invSigmoid(TTTrack_TrackWord::tqMVABins[6]),
+             invSigmoid(TTTrack_TrackWord::tqMVABins[7])}};
+  }
+
 private:
   // Private Member Data
   edm::FileInPath model_;

--- a/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
+++ b/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
@@ -28,9 +28,6 @@ C.Brown 28/07/20
 
 class L1TrackQuality {
 public:
-  // Enum class used for determining prediction behaviour in setL1TrackQuality
-  enum class QualityAlgorithm { Cut, GBDT, GBDT_cpp, NN, None };
-
   //Default Constructor
   L1TrackQuality();
 
@@ -49,17 +46,8 @@ public:
   // and a single output to be returned which is then used to fill the bits in the Track Word for situations
   // where a TTTrack datatype is unavailable to be passed to the track quality
   float runEmulatedTQ(std::vector<ap_fixed<10, 5>> inputFeatures);
-  // To set private member data
-  void setCutParameters(std::string const& AlgorithmString,
-                        float maxZ0,
-                        float maxEta,
-                        float chi2dofMax,
-                        float bendchi2Max,
-                        float minPt,
-                        int nStubmin);
 
-  void setONNXModel(std::string const& AlgorithmString,
-                    edm::FileInPath const& ONNXmodel,
+  void setONNXModel(edm::FileInPath const& ONNXmodel,
                     std::string const& ONNXInputName,
                     std::vector<std::string> const& featureNames);
 
@@ -67,16 +55,9 @@ public:
 
 private:
   // Private Member Data
-  QualityAlgorithm qualityAlgorithm_ = QualityAlgorithm::None;
   edm::FileInPath ONNXmodel_;
   std::string ONNXInputName_;
   std::vector<std::string> featureNames_;
-  float maxZ0_;
-  float maxEta_;
-  float chi2dofMax_;
-  float bendchi2Max_;
-  float minPt_;
-  int nStubsmin_;
   bool useHPH_;
   std::vector<float> bonusFeatures_;
   std::unique_ptr<cms::Ort::ONNXRuntime> runTime_;

--- a/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
+++ b/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
@@ -53,7 +53,7 @@ public:
   // TQ MVA bin conversions
   static constexpr double invSigmoid(double value) { return -log(1. / value - 1.); }
   static constexpr std::array<double, 1 << TTTrack_TrackWord::TrackBitWidths::kMVAQualitySize> getTqMVAPreSigBins() {
-    return {{-15.,
+    return {{-16.,
              invSigmoid(TTTrack_TrackWord::tqMVABins[1]),
              invSigmoid(TTTrack_TrackWord::tqMVABins[2]),
              invSigmoid(TTTrack_TrackWord::tqMVABins[3]),

--- a/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
+++ b/L1Trigger/TrackTrigger/interface/L1TrackQuality.h
@@ -20,7 +20,6 @@ C.Brown 28/07/20
 #include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
-#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
 #include <memory>
 
 #include "conifer.h"
@@ -47,19 +46,15 @@ public:
   // where a TTTrack datatype is unavailable to be passed to the track quality
   float runEmulatedTQ(std::vector<ap_fixed<10, 5>> inputFeatures);
 
-  void setONNXModel(edm::FileInPath const& ONNXmodel,
-                    std::string const& ONNXInputName,
-                    std::vector<std::string> const& featureNames);
+  void setModel(edm::FileInPath const& model, std::vector<std::string> const& featureNames);
 
   void setBonusFeatures(std::vector<float> bonusFeatures);
 
 private:
   // Private Member Data
-  edm::FileInPath ONNXmodel_;
-  std::string ONNXInputName_;
+  edm::FileInPath model_;
   std::vector<std::string> featureNames_;
   bool useHPH_;
   std::vector<float> bonusFeatures_;
-  std::unique_ptr<cms::Ort::ONNXRuntime> runTime_;
 };
 #endif

--- a/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py
@@ -2,10 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 TrackQualityParams = cms.PSet(# This emulation GBDT is optimised for the HYBRID_NEWKF emulation and works with the emulation of the KF out module
                               # It is compatible with the HYBRID simulation and will give equivilant performance with this workflow
-                              ONNXmodel = cms.FileInPath("L1Trigger/TrackTrigger/data/L1_TrackQuality_GBDT_emulation_digitized.json"),
-                              # The ONNX model should be found at this path, if you want a local version of the model:
-                              # git clone https://github.com/cms-data/L1Trigger-TrackTrigger.git L1Trigger/TrackTrigger/data
-                              ONNXInputName = cms.string("feature_input"),
+                              model = cms.FileInPath("L1Trigger/TrackTrigger/data/L1_TrackQuality_GBDT_emulation_digitized.json"),
                               #Vector of strings of training features, in the order that the model was trained with
                               featureNames = cms.vstring(["tanl", "z0_scaled", "bendchi2_bin", "nstub",
                                                           "nlaymiss_interior", "chi2rphi_bin", "chi2rz_bin"]),

--- a/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-TrackQualityParams = cms.PSet(qualityAlgorithm = cms.string("GBDT_cpp"), #None, Cut, NN, GBDT, GBDT_cpp
-                              # This emulation GBDT is optimised for the HYBRID_NEWKF emulation and works with the emulation of the KF out module
+TrackQualityParams = cms.PSet(# This emulation GBDT is optimised for the HYBRID_NEWKF emulation and works with the emulation of the KF out module
                               # It is compatible with the HYBRID simulation and will give equivilant performance with this workflow
                               ONNXmodel = cms.FileInPath("L1Trigger/TrackTrigger/data/L1_TrackQuality_GBDT_emulation_digitized.json"),
                               # The ONNX model should be found at this path, if you want a local version of the model:
@@ -10,14 +9,6 @@ TrackQualityParams = cms.PSet(qualityAlgorithm = cms.string("GBDT_cpp"), #None, 
                               #Vector of strings of training features, in the order that the model was trained with
                               featureNames = cms.vstring(["tanl", "z0_scaled", "bendchi2_bin", "nstub",
                                                           "nlaymiss_interior", "chi2rphi_bin", "chi2rz_bin"]),
-                              # Parameters for cut based classifier, optimized for L1 Track MET
-                              # (Table 3.7  The Phase-2 Upgrade of the CMS Level-1 Trigger http://cds.cern.ch/record/2714892) 
-                              maxZ0 = cms.double ( 15. ) ,    # in cm
-                              maxEta = cms.double ( 2.4 ) ,
-                              chi2dofMax = cms.double( 40. ),
-                              bendchi2Max = cms.double( 2.4 ),
-                              minPt = cms.double( 2. ),       # in GeV
-                              nStubsmin = cms.int32( 4 ),
                               tqemu_TanlScale = cms.double( 128.0),
                               tqemu_Z0Scale = cms.double( 64.0 ),
                               )

--- a/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py
@@ -18,7 +18,6 @@ TrackQualityParams = cms.PSet(qualityAlgorithm = cms.string("GBDT_cpp"), #None, 
                               bendchi2Max = cms.double( 2.4 ),
                               minPt = cms.double( 2. ),       # in GeV
                               nStubsmin = cms.int32( 4 ),
-                              tqemu_bins = cms.vint32( [-480, -62, -35, -16, 0, 16, 35, 62, 480] ),
                               tqemu_TanlScale = cms.double( 128.0),
                               tqemu_Z0Scale = cms.double( 64.0 ),
                               )

--- a/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
@@ -91,7 +91,7 @@ void L1TrackQuality::setL1TrackQuality(TTTrack<Ref_Phase2TrackerDigi_>& aTrack) 
   // collect features and classify using bdt
   std::vector<float> inputs = featureTransform(aTrack, this->featureNames_);
   std::vector<float> output = bdt.decision_function(inputs);
-  aTrack.settrkMVA1Pre(output.at(0));
+  aTrack.settrkMVA1(1. / (1. + exp(-output.at(0))));
 }
 
 float L1TrackQuality::runEmulatedTQ(std::vector<ap_fixed<10, 5>> inputFeatures) {

--- a/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
@@ -92,7 +92,7 @@ void L1TrackQuality::setL1TrackQuality(TTTrack<Ref_Phase2TrackerDigi_>& aTrack) 
   // collect features and classify using bdt
   std::vector<float> inputs = featureTransform(aTrack, this->featureNames_);
   std::vector<float> output = bdt.decision_function(inputs);
-  aTrack.settrkMVA1(output.at(0));  // need logistic sigmoid fcn applied to xgb output
+  aTrack.settrkMVA1Pre(output.at(0));
 }
 
 float L1TrackQuality::runEmulatedTQ(std::vector<ap_fixed<10, 5>> inputFeatures) {

--- a/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
@@ -92,7 +92,7 @@ void L1TrackQuality::setL1TrackQuality(TTTrack<Ref_Phase2TrackerDigi_>& aTrack) 
   // collect features and classify using bdt
   std::vector<float> inputs = featureTransform(aTrack, this->featureNames_);
   std::vector<float> output = bdt.decision_function(inputs);
-  aTrack.settrkMVA1(1. / (1. + exp(-output.at(0))));  // need logistic sigmoid fcn applied to xgb output
+  aTrack.settrkMVA1(output.at(0));  // need logistic sigmoid fcn applied to xgb output
 }
 
 float L1TrackQuality::runEmulatedTQ(std::vector<ap_fixed<10, 5>> inputFeatures) {

--- a/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
@@ -10,26 +10,10 @@ C.Brown & C.Savard 07/2020
 L1TrackQuality::L1TrackQuality() {}
 
 L1TrackQuality::L1TrackQuality(const edm::ParameterSet& qualityParams) : useHPH_(false), bonusFeatures_() {
-  std::string AlgorithmString = qualityParams.getParameter<std::string>("qualityAlgorithm");
   // Unpacks EDM parameter set itself to save unecessary processing within TrackProducers
-  if (AlgorithmString == "Cut") {
-    setCutParameters(AlgorithmString,
-                     (float)qualityParams.getParameter<double>("maxZ0"),
-                     (float)qualityParams.getParameter<double>("maxEta"),
-                     (float)qualityParams.getParameter<double>("chi2dofMax"),
-                     (float)qualityParams.getParameter<double>("bendchi2Max"),
-                     (float)qualityParams.getParameter<double>("minPt"),
-                     qualityParams.getParameter<int>("nStubsmin"));
-  }
-
-  else {
-    setONNXModel(AlgorithmString,
-                 qualityParams.getParameter<edm::FileInPath>("ONNXmodel"),
-                 qualityParams.getParameter<std::string>("ONNXInputName"),
-                 qualityParams.getParameter<std::vector<std::string>>("featureNames"));
-    if ((AlgorithmString == "GBDT") || (AlgorithmString == "NN"))
-      runTime_ = std::make_unique<cms::Ort::ONNXRuntime>(this->ONNXmodel_.fullPath());
-  }
+  setONNXModel(qualityParams.getParameter<edm::FileInPath>("ONNXmodel"),
+               qualityParams.getParameter<std::string>("ONNXInputName"),
+               qualityParams.getParameter<std::vector<std::string>>("featureNames"));
 }
 
 std::vector<float> L1TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDigi_>& aTrack,
@@ -101,73 +85,14 @@ std::vector<float> L1TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDig
 }
 
 void L1TrackQuality::setL1TrackQuality(TTTrack<Ref_Phase2TrackerDigi_>& aTrack) {
-  if (this->qualityAlgorithm_ == QualityAlgorithm::Cut) {
-    // Get Track parameters
-    float trk_pt = aTrack.momentum().perp();
-    float trk_bend_chi2 = aTrack.stubPtConsistency();
-    float trk_z0 = aTrack.z0();
-    float trk_eta = aTrack.momentum().eta();
-    float trk_chi2 = aTrack.chi2();
-    const auto& stubRefs = aTrack.getStubRefs();
-    int nStubs = stubRefs.size();
 
-    float classification = 0.0;  // Default classification is 0
+  // load in bdt
+  conifer::BDT<float, float> bdt(this->ONNXmodel_.fullPath());
 
-    if (trk_pt >= this->minPt_ && abs(trk_z0) < this->maxZ0_ && abs(trk_eta) < this->maxEta_ &&
-        trk_chi2 < this->chi2dofMax_ && trk_bend_chi2 < this->bendchi2Max_ && nStubs >= this->nStubsmin_)
-      classification = 1.0;
-    // Classification updated to 1 if conditions are met
-
-    aTrack.settrkMVA1(classification);
-  }
-
-  else if (this->qualityAlgorithm_ == QualityAlgorithm::GBDT_cpp) {
-    // load in bdt
-    conifer::BDT<float, float> bdt(this->ONNXmodel_.fullPath());
-
-    // collect features and classify using bdt
-    std::vector<float> inputs = featureTransform(aTrack, this->featureNames_);
-    std::vector<float> output = bdt.decision_function(inputs);
-    aTrack.settrkMVA1(1. / (1. + exp(-output.at(0))));  // need logistic sigmoid fcn applied to xgb output
-  }
-
-  else if ((this->qualityAlgorithm_ == QualityAlgorithm::NN) || (this->qualityAlgorithm_ == QualityAlgorithm::GBDT)) {
-    // Setup ONNX input and output names and arrays
-    std::vector<std::string> ortinput_names;
-    std::vector<std::string> ortoutput_names;
-
-    cms::Ort::FloatArrays ortinput;
-    cms::Ort::FloatArrays ortoutputs;
-
-    std::vector<float> Transformed_features = featureTransform(aTrack, this->featureNames_);
-    //    cms::Ort::ONNXRuntime runTime(this->ONNXmodel_.fullPath());  //Setup ONNX runtime
-
-    ortinput_names.push_back(this->ONNXInputName_);
-    ortoutput_names = runTime_->getOutputNames();
-
-    //ONNX runtime recieves a vector of vectors of floats so push back the input
-    // vector of float to create a 1,1,21 ortinput
-    ortinput.push_back(Transformed_features);
-
-    // batch_size 1 as only one set of transformed features is being processed
-    int batch_size = 1;
-    // Run classification
-    ortoutputs = runTime_->run(ortinput_names, ortinput, {}, ortoutput_names, batch_size);
-
-    if (this->qualityAlgorithm_ == QualityAlgorithm::NN) {
-      aTrack.settrkMVA1(ortoutputs[0][0]);
-    }
-
-    else if (this->qualityAlgorithm_ == QualityAlgorithm::GBDT) {
-      aTrack.settrkMVA1(ortoutputs[1][1]);
-    }
-    // Slight differences in the ONNX models of the GBDTs and NNs mean different
-    // indices of the ortoutput need to be accessed
-  }
-
-  else {
-    aTrack.settrkMVA1(-999);
-  }
+  // collect features and classify using bdt
+  std::vector<float> inputs = featureTransform(aTrack, this->featureNames_);
+  std::vector<float> output = bdt.decision_function(inputs);
+  aTrack.settrkMVA1(1. / (1. + exp(-output.at(0))));  // need logistic sigmoid fcn applied to xgb output
 }
 
 float L1TrackQuality::runEmulatedTQ(std::vector<ap_fixed<10, 5>> inputFeatures) {
@@ -180,36 +105,10 @@ float L1TrackQuality::runEmulatedTQ(std::vector<ap_fixed<10, 5>> inputFeatures) 
   return output.at(0).to_float();  // need logistic sigmoid fcn applied to xgb output
 }
 
-void L1TrackQuality::setCutParameters(std::string const& AlgorithmString,
-                                      float maxZ0,
-                                      float maxEta,
-                                      float chi2dofMax,
-                                      float bendchi2Max,
-                                      float minPt,
-                                      int nStubmin) {
-  qualityAlgorithm_ = QualityAlgorithm::Cut;
-  maxZ0_ = maxZ0;
-  maxEta_ = maxEta;
-  chi2dofMax_ = chi2dofMax;
-  bendchi2Max_ = bendchi2Max;
-  minPt_ = minPt;
-  nStubsmin_ = nStubmin;
-}
-
-void L1TrackQuality::setONNXModel(std::string const& AlgorithmString,
-                                  edm::FileInPath const& ONNXmodel,
+void L1TrackQuality::setONNXModel(edm::FileInPath const& ONNXmodel,
                                   std::string const& ONNXInputName,
                                   std::vector<std::string> const& featureNames) {
   //Convert algorithm string to Enum class for track by track comparison
-  if (AlgorithmString == "NN") {
-    qualityAlgorithm_ = QualityAlgorithm::NN;
-  } else if (AlgorithmString == "GBDT") {
-    qualityAlgorithm_ = QualityAlgorithm::GBDT;
-  } else if (AlgorithmString == "GBDT_cpp") {
-    qualityAlgorithm_ = QualityAlgorithm::GBDT_cpp;
-  } else {
-    qualityAlgorithm_ = QualityAlgorithm::None;
-  }
   ONNXmodel_ = ONNXmodel;
   ONNXInputName_ = ONNXInputName;
   featureNames_ = featureNames;

--- a/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/L1TrackQuality.cc
@@ -85,7 +85,6 @@ std::vector<float> L1TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDig
 }
 
 void L1TrackQuality::setL1TrackQuality(TTTrack<Ref_Phase2TrackerDigi_>& aTrack) {
-
   // load in bdt
   conifer::BDT<float, float> bdt(this->ONNXmodel_.fullPath());
 

--- a/L1Trigger/TrackerTFP/src/DataFormats.cc
+++ b/L1Trigger/TrackerTFP/src/DataFormats.cc
@@ -504,13 +504,13 @@ namespace trackerTFP {
     }
     static constexpr int nPar = 4;
     static constexpr double d0 = 0.;
-    static constexpr double trkMVA1 = 0.;
+    static constexpr double trkMVA1Pre = -480.;
     static constexpr double trkMVA2 = 0.;
     static constexpr double trkMVA3 = 0.;
     const int hitPattern = hitVector.val();
     const double bField = setup()->bField();
     TTTrack<Ref_Phase2TrackerDigi_> ttTrack(
-        invR, phi0, cot, z0, d0, chi2phi, chi2z, trkMVA1, trkMVA2, trkMVA3, hitPattern, nPar, bField);
+        invR, phi0, cot, z0, d0, chi2phi, chi2z, trkMVA1Pre, trkMVA2, trkMVA3, hitPattern, nPar, bField);
     ttTrack.setStubRefs(ttStubRefs);
     ttTrack.setPhiSector(frame_.first->phiSector());
     ttTrack.setEtaSector(this->sectorEta());

--- a/L1Trigger/TrackerTFP/src/DataFormats.cc
+++ b/L1Trigger/TrackerTFP/src/DataFormats.cc
@@ -504,13 +504,13 @@ namespace trackerTFP {
     }
     static constexpr int nPar = 4;
     static constexpr double d0 = 0.;
-    static constexpr double trkMVA1Pre = -480.;
+    static constexpr double trkMVA1 = 0.;
     static constexpr double trkMVA2 = 0.;
     static constexpr double trkMVA3 = 0.;
     const int hitPattern = hitVector.val();
     const double bField = setup()->bField();
     TTTrack<Ref_Phase2TrackerDigi_> ttTrack(
-        invR, phi0, cot, z0, d0, chi2phi, chi2z, trkMVA1Pre, trkMVA2, trkMVA3, hitPattern, nPar, bField);
+        invR, phi0, cot, z0, d0, chi2phi, chi2z, trkMVA1, trkMVA2, trkMVA3, hitPattern, nPar, bField);
     ttTrack.setStubRefs(ttStubRefs);
     ttTrack.setPhiSector(frame_.first->phiSector());
     ttTrack.setEtaSector(this->sectorEta());


### PR DESCRIPTION
#### PR description:

This implements the binning scheme for the output of the TQ MVA1 variable. This binning scheme was presented at the offline software general meeting, [here](https://indico.cern.ch/event/1401028/). In order to avoid applying a logistic sigmoid function (which puts the variable within a 0-1 range) to the BDT output in the firmware, the MVA variable is binned before the transformation is applied and the normal calling of trkMVA1() in the TTTrack class will apply the transformation. An additional call to a pre-transformed variable was also included for convenience and extra checks.

#### PR validation:

All checks were run and this was tested with both the HYBRID and NEW_KF configurations of the tracking code. Here are some outputs showing the conversion between the different MVA variables in order to check that everything is working as expected (bins are [-480, -2.197, -1.386, -0.405, 0.405, 1.386, 2.197, 2.944] for pre-logistic sigmoid, corresponding to [0, 0.1, 0.2, 0.4, 0.6, 0.8, 0.9, 0.95]  after the transform):

HYBRID tracking example 1:
TTTrack->trkMVA1Pre(): 2.31981	
TTTrack->trkMVA1(): 0.910505	
TTTrack_Word->getMVAQualityBits(): 6	
TTTrack_Word->getMVAQualityPre(): 2.197	
TTTrack_Word->getMVAQuality(): 0.9

HYBRID tracking example 2:
TTTrack->trkMVA1Pre(): 2.01361	
TTTrack->trkMVA1(): 0.882219	
TTTrack_Word->getMVAQualityBits(): 5	
TTTrack_Word->getMVAQualityPre(): 1.386	
TTTrack_Word->getMVAQuality(): 0.8

NEWKF tracking example (default set to 0, needs fix in separate PR):
TTTrack->trkMVA1Pre(): -480	
TTTrack->trkMVA1(): 3.4566e-209	
TTTrack_Word->getMVAQualityBits(): 0	
TTTrack_Word->getMVAQualityPre(): -480	
TTTrack_Word->getMVAQuality(): 0