### PR TITLE
PurgeDuplicates: fix bugs & reduce CPU

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
+++ b/L1Trigger/TrackFindingTracklet/interface/PurgeDuplicate.h
@@ -36,7 +36,7 @@ namespace trklet {
     void execute(std::vector<Track>& outputtracks, unsigned int iSector);
 
   private:
-    double getPhiRes(Tracklet* curTracklet, const Stub* curStub) const;
+    double getPhiRes(const Tracklet* curTracklet, const Stub* curStub) const;
     bool isSeedingStub(int, int, int) const;
     std::string l1tinfo(const L1TStub*, std::string) const;
     std::pair<int, int> findLayerDisk(const Stub*) const;
@@ -66,9 +66,8 @@ namespace trklet {
     // makes CompareBest comaprison into a function to make code more readable
     void doCompareBest(const std::vector<std::pair<int, int>>& stubsTrk,
                        const std::vector<const Stub*>& fullStubslistsTrk,
-                       const std::vector<Tracklet*>& sortedinputtracklets,
-                       int layStubidsTrk[],
-                       unsigned int itrk) const;
+                       const Tracklet* sortedinputtracklets,
+                       int layStubidsTrk[]) const;
 
     std::vector<Track*> inputtracks_;
     std::vector<std::vector<const Stub*>> inputstublists_;
@@ -78,6 +77,7 @@ namespace trklet {
     std::vector<TrackFitMemory*> inputtrackfits_;
     std::vector<Tracklet*> inputtracklets_;
     std::vector<CleanTrackMemory*> outputtracklets_;
+    double phiSec_;  // phi of sector.
   };
 
 };  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/interface/Sector.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Sector.h
@@ -59,20 +59,20 @@ namespace trklet {
     //Set the sector
     void setSector(unsigned int isector);
 
-    bool addStub(L1TStub stub, std::string dtc);  //TODO - should be pointer or string
+    bool addStub(L1TStub stub, const std::string& dtc);  //TODO - should be pointer or string
 
     // Creates all required memory modules based on wiring map (args: module type, module instance)
-    void addMem(std::string memType, std::string memName);
+    void addMem(const std::string& memType, const std::string& memName);
 
     // Creates all required processing modules based on wiring map (args: module type, module instance)
-    void addProc(std::string procType, std::string procName);
+    void addProc(const std::string& procType, const std::string& procName);
 
     //--- Create all required proc -> mem module connections, based on wiring map
     //--- (args: memory instance & input/output proc modules it connects to in format procName.pinName)
-    void addWire(std::string mem, std::string procinfull, std::string procoutfull);
+    void addWire(const std::string& mem, const std::string& procinfull, const std::string& procoutfull);
 
-    ProcessBase* getProc(std::string procName);
-    MemoryBase* getMem(std::string memName);
+    ProcessBase* getProc(const std::string& procName);
+    MemoryBase* getMem(const std::string& memName);
 
     void writeDTCStubs(bool first);
     void writeIRStubs(bool first);

--- a/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
@@ -85,6 +85,11 @@ namespace trklet {
       return proj_[layerdisk].valid();
     }
 
+    const Projection& proj(int layerdisk) const {
+      assert(validProj(layerdisk));
+      return proj_[layerdisk];
+    }
+
     Projection& proj(int layerdisk) {
       assert(validProj(layerdisk));
       return proj_[layerdisk];

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -59,7 +59,7 @@ void Sector::setSector(unsigned int isector) {
   }
 }
 
-bool Sector::addStub(L1TStub stub, string dtc) {
+bool Sector::addStub(L1TStub stub, const string& dtc) {
   unsigned int layerdisk = stub.layerdisk();
   int nrbits = 3;
 
@@ -84,7 +84,7 @@ bool Sector::addStub(L1TStub stub, string dtc) {
     const string& name = DL_[i]->getName();
     if (name.find("_" + dtc) == string::npos)
       continue;
-    DL_[i]->addStub(stub, fpgastub);
+    DL_[i]->addStub(stub, fpgastub);  // Creates its own copy of stub
     nadd++;
   }
 
@@ -94,7 +94,7 @@ bool Sector::addStub(L1TStub stub, string dtc) {
   return true;
 }
 
-void Sector::addMem(string memType, string memName) {
+void Sector::addMem(const string& memType, const string& memName) {
   if (memType == "DTCLink:") {
     addMemToVec(DL_, memName, settings_, phimin_, phimax_);
   } else if (memType == "InputLink:") {
@@ -125,7 +125,7 @@ void Sector::addMem(string memType, string memName) {
   }
 }
 
-void Sector::addProc(string procType, string procName) {
+void Sector::addProc(const string& procType, const string& procName) {
   if (procType == "InputRouter:") {
     addProcToVec(IR_, procName, settings_, globals_);
   } else if (procType == "VMRouterCM:") {
@@ -152,7 +152,7 @@ void Sector::addProc(string procType, string procName) {
   }
 }
 
-void Sector::addWire(string mem, string procinfull, string procoutfull) {
+void Sector::addWire(const string& mem, const string& procinfull, const string& procoutfull) {
   stringstream ss1(procinfull);
   string procin, output;
   getline(ss1, procin, '.');
@@ -176,7 +176,7 @@ void Sector::addWire(string mem, string procinfull, string procoutfull) {
   }
 }
 
-ProcessBase* Sector::getProc(string procName) {
+ProcessBase* Sector::getProc(const string& procName) {
   auto it = Processes_.find(procName);
 
   if (it != Processes_.end()) {
@@ -186,7 +186,7 @@ ProcessBase* Sector::getProc(string procName) {
   return nullptr;
 }
 
-MemoryBase* Sector::getMem(string memName) {
+MemoryBase* Sector::getMem(const string& memName) {
   auto it = Memories_.find(memName);
 
   if (it != Memories_.end()) {


### PR DESCRIPTION
#### PR description:

The PurgeDuplicate class, which is used by HYBRID for duplicate track removal was buggy. The function getPhiRes(), used to calculate the residuals between stubs and tracklets didn't take into account the fact that tracklet helix params are measured with respect to a phi sector, whereas stub coordinates are measured in the range 0 to 2*PI. The residuals coming out of it were therefore huge. I've fixed this, so the residuals are now small. In addition, it didn't use deltaPhi() to calculate the residuals, so got incorrect results if track & stub were on opposite sides of phi=0 -- also now fixed.

In addition, the CPU use of the "merge" algorithm duplicate track removal (default for HYBRID) was dominated by function doCompareBest(). With a few small changes, reducing the number of calls it makes to getPhiRes(), I've reduced the CPU use of doCompareBest() by a factor 4.

P.S. I also removed some unnecessary data copies in class Sector, so save a little more CPU.

#### PR validation:

Although CPU consumption is down, and the duplicate track algorithm now has one fewer bugs, frustratingly, with this PR the HYBRID duplicate track rate has got worse (measured on 500 ttbar + 200PU events):

**BEFORE PR**

track efficiency (pt > 2 GeV) = 94.66%
tracks/event = 184.5
duplicate tracks = 4.39%

**AFTER PR**

track efficiency (pt > 2 GeV) = 94.70%
tracks/event = 186.1
duplicate tracks = 5.09%

To make sure that I understand this worse duplicate rate, I tried temporarily disabling my two bug fixes two getPhiRes() by: (1) commenting out my new line "phiproj += phiSec_"; (2) replaced my line using deltaPhi() with the original buggy line.  And indeed this gives identical tracking performance to before my PR.
