### PR TITLE
CPU speed up of L1 tracking

### DIFF
--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -358,8 +358,9 @@ void L1FPGATrackProducer::beginRun(const edm::Run& run, const edm::EventSetup& i
   setup_ = &iSetup.getData(esGetTokenSetup_);
   // helper class to store Tracklet spezific configuration
   channelAssignment_ = &iSetup.getData(esGetTokenChannelAssignment_);
-  // helper class to determine track quality
-  trackQuality_ = &iSetup.getData(esGetTokenTrackQuality_);
+  // helper class to determine track quality. (TQ only meaningful if track fit is run)
+  if (not settings_.fakefit())
+    trackQuality_ = &iSetup.getData(esGetTokenTrackQuality_);
 
   settings_.passSetup(setup_);
 

--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerFakeTM.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerFakeTM.cc
@@ -132,7 +132,7 @@ namespace trklet {
         const std::set<TTStubRef>& stubIds = ttStubRefs[offset + iLayer];
         tt::SensorModule* sm = setup->sensorModule(ttStubRef);
         const GlobalPoint gp = setup->stubPos(ttStubRef);
-        const int stubId = std::distance(stubIds.begin(), std::find(stubIds.begin(), stubIds.end(), ttStubRef));
+        const int stubId = std::distance(stubIds.begin(), stubIds.find(ttStubRef));
         const bool pst = (sm->barrel() && sm->tilt()) || (!sm->barrel() && sm->psModule());
         const double r = gp.perp() - setup->chosenRofPhi();
         const double rZ = gp.perp() - setup->chosenRofZ();


### PR DESCRIPTION
#### PR description:

The TrackQuality class wastes lots of CPU because it reprocesses the JSON file containing the BDT model every time it processes a new track. This completely dominated the CPU use of the entire L1 tracking algorithm. After fixing it, HYBRID_NEWKF speeds up by a factor 10 and HYBRID by a factor 3 (though because of the CMSSW framework overhead, the job running time is reduced by less).

In addition, HYBRID_NEWKF outputs two TTTrack collections: (a)after only the tracklet pattern reco is run; (b) at the end of the chain. The TQ used to be run for both these collections. I've disabled it for (a), since the FW will not run TQ there, and it wastes CPU. In addition, the BDT is not tuned to give meaningful output before the KF is run.

I used igprof on 100 ttbar+200PU events to check the CPU time improvement achieved. The times given below are those listed in the igprof output for the various L1track-related EDProducer::produce() functions called by either one::EDProducerBase::doEvent() or stream::edProducerBase::doEvent(). Since the DTC code is unchanged, I used that as a reference time. I exclude the CPU time used for truth association.

**HYBRID_NEWKF**

**Before code changes:**

- L1FPGATrackProducer:produce() = 67
- ProducerTQ::produce() = 21
- ProducerDTC::produce() = 2.5
- Sum all other TF modules = 0.7

**After code changes:**

- L1FPGATrackProducer:produce() = 7.0
- ProducerTQ::produce() = 0.2
- ProducerDTC::produce() = 2.5
- Sum all other TF modules = 0.7

**HYBRID**

**Before code changes:**

- L1FPGATrackProducer:produce() = 24.5
- ProducerDTC::produce() = 2.5

**After code changes:**

- L1FPGATrackProducer:produce() = 8.7
- ProducerDTC::produce() = 2.5

#### PR validation:

No change in tracking performance seen.
