### PR TITLE
Include cut on inner stub r/z-bin during triplet seeding step

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/TripletEngineUnit.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TripletEngineUnit.h
@@ -20,6 +20,8 @@ namespace trklet {
     int start_in_;
     int rzbinfirst_out_;
     int rzdiffmax_out_;
+    int rzbinfirst_in_;
+    int rzdiffmax_in_;
     std::vector<std::tuple<int, int, int> > projbin_out_;  // next z/r bin; outer stub mem; nstub
     std::vector<std::tuple<int, int, int> > projbin_in_;   // next z/r bin; inner stub mem; nstub
   };

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -281,18 +281,20 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
         edm::LogVerbatim("Tracklet") << "In " << getName() << " have middle stub";
       }
 
+      bool negdisk = (stub->disk().value() < 0); // check if disk in negative z region
+      bool negside = (stub->zapprox() < 0); // check if barrel stub but in negative z region
+      
       // get r/z index of the middle stub
       int indexz = (((1 << (stub->z().nbits() - 1)) + stub->z().value()) >> (stub->z().nbits() - nbitszfinebintable_));
       int indexr = -1;
-      bool negdisk = (stub->disk().value() < 0);  // check if disk in negative z region
-      if (layerdisk1_ >= LayerDisk::D1) {         // if a disk
+      if (layerdisk1_ >= LayerDisk::D1) { // if projecting from a disk
         if (negdisk)
           indexz = (1 << nbitszfinebintable_) - indexz;
         indexr = stub->rvalue();
         if (stub->isPSmodule()) {
           indexr = stub->rvalue() >> (stub->r().nbits() + 1 - nbitsrfinebintable_);
         }
-      } else {  // else a layer
+      } else { // else if from a layer
         indexr = (((1 << (stub->r().nbits() - 1)) + stub->rvalue()) >> (stub->r().nbits() - nbitsrfinebintable_));
       }
 
@@ -309,29 +311,42 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
         FPGAWord lookupbits(lutval, lutwidth, true, __LINE__, __FILE__);
 
         // get r/z bins for projection into outer layer/disk
-        int nbitsrzbin_out = N_RZBITS;
+        int nbitsrzbin_out = N_RZBITS; //number of bits for the r/z bins
         if (iSeed_ == Seed::D1D2L2)
           nbitsrzbin_out--;
-        int rzbinfirst_out = lookupbits.bits(0, NFINERZBITS);
-        int rzdiffmax_out = lookupbits.bits(NFINERZBITS + 1 + nbitsrzbin_out, NFINERZBITS);
-        int start_out = lookupbits.bits(NFINERZBITS + 1, nbitsrzbin_out);  // first rz bin projection
+        int rzbinfirst_out = lookupbits.bits(0, NFINERZBITS); // first small rz-bin projection
         int next_out = lookupbits.bits(NFINERZBITS, 1);
+        int start_out = lookupbits.bits(NFINERZBITS + 1, nbitsrzbin_out);  // first large rz-bin projection
+        int rzdiffmax_out = lookupbits.bits(NFINERZBITS + 1 + nbitsrzbin_out, NFINERZBITS);
         if (iSeed_ == Seed::D1D2L2 && negdisk)  // if projecting into disk
           start_out += (1 << nbitsrzbin_out);
         int last_out = start_out + next_out;  // last rz bin projection
 
         // get r/z bins for projection into third (inner) layer/disk
         int nbitsrzbin_in = N_RZBITS;
-        int start_in = lookupbits.bits(lutshift + NFINERZBITS + 1, nbitsrzbin_in);  // first rz bin projection
+        int rzbinfirst_in = lookupbits.bits(lutshift, NFINERZBITS);
         int next_in = lookupbits.bits(lutshift + NFINERZBITS, 1);
-        if (iSeed_ == Seed::D1D2L2 && negdisk)  // if projecting from disk into layer
-          start_in = settings_.NLONGVMBINS() - 1 - start_in - next_in;
-        int last_in = start_in + next_in;  // last rz bin projection
+        int start_in = lookupbits.bits(lutshift + NFINERZBITS + 1, nbitsrzbin_in);  // first rz bin projection
+        int rzdiffmax_in = lookupbits.bits(lutshift+ NFINERZBITS + 1 + nbitsrzbin_in, NFINERZBITS);
+        // LUT doesn't know about z sign. 
+        // So, first, mirror index of large z bin wrt center (as 0-3 bins are for negative z, 4 to 7 on the positive z). 
+        // Then subtract next_in so that we take that into account
+        if (iSeed_ == Seed::D1D2L2 && negdisk){  // if projecting from disk into layer in the negative z region
+          start_in = settings_.NLONGVMBINS() - 1 - start_in - next_in; 
+          if (next_in) 
+            rzbinfirst_in = settings_.NLONGVMBINS() - (rzbinfirst_in + rzdiffmax_in - settings_.NLONGVMBINS()); 
+          else
+            rzbinfirst_in = settings_.NLONGVMBINS() - 1 - rzbinfirst_in - rzdiffmax_in; 
+          if (rzbinfirst_in < 0) rzbinfirst_in = 0;  
+        } 
+        int last_in = start_in + next_in;  // last large rz-bin projection
 
         // fill trpdata with projection info of middle stub
         trpdata.stub_ = stub;
         trpdata.rzbinfirst_out_ = rzbinfirst_out;
         trpdata.rzdiffmax_out_ = rzdiffmax_out;
+        trpdata.rzbinfirst_in_ = rzbinfirst_in;
+        trpdata.rzdiffmax_in_ = rzdiffmax_in;
         trpdata.start_out_ = start_out;
         trpdata.start_in_ = start_in;
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -281,19 +281,19 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
         edm::LogVerbatim("Tracklet") << "In " << getName() << " have middle stub";
       }
 
-      bool negdisk = (stub->disk().value() < 0); // check if disk in negative z region
-      
+      bool negdisk = (stub->disk().value() < 0);  // check if disk in negative z region
+
       // get r/z index of the middle stub
       int indexz = (((1 << (stub->z().nbits() - 1)) + stub->z().value()) >> (stub->z().nbits() - nbitszfinebintable_));
       int indexr = -1;
-      if (layerdisk1_ >= LayerDisk::D1) { // if projecting from a disk
+      if (layerdisk1_ >= LayerDisk::D1) {  // if projecting from a disk
         if (negdisk)
           indexz = (1 << nbitszfinebintable_) - indexz;
         indexr = stub->rvalue();
         if (stub->isPSmodule()) {
           indexr = stub->rvalue() >> (stub->r().nbits() + 1 - nbitsrfinebintable_);
         }
-      } else { // else if from a layer
+      } else {  // else if from a layer
         indexr = (((1 << (stub->r().nbits() - 1)) + stub->rvalue()) >> (stub->r().nbits() - nbitsrfinebintable_));
       }
 
@@ -310,10 +310,10 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
         FPGAWord lookupbits(lutval, lutwidth, true, __LINE__, __FILE__);
 
         // get r/z bins for projection into outer layer/disk
-        int nbitsrzbin_out = N_RZBITS; //number of bits for the r/z bins
+        int nbitsrzbin_out = N_RZBITS;  //number of bits for the r/z bins
         if (iSeed_ == Seed::D1D2L2)
           nbitsrzbin_out--;
-        int rzbinfirst_out = lookupbits.bits(0, NFINERZBITS); // first small rz-bin projection
+        int rzbinfirst_out = lookupbits.bits(0, NFINERZBITS);  // first small rz-bin projection
         int next_out = lookupbits.bits(NFINERZBITS, 1);
         int start_out = lookupbits.bits(NFINERZBITS + 1, nbitsrzbin_out);  // first large rz-bin projection
         int rzdiffmax_out = lookupbits.bits(NFINERZBITS + 1 + nbitsrzbin_out, NFINERZBITS);
@@ -326,18 +326,19 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
         int rzbinfirst_in = lookupbits.bits(lutshift, NFINERZBITS);
         int next_in = lookupbits.bits(lutshift + NFINERZBITS, 1);
         int start_in = lookupbits.bits(lutshift + NFINERZBITS + 1, nbitsrzbin_in);  // first rz bin projection
-        int rzdiffmax_in = lookupbits.bits(lutshift+ NFINERZBITS + 1 + nbitsrzbin_in, NFINERZBITS);
-        // LUT doesn't know about z sign. 
-        // So, first, mirror index of large z bin wrt center (as 0-3 bins are for negative z, 4 to 7 on the positive z). 
+        int rzdiffmax_in = lookupbits.bits(lutshift + NFINERZBITS + 1 + nbitsrzbin_in, NFINERZBITS);
+        // LUT doesn't know about z sign.
+        // So, first, mirror index of large z bin wrt center (as 0-3 bins are for negative z, 4 to 7 on the positive z).
         // Then subtract next_in so that we take that into account
-        if (iSeed_ == Seed::D1D2L2 && negdisk){  // if projecting from disk into layer in the negative z region
-          start_in = settings_.NLONGVMBINS() - 1 - start_in - next_in; 
-          if (next_in) 
-            rzbinfirst_in = settings_.NLONGVMBINS() - (rzbinfirst_in + rzdiffmax_in - settings_.NLONGVMBINS()); 
+        if (iSeed_ == Seed::D1D2L2 && negdisk) {  // if projecting from disk into layer in the negative z region
+          start_in = settings_.NLONGVMBINS() - 1 - start_in - next_in;
+          if (next_in)
+            rzbinfirst_in = settings_.NLONGVMBINS() - (rzbinfirst_in + rzdiffmax_in - settings_.NLONGVMBINS());
           else
-            rzbinfirst_in = settings_.NLONGVMBINS() - 1 - rzbinfirst_in - rzdiffmax_in; 
-          if (rzbinfirst_in < 0) rzbinfirst_in = 0;  
-        } 
+            rzbinfirst_in = settings_.NLONGVMBINS() - 1 - rzbinfirst_in - rzdiffmax_in;
+          if (rzbinfirst_in < 0)
+            rzbinfirst_in = 0;
+        }
         int last_in = start_in + next_in;  // last large rz-bin projection
 
         // fill trpdata with projection info of middle stub

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessorDisplaced.cc
@@ -282,7 +282,6 @@ void TrackletProcessorDisplaced::execute(unsigned int iSector, double phimin, do
       }
 
       bool negdisk = (stub->disk().value() < 0); // check if disk in negative z region
-      bool negside = (stub->zapprox() < 0); // check if barrel stub but in negative z region
       
       // get r/z index of the middle stub
       int indexz = (((1 << (stub->z().nbits() - 1)) + stub->z().value()) >> (stub->z().nbits() - nbitszfinebintable_));

--- a/L1Trigger/TrackFindingTracklet/src/TripletEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TripletEngineUnit.cc
@@ -68,18 +68,30 @@ void TripletEngineUnit::step() {
   const VMStubTE& outervmstub = outervmstubs_[outmem_]->getVMStubTEBinned(ibin_out, istub_out_);
   const VMStubTE& innervmstub = innervmstubs_[inmem_]->getVMStubTEBinned(ibin_in, istub_in_);
 
-  // check if r/z of outer stub is within projection range
-  int rzbin = (outervmstub.vmbits().value() & (settings_->NLONGVMBINS() - 1));
-  if (trpdata_.start_out_ != ibin_out)
-    rzbin += 8;
-  if (rzbin < trpdata_.rzbinfirst_out_ || rzbin - trpdata_.rzbinfirst_out_ > trpdata_.rzdiffmax_out_) {
+  // check if r/z of outer/inner stubs is within projection range
+  int rzbin_out = (outervmstub.vmbits().value() & (settings_->NLONGVMBINS() - 1));
+  int rzbin_in = (innervmstub.vmbits().value() & (settings_->NLONGVMBINS() - 1));
+
+  if (trpdata_.start_out_ != ibin_out) // if looking at the "next" bin
+    rzbin_out += (1 << NFINERZBITS);
+  if (rzbin_out < trpdata_.rzbinfirst_out_ || rzbin_out - trpdata_.rzbinfirst_out_ > trpdata_.rzdiffmax_out_) {
     if (settings_->debugTracklet()) {
       edm::LogVerbatim("Tracklet") << "Outer stub rejected because of wrong r/z bin";
     }
-  } else {
-    candtriplet_ =
-        std::tuple<const Stub*, const Stub*, const Stub*>(innervmstub.stub(), trpdata_.stub_, outervmstub.stub());
-    goodtriplet_ = true;
+  } else { // condition on outer stub satisfied 
+    if ((trpdata_.start_in_ != ibin_in))
+      rzbin_in += (1 << NFINERZBITS);
+    
+    if ( rzbin_in < trpdata_.rzbinfirst_in_ || rzbin_in - trpdata_.rzbinfirst_in_ > trpdata_.rzdiffmax_in_ ){
+      if (settings_->debugTracklet()) {
+        edm::LogVerbatim("Tracklet") << "Inner stub rejected because of wrong r/z bin";
+      }
+    } else { // condition on both inner and outer stubs satisfied    
+
+      candtriplet_ =
+          std::tuple<const Stub*, const Stub*, const Stub*>(innervmstub.stub(), trpdata_.stub_, outervmstub.stub());
+      goodtriplet_ = true;
+    }
   }
 
   // go to next projection (looping through all inner stubs for each outer stub)

--- a/L1Trigger/TrackFindingTracklet/src/TripletEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TripletEngineUnit.cc
@@ -72,21 +72,21 @@ void TripletEngineUnit::step() {
   int rzbin_out = (outervmstub.vmbits().value() & (settings_->NLONGVMBINS() - 1));
   int rzbin_in = (innervmstub.vmbits().value() & (settings_->NLONGVMBINS() - 1));
 
-  if (trpdata_.start_out_ != ibin_out) // if looking at the "next" bin
+  if (trpdata_.start_out_ != ibin_out)  // if looking at the "next" bin
     rzbin_out += (1 << NFINERZBITS);
   if (rzbin_out < trpdata_.rzbinfirst_out_ || rzbin_out - trpdata_.rzbinfirst_out_ > trpdata_.rzdiffmax_out_) {
     if (settings_->debugTracklet()) {
       edm::LogVerbatim("Tracklet") << "Outer stub rejected because of wrong r/z bin";
     }
-  } else { // condition on outer stub satisfied 
+  } else {  // condition on outer stub satisfied
     if ((trpdata_.start_in_ != ibin_in))
       rzbin_in += (1 << NFINERZBITS);
-    
-    if ( rzbin_in < trpdata_.rzbinfirst_in_ || rzbin_in - trpdata_.rzbinfirst_in_ > trpdata_.rzdiffmax_in_ ){
+
+    if (rzbin_in < trpdata_.rzbinfirst_in_ || rzbin_in - trpdata_.rzbinfirst_in_ > trpdata_.rzdiffmax_in_) {
       if (settings_->debugTracklet()) {
         edm::LogVerbatim("Tracklet") << "Inner stub rejected because of wrong r/z bin";
       }
-    } else { // condition on both inner and outer stubs satisfied    
+    } else {  // condition on both inner and outer stubs satisfied
 
       candtriplet_ =
           std::tuple<const Stub*, const Stub*, const Stub*>(innervmstub.stub(), trpdata_.stub_, outervmstub.stub());

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -344,6 +344,7 @@ void VMRouterCM::execute(unsigned int) {
         }
 
         int lutval = -999;
+        int stub_rbin = 0;
 
         if (inner > 0) {
           if (layerdisk_ < N_LAYER) {
@@ -351,10 +352,33 @@ void VMRouterCM::execute(unsigned int) {
           } else {
             if (inner == 2 && iseed == Seed::L2L3D1) {
               lutval = 0;
-              if (stub->rvalue() < 10) {
-                lutval = 8 * (1 + (stub->rvalue() >> 2));
+              if (stub->r().value() < 10 || (stub->r().value() > settings_.rmindiskl2overlapvm() / settings_.kr()) ) { // 2S stub, or PS above certain r
+                // from https://github.com/cms-L1TK/cmssw/blob/68ae83ab542b996d3e46317c3646e300e3602946/L1Trigger/TrackFindingTracklet/src/Stub.cc#L152
+                int NBINS = settings_.NLONGVMBINS() * settings_.NLONGVMBINS() / 2;  
+                double stub_r_approx = stub->rapprox();
+                if (stub_r_approx < settings_.rmindiskvm()) // TrackletLUT L1340, 22.5 cm
+                  stub_r_approx = settings_.rmindiskvm();
+
+                stub_rbin = NBINS * (stub_r_approx - settings_.rmindiskl2overlapvm()) / (settings_.rmaxdisk() - settings_.rmindiskl2overlapvm());
+                if (stub_rbin < 0)
+                  stub_rbin = 0;
+                if (stub_rbin >= NBINS)
+                  stub_rbin = NBINS - 1;
+
+                int value = stub_rbin / 8; //shift right by 3
+                // the positive/negative z region is taken into account within the addVMStub function
+                // https://github.com/cms-L1TK/cmssw/blob/4b3e9e1c8c0bc1d6d2509fd02f39f1510d6e5184/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc#L94
+                // if (stub->zapprox() < 0.0)
+                //   value += 4;
+
+                // the *2 was needed in the LUT to include the next bin flag, but not used here
+                value *= 8; //shift left by 3
+                value += ((stub_rbin) & 7);
+                assert(value / 8 < 15);
+                lutval = value;
+                
               } else {
-                if (stub->rvalue() < settings_.rmindiskl3overlapvm() / settings_.kr()) {
+                if (stub->rvalue() < settings_.rmindiskl2overlapvm() / settings_.kr()) {
                   lutval = -1;
                 }
               }
@@ -363,11 +387,11 @@ void VMRouterCM::execute(unsigned int) {
                                        : diskTableOld_.lookup((indexzOld << nbitsrfinebintable_) + indexrOld));
               if (lutval == 0)
                 continue;
-            }
+            } // end if inner > 0 and in disk
           }
           if (lutval == -1)
             continue;
-        } else {
+        } else { // inner == 0
           if (iseed < Seed::L1D1 || iseed > Seed::L2D1) {
             lutval = innerTable_.lookup((indexzOld << nbitsrfinebintable_) + indexrOld);
           } else {
@@ -398,7 +422,7 @@ void VMRouterCM::execute(unsigned int) {
 
         int bin = -1;
         if (inner != 0) {
-          bin = binlookup.value() >> settings_.NLONGVMBITS();
+          bin = binlookup.value() >> settings_.NLONGVMBITS();  // this is the large grain bin
           unsigned int tmp = binlookup.value() & (settings_.NLONGVMBINS() - 1);  //three bits in outer layers
           binlookup.set(tmp, settings_.NLONGVMBITS(), true, __LINE__, __FILE__);
         }

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -352,31 +352,33 @@ void VMRouterCM::execute(unsigned int) {
           } else {
             if (inner == 2 && iseed == Seed::L2L3D1) {
               lutval = 0;
-              if (stub->rvalue() < 10 || (stub->rvalue() > settings_.rmindiskl2overlapvm() / settings_.kr()) ) { // 2S stub, or PS above certain r
+              if (stub->rvalue() < 10 || (stub->rvalue() > settings_.rmindiskl2overlapvm() /
+                                                               settings_.kr())) {  // 2S stub, or PS above certain r
                 // from https://github.com/cms-L1TK/cmssw/blob/68ae83ab542b996d3e46317c3646e300e3602946/L1Trigger/TrackFindingTracklet/src/Stub.cc#L152
-                int NBINS = settings_.NLONGVMBINS() * settings_.NLONGVMBINS() / 2;  
+                int NBINS = settings_.NLONGVMBINS() * settings_.NLONGVMBINS() / 2;
                 double stub_r_approx = stub->rapprox();
-                if (stub_r_approx < settings_.rmindiskvm()) // TrackletLUT L1340, 22.5 cm
+                if (stub_r_approx < settings_.rmindiskvm())  // TrackletLUT L1340, 22.5 cm
                   stub_r_approx = settings_.rmindiskvm();
 
-                stub_rbin = NBINS * (stub_r_approx - settings_.rmindiskl2overlapvm()) / (settings_.rmaxdisk() - settings_.rmindiskl2overlapvm());
+                stub_rbin = NBINS * (stub_r_approx - settings_.rmindiskl2overlapvm()) /
+                            (settings_.rmaxdisk() - settings_.rmindiskl2overlapvm());
                 if (stub_rbin < 0)
                   stub_rbin = 0;
                 if (stub_rbin >= NBINS)
                   stub_rbin = NBINS - 1;
 
-                int value = stub_rbin / 8; //shift right by 3
+                int value = stub_rbin / 8;  //shift right by 3
                 // the positive/negative z region is taken into account within the addVMStub function
                 // https://github.com/cms-L1TK/cmssw/blob/4b3e9e1c8c0bc1d6d2509fd02f39f1510d6e5184/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc#L94
                 // if (stub->zapprox() < 0.0)
                 //   value += 4;
 
                 // the *2 was needed in the LUT to include the next bin flag, but not used here
-                value *= 8; //shift left by 3
+                value *= 8;  //shift left by 3
                 value += ((stub_rbin) & 7);
                 assert(value / 8 < 15);
                 lutval = value;
-                
+
               } else {
                 if (stub->rvalue() < settings_.rmindiskl2overlapvm() / settings_.kr()) {
                   lutval = -1;
@@ -387,11 +389,11 @@ void VMRouterCM::execute(unsigned int) {
                                        : diskTableOld_.lookup((indexzOld << nbitsrfinebintable_) + indexrOld));
               if (lutval == 0)
                 continue;
-            } // end if inner > 0 and in disk
+            }  // end if inner > 0 and in disk
           }
           if (lutval == -1)
             continue;
-        } else { // inner == 0
+        } else {  // inner == 0
           if (iseed < Seed::L1D1 || iseed > Seed::L2D1) {
             lutval = innerTable_.lookup((indexzOld << nbitsrfinebintable_) + indexrOld);
           } else {
@@ -422,7 +424,7 @@ void VMRouterCM::execute(unsigned int) {
 
         int bin = -1;
         if (inner != 0) {
-          bin = binlookup.value() >> settings_.NLONGVMBITS();  // this is the large grain bin
+          bin = binlookup.value() >> settings_.NLONGVMBITS();                    // this is the large grain bin
           unsigned int tmp = binlookup.value() & (settings_.NLONGVMBINS() - 1);  //three bits in outer layers
           binlookup.set(tmp, settings_.NLONGVMBITS(), true, __LINE__, __FILE__);
         }

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -370,15 +370,15 @@ void VMRouterCM::execute(unsigned int) {
                 if (stub_rbin >= NBINS)
                   stub_rbin = NBINS - 1;
 
-                int value = stub_rbin / 8;  //shift right by 3
+                int value = stub_rbin / 8;  // shift right by 3: get the value for the large grain bin
                 // the positive/negative z region is taken into account within the addVMStub function
                 // https://github.com/cms-L1TK/cmssw/blob/4b3e9e1c8c0bc1d6d2509fd02f39f1510d6e5184/L1Trigger/TrackFindingTracklet/src/VMStubsTEMemory.cc#L94
                 // if (stub->zapprox() < 0.0)
                 //   value += 4;
 
                 // the *2 was needed in the LUT to include the next bin flag, but not used here
-                value *= 8;  //shift left by 3
-                value += ((stub_rbin) & 7);
+                value *= 8;                  //shift left by 3
+                value += ((stub_rbin) & 7);  // add to the lut the value of the fine grain bin (3 bits)
                 assert(value / 8 < 15);
                 lutval = value;
 

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -352,9 +352,12 @@ void VMRouterCM::execute(unsigned int) {
           } else {
             if (inner == 2 && iseed == Seed::L2L3D1) {
               lutval = 0;
-              if (stub->rvalue() < 10 || (stub->rvalue() > settings_.rmindiskl2overlapvm() /
-                                                               settings_.kr())) {  // 2S stub, or PS above certain r
-                // from https://github.com/cms-L1TK/cmssw/blob/68ae83ab542b996d3e46317c3646e300e3602946/L1Trigger/TrackFindingTracklet/src/Stub.cc#L152
+              // Define a lutval for 2S stubs, or PS stubs above a certain radius.
+              // For 2S stubs, the actual radius is not stored, rather, an index to the ring it's returned by ->rvalue(), and
+              // there are N_DSS_MOD (5) rings per each endcap.
+              // Therefore if the index is less than 10 it means the stub is on a 2S module.
+              if (stub->rvalue() < (int)N_DSS_MOD * 2 ||
+                  (stub->rvalue() > settings_.rmindiskl2overlapvm() / settings_.kr())) {
                 int NBINS = settings_.NLONGVMBINS() * settings_.NLONGVMBINS() / 2;
                 double stub_r_approx = stub->rapprox();
                 if (stub_r_approx < settings_.rmindiskvm())  // TrackletLUT L1340, 22.5 cm

--- a/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMRouterCM.cc
@@ -352,7 +352,7 @@ void VMRouterCM::execute(unsigned int) {
           } else {
             if (inner == 2 && iseed == Seed::L2L3D1) {
               lutval = 0;
-              if (stub->r().value() < 10 || (stub->r().value() > settings_.rmindiskl2overlapvm() / settings_.kr()) ) { // 2S stub, or PS above certain r
+              if (stub->rvalue() < 10 || (stub->rvalue() > settings_.rmindiskl2overlapvm() / settings_.kr()) ) { // 2S stub, or PS above certain r
                 // from https://github.com/cms-L1TK/cmssw/blob/68ae83ab542b996d3e46317c3646e300e3602946/L1Trigger/TrackFindingTracklet/src/Stub.cc#L152
                 int NBINS = settings_.NLONGVMBINS() * settings_.NLONGVMBINS() / 2;  
                 double stub_r_approx = stub->rapprox();


### PR DESCRIPTION
#### PR description:
This PR includes a cut on the inner stub r/z bin in the seed creation step for triplets seeds. 
Previously the cut was only applied on the outer stub of the triplets. 
More details and the performance of the new version are available [here](https://indico.cern.ch/event/1538680/contributions/6475486/attachments/3053273/5397460/BESWG_16042025_sara.pdf).

making sure that @aryd also checks my changes