### PR TITLE
For Debugging the new HYBRID_NEWKF_DISPLACED config

### DIFF
--- a/L1Trigger/TrackFindingTracklet/python/ChannelAssignment_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/ChannelAssignment_cfi.py
@@ -8,8 +8,8 @@ ChannelAssignment_params = cms.PSet (
   TM = cms.PSet (
     # The order here approximately dictates the order in which tracks enter the DR,
     # with DR keeping 1st track to arrive, in case two tracks are duplicate.
-    MuxOrder    = cms.vstring( "L1L2", "L2L3", "L1D1", "D1D2", "D3D4", "L2D1", "L3L4", "L5L6" ),
-    NumLayers   = cms.int32( 11 ), # number of layers per track
+    MuxOrder    = cms.vstring( "L1L2", "L2L3", "L1D1", "D1D2", "D3D4", "L2D1", "L3L4", "L5L6", "L3L4L2","L5L6L4", "L2L3D1", "D1D2L2" ),
+    NumLayers   = cms.int32( 15 ), # number of layers per track
     WidthStubId = cms.int32( 10 ), # number of bits used to represent stub id for projected stubs
     WidthCot    = cms.int32( 14 )
   ),
@@ -20,7 +20,7 @@ ChannelAssignment_params = cms.PSet (
     MinIdenticalStubs    = cms.int32(  3 )  # min number of shared stubs to identify duplicates
   ),
 
-  SeedTypes = cms.vstring( "L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1" ), # seed types used in tracklet algorithm (position gives int value)
+  SeedTypes = cms.vstring( "L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1" , "L3L4L2","L5L6L4", "L2L3D1", "D1D2L2" ), # seed types used in tracklet algorithm (position gives int value)
 
   SeedTypesSeedLayers = cms.PSet (      # seeding layers of seed types using default layer id [barrel: 1-6, discs: 11-15]
     L1L2 = cms.vint32(  1,  2 ),
@@ -30,7 +30,11 @@ ChannelAssignment_params = cms.PSet (
     D1D2 = cms.vint32( 11, 12 ),
     D3D4 = cms.vint32( 13, 14 ),
     L1D1 = cms.vint32(  1, 11 ),
-    L2D1 = cms.vint32(  2, 11 )
+    L2D1 = cms.vint32(  2, 11 ),
+    L3L4L2 = cms.vint32(  3, 4,  2 ),
+    L5L6L4 = cms.vint32(  5, 6,  4 ),
+    L2L3D1 = cms.vint32(  2, 3, 11 ),
+    D1D2L2 = cms.vint32( 11, 12,  2 )
   ),
   SeedTypesProjectionLayers = cms.PSet ( # layers a seed types can project to using default layer id [barrel: 1-6, discs: 11-15]
     L1L2 = cms.vint32(  3,  4,  5,  6, 11, 12, 13, 14 ),
@@ -40,7 +44,11 @@ ChannelAssignment_params = cms.PSet (
     D1D2 = cms.vint32(  1,  2, 13, 14, 15 ),
     D3D4 = cms.vint32(  1, 11, 12, 15 ),
     L1D1 = cms.vint32( 12, 13, 14, 15 ),
-    L2D1 = cms.vint32(  1, 12, 13, 14 )
+    L2D1 = cms.vint32(  1, 12, 13, 14 ),
+    L3L4L2 = cms.vint32(  1,  5,  6, 11, 12, 13 ),
+    L5L6L4 = cms.vint32(  1,  2,  3 ),
+    L2L3D1 = cms.vint32(  1, 12, 13, 14 ),
+    D1D2L2 = cms.vint32(  1, 13, 14 )
   ),
 
   IRChannelsIn = cms.vint32( range(0, 48) ) # vector of DTC id indexed by connected IR module id (from order in processingmodules.dat)

--- a/L1Trigger/TrackFindingTracklet/python/ChannelAssignment_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/ChannelAssignment_cfi.py
@@ -9,7 +9,7 @@ ChannelAssignment_params = cms.PSet (
     # The order here approximately dictates the order in which tracks enter the DR,
     # with DR keeping 1st track to arrive, in case two tracks are duplicate.
     MuxOrder    = cms.vstring( "L1L2", "L2L3", "L1D1", "D1D2", "D3D4", "L2D1", "L3L4", "L5L6", "L3L4L2","L5L6L4", "L2L3D1", "D1D2L2" ),
-    NumLayers   = cms.int32( 15 ), # number of layers per track
+    NumLayers   = cms.int32( 11 ), # number of layers per track
     WidthStubId = cms.int32( 10 ), # number of bits used to represent stub id for projected stubs
     WidthCot    = cms.int32( 14 )
   ),

--- a/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
@@ -72,3 +72,13 @@ def oldKFConfig(process):
   process.ProducerKF.TrackFitSettings.KalmanHOalpha           = 0
   process.ProducerKF.TrackFitSettings.KalmanHOhelixExp        = True
   process.ProducerKF.TrackFitSettings.KalmanDebugLevel        = 0
+
+
+def fwConfigDisp(process):
+  process.ProducerKF.use5parfit = cms.bool(True)
+  process.l1tTTTracksFromExtendedTrackletEmulation.FakeFit = cms.bool(True)
+  process.TrackTriggerSetup.TrackFinding.MaxEta =  2.5
+  process.TrackTriggerSetup.GeometricProcessor.ChosenRofZ = 57.76
+  process.l1tTTTracksFromExtendedTrackletEmulation.RemovalType = ""
+  process.l1tTTTracksFromExtendedTrackletEmulation.DoMultipleMatches = False
+  process.l1tTTTracksFromExtendedTrackletEmulation.StoreTrackBuilderOutput = True

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -21,6 +21,7 @@ GEOMETRY = "D98"
 # Set L1 tracking algorithm:
 # 'HYBRID' (baseline, 4par fit) or 'HYBRID_DISPLACED' (extended, 5par fit).
 # 'HYBRID_NEWKF' (baseline, 4par fit, with bit-accurate KF emulation),
+# 'HYBRID_NEWKF_DISPLACED' is extended 5par fit with bit-accurate KF emulation, still under development
 # 'HYBRID_REDUCED' to use the "L5L6" seeding only reduced configuration.
 # (Or legacy algos 'TMTT' or 'TRACKLET').
 L1TRKALGO = 'HYBRID'
@@ -188,6 +189,50 @@ elif (L1TRKALGO == 'HYBRID_NEWKF' or L1TRKALGO == 'HYBRID_REDUCED'):
     if (L1TRKALGO == 'HYBRID_REDUCED'):
         reducedConfig( process )
     # Needed by L1TrackNtupleMaker
+    process.HitPatternHelperSetup.useNewKF = True
+
+# HYBRID_NEWKF_DISPLACED
+elif (L1TRKALGO == 'HYBRID_NEWKF_DISPLACED'):
+    process.load('L1Trigger.TrackFindingTracklet.Producer_cff')
+    process.load('L1Trigger.TrackFindingTracklet.Analyzer_cff')
+
+    NHELIXPAR = 5
+    L1TRK_NAME  = process.TrackFindingTrackletAnalyzer_params.OutputLabelTFP.value()
+    L1TRK_LABEL = process.TrackFindingTrackletProducer_params.BranchTTTracks.value()
+    L1TRUTH_NAME = "TTTrackAssociatorFromPixelDigisExtended"
+
+    process.ProducerTM.InputLabelTM = cms.string("l1tTTTracksFromExtendedTrackletEmulation")
+
+    process.AnalyzerTM.InputTag = cms.InputTag("l1tTTTracksFromExtendedTrackletEmulation", "Level1TTTracks")
+    process.TTTrackAssociatorFromPixelDigisExtended.TTTracks = cms.VInputTag(cms.InputTag(L1TRK_NAME, L1TRK_LABEL))
+
+    process.HybridNewKFDisplaced = cms.Sequence(
+        process.L1TExtendedHybridTracks + 
+        process.ProducerTM + 
+        process.ProducerDR + 
+        process.ProducerKF + 
+        process.ProducerTQ + 
+        process.ProducerTFP
+    )
+
+    process.TTTracksEmulation = cms.Path(process.HybridNewKFDisplaced)
+
+    process.load('SimTracker.TrackTriggerAssociation.StubAssociator_cff')
+    process.TTTracksEmulationWithTruth = cms.Path(
+        process.HybridNewKFDisplaced +
+        process.TrackTriggerAssociatorTracks +
+        process.StubAssociator +
+        process.AnalyzerTracklet + 
+        process.AnalyzerTM + 
+        process.AnalyzerDR + 
+        process.AnalyzerKF + 
+        process.AnalyzerTQ + 
+        process.AnalyzerTFP
+    )
+
+    from L1Trigger.TrackFindingTracklet.Customize_cff import *
+    fwConfigDisp(process)
+
     process.HitPatternHelperSetup.useNewKF = True
 
 # LEGACY ALGORITHM (EXPERTS ONLY): TRACKLET


### PR DESCRIPTION
Work in progress:
Creating a "HYBRID_NEWKF_DISPLACED" option that uses the New KF bit-accurate emulation (which HYBRID_NEWKF does) but for extended tracking (which HYBRID_DISPLACED does).

The main differences between the new HYBRID_NEWKF_DISPLACED and HYBRID_NEWKF are:

L1THybridTracks changes to L1TExtendedHybridTracks
L1TRUTH_NAME: TTTrackAssociatorFromPixelDigis changes to TTTrackAssociatorFromPixelDigisExtended 
Turning the 5par fit on

These modifications needs to happen for parameters and configurations that exist in L1TrackNTupleMaker_cfg.py, Customize_cﬀ.py, Analyzer_cﬀ.py, and Producer_cﬀ.py.

 ChannelAssignment_cfi.py does not have extended seed types (nor their projections), so it needs to be modified