### PR TITLE
ChannelAssignment issue fix

### DIFF
--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerChannelAssignment.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerChannelAssignment.cc
@@ -42,7 +42,8 @@ namespace trklet {
     iConfig_.tmMuxOrderInt_.reserve(iConfig_.tmMuxOrder_.size());
     for (const std::string& s : iConfig_.tmMuxOrder_)
       iConfig_.tmMuxOrderInt_.push_back(std::distance(
-          iConfig_.tmMuxOrder_.begin(), find(iConfig_.tmMuxOrder_.begin(), iConfig_.tmMuxOrder_.end(), s)));
+          iConfig_.seedTypeNames_.begin(),
+find(iConfig_.seedTypeNames_.begin(), iConfig_.seedTypeNames_.end(), s)));
     const edm::ParameterSet& pSetSeedTypesSeedLayers = iConfig.getParameter<edm::ParameterSet>("SeedTypesSeedLayers");
     const edm::ParameterSet& pSetSeedTypesProjectionLayers =
         iConfig.getParameter<edm::ParameterSet>("SeedTypesProjectionLayers");

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -207,7 +207,7 @@ elif (L1TRKALGO == 'HYBRID_NEWKF' or L1TRKALGO == 'HYBRID_REDUCED'):
     # Needed by L1TrackNtupleMaker
     process.HitPatternHelperSetup.useNewKF = True
 
-# HYBRID: extended tracking followd by 5 param fit sim
+# HYBRID: extended tracking followed by 5 param fit sim
 elif (L1TRKALGO == 'HYBRID_DISPLACED_NEWKF_KILL' or L1TRKALGO == 'HYBRID_DISPLACED_NEWKF_MERGE'):
     process.load( 'L1Trigger.TrackFindingTracklet.Producer_cff' )
     process.load( 'L1Trigger.TrackFindingTracklet.Analyzer_cff' )
@@ -216,21 +216,51 @@ elif (L1TRKALGO == 'HYBRID_DISPLACED_NEWKF_KILL' or L1TRKALGO == 'HYBRID_DISPLAC
     NHELIXPAR = 5
     TRACKLET_NAME  = "l1tTTTracksFromExtendedTrackletEmulation"
     TRACKLET_LABEL = "Level1TTTracks"
-    L1TRK_NAME  = process.TrackFindingTrackletAnalyzer_params.OutputLabelTFP.value()
-    L1TRK_LABEL = process.TrackFindingTrackletProducer_params.BranchTTTracks.value()
+    # Update L1TRK variables to point to ProducerKF instead of the removed ProducerTFP
+    L1TRK_NAME  = "ProducerKF"
+    # ProducerKF uses "BranchTracks" ("TrackAccepted") for its TTTracks output, not "BranchTTTracks"
+    L1TRK_LABEL = process.TrackFindingTrackletProducer_params.BranchTracks.value()
     L1TRUTH_NAME = "TTTrackAssociatorFromPixelDigisExtended"
     process.TTTrackAssociatorFromPixelDigisExtended.TTTracks = cms.VInputTag( cms.InputTag(L1TRK_NAME, L1TRK_LABEL) )
     process.AnalyzerTracklet.InputTag = cms.InputTag(TRACKLET_NAME, TRACKLET_LABEL)
     if (L1TRKALGO == 'HYBRID_DISPLACED_NEWKF_MERGE'):
-        displacedNewKFMergeConfig( process )
-        process.HybridNewKF = cms.Sequence(process.L1TExtendedHybridTracks + process.ProducerFakeDR + process.ProducerKF + process.ProducerTQ + process.ProducerTFP)
-        process.TTTracksEmulationWithTruth = cms.Path(process.HybridNewKF + process.L1TExtendedHybridTracksWithAssociators + process.StubAssociator +  process.AnalyzerTracklet + process.AnalyzerDR + process.AnalyzerKF + process.AnalyzerTQ + process.AnalyzerTFP)
+      displacedNewKFMergeConfig( process )
+      # Removed ProducerTQ and ProducerTFP. The chain ends at ProducerKF.
+      process.HybridNewKF = cms.Sequence(
+        process.L1TExtendedHybridTracks + 
+        process.ProducerFakeDR + 
+        process.ProducerKF
+      )
+      # Removed AnalyzerTQ and AnalyzerTFP.
+      process.TTTracksEmulationWithTruth = cms.Path(
+        process.HybridNewKF + 
+        process.L1TExtendedHybridTracksWithAssociators + 
+        process.StubAssociator +  
+        process.AnalyzerTracklet + 
+        process.AnalyzerDR + 
+        process.AnalyzerKF
+      )
     elif(L1TRKALGO == 'HYBRID_DISPLACED_NEWKF_KILL'):
-        displacedNewKFKillConfig( process )
-        process.HybridNewKF = cms.Sequence(process.L1TExtendedHybridTracks + process.ProducerFakeTM + process.ProducerDR + process.ProducerKF + process.ProducerTQ + process.ProducerTFP)
-        process.TTTracksEmulationWithTruth = cms.Path(process.HybridNewKF + process.L1TExtendedHybridTracksWithAssociators + process.StubAssociator +  process.AnalyzerTracklet + process.AnalyzerTM + process.AnalyzerDR + process.AnalyzerKF + process.AnalyzerTQ + process.AnalyzerTFP)
+      displacedNewKFKillConfig( process )
+      # Removed ProducerTQ and ProducerTFP. The chain ends at ProducerKF.
+      process.HybridNewKF = cms.Sequence(
+        process.L1TExtendedHybridTracks + 
+        process.ProducerFakeTM + 
+        process.ProducerDR + 
+        process.ProducerKF
+      )
+      # Removed AnalyzerTQ and AnalyzerTFP.
+      process.TTTracksEmulationWithTruth = cms.Path(
+        process.HybridNewKF + 
+        process.L1TExtendedHybridTracksWithAssociators + 
+        process.StubAssociator +  
+        process.AnalyzerTracklet + 
+        process.AnalyzerTM + 
+        process.AnalyzerDR + 
+        process.AnalyzerKF
+      )
     process.TTTracksEmulation = cms.Path(process.HybridNewKF)
-
+    
 # LEGACY ALGORITHM (EXPERTS ONLY): TRACKLET
 elif (L1TRKALGO == 'TRACKLET'):
     print("\n WARNING: This is not the baseline algorithm! Prefer HYBRID or HYBRID_DISPLACED!")


### PR DESCRIPTION
There is a bug in [ProducerChannelAssignment.cc](https://github.com/cms-L1TK/cmssw/blob/L1TK-dev-15_1_0_pre4/L1Trigger/TrackFindingTracklet/plugins/ProducerChannelAssignment.cc#L45). The Duplicate Removal (DR) seed ranking in the “HYBRID_NEWKF” (prompt and displaced KILL options) comes from the order of the seeds in the “MuxOrder” in [ChannelAssignment_cfi.py](https://github.com/cms-L1TK/cmssw/blob/812bfad496e351be838a58ad6bfdad3e43dc1c65/L1Trigger/TrackFindingTracklet/python/ChannelAssignment_cfi.py#L11). However, changing the seed order does not impact the output at all: exact same trk_seed distrubrion, exact same performance, the output files are identical. I explained why this is happening and the potential fix [here](https://indico.cern.ch/event/1582056/contributions/6668033/attachments/3128488/5549605/UTK_BES_L1_03_09_25.pdf)

Thomas Schuh pointed out that this could be implemented by modifying this [line](https://github.com/cms-L1TK/cmssw/blob/L1TK-dev-15_1_0_pre4/L1Trigger/TrackFindingTracklet/plugins/ProducerChannelAssignment.cc#L45), which is what this PR does.

I tested this fix and it [works](https://indico.cern.ch/event/1590389/contributions/6701838/attachments/3137679/5567828/BES_UTK_L1_AAA_17_09_2025.pdf). 