### PR TITLE
Adding "HYBRID_NEWKF_DISPLACED" option

### DIFF
--- a/L1Trigger/TrackFindingTracklet/python/ChannelAssignment_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/ChannelAssignment_cfi.py
@@ -8,8 +8,8 @@ ChannelAssignment_params = cms.PSet (
   TM = cms.PSet (
     # The order here approximately dictates the order in which tracks enter the DR,
     # with DR keeping 1st track to arrive, in case two tracks are duplicate.
-    MuxOrder    = cms.vstring( "L1L2", "L2L3", "L1D1", "D1D2", "D3D4", "L2D1", "L3L4", "L5L6" ),
-    NumLayers   = cms.int32( 11 ), # number of layers per track
+    MuxOrder    = cms.vstring( "L1L2", "L2L3", "L1D1", "D1D2", "D3D4", "L2D1", "L3L4", "L5L6", "L3L4L2","L5L6L4", "L2L3D1", "D1D2L2" ),
+    NumLayers   = cms.int32( 15 ), # number of layers per track
     WidthStubId = cms.int32( 10 ), # number of bits used to represent stub id for projected stubs
     WidthCot    = cms.int32( 14 )
   ),
@@ -20,7 +20,7 @@ ChannelAssignment_params = cms.PSet (
     MinIdenticalStubs    = cms.int32(  3 )  # min number of shared stubs to identify duplicates
   ),
 
-  SeedTypes = cms.vstring( "L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1" ), # seed types used in tracklet algorithm (position gives int value)
+  SeedTypes = cms.vstring( "L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1" , "L3L4L2","L5L6L4", "L2L3D1", "D1D2L2" ), # seed types used in tracklet algorithm (position gives int value)
 
   SeedTypesSeedLayers = cms.PSet (      # seeding layers of seed types using default layer id [barrel: 1-6, discs: 11-15]
     L1L2 = cms.vint32(  1,  2 ),
@@ -30,7 +30,11 @@ ChannelAssignment_params = cms.PSet (
     D1D2 = cms.vint32( 11, 12 ),
     D3D4 = cms.vint32( 13, 14 ),
     L1D1 = cms.vint32(  1, 11 ),
-    L2D1 = cms.vint32(  2, 11 )
+    L2D1 = cms.vint32(  2, 11 ),
+    L3L4L2 = cms.vint32(  3, 4,  2 ),
+    L5L6L4 = cms.vint32(  5, 6,  4 ),
+    L2L3D1 = cms.vint32(  2, 3, 11 ),
+    D1D2L2 = cms.vint32( 11, 12,  2 )
   ),
   SeedTypesProjectionLayers = cms.PSet ( # layers a seed types can project to using default layer id [barrel: 1-6, discs: 11-15]
     L1L2 = cms.vint32(  3,  4,  5,  6, 11, 12, 13, 14 ),
@@ -40,7 +44,11 @@ ChannelAssignment_params = cms.PSet (
     D1D2 = cms.vint32(  1,  2, 13, 14, 15 ),
     D3D4 = cms.vint32(  1, 11, 12, 15 ),
     L1D1 = cms.vint32( 12, 13, 14, 15 ),
-    L2D1 = cms.vint32(  1, 12, 13, 14 )
+    L2D1 = cms.vint32(  1, 12, 13, 14 ),
+    L3L4L2 = cms.vint32(  1,  5,  6, 11, 12, 13 ),
+    L5L6L4 = cms.vint32(  1,  2,  3 ),
+    L2L3D1 = cms.vint32(  1, 12, 13, 14 ),
+    D1D2L2 = cms.vint32(  1, 13, 14 )
   ),
 
   IRChannelsIn = cms.vint32( range(0, 48) ) # vector of DTC id indexed by connected IR module id (from order in processingmodules.dat)

--- a/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
@@ -72,3 +72,9 @@ def oldKFConfig(process):
   process.ProducerKF.TrackFitSettings.KalmanHOalpha           = 0
   process.ProducerKF.TrackFitSettings.KalmanHOhelixExp        = True
   process.ProducerKF.TrackFitSettings.KalmanDebugLevel        = 0
+
+def customize_HYBRID_NEWKF_DISPLACED(process):
+    print('Applying HYBRID_NEWKF_DISPLACED customization')
+    process.ProducerKF.use5parfit = cms.bool(True)
+    process.ProducerTM.ChannelAssignment = cms.string('HYBRID_DISPLACED')
+    return process

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -21,9 +21,10 @@ GEOMETRY = "D98"
 # Set L1 tracking algorithm:
 # 'HYBRID' (baseline, 4par fit) or 'HYBRID_DISPLACED' (extended, 5par fit).
 # 'HYBRID_NEWKF' (baseline, 4par fit, with bit-accurate KF emulation),
+# 'HYBRID_NEWKF_DISPLACED' (bit-accurate KF emulation with HYBRID_DISPLACED channel assignment, 5par fit)
 # 'HYBRID_REDUCED' to use the "L5L6" seeding only reduced configuration.
 # (Or legacy algos 'TMTT' or 'TRACKLET').
-L1TRKALGO = 'HYBRID_NEWKF_DISPLACED'
+L1TRKALGO = 'HYBRID'
 
 WRITE_DATA = False
 
@@ -168,6 +169,7 @@ elif (L1TRKALGO == 'HYBRID_DISPLACED'):
     L1TRUTH_NAME = "TTTrackAssociatorFromPixelDigisExtended"
 
 # HYBRID_NEWKF: prompt tracking or reduced
+# HYBRID_NEWKF_DISPLACED: 5par fit and uses HYBRID_DISPLACED channel assignment
 elif (L1TRKALGO == 'HYBRID_NEWKF' or L1TRKALGO == 'HYBRID_REDUCED' or L1TRKALGO == 'HYBRID_NEWKF_DISPLACED'):
     process.load( 'L1Trigger.TrackFindingTracklet.Producer_cff' )
     process.load( 'L1Trigger.TrackFindingTracklet.Analyzer_cff' )

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -23,7 +23,7 @@ GEOMETRY = "D98"
 # 'HYBRID_NEWKF' (baseline, 4par fit, with bit-accurate KF emulation),
 # 'HYBRID_REDUCED' to use the "L5L6" seeding only reduced configuration.
 # (Or legacy algos 'TMTT' or 'TRACKLET').
-L1TRKALGO = 'HYBRID'
+L1TRKALGO = 'HYBRID_NEWKF_DISPLACED'
 
 WRITE_DATA = False
 
@@ -168,7 +168,7 @@ elif (L1TRKALGO == 'HYBRID_DISPLACED'):
     L1TRUTH_NAME = "TTTrackAssociatorFromPixelDigisExtended"
 
 # HYBRID_NEWKF: prompt tracking or reduced
-elif (L1TRKALGO == 'HYBRID_NEWKF' or L1TRKALGO == 'HYBRID_REDUCED'):
+elif (L1TRKALGO == 'HYBRID_NEWKF' or L1TRKALGO == 'HYBRID_REDUCED' or L1TRKALGO == 'HYBRID_NEWKF_DISPLACED'):
     process.load( 'L1Trigger.TrackFindingTracklet.Producer_cff' )
     process.load( 'L1Trigger.TrackFindingTracklet.Analyzer_cff' )
     NHELIXPAR = 4
@@ -185,8 +185,13 @@ elif (L1TRKALGO == 'HYBRID_NEWKF' or L1TRKALGO == 'HYBRID_REDUCED'):
     from L1Trigger.TrackFindingTracklet.Customize_cff import *
     if (L1TRKALGO == 'HYBRID_NEWKF'):
         fwConfig( process )
+    if (L1TRKALGO == 'HYBRID_NEWKF_DISPLACED'):
+        customize_HYBRID_NEWKF_DISPLACED(process)     
     if (L1TRKALGO == 'HYBRID_REDUCED'):
         reducedConfig( process )
+       
+
+
     # Needed by L1TrackNtupleMaker
     process.HitPatternHelperSetup.useNewKF = True
 


### PR DESCRIPTION
I added `HYBRID_NEWKF_DISPLACED` option to `L1TrackNtupleMaker_cfg.py`, which:

- Uses the `HYBRID_NEWKF` backend (bit-accurate Kalman Filter)
- Applies `HYBRID_DISPLACED` channel assignment
- Runs a 5-parameter Kalman fit for displaced tracks

This is achieved by adding a `customize_HYBRID_NEWKF_DISPLACED `function to  `Customize_cff.py` and expanding the existing "HYBRID_NEWKF" logic in `L1TrackNtupleMaker_cfg.py`

I managed to run a CMS job with `L1TRKALGO = 'HYBRID_NEWKF_DISPLACED'`, but I have not validated the output.