### PR TITLE
Added d0 correction for phi in PurgeDuplicate

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -1054,18 +1054,15 @@ namespace trklet {
     //Following values are used for duplicate removal
     //Rinv bins were optimised to ensure a similar number of tracks in each bin prior to DR
     //Rinv bin edges for 6 bins.
-    //std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
-    std::vector<double> rinvBins_{-rinvcut(), rinvcut()};
+    std::vector<double> rinvBins_{-rinvcut(), -0.004968, -0.003828, 0, 0.003828, 0.004968, rinvcut()};
     //Phi bin edges for 2 bins.
-    //std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
-    std::vector<double> phiBins_{0, dphisectorHG()};
+    std::vector<double> phiBins_{0, dphisectorHG() / 2, dphisectorHG()};
     //Overlap size for the overlap rinv bins in DR
     double rinvOverlapSize_{0.0004};
     //Overlap size for the overlap phi bins in DR
     double phiOverlapSize_{M_PI / 360};
     //The maximum number of tracks that are compared to all the other tracks per rinv bin
-    //int numTracksComparedPerBin_{32};
-    int numTracksComparedPerBin_{9999};
+    int numTracksComparedPerBin_{32};
 
     double sensorSpacing_2S_{0.18};
   };

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -795,7 +795,13 @@ unsigned int PurgeDuplicate::findPhiBin(const Tracklet* trk) const {
   double phi0 = trk->phi0();
   double rcrit = settings_.rcrit();
   double rinv = trk->rinv();
-  double phi = phi0 - asin(0.5 * rinv * rcrit);
+  double d0 = trk->d0();
+  double phi;
+  if (settings_.extended()) {
+    phi = phi0 - asin(0.5 * rinv * rcrit) + d0 / rcrit;
+  } else {
+    phi = phi0 - asin(0.5 * rinv * rcrit);
+  }
 
   //Check between what 2 values in phibins phi is between
   auto bins = std::upper_bound(phiBins.begin(), phiBins.end(), phi);
@@ -831,7 +837,13 @@ std::vector<unsigned int> PurgeDuplicate::findOverlapPhiBins(const Tracklet* trk
   double phi0 = trk->phi0();
   double rcrit = settings_.rcrit();
   double rinv = trk->rinv();
-  double phi = phi0 - asin(0.5 * rinv * rcrit);
+  double d0 = trk->d0();
+  double phi;
+  if (settings_.extended()) {
+    phi = phi0 - asin(0.5 * rinv * rcrit) + d0 / rcrit;
+  } else {
+    phi = phi0 - asin(0.5 * rinv * rcrit);
+  }
 
   const double phiOverlapSize = settings_.phiOverlapSize();
   const std::vector<double>& phiBins = settings_.phiBins();


### PR DESCRIPTION
As stated in the talk given Wednesday, after the seedRank bug fix, there was still a drop in efficiency in eta with bins for extended tracking. This was solved by adding a d0 term in the calculation for phi crit when extended tracking is available. The efficiency with this fix matches the efficiency of running extended tracking without any bins. 

Before:
[effVsPt_D88_PromptvsExtended.pdf](https://github.com/cms-L1TK/cmssw/files/15199572/effVsPt_D88_PromptvsExtended.pdf)
[effVsEta_D88_PromptvsExtended.pdf](https://github.com/cms-L1TK/cmssw/files/15199573/effVsEta_D88_PromptvsExtended.pdf)
With the correction to phi in green:
[effVsPt_D88_phiCritFix.pdf](https://github.com/cms-L1TK/cmssw/files/15199574/effVsPt_D88_phiCritFix.pdf)
[effVsEta_D88_phiCritFix 1.pdf](https://github.com/cms-L1TK/cmssw/files/15199575/effVsEta_D88_phiCritFix.1.pdf)
