### PR TITLE
Add truncation in TrackletProcessorDisplaced

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -897,6 +897,7 @@ namespace trklet {
         {"TB", 108},
         {"MP", 108},
         {"TP", 108},
+        {"TPD", 108},
         {"TRE", 108},
         {"DR", 108}};  //Specifies how many tracks allowed per bin in DR
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -427,18 +427,24 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
-		      if (countall >= settings_.maxStep("TP")) break;
+                      if (countall >= settings_.maxStep("TP"))
+                        break;
                     }
-		    if (countall >= settings_.maxStep("TP")) break;
+                    if (countall >= settings_.maxStep("TP"))
+                      break;
                   }
-		  if (countall >= settings_.maxStep("TP")) break;
+                  if (countall >= settings_.maxStep("TP"))
+                    break;
                 }
               }
-	      if (countall >= settings_.maxStep("TP")) break;
+              if (countall >= settings_.maxStep("TP"))
+                break;
             }
-	    if (countall >= settings_.maxStep("TP")) break;
+            if (countall >= settings_.maxStep("TP"))
+              break;
           }
-	  if (countall >= settings_.maxStep("TP")) break;
+          if (countall >= settings_.maxStep("TP"))
+            break;
         }
 
       } else if (layer1_ == 2 && layer2_ == 3) {
@@ -546,18 +552,24 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
-		      if (countall >= settings_.maxStep("TP")) break;
+                      if (countall >= settings_.maxStep("TP"))
+                        break;
                     }
-		    if (countall >= settings_.maxStep("TP")) break;
+                    if (countall >= settings_.maxStep("TP"))
+                      break;
                   }
-		  if (countall >= settings_.maxStep("TP")) break;
+                  if (countall >= settings_.maxStep("TP"))
+                    break;
                 }
               }
-	      if (countall >= settings_.maxStep("TP")) break;
+              if (countall >= settings_.maxStep("TP"))
+                break;
             }
-	    if (countall >= settings_.maxStep("TP")) break;
+            if (countall >= settings_.maxStep("TP"))
+              break;
           }
-	  if (countall >= settings_.maxStep("TP")) break;
+          if (countall >= settings_.maxStep("TP"))
+            break;
         }
 
       } else if (disk1_ == 1 && disk2_ == 2) {
@@ -666,23 +678,31 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
-		      if (countall >= settings_.maxStep("TP")) break;
+                      if (countall >= settings_.maxStep("TP"))
+                        break;
                     }
-		    if (countall >= settings_.maxStep("TP")) break;
+                    if (countall >= settings_.maxStep("TP"))
+                      break;
                   }
-		  if (countall >= settings_.maxStep("TP")) break;
+                  if (countall >= settings_.maxStep("TP"))
+                    break;
                 }
               }
-	      if (countall >= settings_.maxStep("TP")) break;
+              if (countall >= settings_.maxStep("TP"))
+                break;
             }
-	    if (countall >= settings_.maxStep("TP")) break;
+            if (countall >= settings_.maxStep("TP"))
+              break;
           }
-	  if (countall >= settings_.maxStep("TP")) break;
+          if (countall >= settings_.maxStep("TP"))
+            break;
         }
       }
-      if (countall >= settings_.maxStep("TP")) break;
+      if (countall >= settings_.maxStep("TP"))
+        break;
     }
-    if (countall >= settings_.maxStep("TP")) break;
+    if (countall >= settings_.maxStep("TP"))
+      break;
   }
 
   if (settings_.writeMonitorData("TPD")) {

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -427,12 +427,18 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
+		      if (countall >= settings_.maxStep("TP")) break;
                     }
+		    if (countall >= settings_.maxStep("TP")) break;
                   }
+		  if (countall >= settings_.maxStep("TP")) break;
                 }
               }
+	      if (countall >= settings_.maxStep("TP")) break;
             }
+	    if (countall >= settings_.maxStep("TP")) break;
           }
+	  if (countall >= settings_.maxStep("TP")) break;
         }
 
       } else if (layer1_ == 2 && layer2_ == 3) {
@@ -540,12 +546,18 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
+		      if (countall >= settings_.maxStep("TP")) break;
                     }
+		    if (countall >= settings_.maxStep("TP")) break;
                   }
+		  if (countall >= settings_.maxStep("TP")) break;
                 }
               }
+	      if (countall >= settings_.maxStep("TP")) break;
             }
+	    if (countall >= settings_.maxStep("TP")) break;
           }
+	  if (countall >= settings_.maxStep("TP")) break;
         }
 
       } else if (disk1_ == 1 && disk2_ == 2) {
@@ -654,15 +666,23 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
+		      if (countall >= settings_.maxStep("TP")) break;
                     }
+		    if (countall >= settings_.maxStep("TP")) break;
                   }
+		  if (countall >= settings_.maxStep("TP")) break;
                 }
               }
+	      if (countall >= settings_.maxStep("TP")) break;
             }
+	    if (countall >= settings_.maxStep("TP")) break;
           }
+	  if (countall >= settings_.maxStep("TP")) break;
         }
       }
+      if (countall >= settings_.maxStep("TP")) break;
     }
+    if (countall >= settings_.maxStep("TP")) break;
   }
 
   if (settings_.writeMonitorData("TPD")) {

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -427,23 +427,23 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
-                      if (countall >= settings_.maxStep("TP"))
+                      if (countall >= settings_.maxStep("TPD"))
                         break;
                     }
-                    if (countall >= settings_.maxStep("TP"))
+                    if (countall >= settings_.maxStep("TPD"))
                       break;
                   }
-                  if (countall >= settings_.maxStep("TP"))
+                  if (countall >= settings_.maxStep("TPD"))
                     break;
                 }
               }
-              if (countall >= settings_.maxStep("TP"))
+              if (countall >= settings_.maxStep("TPD"))
                 break;
             }
-            if (countall >= settings_.maxStep("TP"))
+            if (countall >= settings_.maxStep("TPD"))
               break;
           }
-          if (countall >= settings_.maxStep("TP"))
+          if (countall >= settings_.maxStep("TPD"))
             break;
         }
 
@@ -552,23 +552,23 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
-                      if (countall >= settings_.maxStep("TP"))
+                      if (countall >= settings_.maxStep("TPD"))
                         break;
                     }
-                    if (countall >= settings_.maxStep("TP"))
+                    if (countall >= settings_.maxStep("TPD"))
                       break;
                   }
-                  if (countall >= settings_.maxStep("TP"))
+                  if (countall >= settings_.maxStep("TPD"))
                     break;
                 }
               }
-              if (countall >= settings_.maxStep("TP"))
+              if (countall >= settings_.maxStep("TPD"))
                 break;
             }
-            if (countall >= settings_.maxStep("TP"))
+            if (countall >= settings_.maxStep("TPD"))
               break;
           }
-          if (countall >= settings_.maxStep("TP"))
+          if (countall >= settings_.maxStep("TPD"))
             break;
         }
 
@@ -678,30 +678,30 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                       if (settings_.debugTracklet()) {
                         edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                       }
-                      if (countall >= settings_.maxStep("TP"))
+                      if (countall >= settings_.maxStep("TPD"))
                         break;
                     }
-                    if (countall >= settings_.maxStep("TP"))
+                    if (countall >= settings_.maxStep("TPD"))
                       break;
                   }
-                  if (countall >= settings_.maxStep("TP"))
+                  if (countall >= settings_.maxStep("TPD"))
                     break;
                 }
               }
-              if (countall >= settings_.maxStep("TP"))
+              if (countall >= settings_.maxStep("TPD"))
                 break;
             }
-            if (countall >= settings_.maxStep("TP"))
+            if (countall >= settings_.maxStep("TPD"))
               break;
           }
-          if (countall >= settings_.maxStep("TP"))
+          if (countall >= settings_.maxStep("TPD"))
             break;
         }
       }
-      if (countall >= settings_.maxStep("TP"))
+      if (countall >= settings_.maxStep("TPD"))
         break;
     }
-    if (countall >= settings_.maxStep("TP"))
+    if (countall >= settings_.maxStep("TPD"))
       break;
   }
 


### PR DESCRIPTION
#### PR description:

Truncation has never been added to the TrackletProcessorDisplaced module and so these changes implement truncation there using the maxstep_['TP'] value in Settings.h [here](https://github.com/cms-L1TK/cmssw/blob/L1TK-dev-14_0_0_pre2/L1Trigger/TrackFindingTracklet/interface/Settings.h#L899) (as the other displaced modules do). Truncation in extended tracking is turned off by default and so this doesn't change the performance of anything, but allows us to properly study truncation for the full extended chain.

#### PR validation:

After running a couple of checks, the behavior of these changes is exactly as expected. With truncation off, nothing changes. With truncation on, TrackletProcessorDisplaced is capping its processing of objects to the value set in Settings.h.
