### PR TITLE
Fix for displaced tracking in #304

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -288,12 +288,12 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
       if (layerdisk1_ >= LayerDisk::D1) {         // if a disk
         if (negdisk)
           indexz = (1 << nbitszfinebintable_) - indexz;
-        indexr = stub->r().value();
+        indexr = stub->rvalue();
         if (stub->isPSmodule()) {
-          indexr = stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_);
+          indexr = stub->rvalue() >> (stub->r().nbits() + 1 - nbitsrfinebintable_);
         }
       } else {  // else a layer
-        indexr = (((1 << (stub->r().nbits() - 1)) + stub->r().value()) >> (stub->r().nbits() - nbitsrfinebintable_));
+        indexr = (((1 << (stub->r().nbits() - 1)) + stub->rvalue()) >> (stub->r().nbits() - nbitsrfinebintable_));
       }
 
       // create lookupbits that define projections from middle stub

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -308,13 +308,13 @@ void VMRouterCM::execute(unsigned int) {
         if (negdisk) {
           indexzOld = (1 << nbitszfinebintable_) - indexzOld;
         }
-        indexrOld = stub->r().value();
+        indexrOld = stub->rvalue();
         if (stub->isPSmodule()) {
-          indexrOld = stub->r().value() >> (stub->r().nbits() - nbitsrfinebintable_);
+          indexrOld = stub->rvalue() >> (stub->r().nbits() + 1 - nbitsrfinebintable_);
         }
       } else {
         //Take the top nbitsfinebintable_ bits of the z coordinate. The & is to handle the negative z values.
-        indexrOld = (((1 << (stub->r().nbits() - 1)) + stub->r().value()) >> (stub->r().nbits() - nbitsrfinebintable_));
+        indexrOld = (((1 << (stub->r().nbits() - 1)) + stub->rvalue()) >> (stub->r().nbits() - nbitsrfinebintable_));
       }
 
       assert(indexzOld >= 0);
@@ -351,10 +351,10 @@ void VMRouterCM::execute(unsigned int) {
           } else {
             if (inner == 2 && iseed == Seed::L2L3D1) {
               lutval = 0;
-              if (stub->r().value() < 10) {
-                lutval = 8 * (1 + (stub->r().value() >> 2));
+              if (stub->rvalue() < 10) {
+                lutval = 8 * (1 + (stub->rvalue() >> 2));
               } else {
-                if (stub->r().value() < settings_.rmindiskl3overlapvm() / settings_.kr()) {
+                if (stub->rvalue() < settings_.rmindiskl3overlapvm() / settings_.kr()) {
                   lutval = -1;
                 }
               }

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -327,8 +327,6 @@ void VMRouterCM::execute(unsigned int) {
       assert(melutOld >= 0);
 
       //Fill the TE VM memories
-      if (layerdisk_ >= N_LAYER && (!stub->isPSmodule()))
-        continue;
 
       for (auto& ivmstubTEPHI : vmstubsTEPHI_) {
         unsigned int iseed = ivmstubTEPHI.seednumber;


### PR DESCRIPTION
#### PR description:

This PR should fix the tracking efficiency for displaced tracking in #304, bringing it back to where it currently is. This is done by using the new `Stub::rvalue()` method instead of `Stub::r().value()` for PS stubs in the disks in both the VMRouterCM and TrackletProcessorDisplaced.

#### PR validation:

The changes in this PR were tested on a sample of displaced muons without pileup, and the resulting tracking efficiency was compared to what the current HEAD of the default branch yields (see plot below). The efficiencies are now very similar. 

![effD0Comparison](https://github.com/user-attachments/assets/83ab07d9-9ed4-4b5c-bbd6-a69f75b68834)