### PR TITLE
scram b code-format with latest CMSSW version

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTStub.h
+++ b/DataFormats/L1TrackTrigger/interface/TTStub.h
@@ -111,7 +111,7 @@ private:
   bool thePSModule;
 
   static constexpr float dummyBend = 999999;  // Dumy value should be away from potential bends
-};                                            /// Close class
+};  /// Close class
 
 /*! \brief   Implementation of methods
  *  \details Here, in the header file, the methods which do not depend

--- a/L1Trigger/TrackFindingTMTT/interface/Histos.h
+++ b/L1Trigger/TrackFindingTMTT/interface/Histos.h
@@ -89,9 +89,9 @@ namespace tmtt {
 
     // For Hybrid tracking
     // Produce plots of tracklet seed finding efficiency before track reco
-    virtual void plotTrackletSeedEfficiency(){};
+    virtual void plotTrackletSeedEfficiency() {};
     // Produce plots of hybrid duplicate removal efficiency after track reco
-    virtual void plotHybridDupRemovalEfficiency(){};
+    virtual void plotHybridDupRemovalEfficiency() {};
 
     virtual void makeEfficiencyPlot(
         TFileDirectory& inputDir, TEfficiency* outputEfficiency, TH1F* pass, TH1F* all, TString name, TString title);
@@ -104,10 +104,10 @@ namespace tmtt {
 
     // For Hybrid tracking
     // Print summary of seed finding and extrapolation performance during track pattern reco.
-    virtual void printTrackletSeedFindingPerformance(){};
+    virtual void printTrackletSeedFindingPerformance() {};
 
     // Print summary of duplicate removal performance after track pattern reco.
-    virtual void printHybridDupRemovalPerformance(){};
+    virtual void printHybridDupRemovalPerformance() {};
 
   protected:
     edm::Service<TFileService> fs_;

--- a/L1Trigger/TrackFindingTMTT/interface/PrintL1trk.h
+++ b/L1Trigger/TrackFindingTMTT/interface/PrintL1trk.h
@@ -11,7 +11,7 @@ namespace tmtt {
 
   class PrintL1trk {
   public:
-    PrintL1trk(unsigned int nDigits = 4) : lv_("L1track"), nDigits_(nDigits){};
+    PrintL1trk(unsigned int nDigits = 4) : lv_("L1track"), nDigits_(nDigits) {};
 
     template <class T>
     edm::LogVerbatim& operator<<(const T& t) {

--- a/L1Trigger/TrackFindingTMTT/plugins/TMTrackProducer.cc
+++ b/L1Trigger/TrackFindingTMTT/plugins/TMTrackProducer.cc
@@ -104,8 +104,7 @@ namespace tmtt {
 
     std::stringstream text;
     text << "\n--- B field = " << bField << " Tesla ---\n";
-    std::call_once(
-        printOnce, [](string t) { PrintL1trk() << t; }, text.str());
+    std::call_once(printOnce, [](string t) { PrintL1trk() << t; }, text.str());
 
     // Get tracker geometry
     trackerGeometry_ = &(iSetup.getData(trackerGeometryToken_));

--- a/L1Trigger/TrackFindingTMTT/src/HTrphi.cc
+++ b/L1Trigger/TrackFindingTMTT/src/HTrphi.cc
@@ -160,8 +160,7 @@ namespace tmtt {
     }
     text << "\n";
     static std::once_flag printOnce;
-    std::call_once(
-        printOnce, [](string t) { PrintL1trk() << t; }, text.str());
+    std::call_once(printOnce, [](string t) { PrintL1trk() << t; }, text.str());
 
     // Note helix parameters at the centre of each HT cell.
     cellCenters_.clear();

--- a/L1Trigger/TrackFindingTMTT/src/Histos.cc
+++ b/L1Trigger/TrackFindingTMTT/src/Histos.cc
@@ -673,8 +673,7 @@ namespace tmtt {
               std::stringstream text;
               text << "\n ===== HISTOS MESS UP: Increase size of nLinks ===== " << link << "\n";
               static std::once_flag printOnce;
-              std::call_once(
-                  printOnce, [](string t) { edm::LogWarning("L1track") << t; }, text.str());
+              std::call_once(printOnce, [](string t) { edm::LogWarning("L1track") << t; }, text.str());
             }
           }
         }

--- a/L1Trigger/TrackFindingTMTT/src/MuxHToutputs.cc
+++ b/L1Trigger/TrackFindingTMTT/src/MuxHToutputs.cc
@@ -45,8 +45,7 @@ namespace tmtt {
     text << "=== The R-PHI HT output is multiplexed onto " << this->numLinksPerNonant()
          << " pairs of opto-links per nonant.";
     static std::once_flag printOnce;
-    std::call_once(
-        printOnce, [](string t) { PrintL1trk() << t; }, text.str());
+    std::call_once(printOnce, [](string t) { PrintL1trk() << t; }, text.str());
   }
 
   //=== Determine which tracks are transmitted on each HT output optical link, taking into account the multiplexing

--- a/L1Trigger/TrackFindingTMTT/src/TrackerModule.cc
+++ b/L1Trigger/TrackFindingTMTT/src/TrackerModule.cc
@@ -120,8 +120,7 @@ namespace tmtt {
       std::stringstream text;
       text << "WARNING: TrackerModule found tracker module type unknown to firmware: pitch=" << pitch
            << " separation=" << space << " barrel=" << barrel << " tilted=" << tiltedBarrel << " PS=" << psModule;
-      std::call_once(
-          printOnce, [](string t) { edm::LogWarning("L1track") << t; }, text.str());
+      std::call_once(printOnce, [](string t) { edm::LogWarning("L1track") << t; }, text.str());
     }
     return moduleType;
   }

--- a/L1Trigger/TrackFindingTracklet/interface/HitPatternHelper.h
+++ b/L1Trigger/TrackFindingTracklet/interface/HitPatternHelper.h
@@ -83,7 +83,7 @@ namespace hph {
     std::map<int, std::map<int, std::vector<int>>> layermap_;  // Hard-coded layermap in Old KF
     int nEtaRegions_;                                          // # of eta regions
     int nKalmanLayers_;                                        // # of maximum KF layers allowed
-  };                                                           // Only needed by Old KF
+  };  // Only needed by Old KF
 
   //Class that returns decoded information from hitpattern
   class HitPatternHelper {
@@ -96,8 +96,8 @@ namespace hph {
     int numMissingPS() {
       return numMissingPS_;
     }  //The number of PS layers that are missing. It includes layers that are missing:
-       //1)before the innermost stub on the track,
-       //2)after the outermost stub on the track.
+    //1)before the innermost stub on the track,
+    //2)after the outermost stub on the track.
     int numMissing2S() {
       return numMissing2S_;
     }  //The number of 2S layers that are missing. It includes the two types of layers mentioned above.

--- a/L1Trigger/TrackFindingTracklet/interface/VMRouter.h
+++ b/L1Trigger/TrackFindingTracklet/interface/VMRouter.h
@@ -24,7 +24,7 @@ namespace trklet {
     VMStubsTEPHI(unsigned int seednumber_,
                  unsigned int stubposition_,
                  std::vector<std::vector<VMStubsTEMemory*> > vmstubmem_)
-        : seednumber(seednumber_), stubposition(stubposition_), vmstubmem(vmstubmem_){};
+        : seednumber(seednumber_), stubposition(stubposition_), vmstubmem(vmstubmem_) {};
 
     unsigned int seednumber;    //seed number [0,11]
     unsigned int stubposition;  //stub position in the seed

--- a/L1Trigger/TrackFindingTracklet/interface/VMRouterCM.h
+++ b/L1Trigger/TrackFindingTracklet/interface/VMRouterCM.h
@@ -25,7 +25,7 @@ namespace trklet {
     VMStubsTEPHICM(unsigned int seednumber_,
                    unsigned int stubposition_,
                    std::vector<std::vector<VMStubsTEMemory*> > vmstubmem_)
-        : seednumber(seednumber_), stubposition(stubposition_), vmstubmem(vmstubmem_){};
+        : seednumber(seednumber_), stubposition(stubposition_), vmstubmem(vmstubmem_) {};
 
     unsigned int seednumber;    //seed number [0,11]
     unsigned int stubposition;  //stub position in the seed (only used by triplet seeds)

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerKFout.cc
@@ -307,7 +307,7 @@ namespace trklet {
           temp_tttrack.setTrackWordBits();
           ttTracks.emplace_back(temp_tttrack);
         }  // Iterate over Tracks
-      }    // Iterate over Links
+      }  // Iterate over Links
       const OrphanHandle<tt::TTTracks> orphanHandleTTTracks = iEvent.emplace(edPutTokenTTTracks_, std::move(ttTracks));
 
       // sort partial KFout tracks into 18 separate links (nonant idx * eta idx) with tttrack ref info

--- a/L1Trigger/TrackFindingTracklet/src/TrackDerTable.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackDerTable.cc
@@ -611,7 +611,7 @@ void TrackDerTable::fillTable() {
             ider++;
 
           }  // for (unsigned int ihit = 1; ihit < 12; ++ihit)
-        }    // if (goodseed)
+        }  // if (goodseed)
 
         FPGAWord tmprinvdphi[N_PROJ];
         int nbits = 16;

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1023,7 +1023,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
           v_jets_vhighpt.push_back(0);
 
       }  // end loop over genjets
-    }    // end isValid
+    }  // end isValid
 
   }  // end TrackingInJets
 

--- a/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
+++ b/L1Trigger/TrackTrigger/plugins/TTStubBuilder.cc
@@ -81,7 +81,7 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::updateStubs(
       outputFiller.push_back(tempTTStub);
 
     }  /// End of loop over stubs of this module
-  }    /// End of loop over stub DetSetVector
+  }  /// End of loop over stub DetSetVector
 }
 
 /// Implement the producer
@@ -206,7 +206,7 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
           tempTTStub.setBendBE(thisHardBend);
           tempOutput.push_back(tempTTStub);
         }  /// Stub accepted
-      }    /// End of loop over upper clusters
+      }  /// End of loop over upper clusters
 
       /// Here tempOutput stores all the stubs from this lower cluster
       /// Check if there is need to store only one or two (2S/PS modules cases) (if only one already, skip this step)
@@ -336,8 +336,8 @@ void TTStubBuilder<Ref_Phase2TrackerDigi_>::produce(edm::Event& iEvent, const ed
             }
           }
         }  /// End of check on max number of stubs per module
-      }    /// End of nested loop
-    }      /// End of loop over pairs of Clusters
+      }  /// End of nested loop
+    }  /// End of loop over pairs of Clusters
 
     /// Fill output collections
     if (not tempClusLowerAcc.empty())

--- a/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc
+++ b/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_neighbor.cc
@@ -67,5 +67,5 @@ void TTClusterAlgorithm_neighbor<Ref_Phase2TrackerDigi_>::addNeighbors(std::vect
         used[i] = true;
       }
     }  /// End of loop over candidate neighbours
-  }    /// End of loop over hits
+  }  /// End of loop over hits
 }

--- a/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc
@@ -167,5 +167,5 @@ void TTClusterAlgorithm_official<Ref_Phase2TrackerDigi_>::Cluster(
         output.push_back(candCluster);
       }
     }  /// End of non-PS case
-  }    /// End of loop over mapped 1D Clusters
+  }  /// End of loop over mapped 1D Clusters
 }

--- a/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTStubAlgorithm_official.cc
@@ -123,7 +123,7 @@ void TTStubAlgorithm_official<Ref_Phase2TrackerDigi_>::PatternHitCorrelation(
     aDisplacement = dispI;                                                     /// In HALF-STRIP units!
     anOffset = offsetI;                                                        /// In HALF-STRIP units!
     anHardBend = this->degradeBend(isPS, window, (aDisplacement - anOffset));  // In strips units
-  }                                                                            /// End of stub is accepted
+  }  /// End of stub is accepted
 }
 
 //--- Does the actual work of degrading the bend. (based on I.Tomalin's code)

--- a/L1Trigger/TrackerTFP/interface/DataFormats.h
+++ b/L1Trigger/TrackerTFP/interface/DataFormats.h
@@ -998,7 +998,7 @@ namespace trackerTFP {
           track_(track),
           trackID_(trackID),
           linkID_(linkID),
-          valid_(valid){};
+          valid_(valid) {};
 
     ~TrackKFOut() {}
 


### PR DESCRIPTION
#### PR description:

Ran "scram b code-format" with CMSSW_14_2_0_pre3, so as to minimise conflicts when rebasing to that version.

P.S. This causes code to fail code-format checks in 14_0_0_pre2, but can be fixed next time somone makes a PR.