### PR TITLE
Added duplicate track rate to summary printout

### DIFF
--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -1,10 +1,10 @@
-// ----------------------------------------------------------------------------------------------------------------
-// Basic example ROOT script for making tracking performance plots using the ntuples produced by L1TrackNtupleMaker.cc
+// --------------------------------------------------------------------------------------------------------
+// ROOT script for making tracking performance plots using the ntuples produced by L1TrackNtupleMaker.cc
 //
 // e.g. in ROOT do: .L L1TrackNtuplePlot.C++, L1TrackNtuplePlot("L1TrkNtuple")
 //
 // By Louise Skinnari, June 2013
-// ----------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------
 
 #include "TROOT.h"
 #include "TStyle.h"

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -129,6 +129,7 @@ void L1TrackNtuplePlot(TString type,
   int ntp_pt3 = 0;
   int ntp_pt10 = 0;
   int ntrk_genuine_pt2 = 0;
+  int ntp_nmatch = 0;
   // ----------------------------------------------------------------------------------------------------------------
   // read ntuples
   TChain* tree = new TChain("L1TrackNtuple" + treeName + "/eventTree");
@@ -1070,7 +1071,7 @@ void L1TrackNtuplePlot(TString type,
     vector<unsigned int> nTrksPerSector_pt3(9, 0);
     vector<unsigned int> nTrksPerSector_pt4(9, 0);
 
-    for (int it = 0; it < (int)trk_pt->size(); it++) {
+    for (int it = 0; it < (int)trk_pt->size(); it++) { // Loop reco tracks
       // ----------------------------------------------------------------------------------------------------------------
       // track properties
 
@@ -1204,7 +1205,7 @@ void L1TrackNtuplePlot(TString type,
           h_trk_tracklet_hits->Fill(std::abs(trk_eta->at(it)), layer);  // ...fill this bin with the layer of the track.
         }
       }
-    }
+    } // End loop reco tracks
 
     h_ntrk_pt2->Fill(ntrkevt_pt2);
     h_ntrk_pt3->Fill(ntrkevt_pt3);
@@ -1220,7 +1221,7 @@ void L1TrackNtuplePlot(TString type,
     h_ntrkPerSector_pt4->Fill(*std::max_element(nTrksPerSector_pt4.begin(), nTrksPerSector_pt4.end()));
 
     // ----------------------------------------------------------------------------------------------------------------
-    // tracking particle loop
+    // Loop tracking particles
     for (int it = 0; it < (int)tp_pt->size(); it++) {
       // only look at TPs in (ttbar) jets ?
       if (TP_select_injet > 0) {
@@ -1257,8 +1258,10 @@ void L1TrackNtuplePlot(TString type,
           h_tp_vspt->Fill(tp_pt->at(it));
           // duplicate rate
           if (tp_nmatch->at(it) > 1) {
-            for (int inm = 1; inm < tp_nmatch->at(it); inm++)
+            for (int inm = 1; inm < tp_nmatch->at(it); inm++) { // N.B. Loop doesn't start at zero.
+              ntp_nmatch ++;
               h_trk_duplicate_vspt->Fill(matchtrk_pt->at(it));
+            }
           }
         }
         if (tp_pt->at(it) > 3.0)
@@ -3705,10 +3708,12 @@ void L1TrackNtuplePlot(TString type,
   cout << "# tracks/event (pt > 10.0) = " << (float)ntrk_pt10 / nevt << endl << endl;
 
   // fake track rate
-  if (ntrk_genuine_pt2 > 0)
+  if (ntrk_genuine_pt2 > 0) {
     cout << "Percentage fake tracks (pt > " << std::max(TP_minPt, 2.0f)
-         << ") = " << 100. * (1. - float(ntrk_genuine_pt2) / float(ntrk_pt2)) << "%" << endl
-         << endl;
+         << ") = " << 100. * (1. - float(ntrk_genuine_pt2) / float(ntrk_pt2)) << "%" << endl;
+    cout<<"Percentage duplicate tracks (pt > " << std::max(TP_minPt, 2.0f)
+        << ")= "<<100. * float(ntp_nmatch)/float(ntrk_pt2)<<"%"<<endl<<endl;
+  }
 
   // z0 resolution
   cout << "z0 resolution = " << z0ResSample1 << "cm at |eta| = " << etaSample1 << endl;

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -1071,7 +1071,7 @@ void L1TrackNtuplePlot(TString type,
     vector<unsigned int> nTrksPerSector_pt3(9, 0);
     vector<unsigned int> nTrksPerSector_pt4(9, 0);
 
-    for (int it = 0; it < (int)trk_pt->size(); it++) { // Loop reco tracks
+    for (int it = 0; it < (int)trk_pt->size(); it++) {  // Loop reco tracks
       // ----------------------------------------------------------------------------------------------------------------
       // track properties
 
@@ -1205,7 +1205,7 @@ void L1TrackNtuplePlot(TString type,
           h_trk_tracklet_hits->Fill(std::abs(trk_eta->at(it)), layer);  // ...fill this bin with the layer of the track.
         }
       }
-    } // End loop reco tracks
+    }  // End loop reco tracks
 
     h_ntrk_pt2->Fill(ntrkevt_pt2);
     h_ntrk_pt3->Fill(ntrkevt_pt3);
@@ -1258,8 +1258,8 @@ void L1TrackNtuplePlot(TString type,
           h_tp_vspt->Fill(tp_pt->at(it));
           // duplicate rate
           if (tp_nmatch->at(it) > 1) {
-            for (int inm = 1; inm < tp_nmatch->at(it); inm++) { // N.B. Loop doesn't start at zero.
-              ntp_nmatch ++;
+            for (int inm = 1; inm < tp_nmatch->at(it); inm++) {  // N.B. Loop doesn't start at zero.
+              ntp_nmatch++;
               h_trk_duplicate_vspt->Fill(matchtrk_pt->at(it));
             }
           }
@@ -3711,8 +3711,9 @@ void L1TrackNtuplePlot(TString type,
   if (ntrk_genuine_pt2 > 0) {
     cout << "Percentage fake tracks (pt > " << std::max(TP_minPt, 2.0f)
          << ") = " << 100. * (1. - float(ntrk_genuine_pt2) / float(ntrk_pt2)) << "%" << endl;
-    cout<<"Percentage duplicate tracks (pt > " << std::max(TP_minPt, 2.0f)
-        << ")= "<<100. * float(ntp_nmatch)/float(ntrk_pt2)<<"%"<<endl<<endl;
+    cout << "Percentage duplicate tracks (pt > " << std::max(TP_minPt, 2.0f)
+         << ")= " << 100. * float(ntp_nmatch) / float(ntrk_pt2) << "%" << endl
+         << endl;
   }
 
   // z0 resolution


### PR DESCRIPTION
#### PR description:

Added line printing out duplicate track percentage to the summary printed by L1TrackNtuplePlot.C. It gives 1.3% for HYBRID and 8.2% for HYBRID_NEWKF. (Theoretically, the latter number should be identical to that produced by AnalyzerKFout, which is only 7.1%, but the two seem to use slightly different tracking particle Pt cuts etc.).