### PR TITLE
Migrate L1 tracking to D110 CMSSW 15_1_0 MC

### DIFF
--- a/L1Trigger/TrackFindingTracklet/README.md
+++ b/L1Trigger/TrackFindingTracklet/README.md
@@ -1,4 +1,4 @@
-To run the L1 tracking & create a TTree of tracking performance:
+To run the L1 tracking & create a TTree of tracking performance: 
 
 cmsRun L1TrackNtupleMaker_cfg.py
 

--- a/L1Trigger/TrackFindingTracklet/README.md
+++ b/L1Trigger/TrackFindingTracklet/README.md
@@ -1,4 +1,4 @@
-To run the L1 tracking & create a TTree of tracking performance:  
+To run the L1 tracking & create a TTree of tracking performance:
 
 cmsRun L1TrackNtupleMaker_cfg.py
 


### PR DESCRIPTION
#### PR description:

Migrate L1TrackNtupleMaker_cfg.py to the CMSSW 15_1_0 D110 geometry RelVal sample by default.

Also added printout of summary L1 tracking performance from Thomas's analyzer at end of tracking chain if HYBRID_DISPLACED algo used.