### PR TITLE
Re-naming dxy to lxy in L1TrackNtupleMaker and including a trk_charge branch

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -220,10 +220,10 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
                   if (st1.first == st2.first && st1.second == st2.second) {  // tracks share stub
                     // Converts layer/disk encoded in st1->first to an index in the layer array
                     int i = st1.first;  // layer/disk
-                    bool barrel = (i > 0 && i < 10);
-                    bool endcapA = (i > 10);
+                    bool barrel = (i > 0 && i <= N_LAYER);
+                    bool endcapA = (i > N_LAYER);
                     bool endcapB = (i < 0);
-                    int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
+                    int lay = barrel * (i - 1) + endcapA * (i - (N_LAYER - 1)) - endcapB * i;  // encode in range 0-15
                     if (!layerArr[lay]) {
                       nShareLay++;
                       layerArr[lay] = true;
@@ -260,10 +260,10 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // For each stub on the second track, find the stub with the best residual and store its index in the layStubidsTrk1 array
               for (unsigned int stcount = 0; stcount < stubsTrk2.size(); stcount++) {
                 int i = stubsTrk2[stcount].first;  // layer/disk
-                bool barrel = (i > 0 && i < 10);
-                bool endcapA = (i > 10);
+                bool barrel = (i > 0 && i <= N_LAYER);
+                bool endcapA = (i > N_LAYER);
                 bool endcapB = (i < 0);
-                int lay = barrel * (i - 1) + endcapA * (i - 5) - endcapB * i;  // encode in range 0-15
+                int lay = barrel * (i - 1) + endcapA * (i - (N_LAYER - 1)) - endcapB * i;  // encode in range 0-15
                 double nres = getPhiRes(inputtracklets_[jtrk], fullStubslistsTrk2[stcount]);
                 double ores = 0;
                 if (layStubidsTrk2[lay] != -1)

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -67,6 +67,7 @@
 #include <TCanvas.h>
 #include <TTree.h>
 #include <TFile.h>
+#include <TMath.h>
 #include <TF1.h>
 #include <TH2F.h>
 #include <TH1F.h>
@@ -182,6 +183,7 @@ private:
   std::vector<int>* m_trk_nLost2Sstub_hitpattern;
   std::vector<int>* m_trk_nLoststub_V1_hitpattern;  // Same as the definiton of "nlaymiss_interior" in TrackQuality.cc
   std::vector<int>* m_trk_nLoststub_V2_hitpattern;  // A tighter version of "nlaymiss_interior"
+  std::vector<int>* m_trk_charge;
   std::vector<unsigned int>* m_trk_phiSector;
   std::vector<int>* m_trk_etaSector;
   std::vector<int>* m_trk_genuine;
@@ -195,7 +197,7 @@ private:
   std::vector<float>* m_trk_matchtp_eta;
   std::vector<float>* m_trk_matchtp_phi;
   std::vector<float>* m_trk_matchtp_z0;
-  std::vector<float>* m_trk_matchtp_dxy;
+  std::vector<float>* m_trk_matchtp_lxy;
   std::vector<float>* m_trk_matchtp_d0;
   std::vector<int>* m_trk_injet;          //is the track within dR<0.4 of a genjet with pt > 30 GeV?
   std::vector<int>* m_trk_injet_highpt;   //is the track within dR<0.4 of a genjet with pt > 100 GeV?
@@ -206,7 +208,7 @@ private:
   std::vector<float>* m_tp_pt;
   std::vector<float>* m_tp_eta;
   std::vector<float>* m_tp_phi;
-  std::vector<float>* m_tp_dxy;
+  std::vector<float>* m_tp_lxy;
   std::vector<float>* m_tp_d0;
   std::vector<float>* m_tp_z0;
   std::vector<float>* m_tp_d0_prod;
@@ -239,6 +241,7 @@ private:
   std::vector<int>* m_matchtrk_dhits;
   std::vector<int>* m_matchtrk_seed;
   std::vector<int>* m_matchtrk_hitpattern;
+  std::vector<int>* m_matchtrk_charge;
   std::vector<int>* m_matchtrk_injet;
   std::vector<int>* m_matchtrk_injet_highpt;
   std::vector<int>* m_matchtrk_injet_vhighpt;
@@ -362,6 +365,7 @@ void L1TrackNtupleMaker::endJob() {
   delete m_trk_nLost2Sstub_hitpattern;
   delete m_trk_nLoststub_V1_hitpattern;
   delete m_trk_nLoststub_V2_hitpattern;
+  delete m_trk_charge;
   delete m_trk_phiSector;
   delete m_trk_etaSector;
   delete m_trk_genuine;
@@ -375,7 +379,7 @@ void L1TrackNtupleMaker::endJob() {
   delete m_trk_matchtp_eta;
   delete m_trk_matchtp_phi;
   delete m_trk_matchtp_z0;
-  delete m_trk_matchtp_dxy;
+  delete m_trk_matchtp_lxy;
   delete m_trk_matchtp_d0;
   delete m_trk_injet;
   delete m_trk_injet_highpt;
@@ -384,7 +388,7 @@ void L1TrackNtupleMaker::endJob() {
   delete m_tp_pt;
   delete m_tp_eta;
   delete m_tp_phi;
-  delete m_tp_dxy;
+  delete m_tp_lxy;
   delete m_tp_d0;
   delete m_tp_z0;
   delete m_tp_d0_prod;
@@ -416,6 +420,7 @@ void L1TrackNtupleMaker::endJob() {
   delete m_matchtrk_lhits;
   delete m_matchtrk_seed;
   delete m_matchtrk_hitpattern;
+  delete m_matchtrk_charge;
   delete m_matchtrk_injet;
   delete m_matchtrk_injet_highpt;
   delete m_matchtrk_injet_vhighpt;
@@ -483,6 +488,7 @@ void L1TrackNtupleMaker::beginJob() {
   m_trk_nLost2Sstub_hitpattern = new std::vector<int>;
   m_trk_nLoststub_V1_hitpattern = new std::vector<int>;
   m_trk_nLoststub_V2_hitpattern = new std::vector<int>;
+  m_trk_charge = new std::vector<int>;
   m_trk_phiSector = new std::vector<unsigned int>;
   m_trk_etaSector = new std::vector<int>;
   m_trk_genuine = new std::vector<int>;
@@ -496,7 +502,7 @@ void L1TrackNtupleMaker::beginJob() {
   m_trk_matchtp_eta = new std::vector<float>;
   m_trk_matchtp_phi = new std::vector<float>;
   m_trk_matchtp_z0 = new std::vector<float>;
-  m_trk_matchtp_dxy = new std::vector<float>;
+  m_trk_matchtp_lxy = new std::vector<float>;
   m_trk_matchtp_d0 = new std::vector<float>;
   m_trk_injet = new std::vector<int>;
   m_trk_injet_highpt = new std::vector<int>;
@@ -506,7 +512,7 @@ void L1TrackNtupleMaker::beginJob() {
   m_tp_pt = new std::vector<float>;
   m_tp_eta = new std::vector<float>;
   m_tp_phi = new std::vector<float>;
-  m_tp_dxy = new std::vector<float>;
+  m_tp_lxy = new std::vector<float>;
   m_tp_d0 = new std::vector<float>;
   m_tp_z0 = new std::vector<float>;
   m_tp_d0_prod = new std::vector<float>;
@@ -538,6 +544,7 @@ void L1TrackNtupleMaker::beginJob() {
   m_matchtrk_lhits = new std::vector<int>;
   m_matchtrk_seed = new std::vector<int>;
   m_matchtrk_hitpattern = new std::vector<int>;
+  m_matchtrk_charge = new std::vector<int>;
   m_matchtrk_injet = new std::vector<int>;
   m_matchtrk_injet_highpt = new std::vector<int>;
   m_matchtrk_injet_vhighpt = new std::vector<int>;
@@ -598,6 +605,7 @@ void L1TrackNtupleMaker::beginJob() {
     eventTree->Branch("trk_nLost2Sstub_hitpattern", &m_trk_nLost2Sstub_hitpattern);
     eventTree->Branch("trk_nLoststub_V1_hitpattern", &m_trk_nLoststub_V1_hitpattern);
     eventTree->Branch("trk_nLoststub_V2_hitpattern", &m_trk_nLoststub_V2_hitpattern);
+    eventTree->Branch("trk_charge", &m_trk_charge);
     eventTree->Branch("trk_phiSector", &m_trk_phiSector);
     eventTree->Branch("trk_etaSector", &m_trk_etaSector);
     eventTree->Branch("trk_genuine", &m_trk_genuine);
@@ -611,7 +619,7 @@ void L1TrackNtupleMaker::beginJob() {
     eventTree->Branch("trk_matchtp_eta", &m_trk_matchtp_eta);
     eventTree->Branch("trk_matchtp_phi", &m_trk_matchtp_phi);
     eventTree->Branch("trk_matchtp_z0", &m_trk_matchtp_z0);
-    eventTree->Branch("trk_matchtp_dxy", &m_trk_matchtp_dxy);
+    eventTree->Branch("trk_matchtp_lxy", &m_trk_matchtp_lxy);
     eventTree->Branch("trk_matchtp_d0", &m_trk_matchtp_d0);
     if (TrackingInJets) {
       eventTree->Branch("trk_injet", &m_trk_injet);
@@ -624,7 +632,7 @@ void L1TrackNtupleMaker::beginJob() {
   eventTree->Branch("tp_pt", &m_tp_pt);
   eventTree->Branch("tp_eta", &m_tp_eta);
   eventTree->Branch("tp_phi", &m_tp_phi);
-  eventTree->Branch("tp_dxy", &m_tp_dxy);
+  eventTree->Branch("tp_lxy", &m_tp_lxy);
   eventTree->Branch("tp_d0", &m_tp_d0);
   eventTree->Branch("tp_z0", &m_tp_z0);
   eventTree->Branch("tp_d0_prod", &m_tp_d0_prod);
@@ -658,6 +666,7 @@ void L1TrackNtupleMaker::beginJob() {
   eventTree->Branch("matchtrk_dhits", &m_matchtrk_dhits);
   eventTree->Branch("matchtrk_seed", &m_matchtrk_seed);
   eventTree->Branch("matchtrk_hitpattern", &m_matchtrk_hitpattern);
+  eventTree->Branch("matchtrk_charge", &m_matchtrk_charge);
   if (TrackingInJets) {
     eventTree->Branch("matchtrk_injet", &m_matchtrk_injet);
     eventTree->Branch("matchtrk_injet_highpt", &m_matchtrk_injet_highpt);
@@ -742,6 +751,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_trk_nLost2Sstub_hitpattern->clear();
     m_trk_nLoststub_V1_hitpattern->clear();
     m_trk_nLoststub_V2_hitpattern->clear();
+    m_trk_charge->clear();
     m_trk_phiSector->clear();
     m_trk_etaSector->clear();
     m_trk_genuine->clear();
@@ -755,7 +765,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_trk_matchtp_eta->clear();
     m_trk_matchtp_phi->clear();
     m_trk_matchtp_z0->clear();
-    m_trk_matchtp_dxy->clear();
+    m_trk_matchtp_lxy->clear();
     m_trk_matchtp_d0->clear();
     m_trk_injet->clear();
     m_trk_injet_highpt->clear();
@@ -766,7 +776,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
   m_tp_pt->clear();
   m_tp_eta->clear();
   m_tp_phi->clear();
-  m_tp_dxy->clear();
+  m_tp_lxy->clear();
   m_tp_d0->clear();
   m_tp_z0->clear();
   m_tp_d0_prod->clear();
@@ -798,6 +808,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
   m_matchtrk_dhits->clear();
   m_matchtrk_seed->clear();
   m_matchtrk_hitpattern->clear();
+  m_matchtrk_charge->clear();
   m_matchtrk_injet->clear();
   m_matchtrk_injet_highpt->clear();
   m_matchtrk_injet_vhighpt->clear();
@@ -1066,6 +1077,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_phi = iterL1Track->momentum().phi();
       float tmp_trk_z0 = iterL1Track->z0();  //cm
       float tmp_trk_tanL = iterL1Track->tanL();
+      int tmp_trk_charge = (int)TMath::Sign(1, iterL1Track->rInv());
       bool usingNewKF = hphSetup->useNewKF();
       if (usingNewKF) {
         // Skip crazy tracks to avoid crash (as NewKF applies no cuts to kill them).
@@ -1221,6 +1233,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       m_trk_nLost2Sstub_hitpattern->push_back(tmp_trk_nLost2Sstub_hitpattern);
       m_trk_nLoststub_V1_hitpattern->push_back(tmp_trk_nLoststub_V1_hitpattern);
       m_trk_nLoststub_V2_hitpattern->push_back(tmp_trk_nLoststub_V2_hitpattern);
+      m_trk_charge->push_back(tmp_trk_charge);
       m_trk_phiSector->push_back(tmp_trk_phiSector);
       m_trk_etaSector->push_back(tmp_trk_etaSector);
       m_trk_genuine->push_back(tmp_trk_genuine);
@@ -1241,7 +1254,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_matchtp_eta = -999;
       float tmp_matchtp_phi = -999;
       float tmp_matchtp_z0 = -999;
-      float tmp_matchtp_dxy = -999;
+      float tmp_matchtp_lxy = -999;
       float tmp_matchtp_d0 = -999;
 
       if (my_tp.isNull())
@@ -1262,7 +1275,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         float tmp_matchtp_vz = my_tp->vz();
         float tmp_matchtp_vx = my_tp->vx();
         float tmp_matchtp_vy = my_tp->vy();
-        tmp_matchtp_dxy = sqrt(tmp_matchtp_vx * tmp_matchtp_vx + tmp_matchtp_vy * tmp_matchtp_vy);
+        tmp_matchtp_lxy = sqrt(tmp_matchtp_vx * tmp_matchtp_vx + tmp_matchtp_vy * tmp_matchtp_vy);
 
         // ----------------------------------------------------------------------------------------------
         // get d0/z0 propagated back to the IP
@@ -1294,7 +1307,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
           edm::LogVerbatim("Tracklet") << "TP matched to track has pt = " << my_tp->p4().pt()
                                        << " eta = " << my_tp->momentum().eta() << " phi = " << my_tp->momentum().phi()
                                        << " z0 = " << my_tp->vertex().z() << " pdgid = " << my_tp->pdgId()
-                                       << " dxy = " << tmp_matchtp_dxy;
+                                       << " lxy = " << tmp_matchtp_lxy;
         }
       }
 
@@ -1305,7 +1318,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       m_trk_matchtp_eta->push_back(tmp_matchtp_eta);
       m_trk_matchtp_phi->push_back(tmp_matchtp_phi);
       m_trk_matchtp_z0->push_back(tmp_matchtp_z0);
-      m_trk_matchtp_dxy->push_back(tmp_matchtp_dxy);
+      m_trk_matchtp_lxy->push_back(tmp_matchtp_lxy);
       m_trk_matchtp_d0->push_back(tmp_matchtp_d0);
 
       // ----------------------------------------------------------------------------------------------
@@ -1431,9 +1444,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       continue;
 
     // for pions in ttbar, only consider TPs coming from near the IP!
-    float dxy = sqrt(tmp_tp_vx * tmp_tp_vx + tmp_tp_vy * tmp_tp_vy);
-    float tmp_tp_dxy = dxy;
-    if (MyProcess == 6 && (dxy > 1.0))
+    float lxy = sqrt(tmp_tp_vx * tmp_tp_vx + tmp_tp_vy * tmp_tp_vy);
+    float tmp_tp_lxy = lxy;
+    if (MyProcess == 6 && (lxy > 1.0))
       continue;
 
     if (DebugMode)
@@ -1626,6 +1639,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float tmp_matchtrk_chi2rz_dof = -999;
     float tmp_matchtrk_bendchi2 = -999;
     float tmp_matchtrk_MVA1 = -999;
+    int tmp_matchtrk_charge = -999;
     int tmp_matchtrk_nstub = -999;
     int tmp_matchtrk_dhits = -999;
     int tmp_matchtrk_lhits = -999;
@@ -1637,6 +1651,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
 
     if (nMatch > 0) {
       tmp_matchtrk_pt = matchedTracks.at(i_track)->momentum().perp();
+      tmp_matchtrk_charge = (int)TMath::Sign(1, matchedTracks.at(i_track)->rInv());
       tmp_matchtrk_eta = matchedTracks.at(i_track)->momentum().eta();
       tmp_matchtrk_phi = matchedTracks.at(i_track)->momentum().phi();
       tmp_matchtrk_z0 = matchedTracks.at(i_track)->z0();
@@ -1698,7 +1713,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_tp_pt->push_back(tmp_tp_pt);
     m_tp_eta->push_back(tmp_tp_eta);
     m_tp_phi->push_back(tmp_tp_phi);
-    m_tp_dxy->push_back(tmp_tp_dxy);
+    m_tp_lxy->push_back(tmp_tp_lxy);
     m_tp_z0->push_back(tmp_tp_z0);
     m_tp_d0->push_back(tmp_tp_d0);
     m_tp_z0_prod->push_back(tmp_tp_z0_prod);
@@ -1724,6 +1739,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_matchtrk_lhits->push_back(tmp_matchtrk_lhits);
     m_matchtrk_seed->push_back(tmp_matchtrk_seed);
     m_matchtrk_hitpattern->push_back(tmp_matchtrk_hitpattern);
+    m_matchtrk_charge->push_back(tmp_matchtrk_charge);
     m_matchtrk_chi2_dof->push_back(tmp_matchtrk_chi2_dof);
     m_matchtrk_chi2rphi_dof->push_back(tmp_matchtrk_chi2rphi_dof);
     m_matchtrk_chi2rz_dof->push_back(tmp_matchtrk_chi2rz_dof);

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -54,7 +54,7 @@ void L1TrackNtuplePlot(TString type,
                        float TP_minPt = 2.0,
                        float TP_maxPt = 100.0,
                        float TP_maxEta = 2.4,
-                       float TP_maxDxy = 1.0,
+                       float TP_maxLxy = 1.0,
                        float TP_maxD0 = 1.0,
                        bool doDetailedPlots = false) {
   // type:              this is the name of the input file you want to process (minus ".root" extension)
@@ -68,7 +68,7 @@ void L1TrackNtuplePlot(TString type,
 
   // TP_select_injet: only look at TPs that are within a jet with pt > 30 GeV (==1) or within a jet with pt > 100 GeV (==2), >200 GeV (==3) or all TPs (==0)
 
-  //--  N.B. For standard displaced tracking plots, set TP_minPt=3.0, TP_maxEta=2.0, TP_maxDxy=10.0,
+  //--  N.B. For standard displaced tracking plots, set TP_minPt=3.0, TP_maxEta=2.0, TP_maxLxy=10.0,
   //--  TO_maxD0=10.0, doDetailedPlots=true. (Efficiency plots vs eta also usually made for d0 < 5).
 
   gROOT->SetBatch();
@@ -148,7 +148,7 @@ void L1TrackNtuplePlot(TString type,
   vector<float>* tp_pt;
   vector<float>* tp_eta;
   vector<float>* tp_phi;
-  vector<float>* tp_dxy;
+  vector<float>* tp_lxy;
   vector<float>* tp_z0;
   vector<float>* tp_d0;
   vector<int>* tp_pdgid;
@@ -206,7 +206,7 @@ void L1TrackNtuplePlot(TString type,
   TBranch* b_tp_pt;
   TBranch* b_tp_eta;
   TBranch* b_tp_phi;
-  TBranch* b_tp_dxy;
+  TBranch* b_tp_lxy;
   TBranch* b_tp_z0;
   TBranch* b_tp_d0;
   TBranch* b_tp_pdgid;
@@ -262,7 +262,7 @@ void L1TrackNtuplePlot(TString type,
   tp_pt = 0;
   tp_eta = 0;
   tp_phi = 0;
-  tp_dxy = 0;
+  tp_lxy = 0;
   tp_z0 = 0;
   tp_d0 = 0;
   tp_pdgid = 0;
@@ -318,7 +318,7 @@ void L1TrackNtuplePlot(TString type,
   tree->SetBranchAddress("tp_pt", &tp_pt, &b_tp_pt);
   tree->SetBranchAddress("tp_eta", &tp_eta, &b_tp_eta);
   tree->SetBranchAddress("tp_phi", &tp_phi, &b_tp_phi);
-  tree->SetBranchAddress("tp_dxy", &tp_dxy, &b_tp_dxy);
+  tree->SetBranchAddress("tp_lxy", &tp_lxy, &b_tp_lxy);
   tree->SetBranchAddress("tp_z0", &tp_z0, &b_tp_z0);
   tree->SetBranchAddress("tp_d0", &tp_d0, &b_tp_d0);
   tree->SetBranchAddress("tp_pdgid", &tp_pdgid, &b_tp_pdgid);
@@ -1240,7 +1240,7 @@ void L1TrackNtuplePlot(TString type,
       }
 
       // kinematic cuts
-      if (std::abs(tp_dxy->at(it)) > TP_maxDxy)
+      if (std::abs(tp_lxy->at(it)) > TP_maxLxy)
         continue;
       if (std::abs(tp_d0->at(it)) > TP_maxD0)
         continue;


### PR DESCRIPTION
#### PR description:
In L1TrackNtupleMaker, dxy and d0 are both variable names where dxy is defined as xy-distance of the PV from the interaction point, and d0 is defined as the transverse impact parameter. In displaced vertex studies, both dxy and d0 mean the same thing: the transverse impact parameter. I suggest dxy be changed to lxy in order to avoid confusion. 

Adding trk_charge as a branch is just a matter of convenience since that information is lost in the ntuple.



