### PR TITLE
Replace cout by MessageLogger

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -448,7 +448,7 @@ namespace trklet {
         layerdisk += N_DISK;
       double bendcut = bendcut_[layerdisk][ibend];
       if (bendcut <= 0.0)
-        std::cout << "bendcut : " << layerdisk << " " << ibend << " " << isPSmodule << std::endl;
+        edm::LogError("Tracklet") << "bendcut : " << layerdisk << " " << ibend << " " << isPSmodule;
       assert(bendcut > 0.0);
       return bendcut;
     }

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletProjectionsMemory.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletProjectionsMemory.h
@@ -18,7 +18,7 @@ namespace trklet {
 
     ~TrackletProjectionsMemory() override {
       if (settings_.writeMonitorData("WriteEmptyProj") && (!hasProj_)) {
-        edm::LogPrint("Tracklet") << "Empty Projection Memory : " << getName() << std::endl;
+        edm::LogPrint("Tracklet") << "Empty Projection Memory : " << getName();
       }
     };
 

--- a/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FitTrack.cc
@@ -10,6 +10,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
+#include <sstream>
+
 using namespace std;
 using namespace trklet;
 
@@ -900,14 +902,15 @@ void FitTrack::execute(deque<string>& streamTrackRaw,
     //Counts unique hits in each layer
     int nMatchesUniq = 0;
 
+    std::stringstream mess;
     if (print)
-      std::cout << "istep = " << istep;
+      mess << "istep = " << istep;
 
     for (unsigned int i = 0; i < matches.size(); i++) {
       bool match = false;
       while (indexArray[i] < matches[i].size() && matches[i][indexArray[i]] == bestTracklet) {
         if (print)
-          std::cout << " match" << i;
+          mess << " match" << i;
         indexArray[i]++;
         nMatches++;
         match = true;
@@ -917,12 +920,14 @@ void FitTrack::execute(deque<string>& streamTrackRaw,
         nMatchesUniq++;
     }
 
+    if (print) {
+      mess << " nMatchesUniq = " << nMatchesUniq;
+      edm::LogVerbatim("Tracklet") << mess.str();
+    }
+
     if (settings_.debugTracklet()) {
       edm::LogVerbatim("Tracklet") << getName() << " : nMatches = " << nMatches << " nMatchesUniq = " << nMatchesUniq;
     }
-
-    if (print)
-      std::cout << " nMatchesUniq = " << nMatchesUniq << std::endl;
 
     std::vector<const Stub*> trackstublist;
     std::vector<std::pair<int, int>> stubidslist;
@@ -998,14 +1003,14 @@ void FitTrack::execute(deque<string>& streamTrackRaw,
           bool disk2S = (stub->disk() != 0) && (stub->isPSmodule() == 0);
           if (disk2S) {
             r = string(widthDisk2Sidentifier, '0') + r;
-            //std::cout << "2s stub : " << r << std::endl;
+            // edm::LogVerbatim("Tracklet") << "2s stub : " << r;
           }
           bool diskPS = (stub->disk() != 0) && (stub->isPSmodule() != 0);
           if (diskPS) {
-            //  std::cout << "old r: " << r << " new r: " ;
+            //  string oldr = r;
             FPGAWord tmp(resid.stubptr()->rvalue(), 12);
             r = tmp.str();
-            //  std::cout << r << std::endl;
+            // edm::LogVerbatim("Tracklet") << "old r: "<< oldr << "new r: " << r;
           }
           const string& stubId = resid.fpgastubid().str();
           // store seed, L1TStub, and bit accurate 64 bit word in clock accurate output

--- a/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchEngineUnit.cc
@@ -1,6 +1,7 @@
 #include "L1Trigger/TrackFindingTracklet/interface/MatchEngineUnit.h"
 #include "L1Trigger/TrackFindingTracklet/interface/TrackletLUT.h"
 #include "L1Trigger/TrackFindingTracklet/interface/Settings.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
 using namespace trklet;
@@ -79,7 +80,7 @@ void MatchEngineUnit::init(VMStubsMEMemory* vmstubsmemory,
   proj_ = proj;
 
   if (print) {
-    std::cout << "MEU Init: " << imeu_ << " " << projfinerz << " " << projfinephi << std::endl;
+    edm::LogVerbatim("Tracklet") << "MEU Init: " << imeu_ << " " << projfinerz << " " << projfinephi;
   }
 
   good__ = false;
@@ -109,8 +110,8 @@ void MatchEngineUnit::step(bool print) {
   vmstub__ = vmstubsmemory_->getVMStubMEBin(slot, istub_);
 
   if (print) {
-    std::cout << "Read vmstub MEU " << imeu_ << " " << slot << " " << istub_ << " " << vmstub__.bend().value()
-              << std::endl;
+    edm::LogVerbatim("Tracklet") << "Read vmstub MEU " << imeu_ << " " << slot << " " << istub_ << " "
+                                 << vmstub__.bend().value();
   }
 
   rzbin__ = rzbin_ + use_[iuse_].first;
@@ -187,10 +188,10 @@ void MatchEngineUnit::processPipeline(bool print) {
     }
 
     if (print) {
-      std::cout << "MEU: " << imeu_ << " "
-                << " "
-                << " " << index << " " << luttable_.lookup(index) << " " << pass << " " << dphicut << " " << stubfinephi
-                << " " << projfinephi____ << std::endl;
+      edm::LogVerbatim("Tracklet") << "MEU: " << imeu_ << " "
+                                   << " "
+                                   << " " << index << " " << luttable_.lookup(index) << " " << pass << " " << dphicut
+                                   << " " << stubfinephi << " " << projfinephi____;
     }
 
     bool goodpair = (pass && dphicut) && luttable_.lookup(index);
@@ -199,7 +200,7 @@ void MatchEngineUnit::processPipeline(bool print) {
 
     if (goodpair) {
       if (print) {
-        std::cout << "Write tp match buffer : " << imeu_ << " " << candmatches_.rptr() << std::endl;
+        edm::LogVerbatim("Tracklet") << "Write tp match buffer : " << imeu_ << " " << candmatches_.rptr();
       }
       candmatches_.store(tmppair);
     }

--- a/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MatchProcessor.cc
@@ -260,8 +260,8 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
   if (print) {
     for (unsigned int i = 0; i < inputprojs_.size(); i++) {
       for (unsigned int p = 0; p < inputprojs_[i]->nPage(); p++) {
-        std::cout << "ProjOcc: " << inputprojs_[i]->getName() << " " << p << " " << inputprojs_[i]->nTracklets(p)
-                  << std::endl;
+        edm::LogVerbatim("Tracklet") << "ProjOcc: " << inputprojs_[i]->getName() << " " << p << " "
+                                     << inputprojs_[i]->nTracklets(p);
       }
     }
   }
@@ -318,17 +318,18 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
     // This print statement is useful for detailed comparison with the HLS code
     // It prints out detailed status information for each clock step
 
+    std::stringstream mess;
     if (print) {
-      std::cout << "istep = " << istep << " projBuff: " << inputProjBuffer_.rptr() << " " << inputProjBuffer_.wptr()
-                << " " << projBufferNearFull;
-      std::cout << " " << validin << " " << validin_ << " " << validmem;
+      mess << "istep = " << istep << " projBuff: " << inputProjBuffer_.rptr() << " " << inputProjBuffer_.wptr() << " "
+           << projBufferNearFull;
+      mess << " " << validin << " " << validin_ << " " << validmem;
       unsigned int iMEU = 0;
       for (auto& matchengine : matchengines_) {
-        std::cout << " MEU" << iMEU << ": " << matchengine.rptr() << " " << matchengine.wptr() << " "
-                  << matchengine.idle() << " " << matchengine.empty() << " " << matchengine.TCID();
+        mess << " MEU" << iMEU << ": " << matchengine.rptr() << " " << matchengine.wptr() << " " << matchengine.idle()
+             << " " << matchengine.empty() << " " << matchengine.TCID();
         iMEU++;
       }
-      std::cout << std::endl;
+      edm::LogVerbatim("Tracklet") << mess.str();
     }
 
     //First do some caching of state at the start of the clock
@@ -367,7 +368,7 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
     }
 
     if (print) {
-      std::cout << "hasMatch: " << (!matchengines_[iMEbest].empty()) << std::endl;
+      edm::LogVerbatim("Tracklet") << "hasMatch: " << (!matchengines_[iMEbest].empty());
     }
 
     candidatematch_ = false;
@@ -382,7 +383,7 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
       //Consistency check
       if (oldTracklet != nullptr) {
         //allow equal here since we can have more than one cadidate match per tracklet projection
-        //cout << "old new : "<<oldTracklet->TCID()<<" "<<tracklet->TCID()<<" "<<iMEbest<<endl;
+        //edm::LogVerbatim("Tracklet") << "old new : "<<oldTracklet->TCID()<<" "<<tracklet->TCID()<<" "<<iMEbest;
         assert(oldTracklet->TCID() <= tracklet_->TCID());
       }
       oldTracklet = tracklet_;
@@ -574,7 +575,7 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
                                usesecondPlus,
                                isPSseed);
         if (print) {
-          std::cout << "Add projection to inputProjBuffer istep = " << istep << std::endl;
+          edm::LogVerbatim("Tracklet") << "Add projection to inputProjBuffer istep = " << istep;
         }
         inputProjBuffer_.store(tmpProj);
       }
@@ -589,8 +590,8 @@ void MatchProcessor::execute(unsigned int iSector, double phimin) {
       TrackletProjectionsMemory* projMem = inputprojs_[imem];
       projdata = projMem->getTracklet(read_address, ipage);
       if (print & validin) {
-        std::cout << "Reading iprojmem page, readaddress : " << istep << " " << imem << " " << ipage << " "
-                  << read_address << std::endl;
+        edm::LogVerbatim("Tracklet") << "Reading iprojmem page, readaddress : " << istep << " " << imem << " " << ipage
+                                     << " " << read_address;
       }
     }
 
@@ -727,7 +728,7 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
     if (std::abs(dphi) > 0.5 * settings_.dphisectorHG() || std::abs(dphiapprox) > 0.5 * settings_.dphisectorHG()) {
       //throw cms::Exception("LogicError") << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox
       //                                   << endl;
-      std::cout << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox << std::endl;
+      edm::LogWarning("Tracklet") << "WARNING dphi and/or dphiapprox too large : " << dphi << " " << dphiapprox;
     }
 
     bool keep = true;
@@ -748,7 +749,7 @@ bool MatchProcessor::matchCalculator(Tracklet* tracklet, const Stub* fpgastub, b
 
     if (imatch) {
       if (print) {
-        std::cout << "Adding match on istep = " << istep << std::endl;
+        edm::LogVerbatim("Tracklet") << "Adding match on istep = " << istep;
       }
 
       tracklet->addMatch(layerdisk_,

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -588,7 +588,7 @@ const std::string Tracklet::layerstubstr(const unsigned layer) const {
     oss << "0|0000000|0000000000|0000000|000000000000|000000000";
   else {
     if (trackIndex_ < 0 || trackIndex_ > (int)settings_.ntrackletmax()) {
-      cout << "trackIndex_ = " << trackIndex_ << endl;
+      edm::LogWarning("Tracklet") << "trackIndex_ = " << trackIndex_;
       assert(0);
     }
     const FPGAWord tmp(trackIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);
@@ -611,7 +611,7 @@ const std::string Tracklet::diskstubstr(const unsigned disk) const {
     oss << "0|0000000|0000000000|000000000000|000000000000|0000000";
   else {
     if (trackIndex_ < 0 || trackIndex_ > (int)settings_.ntrackletmax()) {
-      cout << "trackIndex_ = " << trackIndex_ << endl;
+      edm::LogWarning("Tracklet") << "trackIndex_ = " << trackIndex_;
       assert(0);
     }
     const FPGAWord tmp(trackIndex_, settings_.nbitstrackletindex(), true, __LINE__, __FILE__);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
@@ -570,21 +570,21 @@ bool TrackletCalculatorBase::diskSeeding(const Stub* innerFPGAStub,
   calcPars(idr, iphi1, ir1, iz1abs, iphi2, ir2, iz2abs, irinv_new, iphi0_new, iz0_new, it_new);
 
   if (print) {
-    std::cout << "=======================" << std::endl;
-    std::cout << "iphi1, ir1, iz1abs : " << iphi1 << " " << ir1 << " " << iz1abs << std::endl;
-    std::cout << "iphi2, ir2, iz2abs : " << iphi2 << " " << ir2 << " " << iz2abs << std::endl;
-    std::cout << "idr irinv iphi0 iz0 it : " << idr << " " << irinv_new << " " << iphi0_new << " " << iz0_new << " "
-              << it_new << std::endl;
+    edm::LogVerbatim("Tracklet") << "=======================";
+    edm::LogVerbatim("Tracklet") << "iphi1, ir1, iz1abs : " << iphi1 << " " << ir1 << " " << iz1abs;
+    edm::LogVerbatim("Tracklet") << "iphi2, ir2, iz2abs : " << iphi2 << " " << ir2 << " " << iz2abs;
+    edm::LogVerbatim("Tracklet") << "idr irinv iphi0 iz0 it : " << idr << " " << irinv_new << " " << iphi0_new << " "
+                                 << iz0_new << " " << it_new;
   }
 
   bool rinvcut = abs(irinv_new) < settings_.rinvcut() * (120.0 * (1 << n_rinv_)) / phiHG_;
   bool z0cut = abs(iz0_new) < settings_.z0cut() * (1 << n_z_) / 120.0;
 
   if (print) {
-    std::cout << "Pass cuts: " << rinvcut << " " << z0cut << " " << inSector(iphi0_new, irinv_new, phi0, rinv)
-              << std::endl;
-    std::cout << "rinvcut  : " << settings_.rinvmax() * (120.0 * (1 << n_rinv_)) / phiHG_ << " " << settings_.rinvmax()
-              << " " << 1.0 / ((120.0 * (1 << n_rinv_)) / phiHG_) << std::endl;
+    edm::LogVerbatim("Tracklet") << "Pass cuts: " << rinvcut << " " << z0cut << " "
+                                 << inSector(iphi0_new, irinv_new, phi0, rinv);
+    edm::LogVerbatim("Tracklet") << "rinvcut  : " << settings_.rinvmax() * (120.0 * (1 << n_rinv_)) / phiHG_ << " "
+                                 << settings_.rinvmax() << " " << 1.0 / ((120.0 * (1 << n_rinv_)) / phiHG_);
   }
 
   if (!goodTrackPars(rinvcut, z0cut))
@@ -741,12 +741,12 @@ bool TrackletCalculatorBase::overlapSeeding(const Stub* innerFPGAStub,
   calcPars(idr, iphi1, ir1abs, iz1, iphi2, ir2, iz2abs, irinv_new, iphi0_new, iz0_new, it_new);
 
   if (print) {
-    std::cout << "======================================" << std::endl;
-    std::cout << "ir:   " << ir1abs << " " << ir2 << std::endl;
-    std::cout << "iphi: " << iphi1 << " " << iphi2 << std::endl;
-    std::cout << "iz:   " << iz1 << " " << iz2abs << std::endl;
-    std::cout << "iz2 iz2mean " << iz2 << " " << iz2mean << std::endl;
-    std::cout << "pars: " << irinv_new << " " << iphi0_new << " " << iz0_new << " " << it_new << std::endl;
+    edm::LogVerbatim("Tracklet") << "======================================";
+    edm::LogVerbatim("Tracklet") << "ir:   " << ir1abs << " " << ir2;
+    edm::LogVerbatim("Tracklet") << "iphi: " << iphi1 << " " << iphi2;
+    edm::LogVerbatim("Tracklet") << "iz:   " << iz1 << " " << iz2abs;
+    edm::LogVerbatim("Tracklet") << "iz2 iz2mean " << iz2 << " " << iz2mean;
+    edm::LogVerbatim("Tracklet") << "pars: " << irinv_new << " " << iphi0_new << " " << iz0_new << " " << it_new;
   }
 
   bool rinvcut = abs(irinv_new) < settings_.rinvcut() * (120.0 * (1 << n_rinv_)) / phiHG_;

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -15,6 +15,7 @@
 #include "L1Trigger/TrackFindingTracklet/interface/Util.h"
 #include "L1Trigger/TrackTrigger/interface/Setup.h"
 #endif
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
 using namespace trklet;
@@ -669,14 +670,14 @@ void TrackletConfigBuilder::writeMergedProjectionMemories(std::ostream& os,
 
           std::string mtprojname = MPROJName(iSeed, iMergedTC, ilayer, ireg);
 
-          //std::cout << "mtprojname: " << mtprojname << " " << iSeed << std::endl;
+          //edm::LogVerbatim("Tracklet") << "mtprojname: " << mtprojname << " " << iSeed;
 
           if (MPROJNames.find(mtprojname) != MPROJNames.end()) {
-            //std::cout << "Already have: " << mtprojname << std::endl;
+            //edm::LogVerbatim("Tracklet") << "Already have: " << mtprojname;
             continue;
           }
 
-          //std::cout << "Adding: " << mtprojname << std::endl;
+          //edm::LogVerbatim("Tracklet") << "Adding: " << mtprojname;
           MPROJNames.insert(mtprojname);
           if (duplicateMPs_ &&
               (settings_.layersDisksDuplicatedEqualProjBalance()[ilayer] ||

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProcessor.cc
@@ -11,6 +11,7 @@
 
 #include <utility>
 #include <tuple>
+#include <sstream>
 
 using namespace std;
 using namespace trklet;
@@ -236,20 +237,21 @@ void TrackletProcessor::execute(unsigned int iSector, double phimin, double phim
   bool tebuffernearfull;
 
   for (unsigned int istep = 0; istep < maxStep_; istep++) {
-    // These print statements are not on by defaul but can be enabled for the
+    // These print statements are not on by default but can be enabled for the
     // comparison with HLS code to track differences.
     if (print) {
       CircularBuffer<TEData>& tedatabuffer = std::get<0>(tebuffer_);
       unsigned int& istub = std::get<1>(tebuffer_);
       unsigned int& imem = std::get<2>(tebuffer_);
-      cout << "istep=" << istep << " TEBuffer: " << istub << " " << imem << " " << tedatabuffer.rptr() << " "
+      std::stringstream mess;
+      mess << "istep=" << istep << " TEBuffer: " << istub << " " << imem << " " << tedatabuffer.rptr() << " "
            << tedatabuffer.wptr();
       int k = -1;
       for (auto& teunit : teunits_) {
         k++;
-        cout << " [" << k << " " << teunit.rptr() << " " << teunit.wptr() << " " << teunit.idle() << "]";
+        mess << " [" << k << " " << teunit.rptr() << " " << teunit.wptr() << " " << teunit.idle() << "]";
       }
-      cout << endl;
+      edm::LogVerbatim("Tracklet") << mess.str();
     }
 
     CircularBuffer<TEData>& tedatabuffer = std::get<0>(tebuffer_);

--- a/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc
+++ b/L1Trigger/TrackTrigger/src/TTClusterAlgorithm_official.cc
@@ -8,6 +8,7 @@
  */
 
 #include "L1Trigger/TrackTrigger/interface/TTClusterAlgorithm_official.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 /// Function to compare clusters and sort them by row
 template <>
@@ -142,11 +143,11 @@ void TTClusterAlgorithm_official<Ref_Phase2TrackerDigi_>::Cluster(
       /// Sort the vector by row index
       std::sort(candCluster.begin(), candCluster.end(), CompareClusters);
       /*
-      std::cout << candCluster.at(0)->row() - candCluster.back()->row() << " / " 
+      edm::LogPrint("TrackTrigger") << candCluster.at(0)->row() - candCluster.back()->row() << " / " 
 		<< static_cast<int>(candCluster.at(0)->row() - candCluster.back()->row()) << " / " 
 		<< abs( candCluster.at(0)->row() - candCluster.back()->row() ) << " / " 
 		<< std::abs( candCluster.at(0)->row() - candCluster.back()->row() ) << " / " 
-		<< mWidthCut << std::endl;
+		<< mWidthCut;
       */
       if (std::abs(static_cast<int>(candCluster.at(0)->row() - candCluster.back()->row())) <
               mWidthCut ||  /// one should add 1 to use <=


### PR DESCRIPTION
#### PR description:

Replace all "cout" statements by calls to the MessageLogger, since cout is not allowed in CMSSW due to thread safety issues.

#### PR validation:

Only affects rarely used debug printout, which should still work fine if required, but will now to MessageLogger output.
