### PR TITLE
Eliminate inconsistencies in L1 track - truth association & L1 track performance results

### DIFF
--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -90,7 +90,9 @@ public:
   ~TTTrack();
 
   /// Track components
-  const std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > >& getStubRefs() const { return theStubRefs; }
+  const std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > >& getStubRefs() const {
+    return theStubRefs;
+  }
   void addStubRef(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) { theStubRefs.push_back(aStub); }
   void setStubRefs(std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > aStubs) {
     theStubRefs = aStubs;

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -90,14 +90,14 @@ public:
   ~TTTrack();
 
   /// Track components
-  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > getStubRefs() const { return theStubRefs; }
+  const std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > >& getStubRefs() const { return theStubRefs; }
   void addStubRef(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) { theStubRefs.push_back(aStub); }
   void setStubRefs(std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > aStubs) {
     theStubRefs = aStubs;
   }
 
   /// Track momentum
-  GlobalVector momentum() const;
+  const GlobalVector& momentum() const;
 
   /// Track curvature
   double rInv() const;
@@ -121,7 +121,7 @@ public:
   double eta() const;
 
   /// POCA
-  GlobalPoint POCA() const;
+  const GlobalPoint& POCA() const;
 
   /// MVA Track quality variables
   double trkMVA1() const;
@@ -292,7 +292,7 @@ void TTTrack<T>::setFitParNo(unsigned int nPar) {
 // the unpacked values must come from the TTTrack_Trackword member functions.
 
 template <typename T>
-GlobalVector TTTrack<T>::momentum() const {
+const GlobalVector& TTTrack<T>::momentum() const {
   return theMomentum_;
 }
 
@@ -332,7 +332,7 @@ double TTTrack<T>::z0() const {
 }
 
 template <typename T>
-GlobalPoint TTTrack<T>::POCA() const {
+const GlobalPoint& TTTrack<T>::POCA() const {
   return thePOCA_;
 }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackMultiplexer.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackMultiplexer.cc
@@ -147,7 +147,7 @@ namespace trklet {
           std::vector<TTStubRef> seedTTStubRefs;
           seedTTStubRefs.reserve(channelAssignment_->numSeedingLayers());
           std::map<int, TTStubRef> mapStubs;
-          for (TTStubRef& ttStubRef : ttTrackRef->getStubRefs())
+          for (const TTStubRef& ttStubRef : ttTrackRef->getStubRefs())
             mapStubs.emplace(setup_->layerId(ttStubRef), ttStubRef);
           for (int layer : channelAssignment_->seedingLayers(ttTrackRef->trackSeedType()))
             seedTTStubRefs.push_back(mapStubs[layer]);

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerDR.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerDR.cc
@@ -167,7 +167,7 @@ namespace trklet {
     std::set<TPPtr> tpPtrs;
     std::set<TPPtr> tpPtrsSelection;
     std::set<TPPtr> tpPtrsPerfect;
-    int allMatched(0);
+    int nAllMatched(0);
     int allTracks(0);
     for (int region = 0; region < setup_->numRegions(); region++) {
       int nStubs(0);
@@ -184,7 +184,7 @@ namespace trklet {
       int tmp(0);
       associate(tracks, selection, tpPtrsSelection, tmp);
       associate(tracks, selection, tpPtrsPerfect, tmp, true);
-      associate(tracks, reconstructable, tpPtrs, allMatched);
+      associate(tracks, reconstructable, tpPtrs, nAllMatched, true);
       const tt::StreamTrack& stream = streamsTrack[region];
       const auto end = std::find_if(
           stream.rbegin(), stream.rend(), [](const tt::FrameTrack& frame) { return frame.first.isNonnull(); });
@@ -195,7 +195,7 @@ namespace trklet {
       prof_->Fill(1, nStubs);
       prof_->Fill(2, nTracks);
     }
-    prof_->Fill(4, allMatched);
+    prof_->Fill(4, nAllMatched);
     prof_->Fill(5, allTracks);
     prof_->Fill(6, tpPtrs.size());
     prof_->Fill(7, tpPtrsSelection.size());
@@ -209,8 +209,8 @@ namespace trklet {
     // printout summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
-    const double numTracks = prof_->GetBinContent(2);
-    const double totalTracks = prof_->GetBinContent(5);
+    const double numTracks = prof_->GetBinContent(2);  // tracks/nonant/event
+    const double totalTracks = prof_->GetBinContent(5);  // tracks/tracker/event
     const double numTracksMatched = prof_->GetBinContent(4);
     const double numTPsAll = prof_->GetBinContent(6);
     const double numTPsEff = prof_->GetBinContent(7);

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerDR.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerDR.cc
@@ -209,7 +209,7 @@ namespace trklet {
     // printout summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
-    const double numTracks = prof_->GetBinContent(2);  // tracks/nonant/event
+    const double numTracks = prof_->GetBinContent(2);    // tracks/nonant/event
     const double totalTracks = prof_->GetBinContent(5);  // tracks/tracker/event
     const double numTracksMatched = prof_->GetBinContent(4);
     const double numTPsAll = prof_->GetBinContent(6);

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerKF.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerKF.cc
@@ -54,7 +54,7 @@ namespace trklet {
                    int& sum,
                    const std::vector<TH1F*>& his,
                    const std::vector<TProfile*>& prof,
-                   bool perfect = true) const;
+                   bool perfect = false) const;
     //
     void analyzeTPz0(const tt::StubAssociation* sa);
     // ED input token of accepted Tracks
@@ -270,7 +270,7 @@ namespace trklet {
       if (!useMCTruth_)
         continue;
       int tmp(0);
-      associate(tracks, tracksStubs, region, selection, tpPtrsSelection, tmp, hisRes_, profRes_);
+      associate(tracks, tracksStubs, region, selection, tpPtrsSelection, tmp, hisRes_, profRes_, true);
       associate(tracks,
                 tracksStubs,
                 region,
@@ -278,9 +278,10 @@ namespace trklet {
                 tpPtrs,
                 numMatched,
                 std::vector<TH1F*>(),
-                std::vector<TProfile*>());
+                std::vector<TProfile*>(),
+                true);
       associate(
-          tracks, tracksStubs, region, selection, tpPtrsMax, tmp, std::vector<TH1F*>(), std::vector<TProfile*>(), false);
+          tracks, tracksStubs, region, selection, tpPtrsMax, tmp, std::vector<TH1F*>(), std::vector<TProfile*>());
       numTracks += nRegionTracks;
       prof_->Fill(1, nRegionStubs);
       prof_->Fill(2, nRegionTracks);

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerKF.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerKF.cc
@@ -280,8 +280,7 @@ namespace trklet {
                 std::vector<TH1F*>(),
                 std::vector<TProfile*>(),
                 true);
-      associate(
-          tracks, tracksStubs, region, selection, tpPtrsMax, tmp, std::vector<TH1F*>(), std::vector<TProfile*>());
+      associate(tracks, tracksStubs, region, selection, tpPtrsMax, tmp, std::vector<TH1F*>(), std::vector<TProfile*>());
       numTracks += nRegionTracks;
       prof_->Fill(1, nRegionStubs);
       prof_->Fill(2, nRegionTracks);

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerTM.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerTM.cc
@@ -192,7 +192,7 @@ namespace trklet {
       profChannel_->Fill(1, size);
       prof_->Fill(1, nStubs);
       prof_->Fill(2, nTracks);
-  }
+    }
     prof_->Fill(4, nAllMatched);
     prof_->Fill(5, allTracks);
     prof_->Fill(6, tpPtrs.size());
@@ -207,7 +207,7 @@ namespace trklet {
     // printout summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
-    const double numTracks = prof_->GetBinContent(2);   // tracks/nonant/event
+    const double numTracks = prof_->GetBinContent(2);    // tracks/nonant/event
     const double totalTracks = prof_->GetBinContent(5);  // tracks/tracker/event
     const double numTracksMatched = prof_->GetBinContent(4);
     const double numTPsAll = prof_->GetBinContent(6);

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerTM.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerTM.cc
@@ -166,7 +166,7 @@ namespace trklet {
     std::set<TPPtr> tpPtrs;
     std::set<TPPtr> tpPtrsSelection;
     std::set<TPPtr> tpPtrsPerfect;
-    int allMatched(0);
+    int nAllMatched(0);
     int allTracks(0);
     for (int region = 0; region < setup_->numRegions(); region++) {
       int nStubs(0);
@@ -183,7 +183,7 @@ namespace trklet {
       int tmp(0);
       associate(tracks, selection, tpPtrsSelection, tmp);
       associate(tracks, selection, tpPtrsPerfect, tmp, true);
-      associate(tracks, reconstructable, tpPtrs, allMatched);
+      associate(tracks, reconstructable, tpPtrs, nAllMatched, true);
       const tt::StreamTrack& stream = streamsTrack[region];
       const auto end = std::find_if(
           stream.rbegin(), stream.rend(), [](const tt::FrameTrack& frame) { return frame.first.isNonnull(); });
@@ -192,8 +192,8 @@ namespace trklet {
       profChannel_->Fill(1, size);
       prof_->Fill(1, nStubs);
       prof_->Fill(2, nTracks);
-    }
-    prof_->Fill(4, allMatched);
+  }
+    prof_->Fill(4, nAllMatched);
     prof_->Fill(5, allTracks);
     prof_->Fill(6, tpPtrs.size());
     prof_->Fill(7, tpPtrsSelection.size());
@@ -207,8 +207,8 @@ namespace trklet {
     // printout summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
-    const double numTracks = prof_->GetBinContent(2);
-    const double totalTracks = prof_->GetBinContent(5);
+    const double numTracks = prof_->GetBinContent(2);   // tracks/nonant/event
+    const double totalTracks = prof_->GetBinContent(5);  // tracks/tracker/event
     const double numTracksMatched = prof_->GetBinContent(4);
     const double numTPsAll = prof_->GetBinContent(6);
     const double numTPsEff = prof_->GetBinContent(7);

--- a/L1Trigger/TrackFindingTracklet/test/AnalyzerTracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/test/AnalyzerTracklet.cc
@@ -210,7 +210,7 @@ namespace trklet {
       int tmp(0);
       associate(tracks, selection, tpPtrsSelection, tmp);
       associate(tracks, selection, tpPtrsPerfect, tmp, true);
-      associate(tracks, reconstructable, tpPtrs, nAllMatched);
+      associate(tracks, reconstructable, tpPtrs, nAllMatched, true);
     }
     for (const TPPtr& tpPtr : tpPtrsSelection)
       fill(tpPtr, hisEff_);
@@ -233,8 +233,8 @@ namespace trklet {
     // printout SF summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
-    const double numTracks = prof_->GetBinContent(2);
-    const double totalTracks = prof_->GetBinContent(5);
+    const double numTracks = prof_->GetBinContent(2);    // tracks/nonant/event
+    const double totalTracks = prof_->GetBinContent(5);  // tracks/tracker/event
     const double numTracksMatched = prof_->GetBinContent(4);
     const double numTPsAll = prof_->GetBinContent(6);
     const double numTPsEff = prof_->GetBinContent(7);

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 //                                                                  //
 //  Analyzer for making mini-ntuple for L1 track performance plots  //
-//                                                                  //
+//                                                                  //   
 //////////////////////////////////////////////////////////////////////
 
 ////////////////////
@@ -60,6 +60,7 @@
 #include "L1Trigger/TrackFindingTracklet/interface/HitPatternHelper.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "CLHEP/Units/PhysicalConstants.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 
 ///////////////
 // ROOT HEADERS
@@ -190,12 +191,14 @@ private:
   std::vector<int>* m_trk_loose;
   std::vector<int>* m_trk_unknown;
   std::vector<int>* m_trk_combinatoric;
-  std::vector<int>* m_trk_fake;  //0 fake, 1 track from primary interaction, 2 secondary track
   std::vector<float>* m_trk_MVA1;
+  // Matched TP (filled if track genuine)
+  std::vector<int>* m_trk_matchtp_eventtype;  //0 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
   std::vector<int>* m_trk_matchtp_pdgid;
   std::vector<float>* m_trk_matchtp_pt;
   std::vector<float>* m_trk_matchtp_eta;
   std::vector<float>* m_trk_matchtp_phi;
+  std::vector<float>* m_trk_matchtp_lz;
   std::vector<float>* m_trk_matchtp_z0;
   std::vector<float>* m_trk_matchtp_lxy;
   std::vector<float>* m_trk_matchtp_d0;
@@ -210,9 +213,8 @@ private:
   std::vector<float>* m_tp_phi;
   std::vector<float>* m_tp_lxy;
   std::vector<float>* m_tp_d0;
+  std::vector<float>* m_tp_lz;
   std::vector<float>* m_tp_z0;
-  std::vector<float>* m_tp_d0_prod;
-  std::vector<float>* m_tp_z0_prod;
   std::vector<int>* m_tp_pdgid;
   std::vector<int>* m_tp_nmatch;
   std::vector<int>* m_tp_nstub;
@@ -222,7 +224,7 @@ private:
   std::vector<int>* m_tp_injet_highpt;
   std::vector<int>* m_tp_injet_vhighpt;
 
-  // *L1 track* properties if m_tp_nmatch > 0
+  // Best genuine *L1 track* (if any) that matches TP. Will exist if tp_nmatch > 0
   std::vector<float>* m_matchtrk_pt;
   std::vector<float>* m_matchtrk_eta;
   std::vector<float>* m_matchtrk_phi;
@@ -372,27 +374,28 @@ void L1TrackNtupleMaker::endJob() {
   delete m_trk_loose;
   delete m_trk_unknown;
   delete m_trk_combinatoric;
-  delete m_trk_fake;
   delete m_trk_MVA1;
+  delete m_trk_matchtp_eventtype;
   delete m_trk_matchtp_pdgid;
   delete m_trk_matchtp_pt;
   delete m_trk_matchtp_eta;
   delete m_trk_matchtp_phi;
+  delete m_trk_matchtp_lz;
   delete m_trk_matchtp_z0;
   delete m_trk_matchtp_lxy;
   delete m_trk_matchtp_d0;
   delete m_trk_injet;
   delete m_trk_injet_highpt;
   delete m_trk_injet_vhighpt;
+  delete m_trk_layers;
 
   delete m_tp_pt;
   delete m_tp_eta;
   delete m_tp_phi;
   delete m_tp_lxy;
   delete m_tp_d0;
+  delete m_tp_lz;
   delete m_tp_z0;
-  delete m_tp_d0_prod;
-  delete m_tp_z0_prod;
   delete m_tp_pdgid;
   delete m_tp_nmatch;
   delete m_tp_nstub;
@@ -431,6 +434,7 @@ void L1TrackNtupleMaker::endJob() {
   delete m_allstub_isBarrel;
   delete m_allstub_layer;
   delete m_allstub_isPSmodule;
+  delete m_allstub_isTiltedBarrel;
   delete m_allstub_trigDisplace;
   delete m_allstub_trigOffset;
   delete m_allstub_trigPos;
@@ -466,8 +470,8 @@ void L1TrackNtupleMaker::beginJob() {
   m_trk_pt = new std::vector<float>;
   m_trk_eta = new std::vector<float>;
   m_trk_phi = new std::vector<float>;
-  m_trk_z0 = new std::vector<float>;
   m_trk_d0 = new std::vector<float>;
+  m_trk_z0 = new std::vector<float>;
   m_trk_chi2 = new std::vector<float>;
   m_trk_chi2_dof = new std::vector<float>;
   m_trk_chi2rphi = new std::vector<float>;
@@ -495,12 +499,13 @@ void L1TrackNtupleMaker::beginJob() {
   m_trk_loose = new std::vector<int>;
   m_trk_unknown = new std::vector<int>;
   m_trk_combinatoric = new std::vector<int>;
-  m_trk_fake = new std::vector<int>;
   m_trk_MVA1 = new std::vector<float>;
+  m_trk_matchtp_eventtype = new std::vector<int>;
   m_trk_matchtp_pdgid = new std::vector<int>;
   m_trk_matchtp_pt = new std::vector<float>;
   m_trk_matchtp_eta = new std::vector<float>;
   m_trk_matchtp_phi = new std::vector<float>;
+  m_trk_matchtp_lz = new std::vector<float>;
   m_trk_matchtp_z0 = new std::vector<float>;
   m_trk_matchtp_lxy = new std::vector<float>;
   m_trk_matchtp_d0 = new std::vector<float>;
@@ -514,9 +519,8 @@ void L1TrackNtupleMaker::beginJob() {
   m_tp_phi = new std::vector<float>;
   m_tp_lxy = new std::vector<float>;
   m_tp_d0 = new std::vector<float>;
+  m_tp_lz = new std::vector<float>;
   m_tp_z0 = new std::vector<float>;
-  m_tp_d0_prod = new std::vector<float>;
-  m_tp_z0_prod = new std::vector<float>;
   m_tp_pdgid = new std::vector<int>;
   m_tp_nmatch = new std::vector<int>;
   m_tp_nstub = new std::vector<int>;
@@ -612,12 +616,13 @@ void L1TrackNtupleMaker::beginJob() {
     eventTree->Branch("trk_loose", &m_trk_loose);
     eventTree->Branch("trk_unknown", &m_trk_unknown);
     eventTree->Branch("trk_combinatoric", &m_trk_combinatoric);
-    eventTree->Branch("trk_fake", &m_trk_fake);
     eventTree->Branch("trk_MVA1", &m_trk_MVA1);
+    eventTree->Branch("trk_matchtp_eventtype", &m_trk_matchtp_eventtype);
     eventTree->Branch("trk_matchtp_pdgid", &m_trk_matchtp_pdgid);
     eventTree->Branch("trk_matchtp_pt", &m_trk_matchtp_pt);
     eventTree->Branch("trk_matchtp_eta", &m_trk_matchtp_eta);
     eventTree->Branch("trk_matchtp_phi", &m_trk_matchtp_phi);
+    eventTree->Branch("trk_matchtp_lz", &m_trk_matchtp_lz);
     eventTree->Branch("trk_matchtp_z0", &m_trk_matchtp_z0);
     eventTree->Branch("trk_matchtp_lxy", &m_trk_matchtp_lxy);
     eventTree->Branch("trk_matchtp_d0", &m_trk_matchtp_d0);
@@ -626,7 +631,7 @@ void L1TrackNtupleMaker::beginJob() {
       eventTree->Branch("trk_injet_highpt", &m_trk_injet_highpt);
       eventTree->Branch("trk_injet_vhighpt", &m_trk_injet_vhighpt);
     }
-    eventTree->Branch("m_trk_layers", &m_trk_layers);
+    eventTree->Branch("trk_layers", &m_trk_layers);
   }
 
   eventTree->Branch("tp_pt", &m_tp_pt);
@@ -634,9 +639,8 @@ void L1TrackNtupleMaker::beginJob() {
   eventTree->Branch("tp_phi", &m_tp_phi);
   eventTree->Branch("tp_lxy", &m_tp_lxy);
   eventTree->Branch("tp_d0", &m_tp_d0);
+  eventTree->Branch("tp_lz", &m_tp_lz);
   eventTree->Branch("tp_z0", &m_tp_z0);
-  eventTree->Branch("tp_d0_prod", &m_tp_d0_prod);
-  eventTree->Branch("tp_z0_prod", &m_tp_z0_prod);
   eventTree->Branch("tp_pdgid", &m_tp_pdgid);
   eventTree->Branch("tp_nmatch", &m_tp_nmatch);
   eventTree->Branch("tp_nstub", &m_tp_nstub);
@@ -724,7 +728,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     return;
   }
 
-  // clear variables
+  // Reset variables before next event
   if (SaveAllTracks) {
     m_trk_pt->clear();
     m_trk_eta->clear();
@@ -758,12 +762,13 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_trk_loose->clear();
     m_trk_unknown->clear();
     m_trk_combinatoric->clear();
-    m_trk_fake->clear();
     m_trk_MVA1->clear();
+    m_trk_matchtp_eventtype->clear();
     m_trk_matchtp_pdgid->clear();
     m_trk_matchtp_pt->clear();
     m_trk_matchtp_eta->clear();
     m_trk_matchtp_phi->clear();
+    m_trk_matchtp_lz->clear();
     m_trk_matchtp_z0->clear();
     m_trk_matchtp_lxy->clear();
     m_trk_matchtp_d0->clear();
@@ -778,9 +783,8 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
   m_tp_phi->clear();
   m_tp_lxy->clear();
   m_tp_d0->clear();
+  m_tp_lz->clear();
   m_tp_z0->clear();
-  m_tp_d0_prod->clear();
-  m_tp_z0_prod->clear();
   m_tp_pdgid->clear();
   m_tp_nmatch->clear();
   m_tp_nstub->clear();
@@ -1078,14 +1082,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_z0 = iterL1Track->z0();  //cm
       float tmp_trk_tanL = iterL1Track->tanL();
       int tmp_trk_charge = (int)TMath::Sign(1, iterL1Track->rInv());
-      bool usingNewKF = hphSetup->useNewKF();
-      if (usingNewKF) {
-        // Skip crazy tracks to avoid crash (as NewKF applies no cuts to kill them).
-        constexpr float crazy_z0_cut = 30.;  // Cut to kill any crazy tracks found by New KF (which applies no cuts)
-        if (fabs(tmp_trk_z0) > crazy_z0_cut)
-          continue;
-      }
-
+      
       int tmp_trk_hitpattern = 0;
       tmp_trk_hitpattern = (int)iterL1Track->hitPattern();
       hph::HitPatternHelper hph(hphSetup, tmp_trk_hitpattern, tmp_trk_tanL, tmp_trk_z0);
@@ -1245,27 +1242,27 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       // for studying the fake rate
       // ----------------------------------------------------------------------------------------------
 
-      edm::Ptr<TrackingParticle> my_tp = MCTruthTTTrackHandle->findTrackingParticlePtr(l1track_ptr);
-
-      int myFake = 0;
-
+      int tmp_matchtp_eventtype = -999;
       int tmp_matchtp_pdgid = -999;
       float tmp_matchtp_pt = -999;
       float tmp_matchtp_eta = -999;
       float tmp_matchtp_phi = -999;
+      float tmp_matchtp_lz = -999;
       float tmp_matchtp_z0 = -999;
       float tmp_matchtp_lxy = -999;
       float tmp_matchtp_d0 = -999;
 
-      if (my_tp.isNull())
-        myFake = 0;
-      else {
+      if (tmp_trk_genuine) { // Change this to allow matching for loosely genuine tracks too
+      
+        edm::Ptr<TrackingParticle> my_tp = MCTruthTTTrackHandle->findTrackingParticlePtr(l1track_ptr);
+        if (my_tp.isNull()) assert(false); // Should never happen
+
         int tmp_eventid = my_tp->eventId().event();
 
         if (tmp_eventid > 0)
-          myFake = 2;
+          tmp_matchtp_eventtype = 2; // Genuine track from pileup
         else
-          myFake = 1;
+          tmp_matchtp_eventtype = 1; // Genuine track from signal pp vertex
 
         tmp_matchtp_pdgid = my_tp->pdgId();
         tmp_matchtp_pt = my_tp->pt();
@@ -1276,11 +1273,12 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         float tmp_matchtp_vx = my_tp->vx();
         float tmp_matchtp_vy = my_tp->vy();
         tmp_matchtp_lxy = sqrt(tmp_matchtp_vx * tmp_matchtp_vx + tmp_matchtp_vy * tmp_matchtp_vy);
+        tmp_matchtp_lz = tmp_matchtp_vz;
 
         // ----------------------------------------------------------------------------------------------
         // get d0/z0 propagated back to the IP
 
-        float tmp_matchtp_t = 1.0 / tan(2.0 * atan(exp(-tmp_matchtp_eta)));
+        float tmp_matchtp_t = my_tp->tanl();
 
         float delx = -tmp_matchtp_vx;
         float dely = -tmp_matchtp_vy;
@@ -1294,12 +1292,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         float tmp_matchtp_rp = sqrt(tmp_matchtp_x0p * tmp_matchtp_x0p + tmp_matchtp_y0p * tmp_matchtp_y0p);
         tmp_matchtp_d0 = my_tp->charge() * tmp_matchtp_rp - (1. / (2. * r2_inv));
 
-        static double pi = M_PI;
-        float delphi = tmp_matchtp_phi - atan2(-r2_inv * tmp_matchtp_x0p, r2_inv * tmp_matchtp_y0p);
-        if (delphi < -pi)
-          delphi += 2.0 * pi;
-        if (delphi > pi)
-          delphi -= 2.0 * pi;
+        float delphi = reco::deltaPhi(tmp_matchtp_phi, atan2(-r2_inv * tmp_matchtp_x0p, r2_inv * tmp_matchtp_y0p));
         tmp_matchtp_z0 = tmp_matchtp_vz + tmp_matchtp_t * delphi / (2.0 * r2_inv);
         // ----------------------------------------------------------------------------------------------
 
@@ -1311,12 +1304,12 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         }
       }
 
-      m_trk_fake->push_back(myFake);
-
+      m_trk_matchtp_eventtype->push_back(tmp_matchtp_eventtype);
       m_trk_matchtp_pdgid->push_back(tmp_matchtp_pdgid);
       m_trk_matchtp_pt->push_back(tmp_matchtp_pt);
       m_trk_matchtp_eta->push_back(tmp_matchtp_eta);
       m_trk_matchtp_phi->push_back(tmp_matchtp_phi);
+      m_trk_matchtp_lz->push_back(tmp_matchtp_lz);
       m_trk_matchtp_z0->push_back(tmp_matchtp_z0);
       m_trk_matchtp_lxy->push_back(tmp_matchtp_lxy);
       m_trk_matchtp_d0->push_back(tmp_matchtp_d0);
@@ -1335,9 +1328,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
 
         for (int ij = 0; ij < (int)v_jets.size(); ij++) {
           float deta = tmp_trk_eta - (v_jets.at(ij)).eta();
-          float dphi = tmp_trk_phi - (v_jets.at(ij)).phi();
-          while (dphi > 3.14159)
-            dphi = std::abs(2 * 3.14159 - dphi);
+          float dphi = reco::deltaPhi(tmp_trk_phi, (v_jets.at(ij)).phi());
           float dR = sqrt(deta * deta + dphi * dphi);
 
           if (dR < 0.4) {
@@ -1400,17 +1391,14 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       continue;
 
     float tmp_tp_phi = iterTP->phi();
+    float tmp_tp_t = iterTP->tanl();
     float tmp_tp_vz = iterTP->vz();
     float tmp_tp_vx = iterTP->vx();
     float tmp_tp_vy = iterTP->vy();
     int tmp_tp_pdgid = iterTP->pdgId();
-    float tmp_tp_z0_prod = tmp_tp_vz;
-    float tmp_tp_d0_prod = tmp_tp_vx * sin(tmp_tp_phi) - tmp_tp_vy * cos(tmp_tp_phi);
 
     // ----------------------------------------------------------------------------------------------
-    // get d0/z0 propagated back to the IP
-
-    float tmp_tp_t = 1.0 / tan(2.0 * atan(exp(-tmp_tp_eta)));
+    // get d0/z0 accurately propagated back to the IP, rather than using approx from iterTP->d0() or z0().
 
     float delx = -tmp_tp_vx;
     float dely = -tmp_tp_vy;
@@ -1419,18 +1407,14 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float c_converted = CLHEP::c_light / 1.0E5;
     float r2_inv = tmp_tp_charge * c_converted * b_field / tmp_tp_pt / 2.0;
 
-    float tmp_tp_x0p = delx - (1. / (2. * r2_inv) * sin(tmp_tp_phi));
+    float tmp_tp_x0p = delx - (1. / (2. * r2_inv) * sin(tmp_tp_phi)); // centre of track circle (except sign ...)
     float tmp_tp_y0p = dely + (1. / (2. * r2_inv) * cos(tmp_tp_phi));
     float tmp_tp_rp = sqrt(tmp_tp_x0p * tmp_tp_x0p + tmp_tp_y0p * tmp_tp_y0p);
     float tmp_tp_d0 = tmp_tp_charge * tmp_tp_rp - (1. / (2. * r2_inv));
 
-    static double pi = M_PI;
-    float delphi = tmp_tp_phi - atan2(-r2_inv * tmp_tp_x0p, r2_inv * tmp_tp_y0p);
-    if (delphi < -pi)
-      delphi += 2.0 * pi;
-    if (delphi > pi)
-      delphi -= 2.0 * pi;
+    float delphi = reco::deltaPhi(tmp_tp_phi, atan2(-r2_inv * tmp_tp_x0p, r2_inv * tmp_tp_y0p));
     float tmp_tp_z0 = tmp_tp_vz + tmp_tp_t * delphi / (2.0 * r2_inv);
+
     // ----------------------------------------------------------------------------------------------
 
     if (MyProcess == 13 && abs(tmp_tp_pdgid) != 13)
@@ -1443,16 +1427,12 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     if (std::abs(tmp_tp_z0) > TP_maxZ0)
       continue;
 
-    // for pions in ttbar, only consider TPs coming from near the IP!
-    float lxy = sqrt(tmp_tp_vx * tmp_tp_vx + tmp_tp_vy * tmp_tp_vy);
-    float tmp_tp_lxy = lxy;
-    if (MyProcess == 6 && (lxy > 1.0))
-      continue;
+    float tmp_tp_lxy = sqrt(tmp_tp_vx * tmp_tp_vx + tmp_tp_vy * tmp_tp_vy);
+    float tmp_tp_lz = tmp_tp_vz;
 
     if (DebugMode)
       edm::LogVerbatim("Tracklet") << "Tracking particle, pt: " << tmp_tp_pt << " eta: " << tmp_tp_eta
                                    << " phi: " << tmp_tp_phi << " z0: " << tmp_tp_z0 << " d0: " << tmp_tp_d0
-                                   << " z_prod: " << tmp_tp_z0_prod << " d_prod: " << tmp_tp_d0_prod
                                    << " pdgid: " << tmp_tp_pdgid << " eventID: " << iterTP->eventId().event()
                                    << " ttclusters " << MCTruthTTClusterHandle->findTTClusterRefs(tp_ptr).size()
                                    << " ttstubs " << MCTruthTTStubHandle->findTTStubRefs(tp_ptr).size() << " tttracks "
@@ -1486,10 +1466,10 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       //bool isPS = (theTrackerGeom->getDetectorType(detid)==TrackerGeometry::ModuleType::Ph2PSP);
 
       //treat genuine stubs separately (==2 is genuine, ==1 is not)
-      if (MCTruthTTStubHandle->findTrackingParticlePtr(theStubRef).isNull() && hasStubInLayer[layer] < 2)
-        hasStubInLayer[layer] = 1;
-      else
+      if (MCTruthTTStubHandle->isGenuine(theStubRef))
         hasStubInLayer[layer] = 2;
+      else if (hasStubInLayer[layer] == 0)
+        hasStubInLayer[layer] = 1;
     }
 
     int nStubLayerTP = 0;
@@ -1551,8 +1531,6 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
           tmp_trk_genuine = true;
         if (MCTruthTTTrackHandle->isLooselyGenuine(matchedTracks.at(it)))
           tmp_trk_loosegenuine = true;
-        if (!tmp_trk_loosegenuine)
-          continue;
 
         if (DebugMode) {
           if (MCTruthTTTrackHandle->findTrackingParticlePtr(matchedTracks.at(it)).isNull()) {
@@ -1576,6 +1554,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
             edm::LogVerbatim("Tracklet") << "    (loose genuine!) ";
         }
 
+        if (!tmp_trk_genuine) // Change this to study effect on efficiency of looser association
+          continue;
+        
         // ----------------------------------------------------------------------------------------------
         // further require L1 track to be (loosely) genuine, that there is only one TP matched to the track
         // + have >= L1Tk_minNStub stubs for it to be a valid match (only relevant is your track collection
@@ -1607,7 +1588,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         edm::Ptr<TrackingParticle> my_tp = MCTruthTTTrackHandle->findTrackingParticlePtr(matchedTracks.at(it));
         dmatch_pt = std::abs(my_tp->p4().pt() - tmp_tp_pt);
         dmatch_eta = std::abs(my_tp->p4().eta() - tmp_tp_eta);
-        dmatch_phi = std::abs(my_tp->p4().phi() - tmp_tp_phi);
+        dmatch_phi = std::abs(reco::deltaPhi(my_tp->p4().phi(), tmp_tp_phi));
         match_id = my_tp->pdgId();
 
         float tmp_trk_chi2dof = (matchedTracks.at(it)->chi2()) / (2 * tmp_trk_nstub - L1Tk_nPar);
@@ -1626,6 +1607,8 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     }  // end has at least 1 matched L1 track
     // ----------------------------------------------------------------------------------------------
 
+    // Properties of track matching TP.
+    // (If TP matches more than one track, only properties of the track with lowest chi2/dof are stored here).
     float tmp_matchtrk_pt = -999;
     float tmp_matchtrk_eta = -999;
     float tmp_matchtrk_phi = -999;
@@ -1649,7 +1632,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     if (nMatch > 1 && DebugMode)
       edm::LogVerbatim("Tracklet") << "WARNING *** 2 or more matches to genuine L1 tracks ***";
 
-    if (nMatch > 0) {
+    if (nMatch > 0) { // TP matches at least 1 genuine track
       tmp_matchtrk_pt = matchedTracks.at(i_track)->momentum().perp();
       tmp_matchtrk_charge = (int)TMath::Sign(1, matchedTracks.at(i_track)->rInv());
       tmp_matchtrk_eta = matchedTracks.at(i_track)->momentum().eta();
@@ -1713,11 +1696,10 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_tp_pt->push_back(tmp_tp_pt);
     m_tp_eta->push_back(tmp_tp_eta);
     m_tp_phi->push_back(tmp_tp_phi);
+    m_tp_lz->push_back(tmp_tp_lz);
     m_tp_lxy->push_back(tmp_tp_lxy);
     m_tp_z0->push_back(tmp_tp_z0);
     m_tp_d0->push_back(tmp_tp_d0);
-    m_tp_z0_prod->push_back(tmp_tp_z0_prod);
-    m_tp_d0_prod->push_back(tmp_tp_d0_prod);
     m_tp_pdgid->push_back(tmp_tp_pdgid);
     m_tp_nmatch->push_back(nMatch);
     m_tp_nstub->push_back(nStubTP);
@@ -1761,9 +1743,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
 
       for (int ij = 0; ij < (int)v_jets.size(); ij++) {
         float deta = tmp_tp_eta - (v_jets.at(ij)).eta();
-        float dphi = tmp_tp_phi - (v_jets.at(ij)).phi();
-        while (dphi > 3.14159)
-          dphi = std::abs(2 * 3.14159 - dphi);
+        float dphi = reco::deltaPhi(tmp_tp_phi, (v_jets.at(ij)).phi());
         float dR = sqrt(deta * deta + dphi * dphi);
         if (dR < 0.4) {
           tp_InJet = 1;
@@ -1777,9 +1757,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
 
         if (nMatch > 0) {
           deta = tmp_matchtrk_eta - (v_jets.at(ij)).eta();
-          dphi = tmp_matchtrk_phi - (v_jets.at(ij)).phi();
-          while (dphi > 3.14159)
-            dphi = std::abs(2 * 3.14159 - dphi);
+          dphi = reco::deltaPhi(tmp_matchtrk_phi, (v_jets.at(ij)).phi());
           dR = sqrt(deta * deta + dphi * dphi);
           if (dR < 0.4) {
             matchtrk_InJet = 1;

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -195,8 +195,9 @@ private:
 
   //--- Matched TP info (filled if track genuine)
   // N.B. This TP not required to have stubs in at least 4 layers.
-  
-  std::vector<int>* m_trk_matchtp_eventtype; //event type: 0 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
+
+  std::vector<int>*
+      m_trk_matchtp_eventtype;  //event type: 0 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
   std::vector<int>* m_trk_matchtp_pdgid;
   std::vector<float>* m_trk_matchtp_pt;
   std::vector<float>* m_trk_matchtp_eta;

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -193,6 +193,7 @@ private:
   std::vector<int>* m_trk_combinatoric;
   std::vector<float>* m_trk_MVA1;
   // Matched TP (filled if track genuine)
+  // N.B. This TP not required to have stubs in at least 4 layers.
   std::vector<int>*
       m_trk_matchtp_eventtype;  //0 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
   std::vector<int>* m_trk_matchtp_pdgid;
@@ -226,6 +227,7 @@ private:
   std::vector<int>* m_tp_injet_vhighpt;
 
   // Best genuine *L1 track* (if any) that matches TP. Will exist if tp_nmatch > 0
+  // Only filled for TP that have stubs in at least 4 layers.
   std::vector<float>* m_matchtrk_pt;
   std::vector<float>* m_matchtrk_eta;
   std::vector<float>* m_matchtrk_phi;

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1,7 +1,7 @@
 //////////////////////////////////////////////////////////////////////
 //                                                                  //
 //  Analyzer for making mini-ntuple for L1 track performance plots  //
-//                                                                  //   
+//                                                                  //
 //////////////////////////////////////////////////////////////////////
 
 ////////////////////
@@ -193,7 +193,8 @@ private:
   std::vector<int>* m_trk_combinatoric;
   std::vector<float>* m_trk_MVA1;
   // Matched TP (filled if track genuine)
-  std::vector<int>* m_trk_matchtp_eventtype;  //0 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
+  std::vector<int>*
+      m_trk_matchtp_eventtype;  //0 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
   std::vector<int>* m_trk_matchtp_pdgid;
   std::vector<float>* m_trk_matchtp_pt;
   std::vector<float>* m_trk_matchtp_eta;
@@ -1082,7 +1083,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_z0 = iterL1Track->z0();  //cm
       float tmp_trk_tanL = iterL1Track->tanL();
       int tmp_trk_charge = (int)TMath::Sign(1, iterL1Track->rInv());
-      
+
       int tmp_trk_hitpattern = 0;
       tmp_trk_hitpattern = (int)iterL1Track->hitPattern();
       hph::HitPatternHelper hph(hphSetup, tmp_trk_hitpattern, tmp_trk_tanL, tmp_trk_z0);
@@ -1252,17 +1253,18 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_matchtp_lxy = -999;
       float tmp_matchtp_d0 = -999;
 
-      if (tmp_trk_genuine) { // Change this to allow matching for loosely genuine tracks too
-      
+      if (tmp_trk_genuine) {  // Change this to allow matching for loosely genuine tracks too
+
         edm::Ptr<TrackingParticle> my_tp = MCTruthTTTrackHandle->findTrackingParticlePtr(l1track_ptr);
-        if (my_tp.isNull()) assert(false); // Should never happen
+        if (my_tp.isNull())
+          assert(false);  // Should never happen
 
         int tmp_eventid = my_tp->eventId().event();
 
         if (tmp_eventid > 0)
-          tmp_matchtp_eventtype = 2; // Genuine track from pileup
+          tmp_matchtp_eventtype = 2;  // Genuine track from pileup
         else
-          tmp_matchtp_eventtype = 1; // Genuine track from signal pp vertex
+          tmp_matchtp_eventtype = 1;  // Genuine track from signal pp vertex
 
         tmp_matchtp_pdgid = my_tp->pdgId();
         tmp_matchtp_pt = my_tp->pt();
@@ -1407,7 +1409,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float c_converted = CLHEP::c_light / 1.0E5;
     float r2_inv = tmp_tp_charge * c_converted * b_field / tmp_tp_pt / 2.0;
 
-    float tmp_tp_x0p = delx - (1. / (2. * r2_inv) * sin(tmp_tp_phi)); // centre of track circle (except sign ...)
+    float tmp_tp_x0p = delx - (1. / (2. * r2_inv) * sin(tmp_tp_phi));  // centre of track circle (except sign ...)
     float tmp_tp_y0p = dely + (1. / (2. * r2_inv) * cos(tmp_tp_phi));
     float tmp_tp_rp = sqrt(tmp_tp_x0p * tmp_tp_x0p + tmp_tp_y0p * tmp_tp_y0p);
     float tmp_tp_d0 = tmp_tp_charge * tmp_tp_rp - (1. / (2. * r2_inv));
@@ -1554,9 +1556,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
             edm::LogVerbatim("Tracklet") << "    (loose genuine!) ";
         }
 
-        if (!tmp_trk_genuine) // Change this to study effect on efficiency of looser association
+        if (!tmp_trk_genuine)  // Change this to study effect on efficiency of looser association
           continue;
-        
+
         // ----------------------------------------------------------------------------------------------
         // further require L1 track to be (loosely) genuine, that there is only one TP matched to the track
         // + have >= L1Tk_minNStub stubs for it to be a valid match (only relevant is your track collection
@@ -1632,7 +1634,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     if (nMatch > 1 && DebugMode)
       edm::LogVerbatim("Tracklet") << "WARNING *** 2 or more matches to genuine L1 tracks ***";
 
-    if (nMatch > 0) { // TP matches at least 1 genuine track
+    if (nMatch > 0) {  // TP matches at least 1 genuine track
       tmp_matchtrk_pt = matchedTracks.at(i_track)->momentum().perp();
       tmp_matchtrk_charge = (int)TMath::Sign(1, matchedTracks.at(i_track)->rInv());
       tmp_matchtrk_eta = matchedTracks.at(i_track)->momentum().eta();

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -158,7 +158,7 @@ private:
 
   TTree* eventTree;
 
-  // all L1 tracks
+  //--- all L1 tracks
   std::vector<float>* m_trk_pt;
   std::vector<float>* m_trk_eta;
   std::vector<float>* m_trk_phi;
@@ -192,10 +192,11 @@ private:
   std::vector<int>* m_trk_unknown;
   std::vector<int>* m_trk_combinatoric;
   std::vector<float>* m_trk_MVA1;
-  // Matched TP (filled if track genuine)
+
+  //--- Matched TP info (filled if track genuine)
   // N.B. This TP not required to have stubs in at least 4 layers.
-  std::vector<int>*
-      m_trk_matchtp_eventtype;  //0 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
+  
+  std::vector<int>* m_trk_matchtp_eventtype; //event type: 0 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
   std::vector<int>* m_trk_matchtp_pdgid;
   std::vector<float>* m_trk_matchtp_pt;
   std::vector<float>* m_trk_matchtp_eta;
@@ -209,7 +210,7 @@ private:
   std::vector<int>* m_trk_injet_vhighpt;  //is the track within dR<0.4 of a genjet with pt > 200 GeV?
   std::vector<std::vector<int>>* m_trk_layers;
 
-  // all tracking particles
+  //--- all tracking particles passing cuts in cfg file (e.g. >=4 stub layers)
   std::vector<float>* m_tp_pt;
   std::vector<float>* m_tp_eta;
   std::vector<float>* m_tp_phi;
@@ -226,7 +227,7 @@ private:
   std::vector<int>* m_tp_injet_highpt;
   std::vector<int>* m_tp_injet_vhighpt;
 
-  // Best genuine *L1 track* (if any) that matches TP. Will exist if tp_nmatch > 0
+  //--- Best genuine *L1 track* (if any) that matches TP. Will exist if tp_nmatch > 0
   // Only filled for TP that have stubs in at least 4 layers.
   std::vector<float>* m_matchtrk_pt;
   std::vector<float>* m_matchtrk_eta;

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -43,33 +43,47 @@ void makeResidualIntervalPlot(
 // Main script
 // ----------------------------------------------------------------------------------------------------------------
 
-void L1TrackNtuplePlot(TString type,
-                       TString type_dir = "",
-                       TString treeName = "",
+void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
+                       TString inputDir = "./",
+                       bool useDisplacedTrkCuts = false,
+                       bool doDetailedPlots = true,
+                       // For displaced tracking studies, consider using TP_minPt = 3.0, TP_maxEta = 2.0.
+                       float TP_minPt = 2.0,
+                       float TP_maxEta = 2.5,
+                       // The following four options may not work for all plots ...
                        int TP_select_injet = 0,
                        int TP_select_pdgid = 0,
                        int TP_select_eventid = 0,
-                       bool useDeadRegion = false,
-                       float TP_minPt = 2.0,
-                       float TP_maxEta = 2.5,
-                       float TP_maxLxy = 1.0,
-                       float TP_maxLz = 30.0,
-                       float TP_maxD0 = 1.0,
-                       float TP_maxZ0 = 15.,
-                       bool doDetailedPlots = false) {
-  // type:              this is the name of the input file you want to process (minus ".root" extension)
-  // type_dir:          this is the directory containing the input file you want to process. Note that this must end with a "/", as in "EventSets/"
-  // TP_select_pdgid:   if non-zero, only select TPs with a given PDG ID
-  // TP_select_eventid: if zero, only look at TPs from primary interaction, else, include TPs from pileup
+                       bool useDeadRegion = false) {
+  // inputRootFile:     this is the name of the input file you want to process (minus ".root" extension)
+  // inputDir:          this is the directory containing the input file you want to process. It must end with a "/".
+  // useDisplacedTrkCuts: set true if studying displaced tracking performance.
+  // doDetailedPlots:   includes extra plots, such as  performance vs d0.
   // TP_minPt:          only look at TPs with pt > X GeV
   // TP_maxEta:         only look at TPs with |eta| < X
-  // doDetailedPlots:   includes extra plots, such as  performance vs d0.
-
   // TP_select_injet: only look at TPs that are within a jet with pt > 30 GeV (==1) or within a jet with pt > 100 GeV (==2), >200 GeV (==3) or all TPs (==0)
+  // TP_select_pdgid:   if non-zero, only select TPs with a given PDG ID
+  // TP_select_eventid: if zero, only look at TPs from primary interaction, else, include TPs from pileup
+  // useDeadRegion: make (some?) plots only for dead regions of Tracker.
 
-  //--  N.B. For standard displaced tracking plots, set TP_minPt=3.0, TP_maxEta=2.0, TP_maxLxy=10.0, TP_maxLz=60.0,
-  //--  TP_maxD0=10.0, TP_maxZ0=30.0, doDetailedPlots=true. (Efficiency plots vs eta also usually made for d0 < 5).
+  // -----------------------------------------------------------------------------------------
+  // Baseline cut scenario for efficiency and rate plots ==> configure as appropriate
+  constexpr int L1Tk_minNstub = 4;
+  constexpr float L1Tk_maxChi2 = 999999;
+  constexpr float L1Tk_maxChi2dof = 999999.;
+// Use looser impact-parameter related cuts for displaced tracking studies.
+  const float TP_maxLxy = useDisplacedTrkCuts ? 10.0 : 1.0;
+  const float TP_maxLz = useDisplacedTrkCuts ? 60.0 : 30.0;
+  const float TP_maxD0 = useDisplacedTrkCuts ? 10.0 : 1.0;
+  const float TP_maxZ0 = useDisplacedTrkCuts ? 30.0 : 15.0;
+// Optionally also tighten Pt and Eta cuts.
+//if (useDisplacedTrkCuts) {
+//  TP_minPt = 3.0;
+//  TP_maxEta = 2.0;
+//}
 
+  constexpr bool doGausFit = false;  //do gaussian fit for resolution vs eta/pt plots
+  
   gROOT->SetBatch();
   gErrorIgnoreLevel = kWarning;
 
@@ -77,16 +91,6 @@ void L1TrackNtuplePlot(TString type,
 
   cout.setf(ios::fixed);
   cout.precision(2);
-
-  // ----------------------------------------------------------------------------------------------------------------
-  // define input options
-
-  // Baseline cut scenario for efficiency and rate plots ==> configure as appropriate
-  constexpr int L1Tk_minNstub = 4;
-  constexpr float L1Tk_maxChi2 = 999999;
-  constexpr float L1Tk_maxChi2dof = 999999.;
-
-  constexpr bool doGausFit = false;  //do gaussian fit for resolution vs eta/pt plots
 
   // tracklet variables
   int L1Tk_seed = 0;
@@ -121,8 +125,8 @@ void L1TrackNtuplePlot(TString type,
   int ntp_ndupmatch_pt2 = 0;
   // ----------------------------------------------------------------------------------------------------------------
   // read ntuples
-  TChain* tree = new TChain("L1TrackNtuple" + treeName + "/eventTree");
-  tree->Add(type_dir + type + ".root");
+  TChain* tree = new TChain("L1TrackNtuple/eventTree");
+  tree->Add(inputDir + inputRootFile + ".root");
 
   if (tree->GetEntries() == 0) {
     cout << "File doesn't exist or is empty, returning..."
@@ -677,17 +681,14 @@ void L1TrackNtuplePlot(TString type,
   // total track rates
 
   TH1F* h_trk_all_vspt = new TH1F("trk_all_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);
-  TH1F* h_trk_loose_vspt = new TH1F("trk_loose_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);
   TH1F* h_trk_genuine_vspt = new TH1F("trk_genuine_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);
-  TH1F* h_trk_notloose_vspt = new TH1F("trk_notloose_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);  // fake
-  TH1F* h_trk_notgenuine_vspt = new TH1F("trk_notgenuine_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);
-  TH1F* h_trk_duplicate_vspt = new TH1F("trk_duplicate_vspt",
-                                        ";Track p_{T} [GeV]; ",
-                                        50,
-                                        0,
-                                        25);  //where a TP is genuinely matched to more than one L1 track
+  TH1F* h_trk_fake_vspt = new TH1F("trk_fake_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);
+  TH1F* h_trk_duplicate_vspt = new TH1F("trk_duplicate_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);
   TH1F* h_tp_vspt = new TH1F("tp_vspt", ";TP p_{T} [GeV]; ", 50, 0, 25);
 
+  TH1F* h_trk_all_vsseed = new TH1F("trk_all_seed", ";Seed type; ", 15, -0.5, 14.5);
+  TH1F* h_trk_fake_vsseed = new TH1F("trk_fake_seed", ";Seed type; ", 15, -0.5, 14.5);
+  
   // ----------------------------------------------------------------------------------------------------------------
 
   TH1F* h_tp_z0 = new TH1F("tp_z0", ";Tracking particle z_{0} [cm]; Tracking particles / 1.0 cm", 50, -25.0, 25.0);
@@ -1136,16 +1137,15 @@ void L1TrackNtuplePlot(TString type,
         ntrk_pt2++;
         ntrkevt_pt2++;
         h_trk_all_vspt->Fill(trk_pt->at(it));
+        h_trk_all_vsseed->Fill(trk_seed->at(it));
         if (trk_genuine->at(it) == 1) {
           ntrk_genuine_pt2++;
           ntrkevt_genuine_pt2++;
           h_trk_genuine_vspt->Fill(trk_pt->at(it));
-        } else
-          h_trk_notgenuine_vspt->Fill(trk_pt->at(it));
-        if (trk_loose->at(it) == 1)
-          h_trk_loose_vspt->Fill(trk_pt->at(it));
-        else
-          h_trk_notloose_vspt->Fill(trk_pt->at(it));
+        } else {
+          h_trk_fake_vspt->Fill(trk_pt->at(it));
+          h_trk_fake_vsseed->Fill(trk_seed->at(it));
+        }
       }
       if (trk_pt->at(it) > 3.0) {
         ntrk_pt3++;
@@ -2432,6 +2432,8 @@ void L1TrackNtuplePlot(TString type,
   // output file for histograms
   // -------------------------------------------------------------------------------------------
 
+  TString type = inputRootFile;
+  
   if (TP_select_pdgid != 0) {
     char pdgidtxt[500];
     sprintf(pdgidtxt, "_pdgid%i", TP_select_pdgid);
@@ -2461,7 +2463,7 @@ void L1TrackNtuplePlot(TString type,
     type = type + pttxt;
   }
 
-  TFile* fout = new TFile(type_dir + "output_" + type + treeName + ".root", "recreate");
+  TFile* fout = new TFile(inputDir + "output_" + inputRootFile + ".root", "recreate");
 
   // -------------------------------------------------------------------------------------------
   // draw and save plots
@@ -3415,32 +3417,29 @@ void L1TrackNtuplePlot(TString type,
   // "fake rates"
 
   h_trk_all_vspt->Sumw2();
-  h_trk_loose_vspt->Sumw2();
   h_trk_genuine_vspt->Sumw2();
-  h_trk_notloose_vspt->Sumw2();
-  h_trk_notgenuine_vspt->Sumw2();
+  h_trk_fake_vspt->Sumw2();
   h_trk_duplicate_vspt->Sumw2();
   h_tp_vspt->Sumw2();
 
   // fraction of not genuine tracks
-  TH1F* h_notgenuine_pt = (TH1F*)h_trk_notgenuine_vspt->Clone();
-  h_notgenuine_pt->SetName("notgenuine_pt");
-  h_notgenuine_pt->GetYaxis()->SetTitle("Not genuine fraction");
-  h_notgenuine_pt->Divide(h_trk_notgenuine_vspt, h_trk_all_vspt, 1.0, 1.0, "B");
+  TH1F* h_fake_pt = (TH1F*)h_trk_fake_vspt->Clone();
+  h_fake_pt->SetName("fake_pt");
+  h_fake_pt->GetYaxis()->SetTitle("Fake fraction");
+  h_fake_pt->Divide(h_trk_fake_vspt, h_trk_all_vspt, 1.0, 1.0, "B");
 
-  h_notgenuine_pt->Write();
-  h_notgenuine_pt->Draw();
-  c.SaveAs(DIR + type + "_notgenuine.pdf");
+  h_fake_pt->Write();
+  h_fake_pt->Draw();
+  c.SaveAs(DIR + type + "_fake_pt.pdf");
 
-  // fraction of not loosely genuine tracks
-  TH1F* h_notloose_pt = (TH1F*)h_trk_notloose_vspt->Clone();
-  h_notloose_pt->SetName("notloose_pt");
-  h_notloose_pt->GetYaxis()->SetTitle("Not loose fraction");
-  h_notloose_pt->Divide(h_trk_notloose_vspt, h_trk_all_vspt, 1.0, 1.0, "B");
+  TH1F* h_fake_seed = (TH1F*)h_trk_fake_vsseed->Clone();
+  h_fake_seed->SetName("fake_seed");
+  h_fake_seed->GetYaxis()->SetTitle("Fake fraction");
+  h_fake_seed->Divide(h_trk_fake_vsseed, h_trk_all_vsseed, 1.0, 1.0, "B");
 
-  h_notloose_pt->Write();
-  h_notloose_pt->Draw();
-  c.SaveAs(DIR + type + "_notloose.pdf");
+  h_fake_seed->Write();
+  h_fake_seed->Draw();
+  c.SaveAs(DIR + type + "_fake_seed.pdf");
 
   // fraction of DUPLICATE tracks (genuine and not matched)
   TH1F* h_duplicatefrac_pt = (TH1F*)h_trk_duplicate_vspt->Clone();
@@ -3456,10 +3455,8 @@ void L1TrackNtuplePlot(TString type,
   // total track rates vs pt
 
   h_trk_all_vspt->Scale(1.0 / nevt);
-  h_trk_loose_vspt->Scale(1.0 / nevt);
   h_trk_genuine_vspt->Scale(1.0 / nevt);
-  h_trk_notloose_vspt->Scale(1.0 / nevt);
-  h_trk_notgenuine_vspt->Scale(1.0 / nevt);
+  h_trk_fake_vspt->Scale(1.0 / nevt);
   h_trk_duplicate_vspt->Scale(1.0 / nevt);
   h_tp_vspt->Scale(1.0 / nevt);
 
@@ -3468,8 +3465,8 @@ void L1TrackNtuplePlot(TString type,
   h_tp_vspt->SetLineColor(4);
   h_tp_vspt->SetLineStyle(2);
 
-  h_trk_notgenuine_vspt->SetLineColor(2);
-  h_trk_notgenuine_vspt->SetLineStyle(1);
+  h_trk_fake_vspt->SetLineColor(2);
+  h_trk_fake_vspt->SetLineStyle(1);
 
   h_trk_duplicate_vspt->SetLineColor(8);
   h_trk_duplicate_vspt->SetLineStyle(2);
@@ -3482,14 +3479,12 @@ void L1TrackNtuplePlot(TString type,
   h_tp_vspt->Draw("hist");
   h_trk_all_vspt->Draw("same,hist");
   h_tp_vspt->Draw("same,hist");
-  h_trk_notgenuine_vspt->Draw("same,hist");
+  h_trk_fake_vspt->Draw("same,hist");
   //h_trk_duplicate_vspt->Draw("same,hist");
 
   h_trk_all_vspt->Write();
-  h_trk_loose_vspt->Write();
   h_trk_genuine_vspt->Write();
-  h_trk_notloose_vspt->Write();
-  h_trk_notgenuine_vspt->Write();
+  h_trk_fake_vspt->Write();
   h_trk_duplicate_vspt->Write();
   h_tp_vspt->Write();
 
@@ -3503,7 +3498,7 @@ void L1TrackNtuplePlot(TString type,
   mySmallText(0.5, 0.79, 4, txt3);
   mySmallText(0.5, 0.74, 4, txt2);
 
-  sprintf(txt, "# !genuine tracks/event = %.1f", h_trk_notgenuine_vspt->GetSum());
+  sprintf(txt, "# fake tracks/event = %.1f", h_trk_fake_vspt->GetSum());
   mySmallText(0.5, 0.69, 2, txt);
   //sprintf(txt,"# duplicates/event = %.1f",h_trk_duplicate_vspt->GetSum());
   //mySmallText(0.5,0.64,8,txt);
@@ -3513,6 +3508,34 @@ void L1TrackNtuplePlot(TString type,
   gPad->SetLogy();
   c.SaveAs(DIR + type + "_trackrate_vspt_log.pdf");
   gPad->SetLogy(0);
+  
+  // ---------------------------------------------------------------------------------------------------------
+  // total track rates vs seed
+
+  h_trk_all_vsseed->Scale(1.0 / nevt);
+  h_trk_fake_vsseed->Scale(1.0 / nevt);
+
+  h_trk_all_vsseed->GetYaxis()->SetTitle("Tracks / event");
+  h_trk_all_vsseed->GetXaxis()->SetTitle("Seed type");
+  h_trk_all_vsseed->SetLineColor(4);
+  h_trk_all_vsseed->SetLineStyle(1);
+  
+  h_trk_fake_vsseed->SetLineColor(2);
+  h_trk_fake_vsseed->SetLineStyle(2);
+
+  h_trk_all_vsseed->Draw("hist");
+  h_trk_fake_vsseed->Draw("hist,same");
+
+  h_trk_all_vsseed->Write();
+  h_trk_fake_vsseed->Write();
+
+  sprintf(txt, "# tracks/event = %.1f", h_trk_all_vsseed->GetSum());
+  mySmallText(0.5, 0.85, 4, txt);
+  sprintf(txt, "# fake tracks/event = %.1f", h_trk_fake_vsseed->GetSum());
+  mySmallText(0.5, 0.75, 2, txt);
+
+  gPad->SetLogy(0);
+  c.SaveAs(DIR + type + "_trackrate_vsseed.pdf");
 
   // ---------------------------------------------------------------------------------------------------------
   // sum track/ TP pt in jets

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -138,7 +138,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   // ----------------------------------------------------------------------------------------------------------------
   // define leafs & branches
 
-  // tracking particles
+  // all tracking particles passing cuts in cfg file (e.g. >=4 stub layers)
   vector<float>* tp_pt;
   vector<float>* tp_eta;
   vector<float>* tp_phi;
@@ -155,6 +155,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   vector<int>* tp_injet_vhighpt;
 
   // *L1 track* properties, for tracking particles matched to a L1 track
+  // Will exist if tp_nmatch > 0.
   // (If TP matched more than one track, only the track with lowest chi2/dof stored here).
   vector<float>* matchtrk_pt;
   vector<float>* matchtrk_eta;

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -974,15 +974,15 @@ void L1TrackNtuplePlot(TString type,
   TH1F* h_ntrk_genuine_pt10 =
       new TH1F("ntrk_genuine_pt10", ";# genuine tracks (p_{T} > 10 GeV) / event; Events", 100, 0, 100.0);
 
-  // Max N tracks from a sector per event
+  // Max N tracks from a sector per event (electronics truncates at 108)
   TH1F* h_ntrkPerNonantPerLink_all =
-      new TH1F("ntrkPerNonantPerLink_all", ";Max. # tracks from a sector / event; Events", 50, 0, 100.0);
+      new TH1F("ntrkPerNonantPerLink_all", ";Max. # tracks from a sector / event; Events", 30, -2., 118.);
   TH1F* h_ntrkPerNonantPerLink_pt2 = new TH1F(
-      "ntrkPerNonantPerLink_pt2", ";Max. # tracks from a sector (p_{T} > 2 GeV) / event; Events", 50, 0, 100.0);
+      "ntrkPerNonantPerLink_pt2", ";Max. # tracks from a sector (p_{T} > 2 GeV) / event; Events", 30, -2., 118.);
   TH1F* h_ntrkPerNonantPerLink_pt3 = new TH1F(
-      "ntrkPerNonantPerLink_pt3", ";Max. # tracks from a sector (p_{T} > 3 GeV) / event; Events", 50, 0, 100.0);
+      "ntrkPerNonantPerLink_pt3", ";Max. # tracks from a sector (p_{T} > 3 GeV) / event; Events", 30, -2., 118.);
   TH1F* h_ntrkPerNonantPerLink_pt4 = new TH1F(
-      "ntrkPerNonantPerLink_pt4", ";Max. # tracks from a sector (p_{T} > 10 GeV) / event; Events", 50, 0, 100.0);
+      "ntrkPerNonantPerLink_pt4", ";Max. # tracks from a sector (p_{T} > 10 GeV) / event; Events", 30, -2, 118);
 
   // number of tracks vs. efficiency (eta, pT)
   TH1F* h_trk_pt = new TH1F("trk_pt", Form(";Track p_{T} (GeV);Tracks / 0.5 GeV"), 200, 0., 100.);
@@ -1035,10 +1035,10 @@ void L1TrackNtuplePlot(TString type,
 
     // Each sector uses two output links to output tracks to L1 trigger.
     constexpr unsigned int nNonants = 9, nLink = 2;
-    vector<unsigned int> nTrksPerSectorPerLink_all(nNonants * nLink, 0);
-    vector<unsigned int> nTrksPerSectorPerLink_pt2(nNonants * nLink, 0);
-    vector<unsigned int> nTrksPerSectorPerLink_pt3(nNonants * nLink, 0);
-    vector<unsigned int> nTrksPerSectorPerLink_pt4(nNonants * nLink, 0);
+    vector<unsigned int> nTrksPerNonantPerLink_all(nNonants * nLink, 0);
+    vector<unsigned int> nTrksPerNonantPerLink_pt2(nNonants * nLink, 0);
+    vector<unsigned int> nTrksPerNonantPerLink_pt3(nNonants * nLink, 0);
+    vector<unsigned int> nTrksPerNonantPerLink_pt4(nNonants * nLink, 0);
 
     for (int it = 0; it < (int)trk_pt->size(); it++) {  // Loop reco tracks
       // ----------------------------------------------------------------------------------------------------------------
@@ -1120,17 +1120,17 @@ void L1TrackNtuplePlot(TString type,
       if (trk_eta->at(it) > 0)
         linkOut += nNonants;
 
-      ++nTrksPerSectorPerLink_all.at(linkOut);
+      ++nTrksPerNonantPerLink_all.at(linkOut);
 
       if (std::abs(trk_eta->at(it)) > TP_maxEta || trk_pt->at(it) < TP_minPt)
         continue;
 
       if (trk_pt->at(it) > 2.0)
-        ++nTrksPerSectorPerLink_pt2.at(linkOut);
+        ++nTrksPerNonantPerLink_pt2.at(linkOut);
       if (trk_pt->at(it) > 3.0)
-        ++nTrksPerSectorPerLink_pt3.at(linkOut);
+        ++nTrksPerNonantPerLink_pt3.at(linkOut);
       if (trk_pt->at(it) > 4.0)
-        ++nTrksPerSectorPerLink_pt4.at(linkOut);
+        ++nTrksPerNonantPerLink_pt4.at(linkOut);
 
       if (trk_pt->at(it) > 2.0) {
         ntrk_pt2++;
@@ -1194,14 +1194,11 @@ void L1TrackNtuplePlot(TString type,
     h_ntrk_genuine_pt3->Fill(ntrkevt_genuine_pt3);
     h_ntrk_genuine_pt10->Fill(ntrkevt_genuine_pt10);
 
-    h_ntrkPerNonantPerLink_all->Fill(
-        *std::max_element(nTrksPerSectorPerLink_all.begin(), nTrksPerSectorPerLink_all.end()));
-    h_ntrkPerNonantPerLink_pt2->Fill(
-        *std::max_element(nTrksPerSectorPerLink_pt2.begin(), nTrksPerSectorPerLink_pt2.end()));
-    h_ntrkPerNonantPerLink_pt3->Fill(
-        *std::max_element(nTrksPerSectorPerLink_pt3.begin(), nTrksPerSectorPerLink_pt3.end()));
-    h_ntrkPerNonantPerLink_pt4->Fill(
-        *std::max_element(nTrksPerSectorPerLink_pt4.begin(), nTrksPerSectorPerLink_pt4.end()));
+    const float nTrkPerLinkOverflow = h_ntrkPerNonantPerLink_all->GetXaxis()->GetXmax() - 0.1; // Add overflow bin
+    h_ntrkPerNonantPerLink_all->Fill(min(float(*std::max_element(nTrksPerNonantPerLink_all.begin(), nTrksPerNonantPerLink_all.end())), nTrkPerLinkOverflow));
+    h_ntrkPerNonantPerLink_pt2->Fill(min(float(*std::max_element(nTrksPerNonantPerLink_pt2.begin(), nTrksPerNonantPerLink_pt2.end())), nTrkPerLinkOverflow));
+    h_ntrkPerNonantPerLink_pt3->Fill(min(float(*std::max_element(nTrksPerNonantPerLink_pt3.begin(), nTrksPerNonantPerLink_pt3.end())), nTrkPerLinkOverflow));
+    h_ntrkPerNonantPerLink_pt4->Fill(min(float(*std::max_element(nTrksPerNonantPerLink_pt4.begin(), nTrksPerNonantPerLink_pt4.end())), nTrkPerLinkOverflow));
 
     // ----------------------------------------------------------------------------------------------------------------
     // Loop tracking particles
@@ -3569,33 +3566,36 @@ void L1TrackNtuplePlot(TString type,
   h_ntrkPerNonantPerLink_all->GetYaxis()->SetTitle("Fraction of events");
   h_ntrkPerNonantPerLink_all->GetXaxis()->SetTitle("Max no. of transmitted tracks/nonant/link");
 
-  h_ntrkPerNonantPerLink_all->SetLineColor(1);
-  h_ntrkPerNonantPerLink_pt2->SetLineColor(4);
-  h_ntrkPerNonantPerLink_pt3->SetLineColor(2);
-  h_ntrkPerNonantPerLink_pt4->SetLineColor(8);
+  h_ntrkPerNonantPerLink_all->SetFillColor(8);
+  h_ntrkPerNonantPerLink_all->SetFillStyle(1001);
+  h_ntrkPerNonantPerLink_pt2->SetMarkerColor(4);
+  h_ntrkPerNonantPerLink_pt2->SetMarkerStyle(21);
+  h_ntrkPerNonantPerLink_pt3->SetMarkerColor(2);
+  h_ntrkPerNonantPerLink_pt3->SetMarkerStyle(22);
+  h_ntrkPerNonantPerLink_pt4->SetMarkerColor(1);
+  h_ntrkPerNonantPerLink_pt4->SetMarkerStyle(23);
 
   max = h_ntrkPerNonantPerLink_all->GetMaximum();
-  h_ntrkPerNonantPerLink_all->SetAxisRange(0.00001, max * 5, "Y");
-  h_ntrkPerNonantPerLink_all->SetAxisRange(0., 100, "X");
+  h_ntrkPerNonantPerLink_all->SetAxisRange(0.0003, max * 5, "Y");
 
-  h_ntrkPerNonantPerLink_all->Draw("hist");
-  h_ntrkPerNonantPerLink_pt2->Draw("same,hist");
-  h_ntrkPerNonantPerLink_pt3->Draw("same,hist");
-  h_ntrkPerNonantPerLink_pt4->Draw("same,hist");
+  h_ntrkPerNonantPerLink_all->Draw("HIST");
+  h_ntrkPerNonantPerLink_pt4->Draw("PEX0,same");
+  h_ntrkPerNonantPerLink_pt3->Draw("PEX0,same");
+  h_ntrkPerNonantPerLink_pt2->Draw("PEX0,same");
   gPad->SetLogy();
 
-  TLegend* l = new TLegend(0.6, 0.55, 0.85, 0.85);
+  TLegend* l = new TLegend(0.6, 0.7, 0.85, 0.95);
   l->SetFillStyle(0);
   l->SetBorderSize(0);
   l->SetTextSize(0.04);
-  l->AddEntry(h_ntrkPerNonantPerLink_all, "no p_{T}cut", "l");
-  l->AddEntry(h_ntrkPerNonantPerLink_pt2, "p_{T}^{track} > 2 GeV", "l");
-  l->AddEntry(h_ntrkPerNonantPerLink_pt3, "p_{T}^{track} > 3 GeV", "l");
-  l->AddEntry(h_ntrkPerNonantPerLink_pt4, "p_{T}^{track} > 4 GeV", "l");
+  l->AddEntry(h_ntrkPerNonantPerLink_all, "no p_{T}cut", "f");
+  l->AddEntry(h_ntrkPerNonantPerLink_pt2, "p_{T}^{track} > 2 GeV", "p");
+  l->AddEntry(h_ntrkPerNonantPerLink_pt3, "p_{T}^{track} > 3 GeV", "p");
+  l->AddEntry(h_ntrkPerNonantPerLink_pt4, "p_{T}^{track} > 4 GeV", "p");
   l->SetTextFont(42);
   l->Draw();
 
-  c.SaveAs(DIR + type + "_trackRatePerPhiSector_log.pdf");
+  c.SaveAs(DIR + type + "_trackRatePerNonantPerLink_log.pdf");
   gPad->SetLogy(0);
 
   h_ntrk_genuine_pt2->Write();

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -975,14 +975,14 @@ void L1TrackNtuplePlot(TString type,
       new TH1F("ntrk_genuine_pt10", ";# genuine tracks (p_{T} > 10 GeV) / event; Events", 100, 0, 100.0);
 
   // Max N tracks from a sector per event
-  TH1F* h_ntrkPerSector_all =
-      new TH1F("ntrkPerSector_all", ";Max. # tracks from a sector / event; Events", 50, 0, 100.0);
-  TH1F* h_ntrkPerSector_pt2 =
-      new TH1F("ntrkPerSector_pt2", ";Max. # tracks from a sector (p_{T} > 2 GeV) / event; Events", 50, 0, 100.0);
-  TH1F* h_ntrkPerSector_pt3 =
-      new TH1F("ntrkPerSector_pt3", ";Max. # tracks from a sector (p_{T} > 3 GeV) / event; Events", 50, 0, 100.0);
-  TH1F* h_ntrkPerSector_pt4 =
-      new TH1F("ntrkPerSector_pt4", ";Max. # tracks from a sector (p_{T} > 10 GeV) / event; Events", 50, 0, 100.0);
+  TH1F* h_ntrkPerNonantPerLink_all =
+      new TH1F("ntrkPerNonantPerLink_all", ";Max. # tracks from a sector / event; Events", 50, 0, 100.0);
+  TH1F* h_ntrkPerNonantPerLink_pt2 = new TH1F(
+      "ntrkPerNonantPerLink_pt2", ";Max. # tracks from a sector (p_{T} > 2 GeV) / event; Events", 50, 0, 100.0);
+  TH1F* h_ntrkPerNonantPerLink_pt3 = new TH1F(
+      "ntrkPerNonantPerLink_pt3", ";Max. # tracks from a sector (p_{T} > 3 GeV) / event; Events", 50, 0, 100.0);
+  TH1F* h_ntrkPerNonantPerLink_pt4 = new TH1F(
+      "ntrkPerNonantPerLink_pt4", ";Max. # tracks from a sector (p_{T} > 10 GeV) / event; Events", 50, 0, 100.0);
 
   // number of tracks vs. efficiency (eta, pT)
   TH1F* h_trk_pt = new TH1F("trk_pt", Form(";Track p_{T} (GeV);Tracks / 0.5 GeV"), 200, 0., 100.);
@@ -1033,10 +1033,12 @@ void L1TrackNtuplePlot(TString type,
     int ntrkevt_genuine_pt3 = 0;
     int ntrkevt_genuine_pt10 = 0;
 
-    vector<unsigned int> nTrksPerSector_all(9, 0);
-    vector<unsigned int> nTrksPerSector_pt2(9, 0);
-    vector<unsigned int> nTrksPerSector_pt3(9, 0);
-    vector<unsigned int> nTrksPerSector_pt4(9, 0);
+    // Each sector uses two output links to output tracks to L1 trigger.
+    constexpr unsigned int nNonants = 9, nLink = 2;
+    vector<unsigned int> nTrksPerSectorPerLink_all(nNonants * nLink, 0);
+    vector<unsigned int> nTrksPerSectorPerLink_pt2(nNonants * nLink, 0);
+    vector<unsigned int> nTrksPerSectorPerLink_pt3(nNonants * nLink, 0);
+    vector<unsigned int> nTrksPerSectorPerLink_pt4(nNonants * nLink, 0);
 
     for (int it = 0; it < (int)trk_pt->size(); it++) {  // Loop reco tracks
       // ----------------------------------------------------------------------------------------------------------------
@@ -1110,20 +1112,25 @@ void L1TrackNtuplePlot(TString type,
       if (trk_genuine->at(it) == 1)
         ntrk_genuine++;
 
-      if (trk_pt->at(it) >= 0.0)
-        ++nTrksPerSector_all.at(trk_phiSector->at(it) % 9);
+      // Tracklet & Hybrid have 9 nonants, but TMTT has 18 (with sectors 0 & 1 in nonant 0 etc).
+      // As don't know here with algo used, "% 9" added to prevent crash, but not correct for TMTT.
+      // Each nonant has two output opto-links to L1 trigger, carrying tracks from +ve & -ve eta.
+
+      unsigned int linkOut = trk_phiSector->at(it) % nNonants;
+      if (trk_eta->at(it) > 0)
+        linkOut += nNonants;
+
+      ++nTrksPerSectorPerLink_all.at(linkOut);
 
       if (std::abs(trk_eta->at(it)) > TP_maxEta || trk_pt->at(it) < TP_minPt)
         continue;
 
-      // Tracklet & Hybrid have 9 sectors, but TMTT has 18 (with sectors 0 & 1 in nonant 0 etc).
-      // As don't know here with algo used, "% 9" added to prevent crash, but not correct for TMTT.
       if (trk_pt->at(it) > 2.0)
-        ++nTrksPerSector_pt2.at(trk_phiSector->at(it) % 9);
+        ++nTrksPerSectorPerLink_pt2.at(linkOut);
       if (trk_pt->at(it) > 3.0)
-        ++nTrksPerSector_pt3.at(trk_phiSector->at(it) % 9);
+        ++nTrksPerSectorPerLink_pt3.at(linkOut);
       if (trk_pt->at(it) > 4.0)
-        ++nTrksPerSector_pt4.at(trk_phiSector->at(it) % 9);
+        ++nTrksPerSectorPerLink_pt4.at(linkOut);
 
       if (trk_pt->at(it) > 2.0) {
         ntrk_pt2++;
@@ -1187,10 +1194,14 @@ void L1TrackNtuplePlot(TString type,
     h_ntrk_genuine_pt3->Fill(ntrkevt_genuine_pt3);
     h_ntrk_genuine_pt10->Fill(ntrkevt_genuine_pt10);
 
-    h_ntrkPerSector_all->Fill(*std::max_element(nTrksPerSector_all.begin(), nTrksPerSector_all.end()));
-    h_ntrkPerSector_pt2->Fill(*std::max_element(nTrksPerSector_pt2.begin(), nTrksPerSector_pt2.end()));
-    h_ntrkPerSector_pt3->Fill(*std::max_element(nTrksPerSector_pt3.begin(), nTrksPerSector_pt3.end()));
-    h_ntrkPerSector_pt4->Fill(*std::max_element(nTrksPerSector_pt4.begin(), nTrksPerSector_pt4.end()));
+    h_ntrkPerNonantPerLink_all->Fill(
+        *std::max_element(nTrksPerSectorPerLink_all.begin(), nTrksPerSectorPerLink_all.end()));
+    h_ntrkPerNonantPerLink_pt2->Fill(
+        *std::max_element(nTrksPerSectorPerLink_pt2.begin(), nTrksPerSectorPerLink_pt2.end()));
+    h_ntrkPerNonantPerLink_pt3->Fill(
+        *std::max_element(nTrksPerSectorPerLink_pt3.begin(), nTrksPerSectorPerLink_pt3.end()));
+    h_ntrkPerNonantPerLink_pt4->Fill(
+        *std::max_element(nTrksPerSectorPerLink_pt4.begin(), nTrksPerSectorPerLink_pt4.end()));
 
     // ----------------------------------------------------------------------------------------------------------------
     // Loop tracking particles
@@ -3545,42 +3556,42 @@ void L1TrackNtuplePlot(TString type,
   h_ntrk_pt3->Write();
   h_ntrk_pt10->Write();
 
-  h_ntrkPerSector_all->Write();
-  h_ntrkPerSector_pt2->Write();
-  h_ntrkPerSector_pt3->Write();
-  h_ntrkPerSector_pt4->Write();
+  h_ntrkPerNonantPerLink_all->Write();
+  h_ntrkPerNonantPerLink_pt2->Write();
+  h_ntrkPerNonantPerLink_pt3->Write();
+  h_ntrkPerNonantPerLink_pt4->Write();
 
-  h_ntrkPerSector_all->Scale(1.0 / nevt);
-  h_ntrkPerSector_pt2->Scale(1.0 / nevt);
-  h_ntrkPerSector_pt3->Scale(1.0 / nevt);
-  h_ntrkPerSector_pt4->Scale(1.0 / nevt);
+  h_ntrkPerNonantPerLink_all->Scale(1.0 / nevt);
+  h_ntrkPerNonantPerLink_pt2->Scale(1.0 / nevt);
+  h_ntrkPerNonantPerLink_pt3->Scale(1.0 / nevt);
+  h_ntrkPerNonantPerLink_pt4->Scale(1.0 / nevt);
 
-  h_ntrkPerSector_all->GetYaxis()->SetTitle("Fraction of events");
-  h_ntrkPerSector_all->GetXaxis()->SetTitle("Max number of transmitted tracks per #phi sector");
+  h_ntrkPerNonantPerLink_all->GetYaxis()->SetTitle("Fraction of events");
+  h_ntrkPerNonantPerLink_all->GetXaxis()->SetTitle("Max no. of transmitted tracks/nonant/link");
 
-  h_ntrkPerSector_all->SetLineColor(1);
-  h_ntrkPerSector_pt2->SetLineColor(4);
-  h_ntrkPerSector_pt3->SetLineColor(2);
-  h_ntrkPerSector_pt4->SetLineColor(8);
+  h_ntrkPerNonantPerLink_all->SetLineColor(1);
+  h_ntrkPerNonantPerLink_pt2->SetLineColor(4);
+  h_ntrkPerNonantPerLink_pt3->SetLineColor(2);
+  h_ntrkPerNonantPerLink_pt4->SetLineColor(8);
 
-  max = h_ntrkPerSector_all->GetMaximum();
-  h_ntrkPerSector_all->SetAxisRange(0.00001, max * 5, "Y");
-  h_ntrkPerSector_all->SetAxisRange(0., 100, "X");
+  max = h_ntrkPerNonantPerLink_all->GetMaximum();
+  h_ntrkPerNonantPerLink_all->SetAxisRange(0.00001, max * 5, "Y");
+  h_ntrkPerNonantPerLink_all->SetAxisRange(0., 100, "X");
 
-  h_ntrkPerSector_all->Draw("hist");
-  h_ntrkPerSector_pt2->Draw("same,hist");
-  h_ntrkPerSector_pt3->Draw("same,hist");
-  h_ntrkPerSector_pt4->Draw("same,hist");
+  h_ntrkPerNonantPerLink_all->Draw("hist");
+  h_ntrkPerNonantPerLink_pt2->Draw("same,hist");
+  h_ntrkPerNonantPerLink_pt3->Draw("same,hist");
+  h_ntrkPerNonantPerLink_pt4->Draw("same,hist");
   gPad->SetLogy();
 
   TLegend* l = new TLegend(0.6, 0.55, 0.85, 0.85);
   l->SetFillStyle(0);
   l->SetBorderSize(0);
   l->SetTextSize(0.04);
-  l->AddEntry(h_ntrkPerSector_all, "no p_{T}cut", "l");
-  l->AddEntry(h_ntrkPerSector_pt2, "p_{T}^{track} > 2 GeV", "l");
-  l->AddEntry(h_ntrkPerSector_pt3, "p_{T}^{track} > 3 GeV", "l");
-  l->AddEntry(h_ntrkPerSector_pt4, "p_{T}^{track} > 4 GeV", "l");
+  l->AddEntry(h_ntrkPerNonantPerLink_all, "no p_{T}cut", "l");
+  l->AddEntry(h_ntrkPerNonantPerLink_pt2, "p_{T}^{track} > 2 GeV", "l");
+  l->AddEntry(h_ntrkPerNonantPerLink_pt3, "p_{T}^{track} > 3 GeV", "l");
+  l->AddEntry(h_ntrkPerNonantPerLink_pt4, "p_{T}^{track} > 4 GeV", "l");
   l->SetTextFont(42);
   l->Draw();
 

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -49,27 +49,26 @@ void L1TrackNtuplePlot(TString type,
                        int TP_select_injet = 0,
                        int TP_select_pdgid = 0,
                        int TP_select_eventid = 0,
-                       bool useTightCuts = false,
                        bool useDeadRegion = false,
                        float TP_minPt = 2.0,
-                       float TP_maxPt = 100.0,
-                       float TP_maxEta = 2.4,
+                       float TP_maxEta = 2.5,
                        float TP_maxLxy = 1.0,
+                       float TP_maxLz = 30.0,
                        float TP_maxD0 = 1.0,
+                       float TP_maxZ0 = 15.,
                        bool doDetailedPlots = false) {
   // type:              this is the name of the input file you want to process (minus ".root" extension)
   // type_dir:          this is the directory containing the input file you want to process. Note that this must end with a "/", as in "EventSets/"
   // TP_select_pdgid:   if non-zero, only select TPs with a given PDG ID
   // TP_select_eventid: if zero, only look at TPs from primary interaction, else, include TPs from pileup
   // TP_minPt:          only look at TPs with pt > X GeV
-  // TP_maxPt:          only look at TPs with pt < X GeV
   // TP_maxEta:         only look at TPs with |eta| < X
   // doDetailedPlots:   includes extra plots, such as  performance vs d0.
 
   // TP_select_injet: only look at TPs that are within a jet with pt > 30 GeV (==1) or within a jet with pt > 100 GeV (==2), >200 GeV (==3) or all TPs (==0)
 
-  //--  N.B. For standard displaced tracking plots, set TP_minPt=3.0, TP_maxEta=2.0, TP_maxLxy=10.0,
-  //--  TO_maxD0=10.0, doDetailedPlots=true. (Efficiency plots vs eta also usually made for d0 < 5).
+  //--  N.B. For standard displaced tracking plots, set TP_minPt=3.0, TP_maxEta=2.0, TP_maxLxy=10.0, TP_maxLz=60.0,
+  //--  TP_maxD0=10.0, TP_maxZ0=30.0, doDetailedPlots=true. (Efficiency plots vs eta also usually made for d0 < 5).
 
   gROOT->SetBatch();
   gErrorIgnoreLevel = kWarning;
@@ -82,24 +81,12 @@ void L1TrackNtuplePlot(TString type,
   // ----------------------------------------------------------------------------------------------------------------
   // define input options
 
-  // these are the LOOSE cuts, baseline scenario for efficiency and rate plots ==> configure as appropriate
-  int L1Tk_minNstub = 4;
-  float L1Tk_maxChi2 = 999999;
-  float L1Tk_maxChi2dof = 999999.;
+  // Baseline cut scenario for efficiency and rate plots ==> configure as appropriate
+  constexpr int L1Tk_minNstub = 4;
+  constexpr float L1Tk_maxChi2 = 999999;
+  constexpr float L1Tk_maxChi2dof = 999999.;
 
-  // TIGHT cuts (separate plots / rates) ==> configure as appropriate
-  // this is currently set up as an either or for performance plots, to not duplicate a ton of code.
-  int L1Tk_TIGHT_minNstub = 4;
-  float L1Tk_TIGHT_maxChi2 = 999999;
-  float L1Tk_TIGHT_maxChi2dof = 999999.;
-  if (useTightCuts) {
-    L1Tk_minNstub = L1Tk_TIGHT_minNstub;
-    L1Tk_maxChi2 = L1Tk_TIGHT_maxChi2;
-    L1Tk_maxChi2dof = L1Tk_TIGHT_maxChi2dof;
-  }
-
-  bool doGausFit = false;     //do gaussian fit for resolution vs eta/pt plots
-  bool doLooseMatch = false;  //looser MC truth matching
+  constexpr bool doGausFit = false;  //do gaussian fit for resolution vs eta/pt plots
 
   // tracklet variables
   int L1Tk_seed = 0;
@@ -128,8 +115,10 @@ void L1TrackNtuplePlot(TString type,
   int ntp_pt2 = 0;
   int ntp_pt3 = 0;
   int ntp_pt10 = 0;
+  int ntrk_genuine = 0;
   int ntrk_genuine_pt2 = 0;
-  int ntp_nmatch = 0;
+  int ntp_ndupmatch = 0;
+  int ntp_ndupmatch_pt2 = 0;
   // ----------------------------------------------------------------------------------------------------------------
   // read ntuples
   TChain* tree = new TChain("L1TrackNtuple" + treeName + "/eventTree");
@@ -149,8 +138,9 @@ void L1TrackNtuplePlot(TString type,
   vector<float>* tp_eta;
   vector<float>* tp_phi;
   vector<float>* tp_lxy;
-  vector<float>* tp_z0;
   vector<float>* tp_d0;
+  vector<float>* tp_lz;
+  vector<float>* tp_z0;
   vector<int>* tp_pdgid;
   vector<int>* tp_nmatch;
   vector<int>* tp_nstub;
@@ -160,11 +150,12 @@ void L1TrackNtuplePlot(TString type,
   vector<int>* tp_injet_vhighpt;
 
   // *L1 track* properties, for tracking particles matched to a L1 track
+  // (If TP matched more than one track, only the track with lowest chi2/dof stored here).
   vector<float>* matchtrk_pt;
   vector<float>* matchtrk_eta;
   vector<float>* matchtrk_phi;
-  vector<float>* matchtrk_d0;
   vector<float>* matchtrk_z0;
+  vector<float>* matchtrk_d0;
   vector<float>* matchtrk_chi2;
   vector<float>* matchtrk_chi2_dof;
   vector<float>* matchtrk_chi2rphi;
@@ -196,19 +187,20 @@ void L1TrackNtuplePlot(TString type,
   vector<int>* trk_seed;
   vector<int>* trk_hitpattern;
   vector<unsigned int>* trk_phiSector;
+  vector<int>* trk_genuine;
+  vector<int>* trk_loose;
+  vector<int>* trk_matchtp_eventtype;
   vector<int>* trk_injet;
   vector<int>* trk_injet_highpt;
   vector<int>* trk_injet_vhighpt;
-  vector<int>* trk_fake;
-  vector<int>* trk_genuine;
-  vector<int>* trk_loose;
 
   TBranch* b_tp_pt;
   TBranch* b_tp_eta;
   TBranch* b_tp_phi;
   TBranch* b_tp_lxy;
-  TBranch* b_tp_z0;
   TBranch* b_tp_d0;
+  TBranch* b_tp_lz;
+  TBranch* b_tp_z0;
   TBranch* b_tp_pdgid;
   TBranch* b_tp_nmatch;
   TBranch* b_tp_nstub;
@@ -220,8 +212,8 @@ void L1TrackNtuplePlot(TString type,
   TBranch* b_matchtrk_pt;
   TBranch* b_matchtrk_eta;
   TBranch* b_matchtrk_phi;
-  TBranch* b_matchtrk_d0;
   TBranch* b_matchtrk_z0;
+  TBranch* b_matchtrk_d0;
   TBranch* b_matchtrk_chi2;
   TBranch* b_matchtrk_chi2_dof;
   TBranch* b_matchtrk_chi2rphi;
@@ -249,22 +241,23 @@ void L1TrackNtuplePlot(TString type,
   TBranch* b_trk_nstub;
   TBranch* b_trk_lhits;
   TBranch* b_trk_dhits;
-  TBranch* b_trk_phiSector;
   TBranch* b_trk_seed;
   TBranch* b_trk_hitpattern;
+  TBranch* b_trk_phiSector;
+  TBranch* b_trk_genuine;
+  TBranch* b_trk_loose;
+  TBranch* b_trk_matchtp_eventtype;
   TBranch* b_trk_injet;
   TBranch* b_trk_injet_highpt;
   TBranch* b_trk_injet_vhighpt;
-  TBranch* b_trk_fake;
-  TBranch* b_trk_genuine;
-  TBranch* b_trk_loose;
 
   tp_pt = 0;
   tp_eta = 0;
   tp_phi = 0;
   tp_lxy = 0;
-  tp_z0 = 0;
   tp_d0 = 0;
+  tp_lz = 0;
+  tp_z0 = 0;
   tp_pdgid = 0;
   tp_nmatch = 0;
   tp_nstub = 0;
@@ -276,8 +269,8 @@ void L1TrackNtuplePlot(TString type,
   matchtrk_pt = 0;
   matchtrk_eta = 0;
   matchtrk_phi = 0;
-  matchtrk_d0 = 0;
   matchtrk_z0 = 0;
+  matchtrk_d0 = 0;
   matchtrk_chi2 = 0;
   matchtrk_chi2_dof = 0;
   matchtrk_chi2rphi = 0;
@@ -305,27 +298,25 @@ void L1TrackNtuplePlot(TString type,
   trk_nstub = 0;
   trk_lhits = 0;
   trk_dhits = 0;
-  trk_phiSector = 0;
   trk_seed = 0;
   trk_hitpattern = 0;
+  trk_phiSector = 0;
+  trk_genuine = 0;
+  trk_loose = 0;
+  trk_matchtp_eventtype = 0;
   trk_injet = 0;
   trk_injet_highpt = 0;
   trk_injet_vhighpt = 0;
-  trk_fake = 0;
-  trk_genuine = 0;
-  trk_loose = 0;
 
   tree->SetBranchAddress("tp_pt", &tp_pt, &b_tp_pt);
   tree->SetBranchAddress("tp_eta", &tp_eta, &b_tp_eta);
   tree->SetBranchAddress("tp_phi", &tp_phi, &b_tp_phi);
+  tree->SetBranchAddress("tp_lz", &tp_lz, &b_tp_lz);
   tree->SetBranchAddress("tp_lxy", &tp_lxy, &b_tp_lxy);
   tree->SetBranchAddress("tp_z0", &tp_z0, &b_tp_z0);
   tree->SetBranchAddress("tp_d0", &tp_d0, &b_tp_d0);
   tree->SetBranchAddress("tp_pdgid", &tp_pdgid, &b_tp_pdgid);
-  if (doLooseMatch)
-    tree->SetBranchAddress("tp_nloosematch", &tp_nmatch, &b_tp_nmatch);
-  else
-    tree->SetBranchAddress("tp_nmatch", &tp_nmatch, &b_tp_nmatch);
+  tree->SetBranchAddress("tp_nmatch", &tp_nmatch, &b_tp_nmatch);
   tree->SetBranchAddress("tp_nstub", &tp_nstub, &b_tp_nstub);
   tree->SetBranchAddress("tp_eventid", &tp_eventid, &b_tp_eventid);
   if (TP_select_injet > 0) {
@@ -334,48 +325,26 @@ void L1TrackNtuplePlot(TString type,
     tree->SetBranchAddress("tp_injet_vhighpt", &tp_injet_vhighpt, &b_tp_injet_vhighpt);
   }
 
-  if (doLooseMatch) {
-    tree->SetBranchAddress("loosematchtrk_pt", &matchtrk_pt, &b_matchtrk_pt);
-    tree->SetBranchAddress("loosematchtrk_eta", &matchtrk_eta, &b_matchtrk_eta);
-    tree->SetBranchAddress("loosematchtrk_phi", &matchtrk_phi, &b_matchtrk_phi);
-    tree->SetBranchAddress("loosematchtrk_d0", &matchtrk_d0, &b_matchtrk_d0);
-    tree->SetBranchAddress("loosematchtrk_z0", &matchtrk_z0, &b_matchtrk_z0);
-    tree->SetBranchAddress("loosematchtrk_chi2", &matchtrk_chi2, &b_matchtrk_chi2);
-    tree->SetBranchAddress("loosematchtrk_chi2_dof", &matchtrk_chi2_dof, &b_matchtrk_chi2_dof);
-    tree->SetBranchAddress("loosematchtrk_chi2rphi", &matchtrk_chi2rphi, &b_matchtrk_chi2rphi);
-    tree->SetBranchAddress("loosematchtrk_chi2rphi_dof", &matchtrk_chi2rphi_dof, &b_matchtrk_chi2rphi_dof);
-    tree->SetBranchAddress("loosematchtrk_chi2rz", &matchtrk_chi2rz, &b_matchtrk_chi2rz);
-    tree->SetBranchAddress("loosematchtrk_chi2rz_dof", &matchtrk_chi2rz_dof, &b_matchtrk_chi2rz_dof);
-    tree->SetBranchAddress("loosematchtrk_nstub", &matchtrk_nstub, &b_matchtrk_nstub);
-    tree->SetBranchAddress("loosematchtrk_seed", &matchtrk_seed, &b_matchtrk_seed);
-    tree->SetBranchAddress("loosematchtrk_hitpattern", &matchtrk_hitpattern, &b_matchtrk_hitpattern);
-    if (TP_select_injet > 0) {
-      tree->SetBranchAddress("loosematchtrk_injet", &matchtrk_injet, &b_matchtrk_injet);
-      tree->SetBranchAddress("loosematchtrk_injet_highpt", &matchtrk_injet_highpt, &b_matchtrk_injet_highpt);
-      tree->SetBranchAddress("loosematchtrk_injet_vhighpt", &matchtrk_injet_vhighpt, &b_matchtrk_injet_vhighpt);
-    }
-  } else {
-    tree->SetBranchAddress("matchtrk_pt", &matchtrk_pt, &b_matchtrk_pt);
-    tree->SetBranchAddress("matchtrk_eta", &matchtrk_eta, &b_matchtrk_eta);
-    tree->SetBranchAddress("matchtrk_phi", &matchtrk_phi, &b_matchtrk_phi);
-    tree->SetBranchAddress("matchtrk_d0", &matchtrk_d0, &b_matchtrk_d0);
-    tree->SetBranchAddress("matchtrk_z0", &matchtrk_z0, &b_matchtrk_z0);
-    tree->SetBranchAddress("matchtrk_chi2", &matchtrk_chi2, &b_matchtrk_chi2);
-    tree->SetBranchAddress("matchtrk_chi2_dof", &matchtrk_chi2_dof, &b_matchtrk_chi2_dof);
-    tree->SetBranchAddress("matchtrk_chi2rphi", &matchtrk_chi2rphi, &b_matchtrk_chi2rphi);
-    tree->SetBranchAddress("matchtrk_chi2rphi_dof", &matchtrk_chi2rphi_dof, &b_matchtrk_chi2rphi_dof);
-    tree->SetBranchAddress("matchtrk_chi2rz", &matchtrk_chi2rz, &b_matchtrk_chi2rz);
-    tree->SetBranchAddress("matchtrk_chi2rz_dof", &matchtrk_chi2rz_dof, &b_matchtrk_chi2rz_dof);
-    tree->SetBranchAddress("matchtrk_nstub", &matchtrk_nstub, &b_matchtrk_nstub);
-    tree->SetBranchAddress("matchtrk_lhits", &matchtrk_lhits, &b_matchtrk_lhits);
-    tree->SetBranchAddress("matchtrk_dhits", &matchtrk_dhits, &b_matchtrk_dhits);
-    tree->SetBranchAddress("matchtrk_seed", &matchtrk_seed, &b_matchtrk_seed);
-    tree->SetBranchAddress("matchtrk_hitpattern", &matchtrk_hitpattern, &b_matchtrk_hitpattern);
-    if (TP_select_injet > 0) {
-      tree->SetBranchAddress("matchtrk_injet", &matchtrk_injet, &b_matchtrk_injet);
-      tree->SetBranchAddress("matchtrk_injet_highpt", &matchtrk_injet_highpt, &b_matchtrk_injet_highpt);
-      tree->SetBranchAddress("matchtrk_injet_vhighpt", &matchtrk_injet_vhighpt, &b_matchtrk_injet_vhighpt);
-    }
+  tree->SetBranchAddress("matchtrk_pt", &matchtrk_pt, &b_matchtrk_pt);
+  tree->SetBranchAddress("matchtrk_eta", &matchtrk_eta, &b_matchtrk_eta);
+  tree->SetBranchAddress("matchtrk_phi", &matchtrk_phi, &b_matchtrk_phi);
+  tree->SetBranchAddress("matchtrk_d0", &matchtrk_d0, &b_matchtrk_d0);
+  tree->SetBranchAddress("matchtrk_z0", &matchtrk_z0, &b_matchtrk_z0);
+  tree->SetBranchAddress("matchtrk_chi2", &matchtrk_chi2, &b_matchtrk_chi2);
+  tree->SetBranchAddress("matchtrk_chi2_dof", &matchtrk_chi2_dof, &b_matchtrk_chi2_dof);
+  tree->SetBranchAddress("matchtrk_chi2rphi", &matchtrk_chi2rphi, &b_matchtrk_chi2rphi);
+  tree->SetBranchAddress("matchtrk_chi2rphi_dof", &matchtrk_chi2rphi_dof, &b_matchtrk_chi2rphi_dof);
+  tree->SetBranchAddress("matchtrk_chi2rz", &matchtrk_chi2rz, &b_matchtrk_chi2rz);
+  tree->SetBranchAddress("matchtrk_chi2rz_dof", &matchtrk_chi2rz_dof, &b_matchtrk_chi2rz_dof);
+  tree->SetBranchAddress("matchtrk_nstub", &matchtrk_nstub, &b_matchtrk_nstub);
+  tree->SetBranchAddress("matchtrk_lhits", &matchtrk_lhits, &b_matchtrk_lhits);
+  tree->SetBranchAddress("matchtrk_dhits", &matchtrk_dhits, &b_matchtrk_dhits);
+  tree->SetBranchAddress("matchtrk_seed", &matchtrk_seed, &b_matchtrk_seed);
+  tree->SetBranchAddress("matchtrk_hitpattern", &matchtrk_hitpattern, &b_matchtrk_hitpattern);
+  if (TP_select_injet > 0) {
+    tree->SetBranchAddress("matchtrk_injet", &matchtrk_injet, &b_matchtrk_injet);
+    tree->SetBranchAddress("matchtrk_injet_highpt", &matchtrk_injet_highpt, &b_matchtrk_injet_highpt);
+    tree->SetBranchAddress("matchtrk_injet_vhighpt", &matchtrk_injet_vhighpt, &b_matchtrk_injet_vhighpt);
   }
 
   tree->SetBranchAddress("trk_pt", &trk_pt, &b_trk_pt);
@@ -390,12 +359,12 @@ void L1TrackNtuplePlot(TString type,
   tree->SetBranchAddress("trk_nstub", &trk_nstub, &b_trk_nstub);
   tree->SetBranchAddress("trk_lhits", &trk_lhits, &b_trk_lhits);
   tree->SetBranchAddress("trk_dhits", &trk_dhits, &b_trk_dhits);
-  tree->SetBranchAddress("trk_phiSector", &trk_phiSector, &b_trk_phiSector);
   tree->SetBranchAddress("trk_seed", &trk_seed, &b_trk_seed);
   tree->SetBranchAddress("trk_hitpattern", &trk_hitpattern, &b_trk_hitpattern);
-  tree->SetBranchAddress("trk_fake", &trk_fake, &b_trk_fake);
+  tree->SetBranchAddress("trk_phiSector", &trk_phiSector, &b_trk_phiSector);
   tree->SetBranchAddress("trk_genuine", &trk_genuine, &b_trk_genuine);
   tree->SetBranchAddress("trk_loose", &trk_loose, &b_trk_loose);
+  tree->SetBranchAddress("trk_matchtp_eventtype", &trk_matchtp_eventtype, &b_trk_matchtp_eventtype);
   if (TP_select_injet > 0) {
     tree->SetBranchAddress("trk_injet", &trk_injet, &b_trk_injet);
     tree->SetBranchAddress("trk_injet_highpt", &trk_injet_highpt, &b_trk_injet_highpt);
@@ -453,25 +422,25 @@ void L1TrackNtuplePlot(TString type,
   // ----------------------------------------------------------------------------------------------------------------
   // Tracklet propogation efficiencies vs. eta for seeding layers
 
-  int trackletEffEtaBins = 24;
-  double trackletEffMaxEta = 2.4;
+  int trackletEffEtaBins = 25;
+  double trackletEffMaxEta = 2.5;
   int numLayers = 11;
   TH2F* h_trk_tracklet_hits = new TH2F("trk_tracklet_hits",
                                        ";Track |#eta|; Layer index (0-5 = L1-6, 6-10 = D1-5)",
                                        trackletEffEtaBins,
                                        0,
                                        trackletEffMaxEta,
-                                       11,
+                                       numLayers,
                                        0,
-                                       11);  //used to create below hist
+                                       numLayers);  //used to create below hist
   TH2F* h_trk_tracklet_eff = new TH2F("trk_tracklet_eff",
                                       ";Track |#eta|; Layer index (0-5 = L1-6, 6-10 = D1-5)",
                                       trackletEffEtaBins,
                                       0,
                                       trackletEffMaxEta,
-                                      11,
+                                      numLayers,
                                       0,
-                                      11);
+                                      numLayers);
 
   // ----------------------------------------------------------------------------------------------------------------
   // resolution vs. pt histograms
@@ -710,8 +679,7 @@ void L1TrackNtuplePlot(TString type,
   TH1F* h_trk_all_vspt = new TH1F("trk_all_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);
   TH1F* h_trk_loose_vspt = new TH1F("trk_loose_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);
   TH1F* h_trk_genuine_vspt = new TH1F("trk_genuine_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);
-  TH1F* h_trk_notloose_vspt = new TH1F(
-      "trk_notloose_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);  //(same as "fake" according to the trk_fake labeling)
+  TH1F* h_trk_notloose_vspt = new TH1F("trk_notloose_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);  // fake
   TH1F* h_trk_notgenuine_vspt = new TH1F("trk_notgenuine_vspt", ";Track p_{T} [GeV]; ", 50, 0, 25);
   TH1F* h_trk_duplicate_vspt = new TH1F("trk_duplicate_vspt",
                                         ";Track p_{T} [GeV]; ",
@@ -1030,7 +998,6 @@ void L1TrackNtuplePlot(TString type,
   // event loop
   for (int i = 0; i < nevt; i++) {
     tree->GetEntry(i, 0);
-
     /*
     // ----------------------------------------------------------------------------------------------------------------
     // sumpt in jets
@@ -1131,18 +1098,23 @@ void L1TrackNtuplePlot(TString type,
         if (TP_select_injet == 3 && trk_injet_vhighpt->at(it) == 0)
           continue;
       }
-      ntrk++;
-      if (trk_pt->at(it) >= 0.0)
-        ++nTrksPerSector_all.at(trk_phiSector->at(it) % 9);
-      if (std::abs(trk_eta->at(it)) > TP_maxEta)
+
+      if (trk_chi2->at(it) > L1Tk_maxChi2)
         continue;
-      if (trk_pt->at(it) < TP_minPt)
+      if (trk_chi2_dof->at(it) > L1Tk_maxChi2dof)
+        continue;
+      if (trk_nstub->at(it) < L1Tk_minNstub)
         continue;
 
-      // Uncomment these cuts to see effect on rate & fake rate.
-      //if (trk_chi2->at(it) > L1Tk_maxChi2) continue;
-      //if (trk_chi2_dof->at(it) > L1Tk_maxChi2dof) continue;
-      //if (trk_nstub->at(it) < L1Tk_minNstub) continue;
+      ntrk++;
+      if (trk_genuine->at(it) == 1)
+        ntrk_genuine++;
+
+      if (trk_pt->at(it) >= 0.0)
+        ++nTrksPerSector_all.at(trk_phiSector->at(it) % 9);
+
+      if (std::abs(trk_eta->at(it)) > TP_maxEta || trk_pt->at(it) < TP_minPt)
+        continue;
 
       // Tracklet & Hybrid have 9 sectors, but TMTT has 18 (with sectors 0 & 1 in nonant 0 etc).
       // As don't know here with algo used, "% 9" added to prevent crash, but not correct for TMTT.
@@ -1187,9 +1159,9 @@ void L1TrackNtuplePlot(TString type,
       // create an 11-bit long iterable from lhits and dhits
       int num_layers = 6;
       int num_discs = 5;
-      int lhits = trk_lhits->at(it);
+      int lhits = trk_lhits->at(it);  // barrel and disk hit patterns
       int dhits = trk_dhits->at(it);
-      std::vector<int> layers = {};
+      vector<int> layers = {};
       for (int layer_index = 0; layer_index < num_layers + num_discs; layer_index++) {
         if (layer_index < num_layers) {
           layers.push_back(lhits % 10);
@@ -1233,6 +1205,22 @@ void L1TrackNtuplePlot(TString type,
           continue;
       }
 
+      // duplicate rate
+      if (tp_nmatch->at(it) > 1) {
+        // Strictly speaking, should cut on all individual tracks matching this TP, rather than just one of them.
+        // Cuts should match those used to determine ntrk_pt2.
+        if (matchtrk_chi2->at(it) <= L1Tk_maxChi2 && matchtrk_chi2_dof->at(it) <= L1Tk_maxChi2dof &&
+            matchtrk_nstub->at(it) >= L1Tk_minNstub) {
+          for (int inm = 1; inm < tp_nmatch->at(it); inm++) {  // N.B. Loop doesn't start at zero.
+            ntp_ndupmatch++;
+            if (matchtrk_pt->at(it) > 2.0 && std::abs(matchtrk_eta->at(it)) < TP_maxEta) {
+              ntp_ndupmatch_pt2++;
+              h_trk_duplicate_vspt->Fill(matchtrk_pt->at(it));
+            }
+          }
+        }
+      }
+
       // cut on PDG ID at plot stage?
       if (TP_select_pdgid != 0) {
         if (abs(tp_pdgid->at(it)) != abs(TP_select_pdgid))
@@ -1242,11 +1230,11 @@ void L1TrackNtuplePlot(TString type,
       // kinematic cuts
       if (std::abs(tp_lxy->at(it)) > TP_maxLxy)
         continue;
+      if (std::abs(tp_lz->at(it)) > TP_maxLz)
+        continue;
       if (std::abs(tp_d0->at(it)) > TP_maxD0)
         continue;
       if (tp_pt->at(it) < 0.2)
-        continue;
-      if (tp_pt->at(it) > TP_maxPt)
         continue;
       if (std::abs(tp_eta->at(it)) > TP_maxEta)
         continue;
@@ -1256,13 +1244,6 @@ void L1TrackNtuplePlot(TString type,
         if (tp_pt->at(it) > 2.0) {
           ntp_pt2++;
           h_tp_vspt->Fill(tp_pt->at(it));
-          // duplicate rate
-          if (tp_nmatch->at(it) > 1) {
-            for (int inm = 1; inm < tp_nmatch->at(it); inm++) {  // N.B. Loop doesn't start at zero.
-              ntp_nmatch++;
-              h_trk_duplicate_vspt->Fill(matchtrk_pt->at(it));
-            }
-          }
         }
         if (tp_pt->at(it) > 3.0)
           ntp_pt3++;
@@ -1685,7 +1666,7 @@ void L1TrackNtuplePlot(TString type,
   for (double etaBin = 0; etaBin < trackletEffEtaBins;
        etaBin++) {  //loop through eta bin values (constants defined with relevant hist defs)
     maxBinContents = 0;
-    std::vector<double> binContents = {};
+    vector<double> binContents = {};
     for (int layer = 0; layer < numLayers; layer++) {
       binContents.push_back(h_trk_tracklet_hits->GetBinContent(etaBin + 1, layer + 1));
       maxBinContents = std::max(maxBinContents, binContents.back());
@@ -2449,8 +2430,6 @@ void L1TrackNtuplePlot(TString type,
   if (TP_select_eventid != 0)
     type = type + "_wpu";
 
-  if (useTightCuts)
-    type = type + "_tight";
   if (useDeadRegion)
     type = type + "_dead";
 
@@ -2466,11 +2445,7 @@ void L1TrackNtuplePlot(TString type,
     type = type + pttxt;
   }
 
-  TFile* fout;
-  if (doLooseMatch)
-    fout = new TFile("output_looseMatch_" + type + treeName + ".root", "recreate");
-  else
-    fout = new TFile(type_dir + "output_" + type + treeName + ".root", "recreate");
+  TFile* fout = new TFile(type_dir + "output_" + type + treeName + ".root", "recreate");
 
   // -------------------------------------------------------------------------------------------
   // draw and save plots
@@ -3650,7 +3625,11 @@ void L1TrackNtuplePlot(TString type,
   // ---------------------------------------------------------------------------------------------------------
   //some printouts
 
-  cout << "number of events = " << nevt << endl;
+  cout << endl;
+  cout << "Number of events = " << nevt << endl;
+  cout << "All performance results include cuts pt > " << TP_minPt << " & |eta| < " << TP_maxEta
+       << " unless 'no pt or eta cuts' stated." << endl;
+  cout << "Only TP with stubs in at least 4 tracker layers considered" << std::endl;
 
   float k = (float)n_match_eta1p0;
   float N = (float)n_all_eta1p0;
@@ -3702,18 +3681,29 @@ void L1TrackNtuplePlot(TString type,
   cout << "# TP/event (pt > 3.0) = " << (float)ntp_pt3 / nevt << endl;
   cout << "# TP/event (pt > 10.0) = " << (float)ntp_pt10 / nevt << endl;
 
-  cout << "# tracks/event (no pt cut)= " << (float)ntrk / nevt << endl;
+  cout << "# tracks/event (no pt or eta cuts) = " << (float)ntrk / nevt << endl;
   cout << "# tracks/event (pt > " << std::max(TP_minPt, 2.0f) << ") = " << (float)ntrk_pt2 / nevt << endl;
   cout << "# tracks/event (pt > 3.0) = " << (float)ntrk_pt3 / nevt << endl;
   cout << "# tracks/event (pt > 10.0) = " << (float)ntrk_pt10 / nevt << endl << endl;
 
-  // fake track rate
-  if (ntrk_genuine_pt2 > 0) {
-    cout << "Percentage fake tracks (pt > " << std::max(TP_minPt, 2.0f)
-         << ") = " << 100. * (1. - float(ntrk_genuine_pt2) / float(ntrk_pt2)) << "%" << endl;
-    cout << "Percentage duplicate tracks (pt > " << std::max(TP_minPt, 2.0f)
-         << ")= " << 100. * float(ntp_nmatch) / float(ntrk_pt2) << "%" << endl
-         << endl;
+  // fake & duplicate track rate
+  if (ntrk_genuine > 0) {
+    cout << "Percentage fake tracks (no pt or eta cuts) = " << 100. * (1. - float(ntrk_genuine) / float(ntrk)) << "%"
+         << " " << ntrk_genuine << " " << ntrk << endl;
+    /*
+    if (ntrk_genuine_pt2 > 0) { // These also have rapidity cut
+      cout << "Percentage fake tracks (pt > " << std::max(TP_minPt, 2.0f)
+           << ") = " << 100. * (1. - float(ntrk_genuine_pt2) / float(ntrk_pt2)) << "%" << endl;
+    }
+    */
+    cout << "Percentage duplicate tracks (no pt or eta cuts) = " << 100. * float(ntp_ndupmatch) / float(ntrk) << "%"
+         << " " << ntp_ndupmatch << " " << ntrk << endl;
+    /*
+    if (ntrk_genuine_pt2 > 0) { // These also have rapidity cut
+      cout << "Percentage duplicate tracks (pt > " << std::max(TP_minPt, 2.0f)
+           << ")= " << 100. * float(ntp_ndupmatch_pt2) / float(ntrk_pt2) << "%" << endl;
+    }
+    */
   }
 
   // z0 resolution

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -1194,11 +1194,19 @@ void L1TrackNtuplePlot(TString type,
     h_ntrk_genuine_pt3->Fill(ntrkevt_genuine_pt3);
     h_ntrk_genuine_pt10->Fill(ntrkevt_genuine_pt10);
 
-    const float nTrkPerLinkOverflow = h_ntrkPerNonantPerLink_all->GetXaxis()->GetXmax() - 0.1; // Add overflow bin
-    h_ntrkPerNonantPerLink_all->Fill(min(float(*std::max_element(nTrksPerNonantPerLink_all.begin(), nTrksPerNonantPerLink_all.end())), nTrkPerLinkOverflow));
-    h_ntrkPerNonantPerLink_pt2->Fill(min(float(*std::max_element(nTrksPerNonantPerLink_pt2.begin(), nTrksPerNonantPerLink_pt2.end())), nTrkPerLinkOverflow));
-    h_ntrkPerNonantPerLink_pt3->Fill(min(float(*std::max_element(nTrksPerNonantPerLink_pt3.begin(), nTrksPerNonantPerLink_pt3.end())), nTrkPerLinkOverflow));
-    h_ntrkPerNonantPerLink_pt4->Fill(min(float(*std::max_element(nTrksPerNonantPerLink_pt4.begin(), nTrksPerNonantPerLink_pt4.end())), nTrkPerLinkOverflow));
+    const float nTrkPerLinkOverflow = h_ntrkPerNonantPerLink_all->GetXaxis()->GetXmax() - 0.1;  // Add overflow bin
+    h_ntrkPerNonantPerLink_all->Fill(
+        min(float(*std::max_element(nTrksPerNonantPerLink_all.begin(), nTrksPerNonantPerLink_all.end())),
+            nTrkPerLinkOverflow));
+    h_ntrkPerNonantPerLink_pt2->Fill(
+        min(float(*std::max_element(nTrksPerNonantPerLink_pt2.begin(), nTrksPerNonantPerLink_pt2.end())),
+            nTrkPerLinkOverflow));
+    h_ntrkPerNonantPerLink_pt3->Fill(
+        min(float(*std::max_element(nTrksPerNonantPerLink_pt3.begin(), nTrksPerNonantPerLink_pt3.end())),
+            nTrkPerLinkOverflow));
+    h_ntrkPerNonantPerLink_pt4->Fill(
+        min(float(*std::max_element(nTrksPerNonantPerLink_pt4.begin(), nTrksPerNonantPerLink_pt4.end())),
+            nTrkPerLinkOverflow));
 
     // ----------------------------------------------------------------------------------------------------------------
     // Loop tracking particles

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -71,19 +71,20 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   constexpr int L1Tk_minNstub = 4;
   constexpr float L1Tk_maxChi2 = 999999;
   constexpr float L1Tk_maxChi2dof = 999999.;
-// Use looser impact-parameter related cuts for displaced tracking studies.
+  // Use looser impact-parameter related cuts for displaced tracking studies.
+  // (These cuts affect tracking efficiency, but not duplicate or fake rate).
   const float TP_maxLxy = useDisplacedTrkCuts ? 10.0 : 1.0;
   const float TP_maxLz = useDisplacedTrkCuts ? 60.0 : 30.0;
   const float TP_maxD0 = useDisplacedTrkCuts ? 10.0 : 1.0;
   const float TP_maxZ0 = useDisplacedTrkCuts ? 30.0 : 15.0;
-// Optionally also tighten Pt and Eta cuts.
-//if (useDisplacedTrkCuts) {
-//  TP_minPt = 3.0;
-//  TP_maxEta = 2.0;
-//}
+  // Optionally also tighten Pt and Eta cuts.
+  // if (useDisplacedTrkCuts) {
+  //   TP_minPt = 3.0;
+  //   TP_maxEta = 2.0;
+  // }
 
   constexpr bool doGausFit = false;  //do gaussian fit for resolution vs eta/pt plots
-  
+
   gROOT->SetBatch();
   gErrorIgnoreLevel = kWarning;
 
@@ -688,7 +689,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
 
   TH1F* h_trk_all_vsseed = new TH1F("trk_all_seed", ";Seed type; ", 15, -0.5, 14.5);
   TH1F* h_trk_fake_vsseed = new TH1F("trk_fake_seed", ";Seed type; ", 15, -0.5, 14.5);
-  
+
   // ----------------------------------------------------------------------------------------------------------------
 
   TH1F* h_tp_z0 = new TH1F("tp_z0", ";Tracking particle z_{0} [cm]; Tracking particles / 1.0 cm", 50, -25.0, 25.0);
@@ -2433,7 +2434,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   // -------------------------------------------------------------------------------------------
 
   TString type = inputRootFile;
-  
+
   if (TP_select_pdgid != 0) {
     char pdgidtxt[500];
     sprintf(pdgidtxt, "_pdgid%i", TP_select_pdgid);
@@ -3508,7 +3509,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   gPad->SetLogy();
   c.SaveAs(DIR + type + "_trackrate_vspt_log.pdf");
   gPad->SetLogy(0);
-  
+
   // ---------------------------------------------------------------------------------------------------------
   // total track rates vs seed
 
@@ -3519,7 +3520,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   h_trk_all_vsseed->GetXaxis()->SetTitle("Seed type");
   h_trk_all_vsseed->SetLineColor(4);
   h_trk_all_vsseed->SetLineStyle(1);
-  
+
   h_trk_fake_vsseed->SetLineColor(2);
   h_trk_fake_vsseed->SetLineStyle(2);
 

--- a/L1Trigger/TrackFindingTracklet/test/makeHists.csh
+++ b/L1Trigger/TrackFindingTracklet/test/makeHists.csh
@@ -9,7 +9,7 @@
 #                                                                      #
 # (where rootFileName is the name of the input .root file,             #
 #  including its directory name, if its not in the current one.        #
-#  If rootFileName not specified, it defaults to TTbar_PU200_D76.root) #
+#  If rootFileName not specified, it defaults to L1TrkNtuple.root).    #
 ########################################################################
 
 if ($#argv == 0) then
@@ -43,7 +43,7 @@ echo "MVA track quality Histograms written to MVA_plots/"
 # Run track performance plotting macro
 set plotMacro = $CMSSW_BASE/src/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
 if (-e TrkPlots) rm -r TrkPlots
-\root -b -q ${plotMacro}'("'${inputFileStem}'","'${dirName}'")' | tail -n 26 >! results.out 
+\root -b -q ${plotMacro}'("'${inputFileStem}'","'${dirName}'")' | tail -n 29 >! results.out 
 cat results.out
 echo "Tracking performance summary written to results.out"
 echo "Track performance histograms written to TrkPlots/"  

--- a/L1Trigger/TrackFindingTracklet/test/makeHists.csh
+++ b/L1Trigger/TrackFindingTracklet/test/makeHists.csh
@@ -47,5 +47,4 @@ if (-e TrkPlots) rm -r TrkPlots
 cat results.out
 echo "Tracking performance summary written to results.out"
 echo "Track performance histograms written to TrkPlots/"  
-
 exit

--- a/L1Trigger/TrackFindingTracklet/test/skimForCI_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/skimForCI_cfg.py
@@ -38,9 +38,9 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 
-# D88 geometry (T24 tracker)
-process.load('Configuration.Geometry.GeometryExtendedRun4D98Reco_cff')
-process.load('Configuration.Geometry.GeometryExtendedRun4D98_cff')
+# D110 geometry
+process.load('Configuration.Geometry.GeometryExtendedRun4D110Reco_cff')
+process.load('Configuration.Geometry.GeometryExtendedRun4D110_cff')
 
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 
@@ -53,7 +53,7 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))
 from MCsamples.Scripts.getCMSdata_cfi import *
 
 # Read data from card files (defines getCMSdataFromCards()):
-from MCsamples.RelVal_1400_D98.PU0_TTbar_14TeV_cfi import *
+from MCsamples.RelVal_1510_D110.PU0_TTbar_14TeV_cfi import *
 inputMC = getCMSdataFromCards()
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(*inputMC))

--- a/L1Trigger/TrackerDTC/test/Analyzer.cc
+++ b/L1Trigger/TrackerDTC/test/Analyzer.cc
@@ -216,6 +216,7 @@ namespace trackerDTC {
       edm::Handle<tt::StubAssociation> handleReconstructable;
       iEvent.getByToken<tt::StubAssociation>(edGetTokenReconstructable_, handleReconstructable);
       reconstructable = handleReconstructable.product();
+      // TO FIX: The next line should use "perfect" association, which it currently doesnt do.
       profMC_->Fill(3, reconstructable->numTPs() / (double)setup_->numRegions());
       profMC_->Fill(4, selection->numTPs() / (double)setup_->numRegions());
       profMC_->Fill(5, selection->numTPs());

--- a/L1Trigger/TrackerTFP/test/AnalyzerCTB.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerCTB.cc
@@ -53,7 +53,8 @@ namespace trackerTFP {
     void associate(const std::vector<std::vector<TTStubRef>>& tracks,
                    const tt::StubAssociation* ass,
                    std::set<TPPtr>& tps,
-                   int& sum) const;
+                   int& sum,
+                   bool perfect = false) const;
     // ED input token of stubs
     edm::EDGetTokenT<tt::StreamsStub> edGetTokenStubs_;
     // ED input token of tracks
@@ -234,7 +235,7 @@ namespace trackerTFP {
           continue;
         int tmp(0);
         associate(tracks, selection, tpPtrsSelection, tmp);
-        associate(tracks, reconstructable, tpPtrs, allMatched);
+        associate(tracks, reconstructable, tpPtrs, allMatched, true);
       }
       prof_->Fill(1, nStubs);
       prof_->Fill(2, nTracks);
@@ -343,9 +344,10 @@ namespace trackerTFP {
   void AnalyzerCTB::associate(const std::vector<std::vector<TTStubRef>>& tracks,
                               const tt::StubAssociation* ass,
                               std::set<TPPtr>& tps,
-                              int& sum) const {
+                              int& sum,
+                              bool perfect) const {
     for (const std::vector<TTStubRef>& ttStubRefs : tracks) {
-      const std::vector<TPPtr>& tpPtrs = ass->associate(ttStubRefs);
+      const std::vector<TPPtr>& tpPtrs = perfect ? ass->associateFinal(ttStubRefs) : ass->associate(ttStubRefs);
       if (tpPtrs.empty())
         continue;
       sum++;

--- a/L1Trigger/TrackerTFP/test/AnalyzerDR.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerDR.cc
@@ -53,7 +53,7 @@ namespace trackerTFP {
                    const tt::StubAssociation* ass,
                    std::set<TPPtr>& tps,
                    int& sum,
-                   bool perfect = true) const;
+                   bool perfect = false) const;
     // ED input token of stubs
     edm::EDGetTokenT<tt::StreamsStub> edGetTokenStubs_;
     // ED input token of tracks
@@ -181,9 +181,9 @@ namespace trackerTFP {
         if (!useMCTruth_)
           continue;
         int tmp(0);
-        associate(tracks, selection, tpPtrsSelection, tmp);
-        associate(tracks, reconstructable, tpPtrs, allMatched, false);
-        associate(tracks, selection, tpPtrsMax, tmp, false);
+        associate(tracks, selection, tpPtrsSelection, tmp, true);
+        associate(tracks, reconstructable, tpPtrs, allMatched, true);
+        associate(tracks, selection, tpPtrsMax, tmp);
         const int size = acceptedTracks[offset + channel].size();
         hisChannel_->Fill(size);
         profChannel_->Fill(channel, size);

--- a/L1Trigger/TrackerTFP/test/AnalyzerHT.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerHT.cc
@@ -50,7 +50,8 @@ namespace trackerTFP {
     void associate(const std::vector<std::vector<TTStubRef>>& tracks,
                    const tt::StubAssociation* ass,
                    std::set<TPPtr>& tps,
-                   int& sum) const;
+                   int& sum,
+                   bool perfect = false) const;
 
     // ED input token of stubs
     edm::EDGetTokenT<tt::StreamsStub> edGetToken_;
@@ -214,7 +215,7 @@ namespace trackerTFP {
           continue;
         int tmp(0);
         associate(tracks, selection, tpPtrsSelection, tmp);
-        associate(tracks, reconstructable, tpPtrs, allMatched);
+        associate(tracks, reconstructable, tpPtrs, allMatched, true);
       }
       prof_->Fill(1, nStubs);
       prof_->Fill(2, nTracks);
@@ -307,9 +308,10 @@ namespace trackerTFP {
   void AnalyzerHT::associate(const std::vector<std::vector<TTStubRef>>& tracks,
                              const tt::StubAssociation* ass,
                              std::set<TPPtr>& tps,
-                             int& sum) const {
+                             int& sum,
+                             bool perfect) const {
     for (const std::vector<TTStubRef>& ttStubRefs : tracks) {
-      const std::vector<TPPtr>& tpPtrs = ass->associate(ttStubRefs);
+      const std::vector<TPPtr>& tpPtrs = perfect ? ass->associateFinal(ttStubRefs) : ass->associate(ttStubRefs);
       if (tpPtrs.empty())
         continue;
       sum++;

--- a/L1Trigger/TrackerTFP/test/AnalyzerKF.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerKF.cc
@@ -300,14 +300,8 @@ namespace trackerTFP {
                   std::vector<TH1F*>(),
                   std::vector<TProfile*>(),
                   true);
-        associate(tracks,
-                  tracksStubs,
-                  region,
-                  selection,
-                  tpPtrsMax,
-                  tmp,
-                  std::vector<TH1F*>(),
-                  std::vector<TProfile*>());
+        associate(
+            tracks, tracksStubs, region, selection, tpPtrsMax, tmp, std::vector<TH1F*>(), std::vector<TProfile*>());
       }
       numTracks += nRegionTracks;
       prof_->Fill(1, nRegionStubs);

--- a/L1Trigger/TrackerTFP/test/AnalyzerKF.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerKF.cc
@@ -55,7 +55,7 @@ namespace trackerTFP {
                    int& sum,
                    const std::vector<TH1F*>& his,
                    const std::vector<TProfile*>& prof,
-                   bool perfect = true) const;
+                   bool perfect = false) const;
     // ED input token of accepted Tracks
     edm::EDGetTokenT<tt::StreamsStub> edGetTokenStubs_;
     // ED input token of accepted Stubs
@@ -290,7 +290,7 @@ namespace trackerTFP {
         if (!useMCTruth_)
           continue;
         int tmp(0);
-        associate(tracks, tracksStubs, region, selection, tpPtrsSelection, tmp, hisRes_, profRes_);
+        associate(tracks, tracksStubs, region, selection, tpPtrsSelection, tmp, hisRes_, profRes_, true);
         associate(tracks,
                   tracksStubs,
                   region,
@@ -299,7 +299,7 @@ namespace trackerTFP {
                   numMatched,
                   std::vector<TH1F*>(),
                   std::vector<TProfile*>(),
-                  false);
+                  true);
         associate(tracks,
                   tracksStubs,
                   region,
@@ -307,8 +307,7 @@ namespace trackerTFP {
                   tpPtrsMax,
                   tmp,
                   std::vector<TH1F*>(),
-                  std::vector<TProfile*>(),
-                  false);
+                  std::vector<TProfile*>());
       }
       numTracks += nRegionTracks;
       prof_->Fill(1, nRegionStubs);

--- a/L1Trigger/TrackerTFP/test/AnalyzerTFP.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerTFP.cc
@@ -177,6 +177,7 @@ namespace trackerTFP {
     std::set<TPPtr> tpPtrsSelection;
     std::set<TPPtr> tpPtrsPerfect;
     int nAllMatched(0);
+    int nAllMatchedPerf(0);
     // convert vector of tracks to vector of vector of associated stubs
     std::vector<std::vector<TTStubRef>> tracks;
     tracks.reserve(ttTracks.size());
@@ -187,7 +188,7 @@ namespace trackerTFP {
     if (useMCTruth_) {
       int tmp(0);
       associate(tracks, selection, tpPtrsSelection, tmp);
-      associate(tracks, selection, tpPtrsPerfect, tmp, true);
+      associate(tracks, selection, tpPtrsPerfect, nAllMatchedPerf, true);
       associate(tracks, reconstructable, tpPtrs, nAllMatched, true);
     }
     for (const TPPtr& tpPtr : tpPtrsSelection)
@@ -211,8 +212,8 @@ namespace trackerTFP {
     // printout SF summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
-    const double numTracks = prof_->GetBinContent(2);
-    const double totalTracks = prof_->GetBinContent(5);
+    const double numTracks = prof_->GetBinContent(2); // tracks/nonant/event
+    const double totalTracks = prof_->GetBinContent(5); // tracks/tracker/event
     const double numTracksMatched = prof_->GetBinContent(4);
     const double numTPsAll = prof_->GetBinContent(6);
     const double numTPsEff = prof_->GetBinContent(7);
@@ -239,7 +240,7 @@ namespace trackerTFP {
     log_ << "max     tracking efficiency = " << std::setw(wNums) << eff << " +- " << std::setw(wErrs) << errEff
          << std::endl;
     log_ << "                  fake rate = " << std::setw(wNums) << fracFake << std::endl;
-    log_ << "             duplicate rate = " << std::setw(wNums) << fracDup << std::endl;
+    log_ << "             duplicate rate = " << std::setw(wNums) << fracDup <<" "<<numTPsAll<<" "<<numTPsEffPerfect<<" / "<<totalTracks<< std::endl;
     log_ << "=============================================================";
     edm::LogPrint(moduleDescription().moduleName()) << log_.str();
   }

--- a/L1Trigger/TrackerTFP/test/AnalyzerTFP.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerTFP.cc
@@ -188,7 +188,7 @@ namespace trackerTFP {
       int tmp(0);
       associate(tracks, selection, tpPtrsSelection, tmp);
       associate(tracks, selection, tpPtrsPerfect, tmp, true);
-      associate(tracks, reconstructable, tpPtrs, nAllMatched);
+      associate(tracks, reconstructable, tpPtrs, nAllMatched, true);
     }
     for (const TPPtr& tpPtr : tpPtrsSelection)
       fill(tpPtr, hisEff_);

--- a/L1Trigger/TrackerTFP/test/AnalyzerTFP.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerTFP.cc
@@ -240,7 +240,7 @@ namespace trackerTFP {
     log_ << "max     tracking efficiency = " << std::setw(wNums) << eff << " +- " << std::setw(wErrs) << errEff
          << std::endl;
     log_ << "                  fake rate = " << std::setw(wNums) << fracFake << std::endl;
-    log_ << "             duplicate rate = " << std::setw(wNums) << fracDup <<" "<<numTPsAll<<" "<<numTPsEffPerfect<<" / "<<totalTracks<< std::endl;
+    log_ << "             duplicate rate = " << std::setw(wNums) << fracDup << std::endl;
     log_ << "=============================================================";
     edm::LogPrint(moduleDescription().moduleName()) << log_.str();
   }

--- a/L1Trigger/TrackerTFP/test/AnalyzerTFP.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerTFP.cc
@@ -212,8 +212,8 @@ namespace trackerTFP {
     // printout SF summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
-    const double numTracks = prof_->GetBinContent(2); // tracks/nonant/event
-    const double totalTracks = prof_->GetBinContent(5); // tracks/tracker/event
+    const double numTracks = prof_->GetBinContent(2);    // tracks/nonant/event
+    const double totalTracks = prof_->GetBinContent(5);  // tracks/tracker/event
     const double numTracksMatched = prof_->GetBinContent(4);
     const double numTPsAll = prof_->GetBinContent(6);
     const double numTPsEff = prof_->GetBinContent(7);

--- a/L1Trigger/TrackerTFP/test/AnalyzerTQ.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerTQ.cc
@@ -53,7 +53,7 @@ namespace trackerTFP {
                    const tt::StubAssociation* ass,
                    std::set<TPPtr>& tps,
                    int& sum,
-                   bool perfect = true) const;
+                   bool perfect = false) const;
     // ED input token of stubs
     edm::EDGetTokenT<tt::StreamsStub> edGetTokenStubs_;
     // ED input token of tracks
@@ -178,9 +178,9 @@ namespace trackerTFP {
       if (!useMCTruth_)
         continue;
       int tmp(0);
-      associate(tracks, selection, tpPtrsSelection, tmp);
-      associate(tracks, reconstructable, tpPtrs, allMatched, false);
-      associate(tracks, selection, tpPtrsMax, tmp, false);
+      associate(tracks, selection, tpPtrsSelection, tmp, true);
+      associate(tracks, reconstructable, tpPtrs, allMatched, true);
+      associate(tracks, selection, tpPtrsMax, tmp);
       const int size = acceptedTracks[region].size();
       hisChannel_->Fill(size);
       profChannel_->Fill(region, size);
@@ -201,8 +201,8 @@ namespace trackerTFP {
     // printout DR summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
-    const double numTracks = prof_->GetBinContent(2);
-    const double totalTracks = prof_->GetBinContent(5);
+    const double numTracks = prof_->GetBinContent(2);  // tracks/nonant/event
+    const double totalTracks = prof_->GetBinContent(5);  // tracks/tracker/event
     const double numTracksMatched = prof_->GetBinContent(4);
     const double numTPsAll = prof_->GetBinContent(6);
     const double numTPsEff = prof_->GetBinContent(7);

--- a/L1Trigger/TrackerTFP/test/AnalyzerTQ.cc
+++ b/L1Trigger/TrackerTFP/test/AnalyzerTQ.cc
@@ -201,7 +201,7 @@ namespace trackerTFP {
     // printout DR summary
     const double totalTPs = prof_->GetBinContent(9);
     const double numStubs = prof_->GetBinContent(1);
-    const double numTracks = prof_->GetBinContent(2);  // tracks/nonant/event
+    const double numTracks = prof_->GetBinContent(2);    // tracks/nonant/event
     const double totalTracks = prof_->GetBinContent(5);  // tracks/tracker/event
     const double numTracksMatched = prof_->GetBinContent(4);
     const double numTPsAll = prof_->GetBinContent(6);

--- a/SimDataFormats/Associations/interface/TTTrackAssociationMap.h
+++ b/SimDataFormats/Associations/interface/TTTrackAssociationMap.h
@@ -1,18 +1,20 @@
 /*! \class   TTTrackAssociationMap
  *  \brief   Stores association of Truth Particles (TP) to L1 Track-Trigger Tracks
  * 
- *  \details Contains two maps. One associates each L1 track its principle TP.
- *           (i.e. Not to all TP that contributed to it). 
- *           The other associates each TP to a vector of all L1 tracks 
- *           it contributed to. The two maps are therefore not
- *           forward-backward symmetric.
+ *  \details Contains two maps. One map associates each L1 track its principle TP.
+ *           (i.e. Not to all TP that contributed to it), providing that that TP
+ *           contributed to all stubs on the track (allowing for one incorrect stub).
+ *           Function isGenuine() can be used if you want tighter requirements.
+ *           The other map associates each TP to a vector of all L1 tracks 
+ *           it contributed to. 
+ *           The two maps are therefore not forward-backward symmetric.
  *
  *           (The template structure is used to accomodate types
  *           other than PixelDigis, in case they are needed in future). 
  *
  *  \author Nicola Pozzobon
  *  \date   2013, Jul 19
- *  (tidy up: Ian Tomalin, 2020)
+ *  (tidy up: Ian Tomalin, 2020 + 2025)
  */
 
 #ifndef SimDataFormats_Associations_TTTrackAssociationMap_h
@@ -72,36 +74,32 @@ public:
   /// and even if their are other such TP, it is still listed here).
   const std::vector<TTTrackPtrT<T>>& findTTTrackPtrs(TrackingParticlePtr aTrackingParticle) const;
 
-  ///--- Get quality of L1 track based on truth info.
+  ///=== Get quality of L1 track based on truth info.
   /// (N.B. "genuine" tracks are used for official L1 track efficiency measurements).
 
-  /// Exactly one (i.e. not 0 or >= 2) unique TP contributes to every stub on the track.
-  /// (even if it is not the principle TP in a stub, or contributes to only one cluster
-  /// in the stub, it still counts).
-  /// N.B. If cfg param getAllowOneFalse2SStub() is true, then one incorrect stub in
-  /// a 2S module is alowed
-  /// ISSUE: a track with 4 stubs can be accepted if only 3 of its stubs are correct!
-  /// ISSUE: isLooselyGenuine() must also be true. So if 2 TPs match track, one with
-  /// an incorrect PS stub, both isGenuine() & isLooselyGenuine() will be false!
-  bool isGenuine(TTTrackPtrT<T> aTrack) const;
-  /// Same criteria as for "genuine" track, except that one incorrect stub in either
-  /// PS or 2S module is allowed, irrespective of value of cfg param getAllowOneFalse2SStub().
+  // Determine if track is genuine based on logical AND of the two user specified criteria
+  // (1) If one incorrect (2S or 2S+PS) stub is allowed, (2) Minumimum number of stubs
+  // that must be shared between track and TP.
+  enum MatchCrit { allCorrect, allowOneFalse2S, allowOneFalse2SorPS };
+  bool isGenuine(TTTrackPtrT<T> aTrack,
+                 MatchCrit matchCrit = MatchCrit::allowOneFalse2S,
+                 unsigned int minShareStubs = 4) const;
+
+  /// Same as calling isGenuine(trk, allowOneFalse2SorPS, 0), so one incorrect stub allowed.
   bool isLooselyGenuine(TTTrackPtrT<T> aTrack) const;
+
   /// More than one stub on track is "unknown".
   bool isUnknown(TTTrackPtrT<T> aTrack) const;
   /// Both isLooselyGenuine() & isUnknown() are false.
   bool isCombinatoric(TTTrackPtrT<T> aTrack) const;
-
-  // Cfg param allowing one incorrect 2S stub in "genuine" tracks.
-  void setAllowOneFalse2SStub(bool allowFalse2SStub);
-  bool getAllowOneFalse2SStub();
 
 private:
   /// Data members
   MapL1TrackToTP<T> trackToTrackingParticleMap_;
   MapTPToVecL1Track<T> trackingParticleToTrackVectorMap_;
   edm::RefProd<TTStubAssociationMap<T>> theStubAssociationMap_;
-
+  /// This parameter no longer used, as replaced by arguments of function isGenuine().
+  /// But kept for now to avoid changing the EDProduct data members.
   bool AllowOneFalse2SStub;
 
   // Allow functions to return reference to null.
@@ -149,7 +147,10 @@ bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isLooselyGenuine(TTTrackPtr 
 
 /// MC truth
 template <>
-bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(TTTrackPtr aTrack) const;
+bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isGenuine(
+    TTTrackPtr aTrack,
+    TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::MatchCrit matchCrit,
+    unsigned int minSharedStubs) const;
 
 template <>
 bool TTTrackAssociationMap<Ref_Phase2TrackerDigi_>::isCombinatoric(TTTrackPtr aTrack) const;

--- a/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h
+++ b/SimTracker/TrackTriggerAssociation/plugins/TTTrackAssociator.h
@@ -1,5 +1,10 @@
 /*! \class   TTTrackAssociator
- *  \brief   Plugin to create the MC truth for TTTracks.
+ *  \brief   Creates the L1 track reco-truth association object TTTrackAssociationMap,
+ *           which contains two maps. One map associates each L1 track its principle TP.
+ *           (i.e. Not to all TP that contributed to it), providing that that TP
+ *           contributed to all stubs on the track (allowing for one incorrect stub).
+ *           The other map associates each TP to a vector of all L1 tracks 
+ *           it contributed to. 
  *  \details After moving from SimDataFormats to DataFormats,
  *           the template structure of the class was maintained
  *           in order to accomodate any types other than PixelDigis
@@ -7,7 +12,7 @@
  *
  *  \author Nicola Pozzobon
  *  \date   2013, Jul 19
- *  (tidy up: Ian Tomalin, 2020)
+ *  (tidy up: Ian Tomalin, 2020 + 2025)
  *
  */
 
@@ -57,8 +62,6 @@ private:
   edm::EDGetTokenT<TTStubAssociationMap<T> > ttStubTruthToken_;
   edm::EDGetTokenT<TTClusterAssociationMap<T> > ttClusterTruthToken_;
 
-  bool TTTrackAllowOneFalse2SStub;
-
   /// Mandatory methods
   void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
@@ -77,12 +80,6 @@ TTTrackAssociator<T>::TTTrackAssociator(const edm::ParameterSet& iConfig) {
   ttTracksInputTags_ = iConfig.getParameter<std::vector<edm::InputTag> >("TTTracks");
   ttClusterTruthToken_ = consumes<TTClusterAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTClusterTruth"));
   ttStubTruthToken_ = consumes<TTStubAssociationMap<T> >(iConfig.getParameter<edm::InputTag>("TTStubTruth"));
-  TTTrackAllowOneFalse2SStub = iConfig.getParameter<bool>("TTTrackAllowOneFalse2SStub");
-  if (TTTrackAllowOneFalse2SStub) {
-    edm::LogInfo("TTTrackAssociator< ") << "Allow track if no more than one 2S stub doesn't match truth.";
-  } else {
-    edm::LogInfo("TTTrackAssociator< ") << "All 2S stubs must match truth.";
-  }
 
   for (const auto& iTag : ttTracksInputTags_) {
     ttTracksTokens_.push_back(consumes<std::vector<TTTrack<T> > >(iTag));

--- a/SimTracker/TrackTriggerAssociation/python/StubAssociator_cfi.py
+++ b/SimTracker/TrackTriggerAssociation/python/StubAssociator_cfi.py
@@ -8,9 +8,9 @@ StubAssociator_params = cms.PSet (
   BranchSelection         = cms.string  ( "UseForAlgEff"    ),                                        # name of StubAssociation collection used for tracking efficiency 
 
   MinPt           = cms.double(  2.   ), # pt cut in GeV
-  MaxEta0         = cms.double(  2.4  ), # max eta for TP with z0 = 0
+  MaxEta          = cms.double(  2.5  ), # max eta for TP
   MaxZ0           = cms.double( 15.   ), # half lumi region size in cm
-  MaxD0           = cms.double(  5.   ), # cut on impact parameter in cm
+  MaxD0           = cms.double(  1.   ), # cut on impact parameter in cm
   MaxVertR        = cms.double(  1.   ), # cut on vertex pos r in cm
   MaxVertZ        = cms.double( 30.   ), # cut on vertex pos z in cm
   MinLayers       = cms.int32 (  4    ), # required number of associated stub layers to a TP to consider it reconstruct-able

--- a/SimTracker/TrackTriggerAssociation/python/TTTrackAssociation_cfi.py
+++ b/SimTracker/TrackTriggerAssociation/python/TTTrackAssociation_cfi.py
@@ -6,6 +6,9 @@ TTTrackAssociatorFromPixelDigis = cms.EDProducer("TTTrackAssociator_Phase2Tracke
     ),
     TTClusterTruth = cms.InputTag("TTClusterAssociatorFromPixelDigis", "ClusterAccepted"),
     TTStubTruth = cms.InputTag("TTStubAssociatorFromPixelDigis", "StubAccepted"),
-    TTTrackAllowOneFalse2SStub = cms.bool(True),
+                                                 # The following cfg param has been removed, as it was unnecessary.
+                                                 # You can specify if an incorrect 2S or PS stub are allowed
+                                                 # via function TTTrackAssociationMap::isGenuine().
+    #TTTrackAllowOneFalse2SStub = cms.bool(True),
 )
 


### PR DESCRIPTION
#### PR description:

We have two independently-developed methods of associating L1 tracks (TTTracks) to truth particles (Tracking Particles) and two methods of producing L1 tracking summary performance. 

These are:

1) TTTrackAssocationMap to associate + L1TrackNtuplePlot.C to create performance summary
2) StubAssociation to associate + AnalyzerTracklet/TFP.cc etc. to create performance summary

These gave difference results for the tracking efficiency, fake & duplicate rate. This PR eliminates most of these.

In addition, it makes the TTTrackAssociationMap more flexible, since one can now specify on the fly (without rerunning the associator EDProducter) if association should allow (a) no incorrect stubs on the track, (b) one incorrect 2S stub, (c) one incorrect 2S or PS stub. In addition, one can specify the minimum number of stubs that the track and truth particle must share.

This also fixes a bug in the Track Qualiy ROC curve plotting tool L1TrackQualityPlot.C , which was using "loose" criteria for associating tracks-truth, instead of "genuine" criteria. 

This also changes L1TrackNtuplePlot.C histos of number of tracks/nonant to instead plot tracks/nonant/link, since two output links are used per nonant, one for +ve and one for -ve rapidity.

It also simplifies/cleans some of the code.

#### PR validation:

Results are presented in Ian Tomalin's slides at the Tracker BES meeting https://indico.cern.ch/event/1587186/ .
