### PR TITLE
Fix to ProjectionCalculator from @aryd

### DIFF
--- a/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
@@ -24,6 +24,7 @@ def reducedConfig(process):
   # TO DO: Eliminate cfg param IRChannelsIn by taking this info from Tracklet wiring map.
   process.ChannelAssignment.IRChannelsIn = cms.vint32( 0, 1, 25, 2, 26, 4, 5, 29, 6, 30, 7, 31, 8, 9, 33 )
   process.l1tTTTracksFromTrackletEmulation.Reduced = True
+  process.l1tTTTracksFromTrackletEmulation.DoMultipleMatches = False
   process.l1tTTTracksFromTrackletEmulation.memoryModulesFile = 'L1Trigger/TrackFindingTracklet/data/memorymodules_reduced.dat'
   process.l1tTTTracksFromTrackletEmulation.processingModulesFile = 'L1Trigger/TrackFindingTracklet/data/processingmodules_reduced.dat'
   process.l1tTTTracksFromTrackletEmulation.wiresFile = 'L1Trigger/TrackFindingTracklet/data/wires_reduced.dat'

--- a/L1Trigger/TrackFindingTracklet/src/ProjectionCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProjectionCalculator.cc
@@ -359,7 +359,7 @@ void ProjectionCalculator::execute() {
                     edm::LogVerbatim("Tracklet") << "No projection memory exists in " << getName()
                                                  << " for layer = " << layerdisk + 1 << " iphi = " << iphi + 1;
                   }
-                  return;
+                  continue;
                 }
                 assert(!outputproj_[layerdisk][iphi].empty());
 
@@ -384,7 +384,7 @@ void ProjectionCalculator::execute() {
                     edm::LogVerbatim("Tracklet") << "No projection memory exists in " << getName()
                                                  << " for disk = " << layerdisk - N_LAYER + 1 << " iphi = " << iphi + 1;
                   }
-                  return;
+                  continue;
                 }
                 assert(!outputproj_[layerdisk][iphi].empty());
 


### PR DESCRIPTION
#### PR description:

This PR fixes a bug found by @aryd in the ProjectionCalculator where the processing sometimes stopped prematurely, resulting in truncation for some events. The fix is to replace two `return` statements with `continue`.

Additionally, `DoMultipleMatches` is unset in the case of the reduced configuration, to match what the FW is doing with one fewer change to Settings.h.

#### PR validation:

The test vectors generated with these changes have been successfully tested in the HLS repo in this PR:
https://github.com/cms-L1TK/firmware-hls/pull/363