### PR TITLE
Clean up TrackletProcessorDisplaced

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/ProcessBase.h
+++ b/L1Trigger/TrackFindingTracklet/interface/ProcessBase.h
@@ -31,6 +31,10 @@ namespace trklet {
 
     //This function processes the name of a TE module to determine the layerdisks and iseed
     void initLayerDisksandISeed(unsigned int& layerdisk1, unsigned int& layerdisk2, unsigned int& iSeed);
+    void initLayerDisksandISeedDisp(unsigned int& layerdisk1,
+                                    unsigned int& layerdisk2,
+                                    unsigned int& layerdisk3,
+                                    unsigned int& iSeed);
 
     unsigned int getISeed(const std::string& name);
 

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletProcessorDisplaced.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletProcessorDisplaced.h
@@ -40,9 +40,6 @@ namespace trklet {
 
   private:
     int iTC_;
-    int iAllStub_;
-    unsigned int maxStep_;
-    int count_;
 
     unsigned int layerdisk1_;
     unsigned int layerdisk2_;
@@ -58,16 +55,8 @@ namespace trklet {
     TrackletLUT innerTable_;       //projection to next layer/disk
     TrackletLUT innerThirdTable_;  //projection to third disk/layer
 
-    std::vector<StubPairsMemory*> stubpairs_;
-    /* std::vector<StubTripletsMemory*> stubtriplets_; */
     std::vector<VMStubsTEMemory*> innervmstubs_;
     std::vector<VMStubsTEMemory*> outervmstubs_;
-
-    StubTripletsMemory* stubtriplets_;
-
-    std::map<std::string, std::vector<std::vector<std::string> > > tmpSPTable_;
-    std::map<std::string, std::vector<std::map<std::string, unsigned> > > spTable_;
-    std::vector<bool> table_;
   };
 
 };  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletProcessorDisplaced.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletProcessorDisplaced.h
@@ -44,7 +44,6 @@ namespace trklet {
     unsigned int maxStep_;
     int count_;
 
-    unsigned int iSeed_;
     unsigned int layerdisk1_;
     unsigned int layerdisk2_;
     unsigned int layerdisk3_;

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletProcessorDisplaced.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletProcessorDisplaced.h
@@ -43,14 +43,11 @@ namespace trklet {
     int iAllStub_;
     unsigned int maxStep_;
     int count_;
-    unsigned int layerdisk_;
 
-    int layer1_;
-    int layer2_;
-    int layer3_;
-    int disk1_;
-    int disk2_;
-    int disk3_;
+    unsigned int iSeed_;
+    unsigned int layerdisk1_;
+    unsigned int layerdisk2_;
+    unsigned int layerdisk3_;
 
     int firstphibits_;
     int secondphibits_;

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletProcessorDisplaced.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletProcessorDisplaced.h
@@ -56,9 +56,8 @@ namespace trklet {
     int nbitszfinebintable_;
     int nbitsrfinebintable_;
 
-    TrackletLUT innerTable_;         //projection to next layer/disk
-    TrackletLUT innerOverlapTable_;  //projection to disk from layer
-    TrackletLUT innerThirdTable_;    //projection to disk1 for extended - iseed=10
+    TrackletLUT innerTable_;       //projection to next layer/disk
+    TrackletLUT innerThirdTable_;  //projection to third disk/layer
 
     std::vector<StubPairsMemory*> stubpairs_;
     /* std::vector<StubTripletsMemory*> stubtriplets_; */

--- a/L1Trigger/TrackFindingTracklet/src/ProcessBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProcessBase.cc
@@ -116,6 +116,43 @@ void ProcessBase::initLayerDisksandISeed(unsigned int& layerdisk1, unsigned int&
   }
 }
 
+void ProcessBase::initLayerDisksandISeedDisp(unsigned int& layerdisk1,
+                                             unsigned int& layerdisk2,
+                                             unsigned int& layerdisk3,
+                                             unsigned int& iSeed) {
+  layerdisk1 = 99;
+  layerdisk2 = 99;
+  layerdisk3 = 99;
+
+  if (name_.substr(0, 4) == "TPD_") {
+    if (name_[4] == 'L')
+      layerdisk1 = name_[5] - '1';
+    else if (name_[4] == 'D')
+      layerdisk1 = N_LAYER + name_[5] - '1';
+    if (name_[6] == 'L')
+      layerdisk2 = name_[7] - '1';
+    else if (name_[6] == 'D')
+      layerdisk2 = N_LAYER + name_[7] - '1';
+    if (name_[8] == 'L')
+      layerdisk3 = name_[9] - '1';
+    else if (name_[8] == 'D')
+      layerdisk3 = N_LAYER + name_[9] - '1';
+  }
+
+  if (layerdisk1 == LayerDisk::L3 && layerdisk2 == LayerDisk::L4 && layerdisk3 == LayerDisk::L2)
+    iSeed = Seed::L2L3L4;
+  else if (layerdisk1 == LayerDisk::L5 && layerdisk2 == LayerDisk::L6 && layerdisk3 == LayerDisk::L4)
+    iSeed = Seed::L4L5L6;
+  else if (layerdisk1 == LayerDisk::L2 && layerdisk2 == LayerDisk::L3 && layerdisk3 == LayerDisk::D1)
+    iSeed = Seed::L2L3D1;
+  else if (layerdisk1 == LayerDisk::D1 && layerdisk2 == LayerDisk::D2 && layerdisk3 == LayerDisk::L2)
+    iSeed = Seed::D1D2L2;
+  else {
+    throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " layerdisk1 " << layerdisk1 << " layerdisk2 "
+                                       << layerdisk2 << " layerdisk3 " << layerdisk3;
+  }
+}
+
 unsigned int ProcessBase::getISeed(const std::string& name) {
   std::size_t pos = name.find('_');
   std::string name1 = name.substr(pos + 1);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -38,9 +38,10 @@ TrackletProcessorDisplaced::TrackletProcessorDisplaced(string name, Settings con
 
   // get projection tables
   unsigned int region = name.back() - 'A';
-  innerTable_.initVMRTable(layerdisk1_, TrackletLUT::VMRTableType::inner, region);  //projection to next layer/disk
+  innerTable_.initVMRTable(
+      layerdisk1_, TrackletLUT::VMRTableType::inner, region, false);  //projection to next layer/disk
   innerThirdTable_.initVMRTable(
-      layerdisk1_, TrackletLUT::VMRTableType::innerthird, region);  //projection to third layer/disk
+      layerdisk1_, TrackletLUT::VMRTableType::innerthird, region, false);  //projection to third layer/disk
 
   nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk1_);
   nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk1_);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -318,6 +318,8 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
                   if (countall >= settings_.maxStep("TPD"))
                     break;
                 }
+                if (countall >= settings_.maxStep("TPD"))
+                  break;
               }
               if (countall >= settings_.maxStep("TPD"))
                 break;
@@ -328,6 +330,8 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
           if (countall >= settings_.maxStep("TPD"))
             break;
         }
+        if (countall >= settings_.maxStep("TPD"))
+          break;
       }
       if (countall >= settings_.maxStep("TPD"))
         break;

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -57,10 +57,10 @@ TrackletProcessorDisplaced::TrackletProcessorDisplaced(string name, Settings con
   }
 
   // set TC index
-  int iTC = region;
+  iTC_ = region;
   constexpr int TCIndexMin = 128;
   constexpr int TCIndexMax = 191;
-  TCIndex_ = (iSeed_ << 4) + iTC;
+  TCIndex_ = (iSeed_ << 4) + iTC_;
   assert(TCIndex_ >= TCIndexMin && TCIndex_ < TCIndexMax);
 }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -18,6 +18,13 @@
 using namespace std;
 using namespace trklet;
 
+// TrackletProcessorDisplaced
+//
+// This module takes in collections of stubs within a phi region and a
+// displaced seed name and tries to create that displaced seed out of the stubs
+//
+// Update: Claire Savard, Oct. 2024
+
 TrackletProcessorDisplaced::TrackletProcessorDisplaced(string name, Settings const& settings, Globals* globals)
     : TrackletCalculatorDisplaced(name, settings, globals), innerTable_(settings), innerThirdTable_(settings) {
   innerallstubs_.clear();
@@ -26,15 +33,14 @@ TrackletProcessorDisplaced::TrackletProcessorDisplaced(string name, Settings con
   innervmstubs_.clear();
   outervmstubs_.clear();
 
+  // set layer/disk types based on input seed name
   initLayerDisksandISeedDisp(layerdisk1_, layerdisk2_, layerdisk3_, iSeed_);
 
+  // get projection tables
   unsigned int region = name.back() - 'A';
-  if (layerdisk1_ == LayerDisk::L2 || layerdisk1_ == LayerDisk::L3 || layerdisk1_ == LayerDisk::L5 ||
-      layerdisk1_ == LayerDisk::D1) {
-    innerTable_.initVMRTable(layerdisk1_, TrackletLUT::VMRTableType::inner, region);  //projection to next layer/disk
-    innerThirdTable_.initVMRTable(
-				  layerdisk1_, TrackletLUT::VMRTableType::innerthird, region, false);  //projection to third layer/disk
-  }
+  innerTable_.initVMRTable(layerdisk1_, TrackletLUT::VMRTableType::inner, region);  //projection to next layer/disk
+  innerThirdTable_.initVMRTable(
+      layerdisk1_, TrackletLUT::VMRTableType::innerthird, region);  //projection to third layer/disk
 
   nbitszfinebintable_ = settings_.vmrlutzbits(layerdisk1_);
   nbitsrfinebintable_ = settings_.vmrlutrbits(layerdisk1_);
@@ -152,42 +158,34 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
   unsigned int countall = 0;
   unsigned int countsel = 0;
 
-  count_ = 0;
-
   phimin_ = phimin;
   phimax_ = phimax;
   iSector_ = iSector;
 
-  assert(!innerallstubs_.empty());
-  assert(!middleallstubs_.empty());
-  assert(!outerallstubs_.empty());
-  assert(!innervmstubs_.empty());
-  assert(!outervmstubs_.empty());
-
-  for (auto& iInnerMem : middleallstubs_) {
-    for (unsigned int j = 0; j < iInnerMem->nStubs(); j++) {
-      const Stub* firstallstub = iInnerMem->getStub(j);
+  // loop over the middle stubs in the potential seed
+  for (unsigned int midmem = 0; midmem < middleallstubs_.size(); midmem++) {
+    for (unsigned int j = 0; j < middleallstubs_[midmem]->nStubs(); j++) {
+      const Stub* midallstub = middleallstubs_[midmem]->getStub(j);
 
       if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "In " << getName() << " have first stub\n";
+        edm::LogVerbatim("Tracklet") << "In " << getName() << " have middle stub";
       }
 
-      bool negdisk = (firstallstub->disk().value() < 0);
-      int indexz = (((1 << (firstallstub->z().nbits() - 1)) + firstallstub->z().value()) >>
-                    (firstallstub->z().nbits() - nbitszfinebintable_));
+      // get r/z index of the middle stub
+      int indexz = (((1 << (midallstub->z().nbits() - 1)) + midallstub->z().value()) >>
+                    (midallstub->z().nbits() - nbitszfinebintable_));
       int indexr = -1;
-      if (layerdisk1_ > (N_LAYER - 1)) {
-        if (negdisk) {
+      bool negdisk = (midallstub->disk().value() < 0);  // check if disk in negative z region
+      if (layerdisk1_ >= LayerDisk::D1) {               // if a disk
+        if (negdisk)
           indexz = (1 << nbitszfinebintable_) - indexz;
+        indexr = midallstub->r().value();
+        if (midallstub->isPSmodule()) {
+          indexr = midallstub->r().value() >> (midallstub->r().nbits() - nbitsrfinebintable_);
         }
-        indexr = firstallstub->r().value();
-        if (firstallstub->isPSmodule()) {
-          indexr = firstallstub->r().value() >> (firstallstub->r().nbits() - nbitsrfinebintable_);
-        }
-      } else {
-        //Take the top nbitsfinebintable_ bits of the z coordinate. The & is to handle the negative z values.
-        indexr = (((1 << (firstallstub->r().nbits() - 1)) + firstallstub->r().value()) >>
-                  (firstallstub->r().nbits() - nbitsrfinebintable_));
+      } else {  // else a layer
+        indexr = (((1 << (midallstub->r().nbits() - 1)) + midallstub->r().value()) >>
+                  (midallstub->r().nbits() - nbitsrfinebintable_));
       }
 
       assert(indexz >= 0);
@@ -195,6 +193,7 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
       assert(indexz < (1 << nbitszfinebintable_));
       assert(indexr < (1 << nbitsrfinebintable_));
 
+      // create lookupbits that define projections from middle stub
       unsigned int lutwidth = settings_.lutwidthtabextended(0, iSeed_);
       int lutval = -1;
       const auto& lutshift = innerTable_.nbits();
@@ -206,86 +205,86 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
       }
       if (lutval == -1)
         continue;
-
-      if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << getName() << " Layer-layer pair\n";
-      }
-
       FPGAWord lookupbits(lutval, lutwidth, true, __LINE__, __FILE__);
 
-      // get r/z bins for projection into outer layer/disc
+      // get r/z bins for projection into outer layer/disk
       int nbitsrzbin = N_RZBITS;
       if (iSeed_ == Seed::D1D2L2)
         nbitsrzbin--;
-      int rzbinfirst = lookupbits.bits(0, NFINERZBITS);  //finerz
-      int next = lookupbits.bits(NFINERZBITS, 1);        //use next r/z bin
+      int rzbinfirst = lookupbits.bits(0, NFINERZBITS);
+      int next = lookupbits.bits(NFINERZBITS, 1);
       int rzdiffmax = lookupbits.bits(NFINERZBITS + 1 + nbitsrzbin, NFINERZBITS);
 
-      int start = lookupbits.bits(NFINERZBITS + 1, nbitsrzbin);  //rz bin
-      if (iSeed_ == Seed::D1D2L2 && negdisk)                     // projecting from layer/disc into disc
+      int start = lookupbits.bits(NFINERZBITS + 1, nbitsrzbin);  // first rz bin projection
+      if (iSeed_ == Seed::D1D2L2 && negdisk)                     // if projecting into disk
         start += (1 << nbitsrzbin);
-      int last = start + next;
+      int last = start + next;  // last rz bin projection
 
       if (settings_.debugTracklet()) {
-        edm::LogVerbatim("Tracklet") << "Will look in r/zbins " << start << " to " << last << endl;
+        edm::LogVerbatim("Tracklet") << "Will look in r/z bins for outer stub " << start << " to " << last << endl;
       }
 
+      // loop over outer stubs that the middle stub can project to
       for (int ibin = start; ibin <= last; ibin++) {
-        for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
-          for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
-            if (settings_.debugTracklet()) {
-              edm::LogVerbatim("Tracklet") << "In " << getName() << " have second stub(1) " << ibin << " " << j << endl;
-            }
+        for (unsigned int outmem = 0; outmem < outervmstubs_.size(); outmem++) {
+          for (unsigned int j = 0; j < outervmstubs_[outmem]->nVMStubsBinned(ibin); j++) {
+            if (settings_.debugTracklet())
+              edm::LogVerbatim("Tracklet") << "In " << getName() << " have outer stub" << endl;
 
-            const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
-            int rzbin = (secondvmstub.vmbits().value() & (settings_.NLONGVMBINS() - 1));
+            const VMStubTE& outvmstub = outervmstubs_[outmem]->getVMStubTEBinned(ibin, j);
+
+            // check if r/z of outer stub is within projection range
+            int rzbin = (outvmstub.vmbits().value() & (settings_.NLONGVMBINS() - 1));
             if (start != ibin)
               rzbin += 8;
             if (rzbin < rzbinfirst || rzbin - rzbinfirst > rzdiffmax) {
               if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong r/zbin";
+                edm::LogVerbatim("Tracklet") << "Outer stub rejected because of wrong r/z bin";
               }
               continue;
             }
 
-            // get r/z bins for projection into third layer/disc
+            // get r/z bins for projection into third layer/disk
             int nbitsrzbin_ = N_RZBITS;
-            int rzbinfirst_ = lookupbits.bits(lutshift, NFINERZBITS);  //finerz
-            int next_ = lookupbits.bits(lutshift + NFINERZBITS, 1);    //use next r/z bin
+            int rzbinfirst_ = lookupbits.bits(lutshift, NFINERZBITS);
+            int next_ = lookupbits.bits(lutshift + NFINERZBITS, 1);
             int rzdiffmax_ = lookupbits.bits(lutshift + NFINERZBITS + 1 + nbitsrzbin_, NFINERZBITS);
 
-            int start_ = lookupbits.bits(lutshift + NFINERZBITS + 1, nbitsrzbin_);  //rz bin
-            if (iSeed_ == Seed::D1D2L2 && negdisk)                                  // projecting from disk into layer
+            int start_ = lookupbits.bits(lutshift + NFINERZBITS + 1, nbitsrzbin_);  // first rz bin projection
+            if (iSeed_ == Seed::D1D2L2 && negdisk)  // if projecting from disk into layer
               start_ = settings_.NLONGVMBINS() - 1 - start_ - next_;
-            int last_ = start_ + next_;
+            int last_ = start_ + next_;  // last rz bin projection
 
             if (settings_.debugTracklet()) {
-              edm::LogVerbatim("Tracklet") << "Will look in zbins for third stub" << start_ << " to " << last_ << endl;
+              edm::LogVerbatim("Tracklet")
+                  << "Will look in rz bins for inner stub " << start_ << " to " << last_ << endl;
             }
 
+            // loop over inner stubs that the middle stub can project to
             for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
-              for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
-                for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
-                  if (settings_.debugTracklet()) {
-                    edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub\n";
-                  }
+              for (unsigned int inmem = 0; inmem < innervmstubs_.size(); inmem++) {
+                for (unsigned int l = 0; l < innervmstubs_[inmem]->nVMStubsBinned(ibin_); l++) {
+                  if (settings_.debugTracklet())
+                    edm::LogVerbatim("Tracklet") << "In " << getName() << " have inner stub" << endl;
 
-                  const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
-                  int rzbin_ = (thirdvmstub.vmbits().value() & (settings_.NLONGVMBINS() - 1));
+                  const VMStubTE& invmstub = innervmstubs_[inmem]->getVMStubTEBinned(ibin_, l);
+
+                  // check if r/z of inner stub is within projection range
+                  int rzbin_ = (invmstub.vmbits().value() & (settings_.NLONGVMBINS() - 1));
                   if (start_ != ibin_)
                     rzbin_ += 8;
                   if (rzbin_ < rzbinfirst_ || rzbin_ - rzbinfirst_ > rzdiffmax_) {
                     if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong r/zbin";
+                      edm::LogVerbatim("Tracklet") << "Inner stub rejected because of wrong r/z bin";
                     }
                     continue;
                   }
 
                   countall++;
 
-                  const Stub* innerFPGAStub = firstallstub;
-                  const Stub* middleFPGAStub = secondvmstub.stub();
-                  const Stub* outerFPGAStub = thirdvmstub.stub();
+                  const Stub* innerFPGAStub = invmstub.stub();
+                  const Stub* middleFPGAStub = midallstub;
+                  const Stub* outerFPGAStub = outvmstub.stub();
 
                   const L1TStub* innerStub = innerFPGAStub->l1tstub();
                   const L1TStub* middleStub = middleFPGAStub->l1tstub();
@@ -293,24 +292,22 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
 
                   if (settings_.debugTracklet()) {
                     edm::LogVerbatim("Tracklet")
-                        << "LLL seeding\n"
+                        << "triplet seeding\n"
                         << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
                         << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
                         << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk() << outerFPGAStub->layerdisk();
-                  }
-
-                  if (settings_.debugTracklet()) {
                     edm::LogVerbatim("Tracklet")
                         << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
                   }
 
+                  // check if the seed made from the 3 stubs is valid
                   bool accept = false;
                   if (iSeed_ == Seed::L2L3L4 || iSeed_ == Seed::L4L5L6)
-                    accept = LLLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+                    accept = LLLSeeding(innerFPGAStub, innerStub, middleFPGAStub, middleStub, outerFPGAStub, outerStub);
                   else if (iSeed_ == Seed::L2L3D1)
-                    accept = LLDSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+                    accept = LLDSeeding(innerFPGAStub, innerStub, middleFPGAStub, middleStub, outerFPGAStub, outerStub);
                   else if (iSeed_ == Seed::D1D2L2)
-                    accept = DDLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+                    accept = DDLSeeding(innerFPGAStub, innerStub, middleFPGAStub, middleStub, outerFPGAStub, outerStub);
 
                   if (accept)
                     countsel++;

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -198,12 +198,10 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
       unsigned int lutwidth = settings_.lutwidthtabextended(0, iSeed_);
       int lutval = -1;
       const auto& lutshift = innerTable_.nbits();
-      if (iSeed_ == Seed::L2L3L4 || iSeed_ == Seed::L4L5L6 || iSeed_ == Seed::D1D2L2 || iSeed_ == Seed::L2L3D1) {
-        lutval = innerTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-        int lutval2 = innerThirdTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
-        if (lutval != -1 && lutval2 != -1)
-          lutval += (lutval2 << lutshift);
-      }
+      lutval = innerTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+      int lutval2 = innerThirdTable_.lookup((indexz << nbitsrfinebintable_) + indexr);
+      if (lutval != -1 && lutval2 != -1)
+        lutval += (lutval2 << lutshift);
       if (lutval == -1)
         continue;
       FPGAWord lookupbits(lutval, lutwidth, true, __LINE__, __FILE__);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -206,10 +206,7 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
       assert(indexz < (1 << nbitszfinebintable_));
       assert(indexr < (1 << nbitsrfinebintable_));
 
-      unsigned int lutwidth = settings_.lutwidthtab(inner, iSeed_);
-      if (settings_.extended()) {
-        lutwidth = settings_.lutwidthtabextended(inner, iSeed_);
-      }
+      unsigned int lutwidth = settings_.lutwidthtabextended(inner, iSeed_);
 
       int lutval = -1;
       if (iSeed_ == Seed::L2L3L4 || iSeed_ == Seed::L4L5L6 || iSeed_ == Seed::D1D2L2 || iSeed_ == Seed::L2L3D1) {
@@ -223,367 +220,148 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
 
       FPGAWord binlookup(lutval, lutwidth, true, __LINE__, __FILE__);
 
-      if (iSeed_ == Seed::L2L3L4 || iSeed_ == Seed::L4L5L6) {
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << getName() << " Layer-layer pair\n";
-        }
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << getName() << " Layer-layer pair\n";
+      }
 
-        constexpr int andlookupbits = 1023;
-        constexpr int shiftzdiffmax = 7;
-        constexpr int andnewbin = 127;
-        constexpr int divbin = 8;
-        constexpr int andzbinfirst = 7;
-        constexpr int shiftstart = 1;
-        constexpr int andlast = 1;
-        constexpr int maxlast = 8;
+      constexpr int andlookupbits = 1023;
+      constexpr int shiftzdiffmax = 7;
+      constexpr int shiftrdiffmax = 6;
+      int andnewbin = 127;
+      if (iSeed_ == Seed::D1D2L2)
+        andnewbin = 63;
+      constexpr int divbin = 8;
+      constexpr int andzbinfirst = 7;
+      constexpr int andrbinfirst = 7;
+      constexpr int shiftstart = 1;
+      constexpr int andlast = 1;
+      constexpr int maxlast = 8;
 
-        int lookupbits = binlookup.value() & andlookupbits;
-        int zdiffmax = (lookupbits >> shiftzdiffmax);
-        int newbin = (lookupbits & andnewbin);
-        int bin = newbin / divbin;
+      int lookupbits = binlookup.value() & andlookupbits;
+      int zdiffmax = (lookupbits >> shiftzdiffmax);
+      int rdiffmax = (lookupbits >> shiftrdiffmax);
+      int newbin = (lookupbits & andnewbin);
+      int bin = newbin / divbin;
 
-        int zbinfirst = newbin & andzbinfirst;
+      int zbinfirst = newbin & andzbinfirst;
+      int rbinfirst = newbin & andrbinfirst;
 
-        int start = (bin >> shiftstart);
-        int last = start + (bin & andlast);
-
-        assert(last < maxlast);
-
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last << endl;
-        }
-
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
-            for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
-              if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet")
-                    << "In " << getName() << " have second stub(1) " << ibin << " " << j << endl;
-              }
-
-              const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
-
-              int zbin = (secondvmstub.vmbits().value() & 7);
-              if (start != ibin)
-                zbin += 8;
-              if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
-                if (settings_.debugTracklet()) {
-                  edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
-                }
-                continue;
-              }
-
-              constexpr int vmbitshift = 10;
-              constexpr int andlookupbits_ = 1023;
-              constexpr int andnewbin_ = 127;
-              constexpr int divbin_ = 8;
-              constexpr int shiftstart_ = 1;
-              constexpr int andlast_ = 1;
-
-              int lookupbits_ = (int)((binlookup.value() >> vmbitshift) & andlookupbits_);
-              int newbin_ = (lookupbits_ & andnewbin_);
-              int bin_ = newbin_ / divbin_;
-
-              int start_ = (bin_ >> shiftstart_);
-              int last_ = start_ + (bin_ & andlast_);
-
-              if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet")
-                    << "Will look in zbins for third stub" << start_ << " to " << last_ << endl;
-              }
-
-              for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
-                for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
-                  for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub\n";
-                    }
-
-                    countall++;
-
-                    const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
-
-                    const Stub* innerFPGAStub = firstallstub;
-                    const Stub* middleFPGAStub = secondvmstub.stub();
-                    const Stub* outerFPGAStub = thirdvmstub.stub();
-
-                    const L1TStub* innerStub = innerFPGAStub->l1tstub();
-                    const L1TStub* middleStub = middleFPGAStub->l1tstub();
-                    const L1TStub* outerStub = outerFPGAStub->l1tstub();
-
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet")
-                          << "LLL seeding\n"
-                          << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
-                          << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
-                          << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk() << outerFPGAStub->layerdisk();
-                    }
-
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet")
-                          << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
-                    }
-
-                    if (innerFPGAStub->layerdisk() < N_LAYER && middleFPGAStub->layerdisk() < N_LAYER &&
-                        outerFPGAStub->layerdisk() < N_LAYER) {
-                      bool accept =
-                          LLLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
-
-                      if (accept)
-                        countsel++;
-                    } else if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
-                               outerFPGAStub->layerdisk() >= N_LAYER) {
-                      throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
-                    }
-
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
-                    }
-                    if (countall >= settings_.maxStep("TPD"))
-                      break;
-                  }
-                  if (countall >= settings_.maxStep("TPD"))
-                    break;
-                }
-              }
-              if (countall >= settings_.maxStep("TPD"))
-                break;
-            }
-            if (countall >= settings_.maxStep("TPD"))
-              break;
-          }
-          if (countall >= settings_.maxStep("TPD"))
-            break;
-        }
-
-      } else if (iSeed_ == Seed::L2L3D1) {
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << getName() << " Layer-layer pair";
-        }
-
-        constexpr int andlookupbits = 1023;
-        constexpr int shiftzdiffmax = 7;
-        constexpr int andnewbin = 127;
-        constexpr int divbin = 8;
-        constexpr int andzbinfirst = 7;
-        constexpr int shiftstart = 1;
-        constexpr int andlast = 1;
-        constexpr int maxlast = 8;
-
-        int lookupbits = binlookup.value() & andlookupbits;
-        int zdiffmax = (lookupbits >> shiftzdiffmax);
-        int newbin = (lookupbits & andnewbin);
-        int bin = newbin / divbin;
-
-        int zbinfirst = newbin & andzbinfirst;
-
-        int start = (bin >> shiftstart);
-        int last = start + (bin & andlast);
-
-        assert(last < maxlast);
-
-        if (settings_.debugTracklet()) {
-          edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last;
-        }
-
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
-            for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
-              if (settings_.debugTracklet()) {
-                edm::LogVerbatim("Tracklet") << "In " << getName() << " have second stub(1) " << ibin << " " << j;
-              }
-
-              const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
-
-              int zbin = (secondvmstub.vmbits().value() & 7);
-              if (start != ibin)
-                zbin += 8;
-              if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
-                if (settings_.debugTracklet()) {
-                  edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
-                }
-                continue;
-              }
-
-              constexpr int vmbitshift = 10;
-              constexpr int andlookupbits_ = 1023;
-              constexpr int andnewbin_ = 127;
-              constexpr int divbin_ = 8;
-              constexpr int shiftstart_ = 1;
-              constexpr int andlast_ = 1;
-
-              int lookupbits_ = (int)((binlookup.value() >> vmbitshift) & andlookupbits_);
-              int newbin_ = (lookupbits_ & andnewbin_);
-              int bin_ = newbin_ / divbin_;
-
-              int start_ = (bin_ >> shiftstart_);
-              int last_ = start_ + (bin_ & andlast_);
-
-              for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
-                for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
-                  for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
-                    }
-
-                    countall++;
-
-                    const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
-
-                    const Stub* innerFPGAStub = firstallstub;
-                    const Stub* middleFPGAStub = secondvmstub.stub();
-                    const Stub* outerFPGAStub = thirdvmstub.stub();
-
-                    const L1TStub* innerStub = innerFPGAStub->l1tstub();
-                    const L1TStub* middleStub = middleFPGAStub->l1tstub();
-                    const L1TStub* outerStub = outerFPGAStub->l1tstub();
-
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet")
-                          << "LLD seeding\n"
-                          << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
-                          << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
-                          << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk() << outerFPGAStub->layerdisk();
-                    }
-
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet")
-                          << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
-                    }
-
-                    bool accept =
-                        LLDSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
-
-                    if (accept)
-                      countsel++;
-
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
-                    }
-                    if (countall >= settings_.maxStep("TPD"))
-                      break;
-                  }
-                  if (countall >= settings_.maxStep("TPD"))
-                    break;
-                }
-              }
-              if (countall >= settings_.maxStep("TPD"))
-                break;
-            }
-            if (countall >= settings_.maxStep("TPD"))
-              break;
-          }
-          if (countall >= settings_.maxStep("TPD"))
-            break;
-        }
-
-      } else if (iSeed_ == Seed::D1D2L2) {
-        if (settings_.debugTracklet())
-          edm::LogVerbatim("Tracklet") << getName() << " Disk-disk pair";
-
-        constexpr int andlookupbits = 511;
-        constexpr int shiftrdiffmax = 6;
-        constexpr int andnewbin = 63;
-        constexpr int divbin = 8;
-        constexpr int andrbinfirst = 7;
-        constexpr int shiftstart = 1;
-        constexpr int andlast = 1;
-        constexpr int maxlast = 8;
-
-        int lookupbits = binlookup.value() & andlookupbits;
+      int start = (bin >> shiftstart);
+      if (iSeed_ == Seed::D1D2L2) {
         bool negdisk = firstallstub->disk().value() < 0;
-        int rdiffmax = (lookupbits >> shiftrdiffmax);
-        int newbin = (lookupbits & andnewbin);
-        int bin = newbin / divbin;
-
-        int rbinfirst = newbin & andrbinfirst;
-
-        int start = (bin >> shiftstart);
         if (negdisk)
           start += 4;
-        int last = start + (bin & andlast);
-        assert(last < maxlast);
+      }
+      int last = start + (bin & andlast);
 
-        for (int ibin = start; ibin <= last; ibin++) {
-          for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
+      assert(last < maxlast);
+
+      if (settings_.debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << "Will look in zbins " << start << " to " << last << endl;
+      }
+
+      for (int ibin = start; ibin <= last; ibin++) {
+        for (unsigned int m = 0; m < outervmstubs_.size(); m++) {
+          for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
             if (settings_.debugTracklet()) {
-              edm::LogVerbatim("Tracklet")
-                  << getName() << " looking for matching stub in " << outervmstubs_.at(m)->getName()
-                  << " in bin = " << ibin << " with " << outervmstubs_.at(m)->nVMStubsBinned(ibin) << " stubs";
+              edm::LogVerbatim("Tracklet") << "In " << getName() << " have second stub(1) " << ibin << " " << j << endl;
             }
 
-            for (unsigned int j = 0; j < outervmstubs_.at(m)->nVMStubsBinned(ibin); j++) {
-              const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
-              int rbin = (secondvmstub.vmbits().value() & 7);
-              if (start != ibin)
-                rbin += 8;
-              if (rbin < rbinfirst)
-                continue;
-              if (rbin - rbinfirst > rdiffmax)
-                continue;
+            const VMStubTE& secondvmstub = outervmstubs_.at(m)->getVMStubTEBinned(ibin, j);
 
-              constexpr int vmbitshift = 10;
-              constexpr int andlookupbits_ = 1023;
-              constexpr int andnewbin_ = 127;
-              constexpr int divbin_ = 8;
-              constexpr int shiftstart_ = 1;
-              constexpr int andlast_ = 1;
+            int zbin = (secondvmstub.vmbits().value() & 7);
+            if (start != ibin)
+              zbin += 8;
+            if (zbin < zbinfirst || zbin - zbinfirst > zdiffmax) {
+              if (settings_.debugTracklet()) {
+                edm::LogVerbatim("Tracklet") << "Stubpair rejected because of wrong zbin";
+              }
+              continue;
+            }
+            int rbin = (secondvmstub.vmbits().value() & 7);
+            if (start != ibin)
+              rbin += 8;
+            if (rbin < rbinfirst)
+              continue;
+            if (rbin - rbinfirst > rdiffmax)
+              continue;
 
-              int lookupbits_ = (int)((binlookup.value() >> vmbitshift) & andlookupbits_);
-              int newbin_ = (lookupbits_ & andnewbin_);
-              int bin_ = newbin_ / divbin_;
+            constexpr int vmbitshift = 10;
+            constexpr int andlookupbits_ = 1023;
+            constexpr int andnewbin_ = 127;
+            constexpr int divbin_ = 8;
+            constexpr int shiftstart_ = 1;
+            constexpr int andlast_ = 1;
 
-              int start_ = (bin_ >> shiftstart_);
-              int last_ = start_ + (bin_ & andlast_);
+            int lookupbits_ = (int)((binlookup.value() >> vmbitshift) & andlookupbits_);
+            int newbin_ = (lookupbits_ & andnewbin_);
+            int bin_ = newbin_ / divbin_;
 
+            int start_ = (bin_ >> shiftstart_);
+            int last_ = start_ + (bin_ & andlast_);
+            if (iSeed_ == Seed::D1D2L2) {
               if (firstallstub->disk().value() < 0) {  //TODO - negative disk should come from memory
                 start_ = settings_.NLONGVMBINS() - last_ - 1;
                 last_ = settings_.NLONGVMBINS() - start_ - 1;
               }
+            }
 
-              for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
-                for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
-                  for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub";
+            if (settings_.debugTracklet()) {
+              edm::LogVerbatim("Tracklet") << "Will look in zbins for third stub" << start_ << " to " << last_ << endl;
+            }
+
+            for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
+              for (unsigned int k = 0; k < innervmstubs_.size(); k++) {
+                for (unsigned int l = 0; l < innervmstubs_.at(k)->nVMStubsBinned(ibin_); l++) {
+                  if (settings_.debugTracklet()) {
+                    edm::LogVerbatim("Tracklet") << "In " << getName() << " have third stub\n";
+                  }
+
+                  countall++;
+
+                  const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
+
+                  const Stub* innerFPGAStub = firstallstub;
+                  const Stub* middleFPGAStub = secondvmstub.stub();
+                  const Stub* outerFPGAStub = thirdvmstub.stub();
+
+                  const L1TStub* innerStub = innerFPGAStub->l1tstub();
+                  const L1TStub* middleStub = middleFPGAStub->l1tstub();
+                  const L1TStub* outerStub = outerFPGAStub->l1tstub();
+
+                  if (settings_.debugTracklet()) {
+                    edm::LogVerbatim("Tracklet")
+                        << "LLL seeding\n"
+                        << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
+                        << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
+                        << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk() << outerFPGAStub->layerdisk();
+                  }
+
+                  if (settings_.debugTracklet()) {
+                    edm::LogVerbatim("Tracklet")
+                        << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
+                  }
+
+                  bool accept = false;
+                  if (iSeed_ == Seed::L2L3L4 || iSeed_ == Seed::L4L5L6) {
+                    if (innerFPGAStub->layerdisk() < N_LAYER && middleFPGAStub->layerdisk() < N_LAYER &&
+                        outerFPGAStub->layerdisk() < N_LAYER) {
+                      accept =
+                          LLLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+                    } else if (innerFPGAStub->layerdisk() >= N_LAYER && middleFPGAStub->layerdisk() >= N_LAYER &&
+                               outerFPGAStub->layerdisk() >= N_LAYER) {
+                      throw cms::Exception("LogicError") << __FILE__ << " " << __LINE__ << " Invalid seeding!";
                     }
+                  } else if (iSeed_ == Seed::L2L3D1)
+                    accept = LLDSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
+                  else if (iSeed_ == Seed::D1D2L2)
+                    accept = DDLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
 
-                    countall++;
+                  if (accept)
+                    countsel++;
 
-                    const VMStubTE& thirdvmstub = innervmstubs_.at(k)->getVMStubTEBinned(ibin_, l);
-
-                    const Stub* innerFPGAStub = firstallstub;
-                    const Stub* middleFPGAStub = secondvmstub.stub();
-                    const Stub* outerFPGAStub = thirdvmstub.stub();
-
-                    const L1TStub* innerStub = innerFPGAStub->l1tstub();
-                    const L1TStub* middleStub = middleFPGAStub->l1tstub();
-                    const L1TStub* outerStub = outerFPGAStub->l1tstub();
-
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet")
-                          << "DDL seeding\n"
-                          << innerFPGAStub->strbare() << middleFPGAStub->strbare() << outerFPGAStub->strbare()
-                          << innerStub->stubword() << middleStub->stubword() << outerStub->stubword()
-                          << innerFPGAStub->layerdisk() << middleFPGAStub->layerdisk() << outerFPGAStub->layerdisk();
-                    }
-
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet")
-                          << "TrackletCalculatorDisplaced execute " << getName() << "[" << iSector_ << "]";
-                    }
-
-                    bool accept =
-                        DDLSeeding(outerFPGAStub, outerStub, innerFPGAStub, innerStub, middleFPGAStub, middleStub);
-
-                    if (accept)
-                      countsel++;
-
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
-                    }
-                    if (countall >= settings_.maxStep("TPD"))
-                      break;
+                  if (settings_.debugTracklet()) {
+                    edm::LogVerbatim("Tracklet") << "TrackletCalculatorDisplaced execute done";
                   }
                   if (countall >= settings_.maxStep("TPD"))
                     break;

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -164,8 +164,8 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
 
   // loop over the middle stubs in the potential seed
   for (unsigned int midmem = 0; midmem < middleallstubs_.size(); midmem++) {
-    for (unsigned int j = 0; j < middleallstubs_[midmem]->nStubs(); j++) {
-      const Stub* midallstub = middleallstubs_[midmem]->getStub(j);
+    for (unsigned int i = 0; i < middleallstubs_[midmem]->nStubs(); i++) {
+      const Stub* midallstub = middleallstubs_[midmem]->getStub(i);
 
       if (settings_.debugTracklet()) {
         edm::LogVerbatim("Tracklet") << "In " << getName() << " have middle stub";
@@ -246,9 +246,7 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
 
             // get r/z bins for projection into third layer/disk
             int nbitsrzbin_ = N_RZBITS;
-            int rzbinfirst_ = lookupbits.bits(lutshift, NFINERZBITS);
             int next_ = lookupbits.bits(lutshift + NFINERZBITS, 1);
-            int rzdiffmax_ = lookupbits.bits(lutshift + NFINERZBITS + 1 + nbitsrzbin_, NFINERZBITS);
 
             int start_ = lookupbits.bits(lutshift + NFINERZBITS + 1, nbitsrzbin_);  // first rz bin projection
             if (iSeed_ == Seed::D1D2L2 && negdisk)  // if projecting from disk into layer
@@ -263,22 +261,11 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
             // loop over inner stubs that the middle stub can project to
             for (int ibin_ = start_; ibin_ <= last_; ibin_++) {
               for (unsigned int inmem = 0; inmem < innervmstubs_.size(); inmem++) {
-                for (unsigned int l = 0; l < innervmstubs_[inmem]->nVMStubsBinned(ibin_); l++) {
+                for (unsigned int k = 0; k < innervmstubs_[inmem]->nVMStubsBinned(ibin_); k++) {
                   if (settings_.debugTracklet())
                     edm::LogVerbatim("Tracklet") << "In " << getName() << " have inner stub" << endl;
 
-                  const VMStubTE& invmstub = innervmstubs_[inmem]->getVMStubTEBinned(ibin_, l);
-
-                  // check if r/z of inner stub is within projection range
-                  int rzbin_ = (invmstub.vmbits().value() & (settings_.NLONGVMBINS() - 1));
-                  if (start_ != ibin_)
-                    rzbin_ += 8;
-                  if (rzbin_ < rzbinfirst_ || rzbin_ - rzbinfirst_ > rzdiffmax_) {
-                    if (settings_.debugTracklet()) {
-                      edm::LogVerbatim("Tracklet") << "Inner stub rejected because of wrong r/z bin";
-                    }
-                    continue;
-                  }
+                  const VMStubTE& invmstub = innervmstubs_[inmem]->getVMStubTEBinned(ibin_, k);
 
                   countall++;
 


### PR DESCRIPTION
#### PR description:

This work cleans up TrackletProcessorDisplaced in anticipation of the re-structuring required make it follow the TrackletProcessor structure. Clean ups include removing code that is never used, removing repetitive code, removing magic numbers, and using functions that have been developed for TrackletProcessor and have not been updated here. This new version of code should be much easier to work with.

Additionally, one bug was found and fixed. The bug was preventing a lot of D1D2L2 seeds in the negative disk region from being produced (bug [here](https://github.com/cms-L1TK/cmssw/blob/L1TK-dev-14_0_0_pre2/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc#L636-L639)). The fix increases the tracking efficiency in the negative eta region for displaced tracking particles (|d0|>1 cm) while keeping the efficiency the same everywhere else. Following plot shows perfect matching between the clean up and original version of the code, in addition to the increase in efficiency for low eta with the bug fix:
<img width="388" alt="image" src="https://github.com/user-attachments/assets/51f3a4e0-dce2-46b3-a25d-9b2de8947688">


#### PR validation:

I verified that all of the seeds produced before and after these changes are exactly the same, with the exception of more D1D2L2 seeds being produced in the negative disk region due to the bug fix.
