### PR TITLE
Fix to TrackletConfigBuilder and implement truncation in ProjectionCalculator

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/ProjectionCalculator.h
+++ b/L1Trigger/TrackFindingTracklet/interface/ProjectionCalculator.h
@@ -22,7 +22,7 @@ namespace trklet {
     void addOutput(MemoryBase *memory, std::string output) override;
     void addInput(MemoryBase *memory, std::string input) override;
 
-    void execute();
+    void execute(unsigned int iSector, double phimin);
 
     void projLayer(int ir, int irinv, int iphi0, int it, int iz0, int &iz, int &iphi);
 

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -865,6 +865,7 @@ namespace trklet {
         //Set to 108 to match firmware project 240 MHz clock
         {"VMR", 108},
         {"TB", 108},
+        {"PC", 108},
         {"MP", 108},
         {"TP", 108},
         {"TPD", 108},

--- a/L1Trigger/TrackFindingTracklet/src/ProjectionCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProjectionCalculator.cc
@@ -178,7 +178,7 @@ void ProjectionCalculator::execute(unsigned int iSector, double phimin) {
           }
         }
 
-	//FIXME logic here is confusing
+	//FIXME logic here is confusing with two loops and counting nPar1 and nPar2
         for (unsigned int k = 0; k < outputpars_.size(); k++) {  // add copy of par to merged par output memory
           std::string oname = outputpars_[k]->getName();
           int parPage = iname[9] - oname[9];

--- a/L1Trigger/TrackFindingTracklet/src/ProjectionCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProjectionCalculator.cc
@@ -148,7 +148,14 @@ void ProjectionCalculator::addInput(MemoryBase* memory, string input) {
   throw cms::Exception("BadConfig") << __FILE__ << " " << __LINE__ << " could not find input: " << input;
 }
 
-void ProjectionCalculator::execute() {
+void ProjectionCalculator::execute(unsigned int iSector, double phimin) {
+
+
+  //bool print = getName() == "PC_L2L3ABCD" && iSector == 3;
+
+  unsigned int nPar1 = 0;
+  unsigned int nPar2 = 0;
+
   for (unsigned int i = 0; i < inputpars_.size(); i++) {  // send copy of tpars to TB
     int projPage = 0;
     std::string iname = inputpars_[i]->getName();
@@ -156,6 +163,7 @@ void ProjectionCalculator::execute() {
     std::vector<std::string> seedNames = {"L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1"};
 
     for (int iSeed = 0; iSeed < 8; ++iSeed) {
+
       std::string seed = iname.substr(5, 4);  // extract seed from name
       bool psSeed = !(iSeed == Seed::L3L4 || iSeed == Seed::L5L6);
       if (seed == seedNames[iSeed]) {  // FIXME find easier way to get iSeed (probably from seed name)
@@ -170,15 +178,20 @@ void ProjectionCalculator::execute() {
           }
         }
 
+	//FIXME logic here is confusing
         for (unsigned int k = 0; k < outputpars_.size(); k++) {  // add copy of par to merged par output memory
           std::string oname = outputpars_[k]->getName();
           int parPage = iname[9] - oname[9];
           for (unsigned int j = 0; j < inputpars_[i]->nTracklets(); j++) {
+	    if (nPar1>=settings_.maxStep("PC")) continue;
+	    nPar1++;
             outputpars_[k]->addTracklet(inputpars_[i]->getTracklet(j), parPage);
           }
         }
 
         for (unsigned int k = 0; k < inputpars_[i]->nTracklets(); k++) {
+	  if (nPar2>=settings_.maxStep("PC")) continue;
+	  nPar2++;
           auto tracklet = inputpars_[i]->getTracklet(k);
           //double phi0 = tracklet->phi0(); // non-digi track params, currently unneeded / unused
           //double z0 = tracklet->z0();
@@ -240,6 +253,9 @@ void ProjectionCalculator::execute() {
             int izproj = settings_.izmean(iDisk % N_LAYER);
             projDisk(izproj, irinv, iphi0, it, iz0, izr_LD[iDisk], iphi_LD[iDisk], der_phi_LD[1], der_zr_LD[1]);
             valid_LD[iDisk] = izr_LD[iDisk] >= irmindisk && izr_LD[iDisk] < irmaxdisk && ((it > tcut) || (it < -tcut));
+	    //if (print) {
+	    //  std::cout << "iDisk iphi_LD : " << iDisk << " " << iphi_LD[iDisk] << " valid: " << valid_LD[iDisk] << std::endl;
+	    //}
           }
 
           ///////////////////////////////////

--- a/L1Trigger/TrackFindingTracklet/src/ProjectionCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProjectionCalculator.cc
@@ -149,8 +149,6 @@ void ProjectionCalculator::addInput(MemoryBase* memory, string input) {
 }
 
 void ProjectionCalculator::execute(unsigned int iSector, double phimin) {
-
-
   //bool print = getName() == "PC_L2L3ABCD" && iSector == 3;
 
   unsigned int nPar1 = 0;
@@ -163,7 +161,6 @@ void ProjectionCalculator::execute(unsigned int iSector, double phimin) {
     std::vector<std::string> seedNames = {"L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1"};
 
     for (int iSeed = 0; iSeed < 8; ++iSeed) {
-
       std::string seed = iname.substr(5, 4);  // extract seed from name
       bool psSeed = !(iSeed == Seed::L3L4 || iSeed == Seed::L5L6);
       if (seed == seedNames[iSeed]) {  // FIXME find easier way to get iSeed (probably from seed name)
@@ -178,20 +175,22 @@ void ProjectionCalculator::execute(unsigned int iSector, double phimin) {
           }
         }
 
-	//FIXME logic here is confusing with two loops and counting nPar1 and nPar2
+        //FIXME logic here is confusing with two loops and counting nPar1 and nPar2
         for (unsigned int k = 0; k < outputpars_.size(); k++) {  // add copy of par to merged par output memory
           std::string oname = outputpars_[k]->getName();
           int parPage = iname[9] - oname[9];
           for (unsigned int j = 0; j < inputpars_[i]->nTracklets(); j++) {
-	    if (nPar1>=settings_.maxStep("PC")) continue;
-	    nPar1++;
+            if (nPar1 >= settings_.maxStep("PC"))
+              continue;
+            nPar1++;
             outputpars_[k]->addTracklet(inputpars_[i]->getTracklet(j), parPage);
           }
         }
 
         for (unsigned int k = 0; k < inputpars_[i]->nTracklets(); k++) {
-	  if (nPar2>=settings_.maxStep("PC")) continue;
-	  nPar2++;
+          if (nPar2 >= settings_.maxStep("PC"))
+            continue;
+          nPar2++;
           auto tracklet = inputpars_[i]->getTracklet(k);
           //double phi0 = tracklet->phi0(); // non-digi track params, currently unneeded / unused
           //double z0 = tracklet->z0();
@@ -253,9 +252,9 @@ void ProjectionCalculator::execute(unsigned int iSector, double phimin) {
             int izproj = settings_.izmean(iDisk % N_LAYER);
             projDisk(izproj, irinv, iphi0, it, iz0, izr_LD[iDisk], iphi_LD[iDisk], der_phi_LD[1], der_zr_LD[1]);
             valid_LD[iDisk] = izr_LD[iDisk] >= irmindisk && izr_LD[iDisk] < irmaxdisk && ((it > tcut) || (it < -tcut));
-	    //if (print) {
-	    //  std::cout << "iDisk iphi_LD : " << iDisk << " " << iphi_LD[iDisk] << " valid: " << valid_LD[iDisk] << std::endl;
-	    //}
+            //if (print) {
+            //  std::cout << "iDisk iphi_LD : " << iDisk << " " << iphi_LD[iDisk] << " valid: " << valid_LD[iDisk] << std::endl;
+            //}
           }
 
           ///////////////////////////////////

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -312,7 +312,7 @@ void Sector::executeTCD() {
 
 void Sector::executePC() {
   for (auto& i : PC_) {
-    i->execute();
+    i->execute(isector_, phimin_);
   }
 }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletConfigBuilder.cc
@@ -1025,33 +1025,19 @@ void TrackletConfigBuilder::writeASMemories(std::ostream& os, std::ostream& memo
             int ratio = NRegions_[l1] / NRegions_[l2];
             int min = iTCReg * ratio - 1 + jTCReg;
             int max = (iTCReg + 1) * ratio - (nTCReg - jTCReg - 1);
+
             if ((int)iReg < min || (int)iReg > max)
               continue;
 
             if (max - min >= 2) {
               ext = "M";
               if (iReg == min) {
-                if (iReg % 2 == 0)
-                  continue;
                 ext = "R";
               }
               if (iReg == max) {
-                if (iReg % 2 == 1)
-                  continue;
                 ext = "L";
               }
             }
-
-            //old code
-            /*
-	    if (max - min >= 2) {
-	      ext = "M";
-	      if (iReg == min)
-		ext = "R";
-	      if (iReg == max)
-		ext = "L";
-	    }
-	      */
 
             if (max - min == 1) {
               if (nTCReg == 2) {


### PR DESCRIPTION
#### PR description:

There are two smaller updates in this PR:

o TrackletConfigBuilder fix to add some missing memories that caused a small efficiency loss (about 0.2-0.3% improvement)
o Truncation was not (properly) implemented in the ProjectionCalculator

#### PR validation:

I have generated test vectors and these are now allowing for full agreement in both FPGA1 and FPGA2 projects. Also tracking efficiency improved bu 0.2-0.3%
