### PR TITLE
Duplicate MPs to Reduce Truncation in MatchProcessor

### DIFF
--- a/.github/workflows/github_CI.yml
+++ b/.github/workflows/github_CI.yml
@@ -17,7 +17,7 @@ name: PR validation with GitLab CI
 on: # Controls when the action will run.
   workflow_dispatch:
   push: # Please specify your branch down here if you want CI to run for each push to it.
-    branches: [L1TK-dev-14_0_0_pre2]
+    branches: [L1TK-dev-14_0_0_pre2, DuplicateMPs]
     # branches: [myBranchUnderTest]
   pull_request: # Run CI if someone makes a PR to any branch
     # branches: [L1TK-dev-14_0_0_pre2] # Optionally only run CI if PR is to this branch.

--- a/.github/workflows/github_CI.yml
+++ b/.github/workflows/github_CI.yml
@@ -17,7 +17,7 @@ name: PR validation with GitLab CI
 on: # Controls when the action will run.
   workflow_dispatch:
   push: # Please specify your branch down here if you want CI to run for each push to it.
-    branches: [L1TK-dev-14_0_0_pre2, DuplicateMPs]
+    branches: [L1TK-dev-14_0_0_pre2]
     # branches: [myBranchUnderTest]
   pull_request: # Run CI if someone makes a PR to any branch
     # branches: [L1TK-dev-14_0_0_pre2] # Optionally only run CI if PR is to this branch.

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -268,8 +268,12 @@ namespace trklet {
     bool extended() const { return extended_; }
     void setExtended(bool extended) { extended_ = extended; }
     bool duplicateMPs() const { return duplicateMPs_; }
-    std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedEqualProjBalance() const { return layersDisksDuplicatedEqualProjBalance_; }
-    std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedWeightedProjBalance() const { return layersDisksDuplicatedWeightedProjBalance_; }
+    std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedEqualProjBalance() const {
+      return layersDisksDuplicatedEqualProjBalance_;
+    }
+    std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedWeightedProjBalance() const {
+      return layersDisksDuplicatedWeightedProjBalance_;
+    }
     bool combined() const { return combined_; }
     void setCombined(bool combined) { combined_ = combined; }
     bool reduced() const { return reduced_; }
@@ -1042,7 +1046,7 @@ namespace trklet {
     // Balances load from projections roughly in half for each of the two MPs
     bool duplicateMPs_{false};
 
-    // Determines which layers, disks the MatchProcessor is duplicated for 
+    // Determines which layers, disks the MatchProcessor is duplicated for
     // (note: in TCB by default always duplicated for phi B, C as truncation is significantly worse than A, D)
     // All layers, disks disabled by default, also is overwritten by above duplicateMPs bool
 
@@ -1050,7 +1054,7 @@ namespace trklet {
     std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedEqualProjBalance_{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
 
     // Weighted proj balancing is for specifically L4, L5 where the split of the projections is weighted to account for
-    // Higher occupancy in the L1L2 seed to minimize truncation 
+    // Higher occupancy in the L1L2 seed to minimize truncation
     std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedWeightedProjBalance_{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
 
     // Example use where for L3, L4, L5, D2, D3, the layers/disks where truncation is worst

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -267,7 +267,9 @@ namespace trklet {
 
     bool extended() const { return extended_; }
     void setExtended(bool extended) { extended_ = extended; }
-    bool duplicateMPs() const { return duplicatedMPs_; }
+    bool duplicateMPs() const { return duplicateMPs_; }
+    std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedEqualProjBalance() const { return layersDisksDuplicatedEqualProjBalance_; }
+    std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedWeightedProjBalance() const { return layersDisksDuplicatedWeightedProjBalance_; }
     bool combined() const { return combined_; }
     void setCombined(bool combined) { combined_ = combined; }
     bool reduced() const { return reduced_; }
@@ -1038,7 +1040,22 @@ namespace trklet {
 
     // Use chain with duplicated MPs for L3,L4 to reduce truncation issue
     // Balances load from projections roughly in half for each of the two MPs
-    bool duplicatedMPs_{false};
+    bool duplicateMPs_{false};
+
+    // Determines which layers, disks the MatchProcessor is duplicated for 
+    // (note: in TCB by default always duplicated for phi B, C as truncation is significantly worse than A, D)
+    // All layers, disks disabled by default, also is overwritten by above duplicateMPs bool
+
+    // EqualProjBalancing is for layers for which the projections to each duplicated MP are split in half sequentially
+    std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedEqualProjBalance_{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
+
+    // Weighted proj balancing is for specifically L4, L5 where the split of the projections is weighted to account for
+    // Higher occupancy in the L1L2 seed to minimize truncation 
+    std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedWeightedProjBalance_{{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
+
+    // Example use where for L3, L4, L5, D2, D3, the layers/disks where truncation is worst
+    //std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedEqualProjBalance_{{0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0}};
+    //std::array<bool, N_LAYER + N_DISK> layersDisksDuplicatedWeightedProjBalance_{{0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0}};
 
     std::string skimfile_{""};  //if not empty events will be written out in ascii format to this file
 

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -267,6 +267,7 @@ namespace trklet {
 
     bool extended() const { return extended_; }
     void setExtended(bool extended) { extended_ = extended; }
+    bool duplicateMPs() const { return duplicatedMPs_; }
     bool combined() const { return combined_; }
     void setCombined(bool combined) { combined_ = combined; }
     bool reduced() const { return reduced_; }
@@ -1034,6 +1035,10 @@ namespace trklet {
     // to false, but combined modules are nonetheless used by default.
     // If you don't want them, edit l1tTTTracksFromTrackletEmulation_cfi.py
     // to refer to *_hourglassExtended.dat .
+
+    // Use chain with duplicated MPs for L3,L4 to reduce truncation issue
+    // Balances load from projections roughly in half for each of the two MPs
+    bool duplicatedMPs_{false};
 
     std::string skimfile_{""};  //if not empty events will be written out in ascii format to this file
 

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletConfigBuilder.h
@@ -232,6 +232,7 @@ namespace trklet {
     unsigned int NSector_;  //Number of sectors
     double rcrit_;          //critical radius that defines the sector
 
+    bool duplicateMPs_;     //if true write configuration with MPs duplicated for L3,L4
     bool combinedmodules_;  //if true write configuration for combined modules
 
     bool extended_;  //if true write configuration for extended configuration

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -518,48 +518,46 @@ void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostre
         unsigned int iSeed = projections_[ilayer][ireg][imem].first;
         unsigned int iTC = projections_[ilayer][ireg][imem].second;
         if (combinedmodules_) {
-          if (duplicateMPs_){
+          if (duplicateMPs_) {
             if (ilayer == 2) {
-            memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
-            if (imem < projections_[ilayer][ireg].size() / 2) {
+              memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
+              if (imem < projections_[ilayer][ireg].size() / 2) {
+                os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+                   << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
+                   << std::endl;
+              } else {
+                os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+                   << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
+                   << ".projin"  // duplicate MPs
+                   << std::endl;
+              }
+            } else if (ilayer == 3) {
+              memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
+              if (imem < 4 ||
+                  imem >
+                      9) {  // FIXME need to replace magic numbers, corresponds to allowing MP1 4 L1L2 TCs, 3 L5L6 TCs, MP2 3 L1L2 3 L3L4 TCs
+                os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+                   << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
+                   << std::endl;
+              } else {
+                os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+                   << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
+                   << ".projin"  // duplicate MPs
+                   << std::endl;
+              }
+            } else {
+              memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
               os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
                  << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
                  << std::endl;
-            } else {
-              os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-                 << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
-                 << ".projin"  // duplicate MPs
-                 << std::endl;
             }
-          } else if (ilayer == 3) {
-            memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
-            if (imem < 4 ||
-                imem >
-                    9) {  // FIXME need to replace magic numbers, corresponds to allowing MP1 4 L1L2 TCs, 3 L5L6 TCs, MP2 3 L1L2 3 L3L4 TCs
-              os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-                 << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
-                 << std::endl;
-            } else {
-              os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-                 << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
-                 << ".projin"  // duplicate MPs
-                 << std::endl;
-            }
-          } else {
+          } else {  // non-duplicate MPs configuration
             memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
             os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
                << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
                << std::endl;
-            }
           }
-          else { // non-duplicate MPs configuration
-            memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
-            os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-               << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
-               << std::endl;
-          }
-        }
-           else {  // non-combined modules
+        } else {  // non-combined modules
           memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
           os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
              << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
@@ -911,39 +909,39 @@ void TrackletConfigBuilder::writeFMMemories(std::ostream& os, std::ostream& memo
   if (combinedmodules_) {
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        if (duplicateMPs_){
+        if (duplicateMPs_) {
           if (ilayer == 2 || ilayer == 3) {  // regions with worst truncation
-          modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-          modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << std::endl;
-          for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-            if (matchport_[iSeed][ilayer] == -1)
-              continue;
-            memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
-                     << " [36]" << std::endl;
-            memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
-                     << " [36]" << std::endl;
-            os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
-               << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
-               << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
-            os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
-               << " input=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
-               << ".matchout1 output=> FT_" << iSeedStr(iSeed) << ".fullmatch" << matchport_[iSeed][ilayer] << "in"
-               << iReg + 1 << std::endl;
+            modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+            modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << std::endl;
+            for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+              if (matchport_[iSeed][ilayer] == -1)
+                continue;
+              memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
+                       << " [36]" << std::endl;
+              memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI"
+                       << iTCStr(iReg) + "_E"
+                       << " [36]" << std::endl;
+              os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
+                 << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
+                 << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
+              os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
+                 << " input=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
+                 << ".matchout1 output=> FT_" << iSeedStr(iSeed) << ".fullmatch" << matchport_[iSeed][ilayer] << "in"
+                 << iReg + 1 << std::endl;
+            }
+          } else {
+            modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+            for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+              if (matchport_[iSeed][ilayer] == -1)
+                continue;
+              memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
+                       << " [36]" << std::endl;
+              os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
+                 << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
+                 << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
+            }
           }
-        } else {
-          modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-          for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-            if (matchport_[iSeed][ilayer] == -1)
-              continue;
-            memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
-                     << " [36]" << std::endl;
-            os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
-               << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
-               << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
-          }
-        }
-        }
-        else { // non-duplicate MPs configuration
+        } else {  // non-duplicate MPs configuration
           modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
           for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
             if (matchport_[iSeed][ilayer] == -1)
@@ -987,38 +985,37 @@ void TrackletConfigBuilder::writeASMemories(std::ostream& os, std::ostream& memo
     //First write AS memories used by MatchProcessor
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        if (duplicateMPs_){
+        if (duplicateMPs_) {
           if (ilayer == 2 || ilayer == 3) {
-          memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-                   << " [42]" << std::endl;
-          memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
-                   << " [42]" << std::endl;
-          if (combinedmodules_) {
-            modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+            memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+                     << " [42]" << std::endl;
+            memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
+                     << " [42]" << std::endl;
+            if (combinedmodules_) {
+              modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+            } else {
+              modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+            }
+            os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+               << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
+               << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
+            os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
+               << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
+               << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
+               << ".allstubin" << std::endl;
           } else {
-            modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+            memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+                     << " [42]" << std::endl;
+            if (combinedmodules_) {
+              modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+            } else {
+              modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+            }
+            os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+               << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
+               << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
           }
-          os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
-             << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
-          os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
-             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
-             << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
-             << ".allstubin" << std::endl;
-        } else {
-          memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-                   << " [42]" << std::endl;
-          if (combinedmodules_) {
-            modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-          } else {
-            modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-          }
-          os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
-             << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
-        }
-        }
-        else { // non duplicate MPs configuration
+        } else {  // non duplicate MPs configuration
           memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
                    << " [42]" << std::endl;
           if (combinedmodules_) {
@@ -1220,31 +1217,29 @@ void TrackletConfigBuilder::writeVMSMemories(std::ostream& os, std::ostream& mem
     //First write VMS memories used by MatchProcessor
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        if (duplicateMPs_){
+        if (duplicateMPs_) {
           if (ilayer == 2 || ilayer == 3) {
-          memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
-          memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2 [18]" << std::endl;
-          os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
-             << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
-          os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
-             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
-             << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
-             << ".vmstubin" << std::endl;
-        } else {
+            memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
+            memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2 [18]" << std::endl;
+            os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+               << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
+               << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
+            os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
+               << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
+               << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
+               << ".vmstubin" << std::endl;
+          } else {
+            memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
+            os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+               << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
+               << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
+          }
+        } else {  // non duplicate MPs configuration
           memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
           os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
              << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
              << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
         }
-        }
-        else { // non duplicate MPs configuration
-          memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
-          os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
-             << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
-        }
-        
       }
     }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -528,7 +528,7 @@ void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostre
               } else {
                 os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
                    << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
-                   << ".projin"  // duplicate MPs denoted by extra _E 
+                   << ".projin"  // duplicate MPs denoted by extra _E
                    << std::endl;
               }
             } else if ((settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) && (ireg == 1 || ireg == 2)) {
@@ -910,7 +910,9 @@ void TrackletConfigBuilder::writeFMMemories(std::ostream& os, std::ostream& memo
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
         if (duplicateMPs_) {
-          if ((settings_.layersDisksDuplicatedEqualProjBalance()[ilayer] || settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) && (iReg == 1 || iReg == 2)) {  // regions with worst truncation
+          if ((settings_.layersDisksDuplicatedEqualProjBalance()[ilayer] ||
+               settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) &&
+              (iReg == 1 || iReg == 2)) {  // regions with worst truncation
             modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
             modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << std::endl;
             for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
@@ -986,7 +988,9 @@ void TrackletConfigBuilder::writeASMemories(std::ostream& os, std::ostream& memo
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
         if (duplicateMPs_) {
-          if ((settings_.layersDisksDuplicatedEqualProjBalance()[ilayer] || settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) && (iReg == 1 || iReg == 2)) {
+          if ((settings_.layersDisksDuplicatedEqualProjBalance()[ilayer] ||
+               settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) &&
+              (iReg == 1 || iReg == 2)) {
             memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
                      << " [42]" << std::endl;
             memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
@@ -1218,7 +1222,9 @@ void TrackletConfigBuilder::writeVMSMemories(std::ostream& os, std::ostream& mem
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
         if (duplicateMPs_) {
-          if ((settings_.layersDisksDuplicatedEqualProjBalance()[ilayer] || settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) && (iReg == 1 || iReg == 2)) {
+          if ((settings_.layersDisksDuplicatedEqualProjBalance()[ilayer] ||
+               settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) &&
+              (iReg == 1 || iReg == 2)) {
             memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
             memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2 [18]" << std::endl;
             os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -519,7 +519,7 @@ void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostre
         unsigned int iTC = projections_[ilayer][ireg][imem].second;
         if (combinedmodules_) {
           if (duplicateMPs_) {
-            if (ilayer == 2) {
+            if ((settings_.layersDisksDuplicatedEqualProjBalance()[ilayer]) && (ireg == 1 || ireg == 2)) {
               memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
               if (imem < projections_[ilayer][ireg].size() / 2) {
                 os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
@@ -528,10 +528,10 @@ void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostre
               } else {
                 os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
                    << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
-                   << ".projin"  // duplicate MPs
+                   << ".projin"  // duplicate MPs denoted by extra _E 
                    << std::endl;
               }
-            } else if (ilayer == 3) {
+            } else if ((settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) && (ireg == 1 || ireg == 2)) {
               memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
               if (imem < 4 ||
                   imem >
@@ -910,7 +910,7 @@ void TrackletConfigBuilder::writeFMMemories(std::ostream& os, std::ostream& memo
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
         if (duplicateMPs_) {
-          if (ilayer == 2 || ilayer == 3) {  // regions with worst truncation
+          if ((settings_.layersDisksDuplicatedEqualProjBalance()[ilayer] || settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) && (iReg == 1 || iReg == 2)) {  // regions with worst truncation
             modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
             modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << std::endl;
             for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
@@ -986,7 +986,7 @@ void TrackletConfigBuilder::writeASMemories(std::ostream& os, std::ostream& memo
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
         if (duplicateMPs_) {
-          if (ilayer == 2 || ilayer == 3) {
+          if ((settings_.layersDisksDuplicatedEqualProjBalance()[ilayer] || settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) && (iReg == 1 || iReg == 2)) {
             memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
                      << " [42]" << std::endl;
             memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
@@ -1218,7 +1218,7 @@ void TrackletConfigBuilder::writeVMSMemories(std::ostream& os, std::ostream& mem
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
         if (duplicateMPs_) {
-          if (ilayer == 2 || ilayer == 3) {
+          if ((settings_.layersDisksDuplicatedEqualProjBalance()[ilayer] || settings_.layersDisksDuplicatedWeightedProjBalance()[ilayer]) && (iReg == 1 || iReg == 2)) {
             memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
             memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2 [18]" << std::endl;
             os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -516,33 +516,40 @@ void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostre
       for (unsigned int imem = 0; imem < projections_[ilayer][ireg].size(); imem++) {
         unsigned int iSeed = projections_[ilayer][ireg][imem].first;
         unsigned int iTC = projections_[ilayer][ireg][imem].second;
-        if ((ilayer == 2) && (ireg == 1 || ireg == 2)) {
-          memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
-          if (imem < projections_[ilayer][ireg].size() / 2) {
+        if (combinedmodules_) {
+          if (ilayer == 2) {
+            memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
+            if (imem < projections_[ilayer][ireg].size() / 2) {
+              os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+                 << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
+                 << std::endl;
+            } else {
+              os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+                 << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
+                 << ".projin"  // duplicate MPs
+                 << std::endl;
+            }
+          } else if (ilayer == 3) {
+            memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
+            if (imem < 4 ||
+                imem >
+                    9) {  // FIXME need to replace magic numbers, corresponds to allowing MP1 4 L1L2 TCs, 3 L5L6 TCs, MP2 3 L1L2 3 L3L4 TCs
+              os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+                 << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
+                 << std::endl;
+            } else {
+              os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+                 << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
+                 << ".projin"  // duplicate MPs
+                 << std::endl;
+            }
+          } else {
+            memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
             os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
                << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
                << std::endl;
-          } else {
-            os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-               << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
-               << ".projin"  // duplicate MPs
-               << std::endl;
           }
-        } 
-        else if (ilayer == 3 && (ireg == 1 || ireg == 2)) {
-          memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
-          if (imem < 4 || imem > 9) { // FIXME need to replace magic numbers, corresponds to allowing MP1 4 L1L2 TCs, 3 L5L6 TCs, MP2 3 L1L2 3 L3L4 TCs
-            os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-               << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
-               << std::endl;
-          } else {
-            os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-               << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
-               << ".projin"  // duplicate MPs
-               << std::endl;
-          }
-        } 
-        else {
+        } else {  // non-combined modules
           memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
           os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
              << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
@@ -894,7 +901,7 @@ void TrackletConfigBuilder::writeFMMemories(std::ostream& os, std::ostream& memo
   if (combinedmodules_) {
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        if ((ilayer == 2 || ilayer == 3) && (iReg == 1 || iReg == 2)) {  // regions with worst truncation
+        if (ilayer == 2 || ilayer == 3) {  // regions with worst truncation
           modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
           modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << std::endl;
           for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
@@ -956,7 +963,7 @@ void TrackletConfigBuilder::writeASMemories(std::ostream& os, std::ostream& memo
     //First write AS memories used by MatchProcessor
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        if ((ilayer == 2 || ilayer == 3) && (iReg == 1 || iReg == 2)) {
+        if (ilayer == 2 || ilayer == 3) {
           memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
                    << " [42]" << std::endl;
           memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
@@ -1175,7 +1182,7 @@ void TrackletConfigBuilder::writeVMSMemories(std::ostream& os, std::ostream& mem
     //First write VMS memories used by MatchProcessor
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        if ((ilayer == 2 || ilayer == 3) && (iReg == 1 || iReg == 2)) {
+        if (ilayer == 2 || ilayer == 3) {
           memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
           memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2 [18]" << std::endl;
           os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -516,24 +516,23 @@ void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostre
       for (unsigned int imem = 0; imem < projections_[ilayer][ireg].size(); imem++) {
         unsigned int iSeed = projections_[ilayer][ireg][imem].first;
         unsigned int iTC = projections_[ilayer][ireg][imem].second;
-        if ((ilayer == 2 || ilayer == 3 ) && (ireg == 1 || ireg == 2)){
+        if ((ilayer == 2 || ilayer == 3) && (ireg == 1 || ireg == 2)) {
           memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
-          if (imem < projections_[ilayer][ireg].size() / 2){
+          if (imem < projections_[ilayer][ireg].size() / 2) {
             os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-            << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
-            << std::endl;
-          }
-          else{
+               << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
+               << std::endl;
+          } else {
             os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-            << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E" << ".projin" // duplicate MPs 
-            << std::endl;
+               << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
+               << ".projin"  // duplicate MPs
+               << std::endl;
           }
-        }
-        else {
+        } else {
           memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
           os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
-           << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
-           << std::endl;
+             << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
+             << std::endl;
         }
       }
     }
@@ -881,34 +880,34 @@ void TrackletConfigBuilder::writeFMMemories(std::ostream& os, std::ostream& memo
   if (combinedmodules_) {
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        if ((ilayer == 2 || ilayer == 3 ) && (iReg == 1 || iReg == 2)){ // regions with worst truncation 
+        if ((ilayer == 2 || ilayer == 3) && (iReg == 1 || iReg == 2)) {  // regions with worst truncation
           modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
           modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << std::endl;
           for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
             if (matchport_[iSeed][ilayer] == -1)
               continue;
             memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
-                    << " [36]" << std::endl;
+                     << " [36]" << std::endl;
             memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
-                    << " [36]" << std::endl;
+                     << " [36]" << std::endl;
             os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
-              << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
-              << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
-            os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << " input=> MP_"
-              << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << ".matchout1 output=> FT_" << iSeedStr(iSeed)
-              << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
+               << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
+               << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
+            os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
+               << " input=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
+               << ".matchout1 output=> FT_" << iSeedStr(iSeed) << ".fullmatch" << matchport_[iSeed][ilayer] << "in"
+               << iReg + 1 << std::endl;
           }
-        }
-        else{
+        } else {
           modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
           for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
             if (matchport_[iSeed][ilayer] == -1)
               continue;
             memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
-                    << " [36]" << std::endl;
+                     << " [36]" << std::endl;
             os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
-              << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
-              << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
+               << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
+               << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
           }
         }
       }
@@ -943,36 +942,35 @@ void TrackletConfigBuilder::writeASMemories(std::ostream& os, std::ostream& memo
     //First write AS memories used by MatchProcessor
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        if ((ilayer == 2 || ilayer == 3 ) && (iReg == 1 || iReg == 2)){
+        if ((ilayer == 2 || ilayer == 3) && (iReg == 1 || iReg == 2)) {
           memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-                 << " [42]" << std::endl;
+                   << " [42]" << std::endl;
           memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
-            << " [42]" << std::endl;
+                   << " [42]" << std::endl;
           if (combinedmodules_) {
             modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
           } else {
             modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
           }
           os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
-            << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
+             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
+             << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
           os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
-            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
-            << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << ".allstubin" << std::endl;
-        }
-        else{
+             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
+             << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
+             << ".allstubin" << std::endl;
+        } else {
           memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-                 << " [42]" << std::endl;
+                   << " [42]" << std::endl;
           if (combinedmodules_) {
             modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
           } else {
             modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
           }
           os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
-            << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
+             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
+             << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
         }
-        
       }
     }
 
@@ -1163,23 +1161,22 @@ void TrackletConfigBuilder::writeVMSMemories(std::ostream& os, std::ostream& mem
     //First write VMS memories used by MatchProcessor
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        if ((ilayer == 2 || ilayer == 3 ) && (iReg == 1 || iReg == 2)){
+        if ((ilayer == 2 || ilayer == 3) && (iReg == 1 || iReg == 2)) {
           memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
           memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2 [18]" << std::endl;
           os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
-            << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
+             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
+             << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
           os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
-            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
-            << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << ".vmstubin" << std::endl;
-        }
-        else{
+             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
+             << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
+             << ".vmstubin" << std::endl;
+        } else {
           memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
           os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
-            << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
+             << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
+             << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
         }
-        
       }
     }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -516,7 +516,7 @@ void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostre
       for (unsigned int imem = 0; imem < projections_[ilayer][ireg].size(); imem++) {
         unsigned int iSeed = projections_[ilayer][ireg][imem].first;
         unsigned int iTC = projections_[ilayer][ireg][imem].second;
-        if ((ilayer == 2 || ilayer == 3) && (ireg == 1 || ireg == 2)) {
+        if ((ilayer == 2) && (ireg == 1 || ireg == 2)) {
           memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
           if (imem < projections_[ilayer][ireg].size() / 2) {
             os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
@@ -528,7 +528,21 @@ void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostre
                << ".projin"  // duplicate MPs
                << std::endl;
           }
-        } else {
+        } 
+        else if (ilayer == 3 && (ireg == 1 || ireg == 2)) {
+          memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
+          if (imem < 4 || imem > 9) { // FIXME need to replace magic numbers, corresponds to allowing MP1 4 L1L2 TCs, 3 L5L6 TCs, MP2 3 L1L2 3 L3L4 TCs
+            os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+               << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
+               << std::endl;
+          } else {
+            os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+               << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E"
+               << ".projin"  // duplicate MPs
+               << std::endl;
+          }
+        } 
+        else {
           memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
           os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
              << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -516,12 +516,25 @@ void TrackletConfigBuilder::writeProjectionMemories(std::ostream& os, std::ostre
       for (unsigned int imem = 0; imem < projections_[ilayer][ireg].size(); imem++) {
         unsigned int iSeed = projections_[ilayer][ireg][imem].first;
         unsigned int iTC = projections_[ilayer][ireg][imem].second;
-
-        memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
-
-        os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+        if ((ilayer == 2 || ilayer == 3 ) && (ireg == 1 || ireg == 2)){
+          memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
+          if (imem < projections_[ilayer][ireg].size() / 2){
+            os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+            << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
+            << std::endl;
+          }
+          else{
+            os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
+            << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) + "_E" << ".projin" // duplicate MPs 
+            << std::endl;
+          }
+        }
+        else {
+          memories << "TrackletProjections: " + TPROJName(iSeed, iTC, ilayer, ireg) + " [54]" << std::endl;
+          os << TPROJName(iSeed, iTC, ilayer, ireg) << " input=> " << TCName(iSeed, iTC) << ".projout"
            << LayerName(ilayer) << "PHI" << iTCStr(ireg) << " output=> " << PRName(ilayer, ireg) << ".projin"
            << std::endl;
+        }
       }
     }
   }
@@ -868,15 +881,35 @@ void TrackletConfigBuilder::writeFMMemories(std::ostream& os, std::ostream& memo
   if (combinedmodules_) {
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-        for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
-          if (matchport_[iSeed][ilayer] == -1)
-            continue;
-          memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
-                   << " [36]" << std::endl;
-          os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
-             << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
-             << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
+        if ((ilayer == 2 || ilayer == 3 ) && (iReg == 1 || iReg == 2)){ // regions with worst truncation 
+          modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << std::endl;
+          for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+            if (matchport_[iSeed][ilayer] == -1)
+              continue;
+            memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
+                    << " [36]" << std::endl;
+            memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E"
+                    << " [36]" << std::endl;
+            os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
+              << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
+              << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
+            os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << " input=> MP_"
+              << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << ".matchout1 output=> FT_" << iSeedStr(iSeed)
+              << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
+          }
+        }
+        else{
+          modules << "MatchProcessor: MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          for (unsigned int iSeed = 0; iSeed < N_SEED_PROMPT; iSeed++) {
+            if (matchport_[iSeed][ilayer] == -1)
+              continue;
+            memories << "FullMatch: FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg)
+                    << " [36]" << std::endl;
+            os << "FM_" << iSeedStr(iSeed) << "_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << " input=> MP_"
+              << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".matchout1 output=> FT_" << iSeedStr(iSeed)
+              << ".fullmatch" << matchport_[iSeed][ilayer] << "in" << iReg + 1 << std::endl;
+          }
         }
       }
     }
@@ -910,16 +943,36 @@ void TrackletConfigBuilder::writeASMemories(std::ostream& os, std::ostream& memo
     //First write AS memories used by MatchProcessor
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+        if ((ilayer == 2 || ilayer == 3 ) && (iReg == 1 || iReg == 2)){
+          memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
                  << " [42]" << std::endl;
-        if (combinedmodules_) {
-          modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
-        } else {
-          modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
+            << " [42]" << std::endl;
+          if (combinedmodules_) {
+            modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          } else {
+            modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          }
+          os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
+            << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
+          os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
+            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
+            << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << ".allstubin" << std::endl;
         }
-        os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-           << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
-           << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
+        else{
+          memories << "AllStubs: AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+                 << " [42]" << std::endl;
+          if (combinedmodules_) {
+            modules << "VMRouterCM: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          } else {
+            modules << "VMRouter: VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << std::endl;
+          }
+          os << "AS_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubout output=> MP_"
+            << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".allstubin" << std::endl;
+        }
+        
       }
     }
 
@@ -1110,10 +1163,23 @@ void TrackletConfigBuilder::writeVMSMemories(std::ostream& os, std::ostream& mem
     //First write VMS memories used by MatchProcessor
     for (unsigned int ilayer = 0; ilayer < N_LAYER + N_DISK; ilayer++) {
       for (unsigned int iReg = 0; iReg < NRegions_[ilayer]; iReg++) {
-        memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
-        os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
-           << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
-           << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
+        if ((ilayer == 2 || ilayer == 3 ) && (iReg == 1 || iReg == 2)){
+          memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
+          memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2 [18]" << std::endl;
+          os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
+            << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
+          os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n2"
+            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
+            << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) + "_E" << ".vmstubin" << std::endl;
+        }
+        else{
+          memories << "VMStubsME: VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1 [18]" << std::endl;
+          os << "VMSME_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << "n1"
+            << " input=> VMR_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstuboutPHI" << iTCStr(iReg)
+            << " output=> MP_" << LayerName(ilayer) << "PHI" << iTCStr(iReg) << ".vmstubin" << std::endl;
+        }
+        
       }
     }
 

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -256,8 +256,10 @@ void VMRouterCM::execute(unsigned int) {
           FPGAWord(stub->bend().value(), nbendbits, true, __LINE__, __FILE__),
           allStubIndex);
 
-      if (vmstubsMEPHI_[0] != nullptr) {
-        vmstubsMEPHI_[0]->addStub(vmstub, ivm * nvmmebins_ + vmbin);
+      unsigned int nmems = vmstubsMEPHI_.size(); 
+
+      for(unsigned int i = 0; i < nmems; i++){ // allows multiple VMStubs to be written for duplicated MPs 
+        if (vmstubsMEPHI_[i] != nullptr) vmstubsMEPHI_[i]->addStub(vmstub, ivm * nvmmebins_ + vmbin);
       }
 
       //Fill the TE VM memories

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -21,7 +21,6 @@ VMRouterCM::VMRouterCM(string name, Settings const& settings, Globals* global)
   unsigned int region = name[9] - 'A';
   assert(region < settings_.nallstubs(layerdisk_));
 
-  vmstubsMEPHI_.resize(1, nullptr);
 
   overlapbits_ = 7;
   nextrabits_ = overlapbits_ - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_));
@@ -83,8 +82,7 @@ void VMRouterCM::addOutput(MemoryBase* memory, string output) {
       VMStubsMEMemory* tmp = dynamic_cast<VMStubsMEMemory*>(memory);
       assert(tmp != nullptr);
       tmp->resize(nvmmebins_ * settings_.nvmme(layerdisk_));
-      assert(vmstubsMEPHI_[0] == nullptr);
-      vmstubsMEPHI_[0] = tmp;
+      vmstubsMEPHI_.push_back(tmp);
     } else {
       throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " memory: " << memory->getName()
                                          << " => should never get here!";

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -21,7 +21,6 @@ VMRouterCM::VMRouterCM(string name, Settings const& settings, Globals* global)
   unsigned int region = name[9] - 'A';
   assert(region < settings_.nallstubs(layerdisk_));
 
-
   overlapbits_ = 7;
   nextrabits_ = overlapbits_ - (settings_.nbitsallstubs(layerdisk_) + settings_.nbitsvmme(layerdisk_));
 
@@ -256,10 +255,11 @@ void VMRouterCM::execute(unsigned int) {
           FPGAWord(stub->bend().value(), nbendbits, true, __LINE__, __FILE__),
           allStubIndex);
 
-      unsigned int nmems = vmstubsMEPHI_.size(); 
+      unsigned int nmems = vmstubsMEPHI_.size();
 
-      for(unsigned int i = 0; i < nmems; i++){ // allows multiple VMStubs to be written for duplicated MPs 
-        if (vmstubsMEPHI_[i] != nullptr) vmstubsMEPHI_[i]->addStub(vmstub, ivm * nvmmebins_ + vmbin);
+      for (unsigned int i = 0; i < nmems; i++) {  // allows multiple VMStubs to be written for duplicated MPs
+        if (vmstubsMEPHI_[i] != nullptr)
+          vmstubsMEPHI_[i]->addStub(vmstub, ivm * nvmmebins_ + vmbin);
       }
 
       //Fill the TE VM memories


### PR DESCRIPTION
Fixes Issue #212 of reducing truncation in the MatchProcessor by adding the ability to duplicate MatchProcessors for configurable (in Settings.h) layers/disks for phi regions B, C where truncation is the worst. 

Improvement in efficiency ranges relative to base combined modules ranges from 0.4% to 0.6% depending on which layers/disks are included. With the maximum improvement studied (duplicating for L3, L4, L5, D2, and D3) of 0.60%, the efficiency is still 0.17% below that of the non-combined modules. The average resolution, track quality, etc. remain largely unchanged. 

For layers 4 and 5 the projections routed to each duplicated MP are balanced differently (rather than sequentially taking half of the projections to each MP) to account for the higher number of projections from the L1L2 seed. 