### PR TITLE
Add helix fit covariance matrix to HYBRID output

### DIFF
--- a/DataFormats/L1TrackTrigger/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/BuildFile.xml
@@ -8,6 +8,7 @@
 <use name="DataFormats/TrackerCommon"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
+<use name="roothistmatrix"/>
 <use name="hls"/>
 <export>
   <lib name="1"/>

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -25,6 +25,7 @@ class TTTrack : public TTTrack_TrackWord {
 public:
   typedef math::ErrorF<5>::type CovMat;
   typedef edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > TTStubRef;
+  enum Hpar { INVR, PHI0, TANL, Z0, D0 };
 
 private:
   /// Data members
@@ -92,7 +93,7 @@ public:
   double phi() const { return thePhi_; }
 
   // Track phi with respect to centre line of phi nonant, which for sector 0 is parallel to x-axis.
-  double localPhi() const;
+  double localPhi() const { return TTTrack_TrackWord::localPhi(thePhi_, thePhiSector_); }
 
   /// Track tanL
   double tanL() const { return theTanL_; }
@@ -109,7 +110,8 @@ public:
   /// Track charge
   int charge() const { return (theRInv_ > 0) ? 1 : -1; }
 
-  // Helix covariance matrix (always 5x5) in (1/R, phi0, tanL, z0, d0).
+  // Helix covariance matrix (always 5x5) in (1/R, phi0, tanL, z0, d0),
+  // so elements can be accessed with enum Hpar.
   // (Added to study if any elements worth adding to L1 track firmware output).
   const CovMat& helixCovMat() const { return theHelixCovMat_; }
 
@@ -141,12 +143,13 @@ public:
 
   /// Chi2 and chi2/ndf ("Red")
   double chi2() const { return theChi2_; }
-  double chi2Red() const;
+  double chi2Red() const { return theChi2_ / (2 * theStubRefs.size() - theNumFitPars_); }
+
   // Ditto, but split into r-z and x-y components.
   double chi2Z() const { return theChi2_Z_; }
-  double chi2ZRed() const;
+  double chi2ZRed() const { return theChi2_Z_ / (theStubRefs.size() - 2.); }
   double chi2XY() const { return theChi2_XY_; }
-  double chi2XYRed() const;
+  double chi2XYRed() const { return theChi2_XY_ / (theStubRefs.size() - (theNumFitPars_ - 2)); }
 
   /// Stub Pt consistency (i.e. stub bend chi2/dof)
   double chi2BendRed() const { return theStubPtConsistency_; }
@@ -252,29 +255,6 @@ TTTrack<T>::TTTrack(double Rinv,
   theMomentum_ = GlobalVector(GlobalVector::Cylindrical(pT, phi0, pT * tanL));
 }
 
-template <typename T>
-double TTTrack<T>::localPhi() const {
-  return TTTrack_TrackWord::localPhi(thePhi_, thePhiSector_);
-}
-
-/// Chi2/dof
-template <typename T>
-double TTTrack<T>::chi2Red() const {
-  return theChi2_ / (2 * theStubRefs.size() - theNumFitPars_);
-}
-
-/// Chi2 in x-y / dof
-template <typename T>
-double TTTrack<T>::chi2XYRed() const {
-  return theChi2_XY_ / (theStubRefs.size() - (theNumFitPars_ - 2));
-}
-
-/// Chi2 in r-z / dof
-template <typename T>
-double TTTrack<T>::chi2ZRed() const {
-  return theChi2_Z_ / (theStubRefs.size() - 2.);
-}
-
 /// Get helix params & chi2XY after constraining track to x=y=0.
 template <typename T>
 void TTTrack<T>::beamConstraint(
@@ -291,10 +271,10 @@ void TTTrack<T>::beamConstraint(
     // To constrain to beam-spot (XB,YB) rather than (0,0), would need this,
     // in approx that XB,YB,D0 all small.
     // double d0 = this->d0() - (XB*sin(phi_con) - YB cos(phi_con));
-    double lagrange = d0 / theHelixCovMat_[4][4];
+    double lagrange = d0 / theHelixCovMat_[Hpar::D0][Hpar::D0];
     chi2XY_con += lagrange * d0;
-    rInv_con -= lagrange * theHelixCovMat_[4][0];
-    phi_con -= lagrange * theHelixCovMat_[4][1];
+    rInv_con -= lagrange * theHelixCovMat_[Hpar::D0][Hpar::INVR];
+    phi_con -= lagrange * theHelixCovMat_[Hpar::D0][Hpar::PHI0];
     phi_con = reco::deltaPhi(phi_con, 0.);
     pt_con = this->rinvToPt(rInv_con);
     int nHelPar = 4;

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -167,7 +167,7 @@ public:
   std::string print() const;
 
 private:
-  // 1/rinv measured in cm.
+  // Converter - 1/rinv measured in cm.
   double rinvToPt(double rinv) const { return (cLight_ / 1.0e11) * std::abs(theBField_ / rinv); }
 
 };  /// Close class

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -67,7 +67,7 @@ public:
           double trkMVA1,
           double trkMVA2,
           double trkMVA3,
-          unsigned int aHitpattern, // Bit order: Inner-->Outer tracker corresponds to Rightmost-->Leftmost bits
+          unsigned int aHitpattern,  // Bit order: Inner-->Outer tracker corresponds to Rightmost-->Leftmost bits
           unsigned int nPar,
           double Bfield,
           unsigned int phiSector = 99,

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -147,9 +147,15 @@ public:
 
   // Ditto, but split into r-z and x-y components.
   double chi2Z() const { return theChi2_Z_; }
-  double chi2ZRed() const { return theChi2_Z_ / (theStubRefs.size() - 2.); }
+  double chi2ZRed() const {
+    constexpr int nHelixParsRZ = 2;
+    return theChi2_Z_ / (theStubRefs.size() - nHelixParsRZ);
+  }
   double chi2XY() const { return theChi2_XY_; }
-  double chi2XYRed() const { return theChi2_XY_ / (theStubRefs.size() - (theNumFitPars_ - 2)); }
+  double chi2XYRed() const {
+    int nHelixParsRPhi = theNumFitPars_ - 2;
+    return theChi2_XY_ / (theStubRefs.size() - nHelixParsRPhi);
+  }
 
   /// Stub Pt consistency (i.e. stub bend chi2/dof)
   double chi2BendRed() const { return theStubPtConsistency_; }
@@ -277,8 +283,8 @@ void TTTrack<T>::beamConstraint(
     phi_con -= lagrange * theHelixCovMat_[Hpar::D0][Hpar::PHI0];
     phi_con = reco::deltaPhi(phi_con, 0.);
     pt_con = this->rinvToPt(rInv_con);
-    int nHelPar = 4;
-    int dof = theStubRefs.size() - (nHelPar - 2);
+    constexpr int nHelixParsRPhi = 2;  // with d0 = 0 constraint
+    int dof = theStubRefs.size() - nHelixParsRPhi;
     chi2XY_dof_con = chi2XY_con / dof;
   }
 }
@@ -286,6 +292,7 @@ void TTTrack<T>::beamConstraint(
 /// set B field if need be
 template <typename T>
 void TTTrack<T>::setBField(double aBField) {
+  theBField_ = aBField;
   // if, for some reason, we want to change the value of the B-Field, recompute momentum:
   double thePT = this->rinvToPt(theRInv_);
   theMomentum_ = GlobalVector(GlobalVector::Cylindrical(thePT, thePhi_, thePT * theTanL_));
@@ -331,10 +338,9 @@ std::string TTTrack<T>::print() const {
   output << "chi2XYRed = " << chi2XYRed() << " vs " << getChi2RPhi() << "\n";
   output << "trkMVA1   = " << trkMVA1() << " vs " << getMVAQuality() << "\n";
   auto safeSqrt = [](float q) { return q >= 0 ? sqrt(q) : -sqrt(-q); };
-  output << "sigma(z0) = " << safeSqrt(theHelixCovMat_[3][3]) << "\n";
+  output << "sigma(z0) = " << safeSqrt(theHelixCovMat_[Hpar::Z0][Hpar::Z0]) << "\n";
   if (theNumFitPars_ == 5)
-    output << "sigma(d0) = " << safeSqrt(theHelixCovMat_[4][4]) << "\n";
-  output << "sigma(phi0) = " << safeSqrt(theHelixCovMat_[1][1]) << "\n";
+    output << "sigma(d0) = " << safeSqrt(theHelixCovMat_[Hpar::D0][Hpar::D0]) << "\n";
 
   output << "digi(L1 track) word = " << getTrackWord().to_string(16) << "\n";
 

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -50,6 +50,7 @@ private:
   int theTrackSeedType_;
   double theBField_;  // needed for unpacking
   CovMat theHelixCovMat_;
+
   static constexpr double cLight_ = CLHEP::c_light * (CLHEP::second / CLHEP::meter);
 
 public:
@@ -324,7 +325,7 @@ template <typename T>
 std::string TTTrack<T>::print() const {
   const std::string padding("\t");
   std::stringstream output;
-  output << padding << "TTTrack:\n";
+  output << padding << " -- TTTrack --\n";
   // Compare original helix params with undigi(digi()) ones.
   output << "Comparing float vs undigi(digi(float))\n";
   output << "Rinv      = " << rInv() << " vs " << getRinv() << "\n";
@@ -336,7 +337,8 @@ std::string TTTrack<T>::print() const {
   output << "trkMVA1   = " << trkMVA1() << " vs " << getMVAQuality() << "\n";
   auto safeSqrt = [](float q) { return q >= 0 ? sqrt(q) : -sqrt(-q); };
   output << "sigma(z0) = " << safeSqrt(theHelixCovMat_[3][3]) << "\n";
-  output << "sigma(d0) = " << safeSqrt(theHelixCovMat_[4][4]) << "\n";
+  if (theNumFitPars_ == 5)
+    output << "sigma(d0) = " << safeSqrt(theHelixCovMat_[4][4]) << "\n";
   output << "sigma(phi0) = " << safeSqrt(theHelixCovMat_[1][1]) << "\n";
 
   output << "digi(L1 track) word = " << getTrackWord().to_string(16) << "\n";

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -18,6 +18,7 @@
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
 #include "DataFormats/Math/interface/Error.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
 
 template <typename T>
 class TTTrack : public TTTrack_TrackWord {
@@ -106,7 +107,7 @@ public:
   /// Track charge
   int charge() const { return (theRInv_ > 0) ? 1 : -1; }
 
-  // Helix covariance matrix (always 5x5) in (1/2R, phi0, tanL, z0, d0).
+  // Helix covariance matrix (always 5x5) in (1/R, phi0, tanL, z0, d0).
   // (Added to study if any elements worth adding to L1 track firmware output).
   const CovMat& helixCovMat() const { return theHelixCovMat_; }
 
@@ -156,6 +157,10 @@ public:
   /// Hit Pattern
   unsigned int hitPattern() const { return theHitPattern_; }
 
+  /// Get helix params & chi2XY after constraining track to x=y=0.
+  // (Added to study if worth adding to L1 track firmware output).
+  void beamConstaint(double& phiConstr, double& rInvConst, double& chi2XYConstr);
+
   /// set new Bfield
   void setBField(double aBField);
 
@@ -164,7 +169,6 @@ public:
 
   std::string print() const;
 
-private:
   // Converter - 1/rinv measured in cm.
   double rinvToPt(double rinv) const { return (cLight_ / 1.0e11) * std::abs(theBField_ / rinv); }
 
@@ -267,6 +271,22 @@ double TTTrack<T>::chi2ZRed() const {
   return theChi2_Z_ / (theStubRefs.size() - 2.);
 }
 
+/// Get helix params & chi2XY after constraining track to x=y=0.
+template <typename T>
+void TTTrack<T>::beamConstaint(double& phi_constr, double& rInv_constr, double& chi2XY_constr) {
+  phi_constr = thePhi_;
+  rInv_constr = theRInv_;
+  chi2XY_constr = theChi2_XY_;
+  if (theNumFitPars_ == 5) {
+    // Calculated with Lagrange multipliers in approx that d0 is small.
+    double lagrange = theD0_ / theHelixCovMat_[4][4];
+    chi2XY_constr += lagrange * theD0_;
+    rInv_constr -= lagrange * theHelixCovMat_[4][0];
+    phi_constr -= lagrange * theHelixCovMat_[4][1];
+    phi_constr = reco::deltaPhi(phi_constr, 0.);
+  }
+}
+
 /// set B field if need be
 template <typename T>
 void TTTrack<T>::setBField(double aBField) {
@@ -307,13 +327,19 @@ std::string TTTrack<T>::print() const {
   output << padding << "TTTrack:\n";
   // Compare original helix params with undigi(digi()) ones.
   output << "Comparing float vs undigi(digi(float))\n";
-  output << "Rinv      = " << rInv()     << " vs " << getRinv() << "\n";
+  output << "Rinv      = " << rInv() << " vs " << getRinv() << "\n";
   output << "Local phi = " << localPhi() << " vs " << getPhi() << "\n";
-  output << "tanL      = " << tanL()     << " vs " << getTanl() << "\n";
-  output << "z0        = " << z0()       << " vs " << getZ0() << "\n";
-  output << "chi2XYRed = " << chi2XYRed()<< " vs " << getChi2RPhi() << "\n";
-  output << "trkMVA1   = " << trkMVA1()  << " vs " << getMVAQuality() << "\n";
-  output <<"digi(L1 track) word = " << getTrackWord().to_string(16) << "\n";
+  output << "tanL      = " << tanL() << " vs " << getTanl() << "\n";
+  output << "z0        = " << z0() << " vs " << getZ0() << "\n";
+  output << "d0        = " << d0() << " vs " << getD0() << "\n";
+  output << "chi2XYRed = " << chi2XYRed() << " vs " << getChi2RPhi() << "\n";
+  output << "trkMVA1   = " << trkMVA1() << " vs " << getMVAQuality() << "\n";
+  auto safeSqrt = [](float q) { return q >= 0 ? sqrt(q) : -sqrt(-q); };
+  output << "sigma(z0) = " << safeSqrt(theHelixCovMat_[3][3]) << "\n";
+  output << "sigma(d0) = " << safeSqrt(theHelixCovMat_[4][4]) << "\n";
+  output << "sigma(phi0) = " << safeSqrt(theHelixCovMat_[1][1]) << "\n";
+
+  output << "digi(L1 track) word = " << getTrackWord().to_string(16) << "\n";
 
   unsigned int iStub = 0;
   for (const auto& stubIter : theStubRefs) {

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -83,6 +83,7 @@ public:
 
   /// Track momentum
   const GlobalVector& momentum() const { return theMomentum_; }
+  double pt() const { return theMomentum_.perp(); }
 
   /// Track curvature
   double rInv() const { return theRInv_; }
@@ -160,7 +161,7 @@ public:
 
   /// Get helix params & chi2XY after constraining track to x=y=0.
   // (Added to study if worth adding to L1 track firmware output).
-  void beamConstaint(double& phiConstr, double& rInvConst, double& chi2XYConstr);
+  void beamConstraint(float& phi_con, float& rInv_con, float& pt_con, float& chi2XY_con, float& chi2XY_dof_con) const;
 
   /// set new Bfield
   void setBField(double aBField);
@@ -274,17 +275,25 @@ double TTTrack<T>::chi2ZRed() const {
 
 /// Get helix params & chi2XY after constraining track to x=y=0.
 template <typename T>
-void TTTrack<T>::beamConstaint(double& phi_constr, double& rInv_constr, double& chi2XY_constr) {
-  phi_constr = thePhi_;
-  rInv_constr = theRInv_;
-  chi2XY_constr = theChi2_XY_;
+void TTTrack<T>::beamConstraint(
+    float& phi_con, float& rInv_con, float& pt_con, float& chi2XY_con, float& chi2XY_dof_con) const {
+  phi_con = this->phi();
+  rInv_con = this->rInv();
+  pt_con = this->pt();
+  chi2XY_con = this->chi2XY();
+  chi2XY_dof_con = this->chi2XYRed();
+
   if (theNumFitPars_ == 5) {
     // Calculated with Lagrange multipliers in approx that d0 is small.
     double lagrange = theD0_ / theHelixCovMat_[4][4];
-    chi2XY_constr += lagrange * theD0_;
-    rInv_constr -= lagrange * theHelixCovMat_[4][0];
-    phi_constr -= lagrange * theHelixCovMat_[4][1];
-    phi_constr = reco::deltaPhi(phi_constr, 0.);
+    chi2XY_con += lagrange * theD0_;
+    rInv_con -= lagrange * theHelixCovMat_[4][0];
+    phi_con -= lagrange * theHelixCovMat_[4][1];
+    phi_con = reco::deltaPhi(phi_con, 0.);
+    pt_con = this->rinvToPt(rInv_con);
+    int nHelPar = 4;
+    int dof = theStubRefs.size() - (nHelPar - 2);
+    chi2XY_dof_con = chi2XY_con / dof;
   }
 }
 

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -160,7 +160,9 @@ public:
   unsigned int hitPattern() const { return theHitPattern_; }
 
   /// Get helix params & chi2XY after constraining track to x=y=0.
-  // (Added to study if worth adding to L1 track firmware output).
+  //  N.B. Should really constrain to beam-line position!
+  // (Added to study if worth adding to L1 track firmware output.
+  // Outputting constraint chi2 easier than constrained helix params.).
   void beamConstraint(float& phi_con, float& rInv_con, float& pt_con, float& chi2XY_con, float& chi2XY_dof_con) const;
 
   /// set new Bfield
@@ -285,8 +287,12 @@ void TTTrack<T>::beamConstraint(
 
   if (theNumFitPars_ == 5) {
     // Calculated with Lagrange multipliers in approx that d0 is small.
-    double lagrange = theD0_ / theHelixCovMat_[4][4];
-    chi2XY_con += lagrange * theD0_;
+    double d0 = this->d0();
+    // To constrain to beam-spot (XB,YB) rather than (0,0), would need this,
+    // in approx that XB,YB,D0 all small.
+    // double d0 = this->d0() - (XB*sin(phi_con) - YB cos(phi_con));
+    double lagrange = d0 / theHelixCovMat_[4][4];
+    chi2XY_con += lagrange * d0;
     rInv_con -= lagrange * theHelixCovMat_[4][0];
     phi_con -= lagrange * theHelixCovMat_[4][1];
     phi_con = reco::deltaPhi(phi_con, 0.);

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -1,12 +1,10 @@
 /*! \class   TTTrack
  *  \brief   Class to store the L1 Tracks.
- *  \details After moving from SimDataFormats to DataFormats,
- *           the template structure of the class was maintained
+ *  \details The template structure of the class was maintained
  *           in order to accomodate any types other than PixelDigis
  *           in case there is such a need in the future.
  *
  *  \author Nicola Pozzobon (+ update Ian Tomalin)
- *
  */
 
 #ifndef L1_TRACK_TRIGGER_TRACK_FORMAT_H
@@ -57,11 +55,11 @@ public:
   /// Constructors
   TTTrack();
 
-  TTTrack(double aRinv,
-          double aphi,
+  TTTrack(double Rinv,
+          double phi0,
           double tanL,
-          double az0,
-          double ad0,
+          double z0,
+          double d0,
           double aChi2xyfit,
           double aChi2zfit,
           double trkMVA1,
@@ -87,7 +85,7 @@ public:
   /// Track curvature
   double rInv() const { return theRInv_; }
 
-  /// Track phi
+  /// Track phi0
   double phi() const { return thePhi_; }
 
   // Track phi with respect to centre line of phi nonant, which for sector 0 is parallel to x-axis.
@@ -204,11 +202,11 @@ TTTrack<T>::TTTrack()
 
 /// Default constructor
 template <typename T>
-TTTrack<T>::TTTrack(double aRinv,
-                    double aphi0,
+TTTrack<T>::TTTrack(double Rinv,
+                    double phi0,
                     double tanL,
-                    double az0,
-                    double ad0,
+                    double z0,
+                    double d0,
                     double aChi2XY,
                     double aChi2Z,
                     double trkMVA1,
@@ -222,13 +220,12 @@ TTTrack<T>::TTTrack(double aRinv,
                     double chi2BendRed,
                     unsigned int seedType,
                     const CovMat& helixCovMat)
-    : theMomentum_(GlobalVector::Cylindrical(rinvToPt(aRinv), aphi0, rinvToPt(aRinv) * tanL)),
-      thePOCA_(ad0 * sin(aphi0), -ad0 * cos(aphi0), az0),
-      theRInv_(aRinv),
-      thePhi_(aphi0),
+    : thePOCA_(d0 * sin(phi0), -d0 * cos(phi0), z0),
+      theRInv_(Rinv),
+      thePhi_(phi0),
       theTanL_(tanL),
-      theD0_(ad0),
-      theZ0_(az0),
+      theD0_(d0),
+      theZ0_(z0),
       thePhiSector_(phiSector),
       theEtaSector_(etaSector),
       theStubPtConsistency_(chi2BendRed),
@@ -242,7 +239,10 @@ TTTrack<T>::TTTrack(double aRinv,
       theTrkMVA3_(trkMVA3),
       theTrackSeedType_(seedType),
       theBField_(Bfield),
-      theHelixCovMat_(helixCovMat) {}
+      theHelixCovMat_(helixCovMat) {
+  double pT = rinvToPt(Rinv);
+  theMomentum_ = GlobalVector(GlobalVector::Cylindrical(pT, phi0, pT * tanL));
+}
 
 template <typename T>
 double TTTrack<T>::localPhi() const {
@@ -281,11 +281,12 @@ void TTTrack<T>::setBField(double aBField) {
 template <typename T>
 void TTTrack<T>::setTrackWordBits() {
   constexpr unsigned int valid = true;
+  constexpr double mvaOther = 0.;
 
   // missing conversion of global phi to difference from sector center phi
 
   setTrackWord(valid,
-               theMomentum_,
+               momentum(),
                POCA(),
                rInv(),
                chi2XYRed(),
@@ -293,9 +294,8 @@ void TTTrack<T>::setTrackWordBits() {
                chi2BendRed(),
                hitPattern(),
                trkMVA1(),
-               trkMVA2(),
-               trkMVA3(),
-               thePhiSector_);
+               mvaOther,
+               phiSector());
 
   return;
 }
@@ -304,11 +304,20 @@ template <typename T>
 std::string TTTrack<T>::print() const {
   const std::string padding("\t");
   std::stringstream output;
-  output << padding << "TTTrack:\n\n";
+  output << padding << "TTTrack:\n";
+  // Compare original helix params with undigi(digi()) ones.
+  output << "Comparing float vs undigi(digi(float))\n";
+  output << "Rinv      = " << rInv()     << " vs " << getRinv() << "\n";
+  output << "Local phi = " << localPhi() << " vs " << getPhi() << "\n";
+  output << "tanL      = " << tanL()     << " vs " << getTanl() << "\n";
+  output << "z0        = " << z0()       << " vs " << getZ0() << "\n";
+  output << "chi2XYRed = " << chi2XYRed()<< " vs " << getChi2RPhi() << "\n";
+  output << "trkMVA1   = " << trkMVA1()  << " vs " << getMVAQuality() << "\n";
+  output <<"digi(L1 track) word = " << getTrackWord().to_string(16) << "\n";
 
   unsigned int iStub = 0;
   for (const auto& stubIter : theStubRefs) {
-    output << padding << "stub: " << iStub++ << ", DetId: " << ((*stubIter)->getDetId()).rawId() << '\n';
+    output << padding << "stub: " << iStub++ << ", DetId: " << (stubIter->getDetId()).rawId() << '\n';
   }
 
   return output.str();

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -67,7 +67,7 @@ public:
           double trkMVA1,
           double trkMVA2,
           double trkMVA3,
-          unsigned int aHitpattern,
+          unsigned int aHitpattern, // Bit order: Inner-->Outer tracker corresponds to Rightmost-->Leftmost bits
           unsigned int nPar,
           double Bfield,
           unsigned int phiSector = 99,

--- a/DataFormats/L1TrackTrigger/interface/TTTrack.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack.h
@@ -1,12 +1,11 @@
 /*! \class   TTTrack
- *  \brief   Class to store the L1 Track Trigger tracks
+ *  \brief   Class to store the L1 Tracks.
  *  \details After moving from SimDataFormats to DataFormats,
  *           the template structure of the class was maintained
  *           in order to accomodate any types other than PixelDigis
  *           in case there is such a need in the future.
  *
- *  \author Nicola Pozzobon
- *  \date   2013, Jul 12
+ *  \author Nicola Pozzobon (+ update Ian Tomalin)
  *
  */
 
@@ -20,16 +19,17 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
-
-namespace tttrack {
-  void errorSetTrackWordBits(unsigned int);
-}
+#include "DataFormats/Math/interface/Error.h"
 
 template <typename T>
 class TTTrack : public TTTrack_TrackWord {
+public:
+  typedef math::ErrorF<5>::type CovMat;
+  typedef edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > TTStubRef;
+
 private:
   /// Data members
-  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > theStubRefs;
+  std::vector<TTStubRef> theStubRefs;
   GlobalVector theMomentum_;
   GlobalPoint thePOCA_;
   double theRInv_;
@@ -50,10 +50,8 @@ private:
   double theTrkMVA3_;
   int theTrackSeedType_;
   double theBField_;  // needed for unpacking
-  static constexpr unsigned int Npars4 = 4;
-  static constexpr unsigned int Npars5 = 5;
-  static constexpr float MagConstant =
-      CLHEP::c_light / 1.0E3;  //constant is 0.299792458; who knew c_light was in mm/ns?
+  CovMat theHelixCovMat_;
+  static constexpr double cLight_ = CLHEP::c_light * (CLHEP::second / CLHEP::meter);
 
 public:
   /// Constructors
@@ -61,20 +59,7 @@ public:
 
   TTTrack(double aRinv,
           double aphi,
-          double aTanLambda,
-          double az0,
-          double ad0,
-          double aChi2,
-          double trkMVA1,
-          double trkMVA2,
-          double trkMVA3,
-          unsigned int aHitpattern,
-          unsigned int nPar,
-          double Bfield);
-
-  TTTrack(double aRinv,
-          double aphi,
-          double aTanLambda,
+          double tanL,
           double az0,
           double ad0,
           double aChi2xyfit,
@@ -84,98 +69,106 @@ public:
           double trkMVA3,
           unsigned int aHitpattern,
           unsigned int nPar,
-          double Bfield);
+          double Bfield,
+          unsigned int phiSector = 99,
+          unsigned int etaSector = 99,
+          double chi2BendRed = -99,
+          unsigned int seedType = 99,
+          const CovMat& helixCovMat = CovMat());
 
-  /// Destructor
-  ~TTTrack();
-
-  /// Track components
-  const std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > >& getStubRefs() const {
-    return theStubRefs;
-  }
-  void addStubRef(edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > aStub) { theStubRefs.push_back(aStub); }
-  void setStubRefs(std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > > aStubs) {
-    theStubRefs = aStubs;
-  }
+  /// Track stubs (not available in firmware)
+  const std::vector<TTStubRef>& getStubRefs() const { return theStubRefs; }
+  void addStubRef(const TTStubRef& aStub) { theStubRefs.push_back(aStub); }
+  void setStubRefs(const std::vector<TTStubRef>& aStubs) { theStubRefs = aStubs; }
 
   /// Track momentum
-  const GlobalVector& momentum() const;
+  const GlobalVector& momentum() const { return theMomentum_; }
 
   /// Track curvature
-  double rInv() const;
+  double rInv() const { return theRInv_; }
 
   /// Track phi
-  double phi() const;
+  double phi() const { return thePhi_; }
 
-  /// Local track phi (within the sector)
+  // Track phi with respect to centre line of phi nonant, which for sector 0 is parallel to x-axis.
   double localPhi() const;
 
   /// Track tanL
-  double tanL() const;
+  double tanL() const { return theTanL_; }
 
   /// Track d0
-  double d0() const;
+  double d0() const { return theD0_; }
 
   /// Track z0
-  double z0() const;
+  double z0() const { return theZ0_; }
 
   /// Track eta
-  double eta() const;
+  double eta() const { return theMomentum_.eta(); }
+
+  /// Track charge
+  int charge() const { return (theRInv_ > 0) ? 1 : -1; }
+
+  // Helix covariance matrix (always 5x5) in (1/2R, phi0, tanL, z0, d0).
+  // (Added to study if any elements worth adding to L1 track firmware output).
+  const CovMat& helixCovMat() const { return theHelixCovMat_; }
 
   /// POCA
-  const GlobalPoint& POCA() const;
+  const GlobalPoint& POCA() const { return thePOCA_; }
 
   /// MVA Track quality variables
-  double trkMVA1() const;
-  void settrkMVA1(double atrkMVA1);
-  double trkMVA2() const;
-  void settrkMVA2(double atrkMVA2);
-  double trkMVA3() const;
-  void settrkMVA3(double atrkMVA3);
+  double trkMVA1() const { return theTrkMVA1_; }  // Tuned for prompt tracks
+  void settrkMVA1(double atrkMVA1) { theTrkMVA1_ = atrkMVA1; }
+  double trkMVA2() const { return theTrkMVA2_; }  // Tuned for prompt electron tracks
+  void settrkMVA2(double atrkMVA2) { theTrkMVA2_ = atrkMVA2; }
+  double trkMVA3() const { return theTrkMVA3_; }  // Tuned for displaced tracks
+  void settrkMVA3(double atrkMVA3) { theTrkMVA3_ = atrkMVA3; }
 
   /// Phi Sector
   unsigned int phiSector() const { return thePhiSector_; }
+  // Obsolete. Use constructor instead.
   void setPhiSector(unsigned int aSector) { thePhiSector_ = aSector; }
 
   /// Eta Sector
   unsigned int etaSector() const { return theEtaSector_; }
+  // Obsolete. Use constructor instead.
   void setEtaSector(unsigned int aSector) { theEtaSector_ = aSector; }
 
   /// Track seeding (for debugging)
   unsigned int trackSeedType() const { return theTrackSeedType_; }
+  // Obsolete. Use constructor instead.
   void setTrackSeedType(int aSeed) { theTrackSeedType_ = aSeed; }
 
-  /// Chi2
-  double chi2() const;
+  /// Chi2 and chi2/ndf ("Red")
+  double chi2() const { return theChi2_; }
   double chi2Red() const;
-  double chi2Z() const;
+  // Ditto, but split into r-z and x-y components.
+  double chi2Z() const { return theChi2_Z_; }
   double chi2ZRed() const;
-  double chi2XY() const;
+  double chi2XY() const { return theChi2_XY_; }
   double chi2XYRed() const;
 
   /// Stub Pt consistency (i.e. stub bend chi2/dof)
-  /// Note: The "stubPtConsistency" names are historic and people are encouraged
-  ///       to adopt the "chi2Bend" names.
-  double stubPtConsistency() const;
-  void setStubPtConsistency(double aPtConsistency);
-  double chi2BendRed() { return stubPtConsistency(); }
-  void setChi2BendRed(double aChi2BendRed) { setStubPtConsistency(aChi2BendRed); }
-  double chi2Bend() { return chi2BendRed() * theStubRefs.size(); }
+  double chi2BendRed() const { return theStubPtConsistency_; }
+  double chi2Bend() const { return chi2BendRed() * theStubRefs.size(); }
+  // Obsolete. Use constructor instead
+  void setChi2BendRed(double aChi2BendRed) { theStubPtConsistency_ = aChi2BendRed; }
 
-  void setFitParNo(unsigned int aFitParNo);
   int nFitPars() const { return theNumFitPars_; }
 
   /// Hit Pattern
-  unsigned int hitPattern() const;
+  unsigned int hitPattern() const { return theHitPattern_; }
 
   /// set new Bfield
   void setBField(double aBField);
 
+  /// Set bits in 96-bit Track word that corresponds to TFP firwmare output.
   void setTrackWordBits();
-  void testTrackWordBits();
 
-  /// Information
-  std::string print(unsigned int i = 0) const;
+  std::string print() const;
+
+private:
+  // 1/rinv measured in cm.
+  double rinvToPt(double rinv) const { return (cLight_ / 1.0e11) * std::abs(theBField_ / rinv); }
 
 };  /// Close class
 
@@ -186,73 +179,34 @@ public:
  *           in the source file.
  */
 
-/// Default Constructor
+/// Empty constructor
 template <typename T>
-TTTrack<T>::TTTrack() {
-  theStubRefs.clear();
-  theMomentum_ = GlobalVector(0.0, 0.0, 0.0);
-  theRInv_ = 0.0;
-  thePOCA_ = GlobalPoint(0.0, 0.0, 0.0);
-  theD0_ = 0.;
-  theZ0_ = 0.;
-  theTanL_ = 0;
-  thePhi_ = 0;
-  theTrkMVA1_ = 0;
-  theTrkMVA2_ = 0;
-  theTrkMVA3_ = 0;
-  thePhiSector_ = 0;
-  theEtaSector_ = 0;
-  theTrackSeedType_ = 0;
-  theChi2_ = 0.0;
-  theChi2_XY_ = 0.0;
-  theChi2_Z_ = 0.0;
-  theStubPtConsistency_ = 0.0;
-  theNumFitPars_ = 0;
-}
+TTTrack<T>::TTTrack()
+    : theMomentum_(0., 0., 0.),
+      thePOCA_(0., 0., 0.),
+      theRInv_(0.),
+      thePhi_(0.),
+      theTanL_(0.),
+      theD0_(0.),
+      theZ0_(0.),
+      thePhiSector_(0),
+      theEtaSector_(0),
+      theStubPtConsistency_(0.),
+      theChi2_(0.),
+      theChi2_XY_(0.),
+      theChi2_Z_(0.),
+      theNumFitPars_(0),
+      theTrkMVA1_(0.),
+      theTrkMVA2_(0.),
+      theTrkMVA3_(0.),
+      theTrackSeedType_(0),
+      theBField_(0.) {}
 
-/// Meant to be default constructor
+/// Default constructor
 template <typename T>
 TTTrack<T>::TTTrack(double aRinv,
                     double aphi0,
-                    double aTanlambda,
-                    double az0,
-                    double ad0,
-                    double aChi2,
-                    double trkMVA1,
-                    double trkMVA2,
-                    double trkMVA3,
-                    unsigned int aHitPattern,
-                    unsigned int nPar,
-                    double aBfield) {
-  theStubRefs.clear();
-  double thePT = std::abs(MagConstant / aRinv * aBfield / 100.0);  // Rinv is in cm-1
-  theMomentum_ = GlobalVector(GlobalVector::Cylindrical(thePT, aphi0, thePT * aTanlambda));
-  theRInv_ = aRinv;
-  thePOCA_ = GlobalPoint(ad0 * sin(aphi0), -ad0 * cos(aphi0), az0);
-  theD0_ = ad0;
-  theZ0_ = az0;
-  thePhi_ = aphi0;
-  theTanL_ = aTanlambda;
-  thePhiSector_ = 0;      // must be set externally
-  theEtaSector_ = 0;      // must be set externally
-  theTrackSeedType_ = 0;  // must be set externally
-  theChi2_ = aChi2;
-  theTrkMVA1_ = trkMVA1;
-  theTrkMVA2_ = trkMVA2;
-  theTrkMVA3_ = trkMVA3;
-  theStubPtConsistency_ = 0.0;  // must be set externally
-  theNumFitPars_ = nPar;
-  theHitPattern_ = aHitPattern;
-  theBField_ = aBfield;
-  theChi2_XY_ = -999.;
-  theChi2_Z_ = -999.;
-}
-
-/// Second default constructor with split chi2
-template <typename T>
-TTTrack<T>::TTTrack(double aRinv,
-                    double aphi0,
-                    double aTanlambda,
+                    double tanL,
                     double az0,
                     double ad0,
                     double aChi2XY,
@@ -262,176 +216,62 @@ TTTrack<T>::TTTrack(double aRinv,
                     double trkMVA3,
                     unsigned int aHitPattern,
                     unsigned int nPar,
-                    double aBfield)
-    : TTTrack(aRinv,
-              aphi0,
-              aTanlambda,
-              az0,
-              ad0,
-              aChi2XY + aChi2Z,  // add chi2 values
-              trkMVA1,
-              trkMVA2,
-              trkMVA3,
-              aHitPattern,
-              nPar,
-              aBfield) {
-  this->theChi2_XY_ = aChi2XY;
-  this->theChi2_Z_ = aChi2Z;
-}
-
-/// Destructor
-template <typename T>
-TTTrack<T>::~TTTrack() {}
-
-template <typename T>
-void TTTrack<T>::setFitParNo(unsigned int nPar) {
-  theNumFitPars_ = nPar;
-
-  return;
-}
-
-// Note that these calls return the floating point values.  If a TTTrack is made with only ditized values,
-// the unpacked values must come from the TTTrack_Trackword member functions.
-
-template <typename T>
-const GlobalVector& TTTrack<T>::momentum() const {
-  return theMomentum_;
-}
-
-template <typename T>
-double TTTrack<T>::rInv() const {
-  return theRInv_;
-}
-
-template <typename T>
-double TTTrack<T>::tanL() const {
-  return theTanL_;
-}
-
-template <typename T>
-double TTTrack<T>::eta() const {
-  return theMomentum_.eta();
-}
-
-template <typename T>
-double TTTrack<T>::phi() const {
-  return thePhi_;
-}
+                    double Bfield,
+                    unsigned int phiSector,
+                    unsigned int etaSector,
+                    double chi2BendRed,
+                    unsigned int seedType,
+                    const CovMat& helixCovMat)
+    : theMomentum_(GlobalVector::Cylindrical(rinvToPt(aRinv), aphi0, rinvToPt(aRinv) * tanL)),
+      thePOCA_(ad0 * sin(aphi0), -ad0 * cos(aphi0), az0),
+      theRInv_(aRinv),
+      thePhi_(aphi0),
+      theTanL_(tanL),
+      theD0_(ad0),
+      theZ0_(az0),
+      thePhiSector_(phiSector),
+      theEtaSector_(etaSector),
+      theStubPtConsistency_(chi2BendRed),
+      theChi2_(aChi2XY + aChi2Z),
+      theChi2_XY_(aChi2XY),
+      theChi2_Z_(aChi2Z),
+      theNumFitPars_(nPar),
+      theHitPattern_(aHitPattern),
+      theTrkMVA1_(trkMVA1),
+      theTrkMVA2_(trkMVA2),
+      theTrkMVA3_(trkMVA3),
+      theTrackSeedType_(seedType),
+      theBField_(Bfield),
+      theHelixCovMat_(helixCovMat) {}
 
 template <typename T>
 double TTTrack<T>::localPhi() const {
   return TTTrack_TrackWord::localPhi(thePhi_, thePhiSector_);
 }
 
-template <typename T>
-double TTTrack<T>::d0() const {
-  return theD0_;
-}
-
-template <typename T>
-double TTTrack<T>::z0() const {
-  return theZ0_;
-}
-
-template <typename T>
-const GlobalPoint& TTTrack<T>::POCA() const {
-  return thePOCA_;
-}
-
-/// Chi2
-template <typename T>
-double TTTrack<T>::chi2() const {
-  return theChi2_;
-}
-
-/// Chi2Z
-template <typename T>
-double TTTrack<T>::chi2Z() const {
-  return theChi2_Z_;
-}
-
-/// Chi2XY
-template <typename T>
-double TTTrack<T>::chi2XY() const {
-  return theChi2_XY_;
-}
-
-/// Chi2 reduced
+/// Chi2/dof
 template <typename T>
 double TTTrack<T>::chi2Red() const {
   return theChi2_ / (2 * theStubRefs.size() - theNumFitPars_);
 }
 
-/// Chi2XY reduced
+/// Chi2 in x-y / dof
 template <typename T>
 double TTTrack<T>::chi2XYRed() const {
   return theChi2_XY_ / (theStubRefs.size() - (theNumFitPars_ - 2));
 }
 
-/// Chi2Z reduced
+/// Chi2 in r-z / dof
 template <typename T>
 double TTTrack<T>::chi2ZRed() const {
   return theChi2_Z_ / (theStubRefs.size() - 2.);
 }
 
-/// prompt track quality MVA
-template <typename T>
-double TTTrack<T>::trkMVA1() const {
-  return theTrkMVA1_;
-}
-
-template <typename T>
-void TTTrack<T>::settrkMVA1(double atrkMVA1) {
-  theTrkMVA1_ = atrkMVA1;
-  return;
-}
-
-template <typename T>
-double TTTrack<T>::trkMVA2() const {
-  return theTrkMVA2_;
-}
-
-template <typename T>
-void TTTrack<T>::settrkMVA2(double atrkMVA2) {
-  theTrkMVA2_ = atrkMVA2;
-  return;
-}
-
-template <typename T>
-double TTTrack<T>::trkMVA3() const {
-  return theTrkMVA3_;
-}
-
-template <typename T>
-void TTTrack<T>::settrkMVA3(double atrkMVA3) {
-  theTrkMVA3_ = atrkMVA3;
-  return;
-}
-
-/// StubPtConsistency
-template <typename T>
-void TTTrack<T>::setStubPtConsistency(double aStubPtConsistency) {
-  theStubPtConsistency_ = aStubPtConsistency;
-  return;
-}
-
-/// StubPtConsistency
-template <typename T>
-double TTTrack<T>::stubPtConsistency() const {
-  return theStubPtConsistency_;
-}
-
-/// Hit Pattern
-template <typename T>
-unsigned int TTTrack<T>::hitPattern() const {
-  return theHitPattern_;
-}
-
 /// set B field if need be
 template <typename T>
 void TTTrack<T>::setBField(double aBField) {
-  // if, for some reason, we want to change the value of the B-Field, recompute pT and momentum:
-  double thePT = std::abs(MagConstant / theRInv_ * aBField / 100.0);  // Rinv is in cm-1
+  // if, for some reason, we want to change the value of the B-Field, recompute momentum:
+  double thePT = this->rinvToPt(theRInv_);
   theMomentum_ = GlobalVector(GlobalVector::Cylindrical(thePT, thePhi_, thePT * theTanL_));
 
   return;
@@ -440,80 +280,34 @@ void TTTrack<T>::setBField(double aBField) {
 /// Set bits in 96-bit Track word
 template <typename T>
 void TTTrack<T>::setTrackWordBits() {
-  if (!(theNumFitPars_ == Npars4 || theNumFitPars_ == Npars5)) {
-    tttrack::errorSetTrackWordBits(theNumFitPars_);
-    return;
-  }
-
-  unsigned int valid = true;
-  unsigned int mvaOther = 0;
+  constexpr unsigned int valid = true;
 
   // missing conversion of global phi to difference from sector center phi
 
-  if (theChi2_Z_ < 0) {
-    setTrackWord(valid,
-                 theMomentum_,
-                 thePOCA_,
-                 theRInv_,
-                 theChi2_,
-                 0,
-                 theStubPtConsistency_,
-                 theHitPattern_,
-                 theTrkMVA1_,
-                 mvaOther,
-                 thePhiSector_);
-  } else {
-    setTrackWord(valid,
-                 theMomentum_,
-                 thePOCA_,
-                 theRInv_,
-                 chi2XYRed(),
-                 chi2ZRed(),
-                 chi2BendRed(),
-                 theHitPattern_,
-                 theTrkMVA1_,
-                 mvaOther,
-                 thePhiSector_);
-  }
-  return;
-}
-
-/// Test bits in 96-bit Track word
-template <typename T>
-void TTTrack<T>::testTrackWordBits() {
-  //  float rPhi = theMomentum_.phi();  // this needs to be phi relative to center of sector ****
-  //float rEta = theMomentum_.eta();
-  //float rZ0 = thePOCA_.z();
-  //float rD0 = thePOCA_.perp();
-
-  //this is meant for debugging only.
-
-  //std::cout << " phi " << rPhi << " " << get_iphi() << std::endl;
-  //std::cout << " eta " << rEta << " " << get_ieta() << std::endl;
-  //std::cout << " Z0 " << rZ0 << " " << get_iz0() << std::endl;
-  //std::cout << " D0 " << rD0 << " " << get_id0() << std::endl;
-  //std::cout << " Rinv " << theRInv_ << " " << get_iRinv() << std::endl;
-  //std::cout << " chi2 " << theChi2_ << " " << get_ichi2() << std::endl;
+  setTrackWord(valid,
+               theMomentum_,
+               POCA(),
+               rInv(),
+               chi2XYRed(),
+               chi2ZRed(),
+               chi2BendRed(),
+               hitPattern(),
+               trkMVA1(),
+               trkMVA2(),
+               trkMVA3(),
+               thePhiSector_);
 
   return;
 }
 
-/// Information
 template <typename T>
-std::string TTTrack<T>::print(unsigned int i) const {
-  std::string padding("");
-  for (unsigned int j = 0; j != i; ++j) {
-    padding += "\t";
-  }
-
+std::string TTTrack<T>::print() const {
+  const std::string padding("\t");
   std::stringstream output;
-  output << padding << "TTTrack:\n";
-  padding += '\t';
-  output << '\n';
-  unsigned int iStub = 0;
+  output << padding << "TTTrack:\n\n";
 
-  typename std::vector<edm::Ref<edmNew::DetSetVector<TTStub<T> >, TTStub<T> > >::const_iterator stubIter;
-  for (stubIter = theStubRefs.begin(); stubIter != theStubRefs.end(); ++stubIter) {
+  unsigned int iStub = 0;
+  for (const auto& stubIter : theStubRefs) {
     output << padding << "stub: " << iStub++ << ", DetId: " << ((*stubIter)->getDetId()).rawId() << '\n';
   }
 

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -91,7 +91,7 @@ public:
   static constexpr double stepZ0 = (2. * std::abs(minZ0)) / (1 << TrackBitWidths::kZ0Size);
   static constexpr double stepD0 = (1. / (1 << 8));
 
-  // Bin edges for chi2/dof (intentionally dropping last element)
+  // Lower edges of each bin in chi2/dof.
   static constexpr std::array<double, 1 << TrackBitWidths::kChi2RPhiSize> chi2RPhiBins = {
       {0.0, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 10.0, 15.0, 20.0, 35.0, 60.0, 200.0}};
   static constexpr std::array<double, 1 << TrackBitWidths::kChi2RZSize> chi2RZBins = {

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -210,7 +210,7 @@ public:
   qualityMVAD_t getMVAQualityDWord() const {
     return getTrackWord()(TrackBitLocations::kMVAQualityDMSB, TrackBitLocations::kMVAQualityDLSB);
   }
-  
+
   // Get entire data word
   tkword_t getTrackWord() const { return tkword_t(trackWord_.to_string().c_str(), 2); }
   tkword_bs_t getTrackWordBS() const { return trackWord_; }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -250,6 +250,8 @@ public:
   double getMVADQuality() const { return tqMVADBins[getMVAQualityDBits()]; }
 
   // ----------member functions (setters) ------------
+  void setTrackWord(const tkword_bs_t& trackWord) {trackWord_ = trackWord;}
+
   void setTrackWord(unsigned int valid,
                     const GlobalVector& momentum,
                     const GlobalPoint& POCA,

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -172,11 +172,11 @@ public:
   TTTrack_TrackWord(const tkword_bs_t& trackWord) : trackWord_(trackWord) {}
 
   // ----------copy constructor ----------------------
-  TTTrack_TrackWord(const TTTrack_TrackWord& word) { trackWord_ = word.trackWord_; }
+  TTTrack_TrackWord(const TTTrack_TrackWord& word) { trackWord_ = word.getTrackWordBS(); }
 
   // ----------operators -----------------------------
   TTTrack_TrackWord& operator=(const TTTrack_TrackWord& word) {
-    trackWord_ = word.trackWord_;
+    trackWord_ = word.getTrackWordBS();
     return *this;
   }
 
@@ -210,7 +210,10 @@ public:
   qualityMVAD_t getMVAQualityDWord() const {
     return getTrackWord()(TrackBitLocations::kMVAQualityDMSB, TrackBitLocations::kMVAQualityDLSB);
   }
+  
+  // Get entire data word
   tkword_t getTrackWord() const { return tkword_t(trackWord_.to_string().c_str(), 2); }
+  tkword_bs_t getTrackWordBS() const { return trackWord_; }
 
   // These functions return the packed bits in unsigned integer format for each quantity
   // Signed quantities have the sign enconded in the left-most bit of the pattern using

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -37,29 +37,31 @@ public:
   // ----------constants, enums and typedefs ---------
   enum TrackBitWidths {
     // The sizes of the track word components
-    kMVAOtherSize = 6,    // Space for two specialized MVA selections
-    kMVAQualitySize = 3,  // Width of track quality MVA
-    kHitPatternSize = 7,  // Width of the hit pattern for stubs
-    kBendChi2Size = 3,    // Width of the bend-chi2/dof
-    kD0Size = 13,         // Width of D0
-    kChi2RZSize = 4,      // Width of chi2/dof for r-z
-    kZ0Size = 12,         // Width of z-position (40cm / 0.1)
-    kTanlSize = 16,       // Width of tan(lambda)
-    kChi2RPhiSize = 4,    // Width of chi2/dof for r-phi
-    kPhiSize = 12,        // Width of phi
-    kRinvSize = 15,       // Width of Rinv
-    kValidSize = 1,       // Valid bit
+    kMVAQualityDSize = 3,  // Width of track quality MVA (prompt displaced tracks)
+    kMVAQualityESize = 3,  // Width of track quality MVA (prompt electrons tracks)
+    kMVAQualitySize = 3,   // Width of track quality MVA (prompt generic tracks)
+    kHitPatternSize = 7,   // Width of the hit pattern for stubs
+    kBendChi2Size = 3,     // Width of the bend-chi2/dof
+    kD0Size = 13,          // Width of D0
+    kChi2RZSize = 4,       // Width of chi2/dof for r-z
+    kZ0Size = 12,          // Width of z-position (40cm / 0.1)
+    kTanlSize = 16,        // Width of tan(lambda)
+    kChi2RPhiSize = 4,     // Width of chi2/dof for r-phi
+    kPhiSize = 12,         // Width of phi
+    kRinvSize = 15,        // Width of Rinv
+    kValidSize = 1,        // Valid bit
   };
+  // Width of the track word in bits
   static constexpr int kTrackWordSize = kValidSize + kRinvSize + kPhiSize + kChi2RPhiSize + kTanlSize + kZ0Size +
                                         kChi2RZSize + kD0Size + kBendChi2Size + kHitPatternSize + kMVAQualitySize +
-                                        kMVAOtherSize  // Width of the track word in bits
-      ;
-
+                                        kMVAQualityESize + kMVAQualityDSize;
   enum TrackBitLocations {
     // The location of the least significant bit (LSB) and most significant bit (MSB) in the track word for different fields
-    kMVAOtherLSB = 0,
-    kMVAOtherMSB = kMVAOtherLSB + TrackBitWidths::kMVAOtherSize - 1,
-    kMVAQualityLSB = kMVAOtherMSB + 1,
+    kMVAQualityDLSB = 0,
+    kMVAQualityDMSB = kMVAQualityDLSB + TrackBitWidths::kMVAQualityDSize - 1,
+    kMVAQualityELSB = kMVAQualityDMSB + 1,
+    kMVAQualityEMSB = kMVAQualityELSB + TrackBitWidths::kMVAQualityESize - 1,
+    kMVAQualityLSB = kMVAQualityEMSB + 1,
     kMVAQualityMSB = kMVAQualityLSB + TrackBitWidths::kMVAQualitySize - 1,
     kHitPatternLSB = kMVAQualityMSB + 1,
     kHitPatternMSB = kHitPatternLSB + TrackBitWidths::kHitPatternSize - 1,
@@ -107,6 +109,8 @@ public:
   // Bin edges for TQ MVA
   static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVABins = {
       {0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.750, 0.875}};
+  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVAEBins = tqMVABins;
+  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVADBins = tqMVABins;
 
   // Sector constants
   static constexpr unsigned int nSectors = 9;
@@ -123,12 +127,13 @@ public:
   typedef ap_uint<TrackBitWidths::kD0Size> d0_t;      // D0
 
   // Track quality types
-  typedef ap_uint<TrackBitWidths::kChi2RPhiSize> chi2rphi_t;      // Chi2 r-phi
-  typedef ap_uint<TrackBitWidths::kChi2RZSize> chi2rz_t;          // Chi2 r-z
-  typedef ap_uint<TrackBitWidths::kBendChi2Size> bendChi2_t;      // Bend-Chi2
-  typedef ap_uint<TrackBitWidths::kHitPatternSize> hit_t;         // Hit mask bits
-  typedef ap_uint<TrackBitWidths::kMVAQualitySize> qualityMVA_t;  // Track quality MVA
-  typedef ap_uint<TrackBitWidths::kMVAOtherSize> otherMVA_t;      // Specialized MVA selection
+  typedef ap_uint<TrackBitWidths::kChi2RPhiSize> chi2rphi_t;        // Chi2 r-phi
+  typedef ap_uint<TrackBitWidths::kChi2RZSize> chi2rz_t;            // Chi2 r-z
+  typedef ap_uint<TrackBitWidths::kBendChi2Size> bendChi2_t;        // Bend-Chi2
+  typedef ap_uint<TrackBitWidths::kHitPatternSize> hit_t;           // Hit mask bits
+  typedef ap_uint<TrackBitWidths::kMVAQualityDSize> qualityMVAD_t;  // Track quality MVA (displaced)
+  typedef ap_uint<TrackBitWidths::kMVAQualityESize> qualityMVAE_t;  // Track quality MVA (prompt electron)
+  typedef ap_uint<TrackBitWidths::kMVAQualitySize> qualityMVA_t;    // Track quality MVA (prompt)
 
   // Track word types
   typedef std::bitset<kTrackWordSize> tkword_bs_t;  // Entire track word;
@@ -145,9 +150,11 @@ public:
                     double chi2RZ,
                     double bendChi2,
                     unsigned int hitPattern,
-                    double mvaQuality,
-                    double mvaOther,
+                    double trkQualMVA,
+                    double trkQualMVAE,
+                    double trkQualMVAD,
                     unsigned int sector);
+
   TTTrack_TrackWord(unsigned int valid,
                     unsigned int rInv,
                     unsigned int phi0,  // local phi
@@ -158,8 +165,9 @@ public:
                     unsigned int chi2RZ,
                     unsigned int bendChi2,
                     unsigned int hitPattern,
-                    unsigned int mvaQuality,
-                    unsigned int mvaOther);
+                    unsigned int trkQualMVA,
+                    unsigned int trkQualMVAE,
+                    unsigned int trkQualMVAD);
 
   // ----------copy constructor ----------------------
   TTTrack_TrackWord(const TTTrack_TrackWord& word) { trackWord_ = word.trackWord_; }
@@ -194,8 +202,11 @@ public:
   qualityMVA_t getMVAQualityWord() const {
     return getTrackWord()(TrackBitLocations::kMVAQualityMSB, TrackBitLocations::kMVAQualityLSB);
   }
-  otherMVA_t getMVAOtherWord() const {
-    return getTrackWord()(TrackBitLocations::kMVAOtherMSB, TrackBitLocations::kMVAOtherLSB);
+  qualityMVAE_t getMVAQualityEWord() const {
+    return getTrackWord()(TrackBitLocations::kMVAQualityEMSB, TrackBitLocations::kMVAQualityELSB);
+  }
+  qualityMVAD_t getMVAQualityDWord() const {
+    return getTrackWord()(TrackBitLocations::kMVAQualityDMSB, TrackBitLocations::kMVAQualityDLSB);
   }
   tkword_t getTrackWord() const { return tkword_t(trackWord_.to_string().c_str(), 2); }
 
@@ -213,7 +224,8 @@ public:
   unsigned int getBendChi2Bits() const { return getBendChi2Word().to_uint(); }
   unsigned int getHitPatternBits() const { return getHitPatternWord().to_uint(); }
   unsigned int getMVAQualityBits() const { return getMVAQualityWord().to_uint(); }
-  unsigned int getMVAOtherBits() const { return getMVAOtherWord().to_uint(); }
+  unsigned int getMVAQualityEBits() const { return getMVAQualityEWord().to_uint(); }
+  unsigned int getMVAQualityDBits() const { return getMVAQualityDWord().to_uint(); }
 
   // These functions return the unpacked and converted values
   // These functions return real numbers converted from the digitized quantities by unpacking the 96-bit track word
@@ -229,7 +241,8 @@ public:
   unsigned int getHitPattern() const { return getHitPatternBits(); }
   unsigned int getNStubs() const { return countSetBits(getHitPatternBits()); }
   double getMVAQuality() const { return tqMVABins[getMVAQualityBits()]; }
-  double getMVAOther() const { return getMVAOtherBits(); }
+  double getMVAEQuality() const { return tqMVABins[getMVAQualityEBits()]; }
+  double getMVADQuality() const { return tqMVABins[getMVAQualityDBits()]; }
 
   // ----------member functions (setters) ------------
   void setTrackWord(unsigned int valid,
@@ -240,8 +253,9 @@ public:
                     double chi2RZ,
                     double bendChi2,
                     unsigned int hitPattern,
-                    double mvaQuality,
-                    double mvaOther,
+                    double trkQualMVA,
+                    double trkQualMVAE,
+                    double trkQualMVAD,
                     unsigned int sector);
 
   void setTrackWord(unsigned int valid,
@@ -254,8 +268,9 @@ public:
                     unsigned int chi2RZ,
                     unsigned int bendChi2,
                     unsigned int hitPattern,
-                    unsigned int mvaQuality,
-                    unsigned int mvaOther);
+                    unsigned int trkQualMVA,
+                    unsigned int trkQualMVAE,
+                    unsigned int trkQualMVAD);
 
   void setTrackWord(ap_uint<TrackBitWidths::kValidSize> valid,
                     ap_uint<TrackBitWidths::kRinvSize> rInv,
@@ -267,8 +282,9 @@ public:
                     ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
                     ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
                     ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
-                    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
-                    ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther);
+                    ap_uint<TrackBitWidths::kMVAQualitySize> trkQualMVA,
+                    ap_uint<TrackBitWidths::kMVAQualitySize> trkQualMVAE,
+                    ap_uint<TrackBitWidths::kMVAQualitySize> trkQualMVAD);
 
   // ----------member functions (testers) ------------
   bool singleDigitizationSchemeTest(const double floatingPointValue, const unsigned int nBits, const double lsb) const;
@@ -276,6 +292,7 @@ public:
 
 protected:
   // ----------protected member functions ------------
+  // Phi with respect to centre line of phi nonant, which for sector 0 is parallel to x-axis.
   float localPhi(float globalPhi, unsigned int sector) const {
     return reco::deltaPhi(globalPhi, (sector * sectorWidth));
   }

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -169,6 +169,8 @@ public:
                     unsigned int trkQualMVAE,
                     unsigned int trkQualMVAD);
 
+  TTTrack_TrackWord(const tkword_bs_t& trackWord) : trackWord_(trackWord) {}
+
   // ----------copy constructor ----------------------
   TTTrack_TrackWord(const TTTrack_TrackWord& word) { trackWord_ = word.trackWord_; }
 
@@ -241,8 +243,8 @@ public:
   unsigned int getHitPattern() const { return getHitPatternBits(); }
   unsigned int getNStubs() const { return countSetBits(getHitPatternBits()); }
   double getMVAQuality() const { return tqMVABins[getMVAQualityBits()]; }
-  double getMVAEQuality() const { return tqMVABins[getMVAQualityEBits()]; }
-  double getMVADQuality() const { return tqMVABins[getMVAQualityDBits()]; }
+  double getMVAEQuality() const { return tqMVAEBins[getMVAQualityEBits()]; }
+  double getMVADQuality() const { return tqMVADBins[getMVAQualityDBits()]; }
 
   // ----------member functions (setters) ------------
   void setTrackWord(unsigned int valid,

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -93,15 +93,15 @@ public:
 
   // Bin edges for chi2/dof (intentionally dropping last element)
   static constexpr std::array<double, 1 << TrackBitWidths::kChi2RPhiSize> chi2RPhiBins = {
-    {0.0, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 10.0, 15.0, 20.0, 35.0, 60.0, 200.0}};
+      {0.0, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 10.0, 15.0, 20.0, 35.0, 60.0, 200.0}};
   static constexpr std::array<double, 1 << TrackBitWidths::kChi2RZSize> chi2RZBins = {
-    {0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 8.0, 10.0, 20.0, 50.0}};
+      {0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 8.0, 10.0, 20.0, 50.0}};
   static constexpr std::array<double, 1 << TrackBitWidths::kBendChi2Size> bendChi2Bins = {
-    {0.0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
+      {0.0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
 
   // Bin edges for TQ MVA
   static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVABins = {
-    {0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.750, 0.875}};
+      {0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.750, 0.875}};
 
   // Sector constants
   static constexpr unsigned int nSectors = 9;
@@ -136,7 +136,7 @@ public:
                     const GlobalVector& momentum,
                     const GlobalPoint& POCA,
                     double rInv,
-                    double chi2RPhiRed, // normalized to dof
+                    double chi2RPhiRed,  // normalized to dof
                     double chi2RZRed,
                     double bendChi2Red,
                     unsigned int hitPattern,
@@ -146,11 +146,11 @@ public:
 
   TTTrack_TrackWord(unsigned int valid,
                     unsigned int rInv,
-                    unsigned int localPhi, // phi relative to centre of phi nonant 
+                    unsigned int localPhi,  // phi relative to centre of phi nonant
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int chi2RPhiRed, // normalized to dof
+                    unsigned int chi2RPhiRed,  // normalized to dof
                     unsigned int chi2RZRed,
                     unsigned int bendChi2Red,
                     unsigned int hitPattern,
@@ -173,7 +173,9 @@ public:
   // Signed quantities have the sign enconded in the left-most bit.
   valid_t getValidWord() const { return getTrackWord()(TrackBitLocations::kValidMSB, TrackBitLocations::kValidLSB); }
   rinv_t getRinvWord() const { return getTrackWord()(TrackBitLocations::kRinvMSB, TrackBitLocations::kRinvLSB); }
-  phi_t getPhiWord() const { return getTrackWord()(TrackBitLocations::kPhiMSB, TrackBitLocations::kPhiLSB); } // relative to centre of phi nonant
+  phi_t getPhiWord() const {
+    return getTrackWord()(TrackBitLocations::kPhiMSB, TrackBitLocations::kPhiLSB);
+  }  // relative to centre of phi nonant
   tanl_t getTanlWord() const { return getTrackWord()(TrackBitLocations::kTanlMSB, TrackBitLocations::kTanlLSB); }
   z0_t getZ0Word() const { return getTrackWord()(TrackBitLocations::kZ0MSB, TrackBitLocations::kZ0LSB); }
   d0_t getD0Word() const { return getTrackWord()(TrackBitLocations::kD0MSB, TrackBitLocations::kD0LSB); }
@@ -206,7 +208,7 @@ public:
   //   a two's complement representation
   unsigned int getValidBits() const { return getValidWord().to_uint(); }
   unsigned int getRinvBits() const { return getRinvWord().to_uint(); }
-  unsigned int getPhiBits() const { return getPhiWord().to_uint(); } // phi relative to centre of phi nonant
+  unsigned int getPhiBits() const { return getPhiWord().to_uint(); }  // phi relative to centre of phi nonant
   unsigned int getTanlBits() const { return getTanlWord().to_uint(); }
   unsigned int getZ0Bits() const { return getZ0Word().to_uint(); }
   unsigned int getD0Bits() const { return getD0Word().to_uint(); }
@@ -222,7 +224,9 @@ public:
   // These functions return real numbers converted from the digitized quantities by unpacking the 96-bit track word
   bool getValid() const { return getValidWord().to_bool(); }
   double getRinv() const { return undigitizeSignedValue(getRinvBits(), TrackBitWidths::kRinvSize, stepRinv); }
-  double getPhi() const { return undigitizeSignedValue(getPhiBits(), TrackBitWidths::kPhiSize, stepPhi0); } // phi relative to centre of phi nonant
+  double getPhi() const {
+    return undigitizeSignedValue(getPhiBits(), TrackBitWidths::kPhiSize, stepPhi0);
+  }  // phi relative to centre of phi nonant
   double getTanl() const { return undigitizeSignedValue(getTanlBits(), TrackBitWidths::kTanlSize, stepTanL); }
   double getZ0() const { return undigitizeSignedValue(getZ0Bits(), TrackBitWidths::kZ0Size, stepZ0); }
   double getD0() const { return undigitizeSignedValue(getD0Bits(), TrackBitWidths::kD0Size, stepD0); }
@@ -277,7 +281,8 @@ public:
                     ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther);
 
   // ----------member functions (testers) ------------
-  void printTestDigitizationScheme(const unsigned int, const double, const double, const unsigned int, const double, const unsigned int) const;
+  void printTestDigitizationScheme(
+      const unsigned int, const double, const double, const unsigned int, const double, const unsigned int) const;
   bool singleDigitizationSchemeTest(const double floatingPointValue, const unsigned int nBits, const double lsb) const;
   void testDigitizationScheme() const;
 

--- a/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
+++ b/DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h
@@ -7,9 +7,9 @@
 // packing scheme given below.
 //
 // author:      Mike Hildreth
-// modified by: Alexx Perloff
-// created:     April 9, 2019
-// modified:    March 9, 2021
+// modified by: Alexx Perloff + Ian Tomalin
+// created:     Apr. 2019
+// modified:    Mar. 2021 + Dec. 2025
 //
 ///////
 
@@ -27,41 +27,34 @@
 #include <string>
 #include <vector>
 
-namespace tttrack_trackword {
-  void infoTestDigitizationScheme(
-      const unsigned int, const double, const double, const unsigned int, const double, const unsigned int);
-}
-
 class TTTrack_TrackWord {
 public:
   // ----------constants, enums and typedefs ---------
   enum TrackBitWidths {
     // The sizes of the track word components
-    kMVAQualityDSize = 3,  // Width of track quality MVA (prompt displaced tracks)
-    kMVAQualityESize = 3,  // Width of track quality MVA (prompt electrons tracks)
-    kMVAQualitySize = 3,   // Width of track quality MVA (prompt generic tracks)
-    kHitPatternSize = 7,   // Width of the hit pattern for stubs
-    kBendChi2Size = 3,     // Width of the bend-chi2/dof
-    kD0Size = 13,          // Width of D0
-    kChi2RZSize = 4,       // Width of chi2/dof for r-z
-    kZ0Size = 12,          // Width of z-position (40cm / 0.1)
-    kTanlSize = 16,        // Width of tan(lambda)
-    kChi2RPhiSize = 4,     // Width of chi2/dof for r-phi
-    kPhiSize = 12,         // Width of phi
-    kRinvSize = 15,        // Width of Rinv
-    kValidSize = 1,        // Valid bit
+    kMVAOtherSize = 6,    // Space for two specialized MVA selections
+    kMVAQualitySize = 3,  // Width of track quality MVA (generic prompt tracks)
+    kHitPatternSize = 7,  // Width of the hit pattern for stubs
+    kBendChi2Size = 3,    // Width of the bend-chi2/dof
+    kD0Size = 13,         // Width of D0
+    kChi2RZSize = 4,      // Width of chi2/dof for r-z
+    kZ0Size = 12,         // Width of z-position (40cm / 0.1)
+    kTanlSize = 16,       // Width of tan(lambda)
+    kChi2RPhiSize = 4,    // Width of chi2/dof for r-phi
+    kPhiSize = 12,        // Width of phi
+    kRinvSize = 15,       // Width of Rinv
+    kValidSize = 1,       // Valid bit
   };
   // Width of the track word in bits
   static constexpr int kTrackWordSize = kValidSize + kRinvSize + kPhiSize + kChi2RPhiSize + kTanlSize + kZ0Size +
                                         kChi2RZSize + kD0Size + kBendChi2Size + kHitPatternSize + kMVAQualitySize +
-                                        kMVAQualityESize + kMVAQualityDSize;
+                                        kMVAOtherSize;
+
   enum TrackBitLocations {
     // The location of the least significant bit (LSB) and most significant bit (MSB) in the track word for different fields
-    kMVAQualityDLSB = 0,
-    kMVAQualityDMSB = kMVAQualityDLSB + TrackBitWidths::kMVAQualityDSize - 1,
-    kMVAQualityELSB = kMVAQualityDMSB + 1,
-    kMVAQualityEMSB = kMVAQualityELSB + TrackBitWidths::kMVAQualityESize - 1,
-    kMVAQualityLSB = kMVAQualityEMSB + 1,
+    kMVAOtherLSB = 0,
+    kMVAOtherMSB = kMVAOtherLSB + TrackBitWidths::kMVAOtherSize - 1,
+    kMVAQualityLSB = kMVAOtherMSB + 1,
     kMVAQualityMSB = kMVAQualityLSB + TrackBitWidths::kMVAQualitySize - 1,
     kHitPatternLSB = kMVAQualityMSB + 1,
     kHitPatternMSB = kHitPatternLSB + TrackBitWidths::kHitPatternSize - 1,
@@ -98,19 +91,17 @@ public:
   static constexpr double stepZ0 = (2. * std::abs(minZ0)) / (1 << TrackBitWidths::kZ0Size);
   static constexpr double stepD0 = (1. / (1 << 8));
 
-  // Bin edges for chi2/dof
+  // Bin edges for chi2/dof (intentionally dropping last element)
   static constexpr std::array<double, 1 << TrackBitWidths::kChi2RPhiSize> chi2RPhiBins = {
-      {0.0, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 10.0, 15.0, 20.0, 35.0, 60.0, 200.0}};
+    {0.0, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 10.0, 15.0, 20.0, 35.0, 60.0, 200.0}};
   static constexpr std::array<double, 1 << TrackBitWidths::kChi2RZSize> chi2RZBins = {
-      {0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 8.0, 10.0, 20.0, 50.0}};
+    {0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 6.0, 8.0, 10.0, 20.0, 50.0}};
   static constexpr std::array<double, 1 << TrackBitWidths::kBendChi2Size> bendChi2Bins = {
-      {0.0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
+    {0.0, 0.75, 1.0, 1.5, 2.25, 3.5, 5.0, 20.0}};
 
   // Bin edges for TQ MVA
   static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVABins = {
-      {0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.750, 0.875}};
-  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVAEBins = tqMVABins;
-  static constexpr std::array<double, 1 << TrackBitWidths::kMVAQualitySize> tqMVADBins = tqMVABins;
+    {0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.750, 0.875}};
 
   // Sector constants
   static constexpr unsigned int nSectors = 9;
@@ -119,25 +110,24 @@ public:
   // Track flags
   typedef ap_uint<TrackBitWidths::kValidSize> valid_t;  // valid bit
 
-  // Track parameters types
+  // Track parameter HLS types
   typedef ap_uint<TrackBitWidths::kRinvSize> rinv_t;  // Track Rinv
   typedef ap_uint<TrackBitWidths::kPhiSize> phi_t;    // Track phi
   typedef ap_uint<TrackBitWidths::kTanlSize> tanl_t;  // Track tan(l)
   typedef ap_uint<TrackBitWidths::kZ0Size> z0_t;      // Track z
   typedef ap_uint<TrackBitWidths::kD0Size> d0_t;      // D0
 
-  // Track quality types
-  typedef ap_uint<TrackBitWidths::kChi2RPhiSize> chi2rphi_t;        // Chi2 r-phi
-  typedef ap_uint<TrackBitWidths::kChi2RZSize> chi2rz_t;            // Chi2 r-z
-  typedef ap_uint<TrackBitWidths::kBendChi2Size> bendChi2_t;        // Bend-Chi2
-  typedef ap_uint<TrackBitWidths::kHitPatternSize> hit_t;           // Hit mask bits
-  typedef ap_uint<TrackBitWidths::kMVAQualityDSize> qualityMVAD_t;  // Track quality MVA (displaced)
-  typedef ap_uint<TrackBitWidths::kMVAQualityESize> qualityMVAE_t;  // Track quality MVA (prompt electron)
-  typedef ap_uint<TrackBitWidths::kMVAQualitySize> qualityMVA_t;    // Track quality MVA (prompt)
+  // Track quality HLS types
+  typedef ap_uint<TrackBitWidths::kChi2RPhiSize> chi2rphi_t;      // Chi2 r-phi
+  typedef ap_uint<TrackBitWidths::kChi2RZSize> chi2rz_t;          // Chi2 r-z
+  typedef ap_uint<TrackBitWidths::kBendChi2Size> bendChi2_t;      // Bend-Chi2
+  typedef ap_uint<TrackBitWidths::kHitPatternSize> hit_t;         // Hit mask bits
+  typedef ap_uint<TrackBitWidths::kMVAQualitySize> qualityMVA_t;  // Track quality MVA (generic prompt)
+  typedef ap_uint<TrackBitWidths::kMVAOtherSize> otherMVA_t;      // Specialized MVA selection
 
   // Track word types
   typedef std::bitset<kTrackWordSize> tkword_bs_t;  // Entire track word;
-  typedef ap_uint<kTrackWordSize> tkword_t;         // Entire track word;
+  typedef ap_uint<kTrackWordSize> tkword_t;         // Entire track word HLS type;
 
 public:
   // ----------Constructors --------------------------
@@ -146,28 +136,26 @@ public:
                     const GlobalVector& momentum,
                     const GlobalPoint& POCA,
                     double rInv,
-                    double chi2RPhi,  // would be xy chisq if chi2Z is non-zero
-                    double chi2RZ,
-                    double bendChi2,
+                    double chi2RPhiRed, // normalized to dof
+                    double chi2RZRed,
+                    double bendChi2Red,
                     unsigned int hitPattern,
-                    double trkQualMVA,
-                    double trkQualMVAE,
-                    double trkQualMVAD,
+                    double mvaQuality,
+                    double mvaOther,
                     unsigned int sector);
 
   TTTrack_TrackWord(unsigned int valid,
                     unsigned int rInv,
-                    unsigned int phi0,  // local phi
+                    unsigned int localPhi, // phi relative to centre of phi nonant 
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
-                    unsigned int chi2RZ,
-                    unsigned int bendChi2,
+                    unsigned int chi2RPhiRed, // normalized to dof
+                    unsigned int chi2RZRed,
+                    unsigned int bendChi2Red,
                     unsigned int hitPattern,
-                    unsigned int trkQualMVA,
-                    unsigned int trkQualMVAE,
-                    unsigned int trkQualMVAD);
+                    unsigned int mvaQuality,
+                    unsigned int mvaOther);
 
   TTTrack_TrackWord(const tkword_bs_t& trackWord) : trackWord_(trackWord) {}
 
@@ -181,14 +169,15 @@ public:
   }
 
   // ----------member functions (getters) ------------
-  // These functions return arbitarary precision unsigned int words (lists of bits) for each quantity
+  // These functions return HLS-type finite bits words.
   // Signed quantities have the sign enconded in the left-most bit.
   valid_t getValidWord() const { return getTrackWord()(TrackBitLocations::kValidMSB, TrackBitLocations::kValidLSB); }
   rinv_t getRinvWord() const { return getTrackWord()(TrackBitLocations::kRinvMSB, TrackBitLocations::kRinvLSB); }
-  phi_t getPhiWord() const { return getTrackWord()(TrackBitLocations::kPhiMSB, TrackBitLocations::kPhiLSB); }
+  phi_t getPhiWord() const { return getTrackWord()(TrackBitLocations::kPhiMSB, TrackBitLocations::kPhiLSB); } // relative to centre of phi nonant
   tanl_t getTanlWord() const { return getTrackWord()(TrackBitLocations::kTanlMSB, TrackBitLocations::kTanlLSB); }
   z0_t getZ0Word() const { return getTrackWord()(TrackBitLocations::kZ0MSB, TrackBitLocations::kZ0LSB); }
   d0_t getD0Word() const { return getTrackWord()(TrackBitLocations::kD0MSB, TrackBitLocations::kD0LSB); }
+  // These return chi2/dof
   chi2rphi_t getChi2RPhiWord() const {
     return getTrackWord()(TrackBitLocations::kChi2RPhiMSB, TrackBitLocations::kChi2RPhiLSB);
   }
@@ -204,11 +193,8 @@ public:
   qualityMVA_t getMVAQualityWord() const {
     return getTrackWord()(TrackBitLocations::kMVAQualityMSB, TrackBitLocations::kMVAQualityLSB);
   }
-  qualityMVAE_t getMVAQualityEWord() const {
-    return getTrackWord()(TrackBitLocations::kMVAQualityEMSB, TrackBitLocations::kMVAQualityELSB);
-  }
-  qualityMVAD_t getMVAQualityDWord() const {
-    return getTrackWord()(TrackBitLocations::kMVAQualityDMSB, TrackBitLocations::kMVAQualityDLSB);
+  otherMVA_t getMVAOtherWord() const {
+    return getTrackWord()(TrackBitLocations::kMVAOtherMSB, TrackBitLocations::kMVAOtherLSB);
   }
 
   // Get entire data word
@@ -220,80 +206,78 @@ public:
   //   a two's complement representation
   unsigned int getValidBits() const { return getValidWord().to_uint(); }
   unsigned int getRinvBits() const { return getRinvWord().to_uint(); }
-  unsigned int getPhiBits() const { return getPhiWord().to_uint(); }
+  unsigned int getPhiBits() const { return getPhiWord().to_uint(); } // phi relative to centre of phi nonant
   unsigned int getTanlBits() const { return getTanlWord().to_uint(); }
   unsigned int getZ0Bits() const { return getZ0Word().to_uint(); }
   unsigned int getD0Bits() const { return getD0Word().to_uint(); }
+  // These return chi2/dof
   unsigned int getChi2RPhiBits() const { return getChi2RPhiWord().to_uint(); }
   unsigned int getChi2RZBits() const { return getChi2RZWord().to_uint(); }
   unsigned int getBendChi2Bits() const { return getBendChi2Word().to_uint(); }
   unsigned int getHitPatternBits() const { return getHitPatternWord().to_uint(); }
   unsigned int getMVAQualityBits() const { return getMVAQualityWord().to_uint(); }
-  unsigned int getMVAQualityEBits() const { return getMVAQualityEWord().to_uint(); }
-  unsigned int getMVAQualityDBits() const { return getMVAQualityDWord().to_uint(); }
+  unsigned int getMVAOtherBits() const { return getMVAOtherWord().to_uint(); }
 
   // These functions return the unpacked and converted values
   // These functions return real numbers converted from the digitized quantities by unpacking the 96-bit track word
   bool getValid() const { return getValidWord().to_bool(); }
   double getRinv() const { return undigitizeSignedValue(getRinvBits(), TrackBitWidths::kRinvSize, stepRinv); }
-  double getPhi() const { return undigitizeSignedValue(getPhiBits(), TrackBitWidths::kPhiSize, stepPhi0); }
+  double getPhi() const { return undigitizeSignedValue(getPhiBits(), TrackBitWidths::kPhiSize, stepPhi0); } // phi relative to centre of phi nonant
   double getTanl() const { return undigitizeSignedValue(getTanlBits(), TrackBitWidths::kTanlSize, stepTanL); }
   double getZ0() const { return undigitizeSignedValue(getZ0Bits(), TrackBitWidths::kZ0Size, stepZ0); }
   double getD0() const { return undigitizeSignedValue(getD0Bits(), TrackBitWidths::kD0Size, stepD0); }
+  // These return chi2/dof
   double getChi2RPhi() const { return chi2RPhiBins[getChi2RPhiBits()]; }
   double getChi2RZ() const { return chi2RZBins[getChi2RZBits()]; }
   double getBendChi2() const { return bendChi2Bins[getBendChi2Bits()]; }
   unsigned int getHitPattern() const { return getHitPatternBits(); }
   unsigned int getNStubs() const { return countSetBits(getHitPatternBits()); }
   double getMVAQuality() const { return tqMVABins[getMVAQualityBits()]; }
-  double getMVAEQuality() const { return tqMVAEBins[getMVAQualityEBits()]; }
-  double getMVADQuality() const { return tqMVADBins[getMVAQualityDBits()]; }
+  double getMVAOtherQuality() const { return getMVAOtherBits(); }
 
   // ----------member functions (setters) ------------
-  void setTrackWord(const tkword_bs_t& trackWord) {trackWord_ = trackWord;}
+  void setTrackWord(const tkword_bs_t& trackWord) { trackWord_ = trackWord; }
 
   void setTrackWord(unsigned int valid,
                     const GlobalVector& momentum,
                     const GlobalPoint& POCA,
                     double rInv,
-                    double chi2RPhi,  // would be total chisq if chi2Z is zero
-                    double chi2RZ,
-                    double bendChi2,
+                    double chi2RPhiRed,  // normalized to dof
+                    double chi2RZRed,
+                    double bendChi2Red,
                     unsigned int hitPattern,
-                    double trkQualMVA,
-                    double trkQualMVAE,
-                    double trkQualMVAD,
+                    double mvaQuality,
+                    double mvaOther,
                     unsigned int sector);
 
   void setTrackWord(unsigned int valid,
                     unsigned int rInv,
-                    unsigned int phi0,  // local phi
+                    unsigned int localPhi,  // local phi
                     unsigned int tanl,
                     unsigned int z0,
                     unsigned int d0,
-                    unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
-                    unsigned int chi2RZ,
-                    unsigned int bendChi2,
+                    unsigned int chi2RPhiRed,  // normalized to dof
+                    unsigned int chi2RZRed,
+                    unsigned int bendChi2Red,
                     unsigned int hitPattern,
-                    unsigned int trkQualMVA,
-                    unsigned int trkQualMVAE,
-                    unsigned int trkQualMVAD);
+                    unsigned int mvaQuality,
+                    unsigned int mvaOther);
 
   void setTrackWord(ap_uint<TrackBitWidths::kValidSize> valid,
                     ap_uint<TrackBitWidths::kRinvSize> rInv,
-                    ap_uint<TrackBitWidths::kPhiSize> phi0,  // local phi
+                    ap_uint<TrackBitWidths::kPhiSize> localPhi,  // local phi
                     ap_uint<TrackBitWidths::kTanlSize> tanl,
                     ap_uint<TrackBitWidths::kZ0Size> z0,
                     ap_uint<TrackBitWidths::kD0Size> d0,
-                    ap_uint<TrackBitWidths::kChi2RPhiSize> chi2RPhi,  // would be total chisq if chi2Z is zero
-                    ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
-                    ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
+                    ap_uint<TrackBitWidths::kChi2RPhiSize> chi2RPhiRed,  // normalized to dof
+                    ap_uint<TrackBitWidths::kChi2RZSize> chi2RZRed,
+                    ap_uint<TrackBitWidths::kBendChi2Size> bendChi2Red,
                     ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
-                    ap_uint<TrackBitWidths::kMVAQualitySize> trkQualMVA,
-                    ap_uint<TrackBitWidths::kMVAQualitySize> trkQualMVAE,
-                    ap_uint<TrackBitWidths::kMVAQualitySize> trkQualMVAD);
+                    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
+                    ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther);
 
   // ----------member functions (testers) ------------
+  void printTestDigitizationScheme(const unsigned int, const double, const double, const unsigned int, const double, const unsigned int) const;
   bool singleDigitizationSchemeTest(const double floatingPointValue, const unsigned int nBits, const double lsb) const;
   void testDigitizationScheme() const;
 

--- a/DataFormats/L1TrackTrigger/src/TTTrack.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack.cc
@@ -1,7 +1,0 @@
-#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-void tttrack::errorSetTrackWordBits(unsigned int theNumFitPars) {
-  edm::LogError("TTTrack") << " setTrackWordBits method is called with theNumFitPars_=" << theNumFitPars
-                           << " only possible values are 4/5" << std::endl;
-}

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -13,51 +13,34 @@
 #include "DataFormats/L1TrackTrigger/interface/TTTrack_TrackWord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-void tttrack_trackword::infoTestDigitizationScheme(const unsigned int nBits,
-                                                   const double lsb,
-                                                   const double floatingPointValue,
-                                                   const unsigned int digitizedSignedValue,
-                                                   const double undigitizedSignedValue,
-                                                   const unsigned int redigitizedSignedValue) {
-  edm::LogInfo("TTTrack_TrackWord") << "testDigitizationScheme: (nBits, lsb) = (" << nBits << ", " << lsb << ")\n"
-                                    << "Floating point value = " << floatingPointValue
-                                    << "\tDigitized value = " << digitizedSignedValue
-                                    << "\tUn-digitized value = " << undigitizedSignedValue
-                                    << "\tRe-digitized value = " << redigitizedSignedValue;
-}
-
 //Constructor - turn track parameters into 96-bit word
 TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      const GlobalVector& momentum,
                                      const GlobalPoint& POCA,
                                      double rInv,
-                                     double chi2RPhi,  // would be xy chisq if chi2Z is non-zero
-                                     double chi2RZ,
-                                     double bendChi2,
+                                     double chi2RPhiRed,  // normalized to dof
+                                     double chi2RZRed,
+                                     double bendChi2Red,
                                      unsigned int hitPattern,
                                      double mvaQuality,
-                                     double mvaQualityE,
-                                     double mvaQualityD,
+                                     double mvaOther,
                                      unsigned int sector) {
-  setTrackWord(
-      valid, momentum, POCA, rInv, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaQualityE, mvaQualityD, sector);
+  setTrackWord(valid, momentum, POCA, rInv, chi2RPhiRed, chi2RZRed, bendChi2Red, hitPattern, mvaQuality, mvaOther, sector);
 }
 
 TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      unsigned int rInv,
-                                     unsigned int phi0,
+                                     unsigned int localPhi, // relative to centre of phi nonant
                                      unsigned int tanl,
                                      unsigned int z0,
                                      unsigned int d0,
-                                     unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
-                                     unsigned int chi2RZ,
-                                     unsigned int bendChi2,
+                                     unsigned int chi2RPhiRed,  // normalized to dof
+                                     unsigned int chi2RZRed,
+                                     unsigned int bendChi2Red,
                                      unsigned int hitPattern,
                                      unsigned int mvaQuality,
-                                     unsigned int mvaQualityE,
-                                     unsigned int mvaQualityD) {
-  setTrackWord(
-      valid, rInv, phi0, tanl, z0, d0, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaQualityE, mvaQualityD);
+                                     unsigned int mvaOther) {
+  setTrackWord(valid, rInv, localPhi, tanl, z0, d0, chi2RPhiRed, chi2RZRed, bendChi2Red, hitPattern, mvaQuality, mvaOther);
 }
 
 // A setter for the floating point values
@@ -65,163 +48,133 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
                                      const GlobalVector& momentum,
                                      const GlobalPoint& POCA,
                                      double rInv,
-                                     double chi2RPhi,  // would be total chisq if chi2Z is zero
-                                     double chi2RZ,
-                                     double bendChi2,
+                                     double chi2RPhiRed,  // normalized to dof
+                                     double chi2RZRed,
+                                     double bendChi2Red,
                                      unsigned int hitPattern,
                                      double mvaQuality,
-                                     double mvaQualityE,
-                                     double mvaQualityD,
+                                     double mvaOther,
                                      unsigned int sector) {
   // first, derive quantities to be packed
-  float rPhi = localPhi(momentum.phi(), sector);  // this needs to be phi relative to the center of the sector
+  float rLocalPhi = localPhi(momentum.phi(), sector);  // phi relative to the center of the sector
   float rTanl = momentum.z() / momentum.perp();
   float rZ0 = POCA.z();
   float rD0 = POCA.x() * sin(momentum.phi()) - POCA.y() * cos(momentum.phi());
 
   // bin and convert to integers
-  valid_t valid_ = valid;
-  rinv_t rInv_ = digitizeSignedValue(rInv, TrackBitWidths::kRinvSize, stepRinv);
-  phi_t phi0_ = digitizeSignedValue(rPhi, TrackBitWidths::kPhiSize, stepPhi0);
-  tanl_t tanl_ = digitizeSignedValue(rTanl, TrackBitWidths::kTanlSize, stepTanL);
-  z0_t z0_ = digitizeSignedValue(rZ0, TrackBitWidths::kZ0Size, stepZ0);
-  d0_t d0_ = digitizeSignedValue(rD0, TrackBitWidths::kD0Size, stepD0);
-  chi2rphi_t chi2RPhi_ = getBin(chi2RPhi, chi2RPhiBins);
-  chi2rz_t chi2RZ_ = getBin(chi2RZ, chi2RZBins);
-  bendChi2_t bendChi2_ = getBin(bendChi2, bendChi2Bins);
-  hit_t hitPattern_ = hitPattern;
-  qualityMVA_t mvaQuality_ = getBin(mvaQuality, tqMVABins);
-  qualityMVAE_t mvaQualityE_ = getBin(mvaQualityE, tqMVAEBins);
-  qualityMVAD_t mvaQualityD_ = getBin(mvaQualityD, tqMVADBins);
+  valid_t valid_HLS = valid;
+  rinv_t rInv_HLS = digitizeSignedValue(rInv, TrackBitWidths::kRinvSize, stepRinv);
+  phi_t phi0_HLS = digitizeSignedValue(rLocalPhi, TrackBitWidths::kPhiSize, stepPhi0);
+  tanl_t tanl_HLS = digitizeSignedValue(rTanl, TrackBitWidths::kTanlSize, stepTanL);
+  z0_t z0_HLS = digitizeSignedValue(rZ0, TrackBitWidths::kZ0Size, stepZ0);
+  d0_t d0_HLS = digitizeSignedValue(rD0, TrackBitWidths::kD0Size, stepD0);
+  chi2rphi_t chi2RPhiRed_HLS = getBin(chi2RPhiRed, chi2RPhiBins);
+  chi2rz_t chi2RZRed_HLS = getBin(chi2RZRed, chi2RZBins);
+  bendChi2_t bendChi2Red_HLS = getBin(bendChi2Red, bendChi2Bins);
+  hit_t hitPattern_HLS = hitPattern;
+  qualityMVA_t mvaQuality_HLS = getBin(mvaQuality, tqMVABins);
+  otherMVA_t mvaOther_HLS = (unsigned int)(mvaOther);
 
   // pack the track word
-  setTrackWord(valid_,
-               rInv_,
-               phi0_,
-               tanl_,
-               z0_,
-               d0_,
-               chi2RPhi_,
-               chi2RZ_,
-               bendChi2_,
-               hitPattern_,
-               mvaQuality_,
-               mvaQualityE_,
-               mvaQualityD_);
+  setTrackWord(
+      valid_HLS, rInv_HLS, phi0_HLS, tanl_HLS, z0_HLS, d0_HLS, chi2RPhiRed_HLS, chi2RZRed_HLS, bendChi2Red_HLS, hitPattern_HLS, mvaQuality_HLS, mvaOther_HLS);
 }
 
 // A setter for already-digitized values
 void TTTrack_TrackWord::setTrackWord(unsigned int valid,
                                      unsigned int rInv,
-                                     unsigned int phi0,
+                                     unsigned int localPhi, // relative to centre of phi nonant
                                      unsigned int tanl,
                                      unsigned int z0,
                                      unsigned int d0,
-                                     unsigned int chi2RPhi,  // would be total chisq if chi2Z is zero
-                                     unsigned int chi2RZ,
-                                     unsigned int bendChi2,
+                                     unsigned int chi2RPhiRed, // normalized to dof
+                                     unsigned int chi2RZRed,
+                                     unsigned int bendChi2Red,
                                      unsigned int hitPattern,
                                      unsigned int mvaQuality,
-                                     unsigned int mvaQualityE,
-                                     unsigned int mvaQualityD) {
+                                     unsigned int mvaOther) {
   // bin and convert to integers
-  valid_t valid_ = valid;
-  rinv_t rInv_ = rInv;
-  phi_t phi0_ = phi0;
-  tanl_t tanl_ = tanl;
-  z0_t z0_ = z0;
-  d0_t d0_ = d0;
-  chi2rphi_t chi2RPhi_ = chi2RPhi;
-  chi2rz_t chi2RZ_ = chi2RZ;
-  bendChi2_t bendChi2_ = bendChi2;
-  hit_t hitPattern_ = hitPattern;
-  qualityMVA_t mvaQuality_ = mvaQuality;
-  qualityMVAE_t mvaQualityE_ = mvaQualityE;
-  qualityMVAD_t mvaQualityD_ = mvaQualityD;
+  valid_t valid_HLS = valid;
+  rinv_t rInv_HLS = rInv;
+  phi_t localPhi_HLS = localPhi;
+  tanl_t tanl_HLS = tanl;
+  z0_t z0_HLS = z0;
+  d0_t d0_HLS = d0;
+  chi2rphi_t chi2RPhiRed_HLS = chi2RPhiRed;
+  chi2rz_t chi2RZRed_HLS = chi2RZRed;
+  bendChi2_t bendChi2Red_HLS = bendChi2Red;
+  hit_t hitPattern_HLS = hitPattern;
+  qualityMVA_t mvaQuality_HLS = mvaQuality;
+  otherMVA_t mvaOther_HLS = mvaOther;
 
   // pack the track word
-  setTrackWord(valid_,
-               rInv_,
-               phi0_,
-               tanl_,
-               z0_,
-               d0_,
-               chi2RPhi_,
-               chi2RZ_,
-               bendChi2_,
-               hitPattern_,
-               mvaQuality_,
-               mvaQualityE_,
-               mvaQualityD_);
+  setTrackWord(
+      valid_HLS, rInv_HLS, localPhi_HLS, tanl_HLS, z0_HLS, d0_HLS, chi2RPhiRed_HLS, chi2RZRed_HLS, bendChi2Red_HLS, hitPattern_HLS, mvaQuality_HLS, mvaOther_HLS);
 }
 
-void TTTrack_TrackWord::setTrackWord(
-    ap_uint<TrackBitWidths::kValidSize> valid,
-    ap_uint<TrackBitWidths::kRinvSize> rInv,
-    ap_uint<TrackBitWidths::kPhiSize> phi0,
-    ap_uint<TrackBitWidths::kTanlSize> tanl,
-    ap_uint<TrackBitWidths::kZ0Size> z0,
-    ap_uint<TrackBitWidths::kD0Size> d0,
-    ap_uint<TrackBitWidths::kChi2RPhiSize> chi2RPhi,  // would be total chisq if chi2Z is zero
-    ap_uint<TrackBitWidths::kChi2RZSize> chi2RZ,
-    ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
-    ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
-    ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
-    ap_uint<TrackBitWidths::kMVAQualityESize> mvaQualityE,
-    ap_uint<TrackBitWidths::kMVAQualityDSize> mvaQualityD) {
+// A setting for already-digitized values in HLS format
+void TTTrack_TrackWord::setTrackWord(ap_uint<TrackBitWidths::kValidSize> valid,
+                                     ap_uint<TrackBitWidths::kRinvSize> rInv,
+                                     ap_uint<TrackBitWidths::kPhiSize> localPhi,
+                                     ap_uint<TrackBitWidths::kTanlSize> tanl,
+                                     ap_uint<TrackBitWidths::kZ0Size> z0,
+                                     ap_uint<TrackBitWidths::kD0Size> d0,
+                                     ap_uint<TrackBitWidths::kChi2RPhiSize> chi2RPhiRed,
+                                     ap_uint<TrackBitWidths::kChi2RZSize> chi2RZRed,
+                                     ap_uint<TrackBitWidths::kBendChi2Size> bendChi2Red,
+                                     ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
+                                     ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
+                                     ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther) {
   // pack the track word
-  unsigned int offset = 0;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualityDSize); b++) {
-    trackWord_.set(b, mvaQualityD[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kMVAOtherSize; b++) {
+    trackWord_.set(TrackBitLocations::kMVAOtherLSB + b, mvaOther[b]);
   }
-  offset += TrackBitWidths::kMVAQualityDSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualityESize); b++) {
-    trackWord_.set(b, mvaQualityE[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kMVAQualitySize; b++) {
+    trackWord_.set(TrackBitLocations::kMVAQualityLSB + b, mvaQuality[b]);
   }
-  offset += TrackBitWidths::kMVAQualityESize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualitySize); b++) {
-    trackWord_.set(b, mvaQuality[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kHitPatternSize; b++) {
+    trackWord_.set(TrackBitLocations::kHitPatternLSB + b, hitPattern[b]);
   }
-  offset += TrackBitWidths::kMVAQualitySize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kHitPatternSize); b++) {
-    trackWord_.set(b, hitPattern[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kBendChi2Size; b++) {
+    trackWord_.set(TrackBitLocations::kBendChi2LSB + b, bendChi2Red[b]);
   }
-  offset += TrackBitWidths::kHitPatternSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kBendChi2Size); b++) {
-    trackWord_.set(b, bendChi2[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kD0Size; b++) {
+    trackWord_.set(TrackBitLocations::kD0LSB + b, d0[b]);
   }
-  offset += TrackBitWidths::kBendChi2Size;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kD0Size); b++) {
-    trackWord_.set(b, d0[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kChi2RZSize; b++) {
+    trackWord_.set(TrackBitLocations::kChi2RZLSB + b, chi2RZRed[b]);
   }
-  offset += TrackBitWidths::kD0Size;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kChi2RZSize); b++) {
-    trackWord_.set(b, chi2RZ[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kZ0Size; b++) {
+    trackWord_.set(TrackBitLocations::kZ0LSB + b, z0[b]);
   }
-  offset += TrackBitWidths::kChi2RZSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kZ0Size); b++) {
-    trackWord_.set(b, z0[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kTanlSize; b++) {
+    trackWord_.set(TrackBitLocations::kTanlLSB + b, tanl[b]);
   }
-  offset += TrackBitWidths::kZ0Size;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kTanlSize); b++) {
-    trackWord_.set(b, tanl[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kChi2RPhiSize; b++) {
+    trackWord_.set(TrackBitLocations::kChi2RPhiLSB + b, chi2RPhiRed[b]);
   }
-  offset += TrackBitWidths::kTanlSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kChi2RPhiSize); b++) {
-    trackWord_.set(b, chi2RPhi[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kPhiSize; b++) {
+    trackWord_.set(TrackBitLocations::kPhiLSB + b, localPhi[b]);
   }
-  offset += TrackBitWidths::kChi2RPhiSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kPhiSize); b++) {
-    trackWord_.set(b, phi0[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kRinvSize; b++) {
+    trackWord_.set(TrackBitLocations::kRinvLSB + b, rInv[b]);
   }
-  offset += TrackBitWidths::kPhiSize;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kRinvSize); b++) {
-    trackWord_.set(b, rInv[b - offset]);
+  for (unsigned int b = 0; b < TrackBitWidths::kValidSize; b++) {
+    trackWord_.set(TrackBitLocations::kValidLSB + b, valid[b]);
   }
-  offset += TrackBitWidths::kRinvSize;
-  for (unsigned int b = offset; b < offset + TrackBitWidths::kValidSize; b++) {
-    trackWord_.set(b, valid[b - offset]);
-  }
+}
+
+void TTTrack_TrackWord::printTestDigitizationScheme(const unsigned int nBits,
+                                                   const double lsb,
+                                                   const double floatingPointValue,
+                                                   const unsigned int digitizedSignedValue,
+                                                   const double undigitizedSignedValue,
+                                                   const unsigned int redigitizedSignedValue) const {
+  edm::LogInfo("TTTrack_TrackWord") << "testDigitizationScheme: (nBits, lsb) = (" << nBits << ", " << lsb << ")\n"
+                                    << "Floating point value = " << floatingPointValue
+                                    << "\tDigitized value = " << digitizedSignedValue
+                                    << "\tUn-digitized value = " << undigitizedSignedValue
+                                    << "\tRe-digitized value = " << redigitizedSignedValue;
 }
 
 bool TTTrack_TrackWord::singleDigitizationSchemeTest(const double floatingPointValue,
@@ -230,8 +183,7 @@ bool TTTrack_TrackWord::singleDigitizationSchemeTest(const double floatingPointV
   unsigned int digitizedSignedValue = digitizeSignedValue(floatingPointValue, nBits, lsb);
   double undigitizedSignedValue = undigitizeSignedValue(digitizedSignedValue, nBits, lsb);
   unsigned int redigitizedSignedValue = digitizeSignedValue(undigitizedSignedValue, nBits, lsb);
-  tttrack_trackword::infoTestDigitizationScheme(
-      nBits, lsb, floatingPointValue, digitizedSignedValue, undigitizedSignedValue, redigitizedSignedValue);
+  this->printTestDigitizationScheme(nBits, lsb, floatingPointValue, digitizedSignedValue, undigitizedSignedValue, redigitizedSignedValue);
   return (std::abs(floatingPointValue - undigitizedSignedValue) <= (lsb / 2.0)) &&
          (digitizedSignedValue == redigitizedSignedValue);
 }

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -36,9 +36,11 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      double bendChi2,
                                      unsigned int hitPattern,
                                      double mvaQuality,
-                                     double mvaOther,
+                                     double mvaQualityE,
+                                     double mvaQualityD,
                                      unsigned int sector) {
-  setTrackWord(valid, momentum, POCA, rInv, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther, sector);
+  setTrackWord(
+      valid, momentum, POCA, rInv, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaQualityE, mvaQualityD, sector);
 }
 
 TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
@@ -52,8 +54,10 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      unsigned int bendChi2,
                                      unsigned int hitPattern,
                                      unsigned int mvaQuality,
-                                     unsigned int mvaOther) {
-  setTrackWord(valid, rInv, phi0, tanl, z0, d0, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaOther);
+                                     unsigned int mvaQualityE,
+                                     unsigned int mvaQualityD) {
+  setTrackWord(
+      valid, rInv, phi0, tanl, z0, d0, chi2RPhi, chi2RZ, bendChi2, hitPattern, mvaQuality, mvaQualityE, mvaQualityD);
 }
 
 // A setter for the floating point values
@@ -66,7 +70,8 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
                                      double bendChi2,
                                      unsigned int hitPattern,
                                      double mvaQuality,
-                                     double mvaOther,
+                                     double mvaQualityE,
+                                     double mvaQualityD,
                                      unsigned int sector) {
   // first, derive quantities to be packed
   float rPhi = localPhi(momentum.phi(), sector);  // this needs to be phi relative to the center of the sector
@@ -86,12 +91,23 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   bendChi2_t bendChi2_ = getBin(bendChi2, bendChi2Bins);
   hit_t hitPattern_ = hitPattern;
   qualityMVA_t mvaQuality_ = getBin(mvaQuality, tqMVABins);
-  otherMVA_t mvaOther_ = mvaOther;
+  qualityMVAE_t mvaQualityE_ = getBin(mvaQualityE, tqMVAEBins);
+  qualityMVAD_t mvaQualityD_ = getBin(mvaQualityD, tqMVADBins);
 
   // pack the track word
-  //trackWord = ( mvaOther_, mvaQuality_, hitPattern_, bendChi2_, chi2RZ_, chi2RPhi_, d0_, z0_, tanl_, phi0_, rInv_, valid_ );
-  setTrackWord(
-      valid_, rInv_, phi0_, tanl_, z0_, d0_, chi2RPhi_, chi2RZ_, bendChi2_, hitPattern_, mvaQuality_, mvaOther_);
+  setTrackWord(valid_,
+               rInv_,
+               phi0_,
+               tanl_,
+               z0_,
+               d0_,
+               chi2RPhi_,
+               chi2RZ_,
+               bendChi2_,
+               hitPattern_,
+               mvaQuality_,
+               mvaQualityE_,
+               mvaQualityD_);
 }
 
 // A setter for already-digitized values
@@ -106,7 +122,8 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
                                      unsigned int bendChi2,
                                      unsigned int hitPattern,
                                      unsigned int mvaQuality,
-                                     unsigned int mvaOther) {
+                                     unsigned int mvaQualityE,
+                                     unsigned int mvaQualityD) {
   // bin and convert to integers
   valid_t valid_ = valid;
   rinv_t rInv_ = rInv;
@@ -119,14 +136,23 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   bendChi2_t bendChi2_ = bendChi2;
   hit_t hitPattern_ = hitPattern;
   qualityMVA_t mvaQuality_ = mvaQuality;
-  otherMVA_t mvaOther_ = mvaOther;
+  qualityMVAE_t mvaQualityE_ = mvaQualityE;
+  qualityMVAD_t mvaQualityD_ = mvaQualityD;
 
   // pack the track word
-  //trackWord = ( otherMVA_t(mvaOther), qualityMVA_t(mvaQuality), hit_t(hitPattern),
-  //              bendChi2_t(bendChi2), chi2rz_t(chi2RZ), chi2rphi_t(chi2RPhi),
-  //              d0_t(d0), z0_t(z0), tanl_t(tanl), phi_t(phi0), rinv_t(rInv), valid_t(valid) );
-  setTrackWord(
-      valid_, rInv_, phi0_, tanl_, z0_, d0_, chi2RPhi_, chi2RZ_, bendChi2_, hitPattern_, mvaQuality_, mvaOther_);
+  setTrackWord(valid_,
+               rInv_,
+               phi0_,
+               tanl_,
+               z0_,
+               d0_,
+               chi2RPhi_,
+               chi2RZ_,
+               bendChi2_,
+               hitPattern_,
+               mvaQuality_,
+               mvaQualityE_,
+               mvaQualityD_);
 }
 
 void TTTrack_TrackWord::setTrackWord(
@@ -141,13 +167,18 @@ void TTTrack_TrackWord::setTrackWord(
     ap_uint<TrackBitWidths::kBendChi2Size> bendChi2,
     ap_uint<TrackBitWidths::kHitPatternSize> hitPattern,
     ap_uint<TrackBitWidths::kMVAQualitySize> mvaQuality,
-    ap_uint<TrackBitWidths::kMVAOtherSize> mvaOther) {
+    ap_uint<TrackBitWidths::kMVAQualityESize> mvaQualityE,
+    ap_uint<TrackBitWidths::kMVAQualityDSize> mvaQualityD) {
   // pack the track word
   unsigned int offset = 0;
-  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAOtherSize); b++) {
-    trackWord_.set(b, mvaOther[b - offset]);
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualityDSize); b++) {
+    trackWord_.set(b, mvaQualityD[b - offset]);
   }
-  offset += TrackBitWidths::kMVAOtherSize;
+  offset += TrackBitWidths::kMVAQualityDSize;
+  for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualityESize); b++) {
+    trackWord_.set(b, mvaQualityE[b - offset]);
+  }
+  offset += TrackBitWidths::kMVAQualityESize;
   for (unsigned int b = offset; b < (offset + TrackBitWidths::kMVAQualitySize); b++) {
     trackWord_.set(b, mvaQuality[b - offset]);
   }

--- a/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
+++ b/DataFormats/L1TrackTrigger/src/TTTrack_TrackWord.cc
@@ -25,12 +25,13 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      double mvaQuality,
                                      double mvaOther,
                                      unsigned int sector) {
-  setTrackWord(valid, momentum, POCA, rInv, chi2RPhiRed, chi2RZRed, bendChi2Red, hitPattern, mvaQuality, mvaOther, sector);
+  setTrackWord(
+      valid, momentum, POCA, rInv, chi2RPhiRed, chi2RZRed, bendChi2Red, hitPattern, mvaQuality, mvaOther, sector);
 }
 
 TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      unsigned int rInv,
-                                     unsigned int localPhi, // relative to centre of phi nonant
+                                     unsigned int localPhi,  // relative to centre of phi nonant
                                      unsigned int tanl,
                                      unsigned int z0,
                                      unsigned int d0,
@@ -40,7 +41,8 @@ TTTrack_TrackWord::TTTrack_TrackWord(unsigned int valid,
                                      unsigned int hitPattern,
                                      unsigned int mvaQuality,
                                      unsigned int mvaOther) {
-  setTrackWord(valid, rInv, localPhi, tanl, z0, d0, chi2RPhiRed, chi2RZRed, bendChi2Red, hitPattern, mvaQuality, mvaOther);
+  setTrackWord(
+      valid, rInv, localPhi, tanl, z0, d0, chi2RPhiRed, chi2RZRed, bendChi2Red, hitPattern, mvaQuality, mvaOther);
 }
 
 // A setter for the floating point values
@@ -76,18 +78,28 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   otherMVA_t mvaOther_HLS = (unsigned int)(mvaOther);
 
   // pack the track word
-  setTrackWord(
-      valid_HLS, rInv_HLS, phi0_HLS, tanl_HLS, z0_HLS, d0_HLS, chi2RPhiRed_HLS, chi2RZRed_HLS, bendChi2Red_HLS, hitPattern_HLS, mvaQuality_HLS, mvaOther_HLS);
+  setTrackWord(valid_HLS,
+               rInv_HLS,
+               phi0_HLS,
+               tanl_HLS,
+               z0_HLS,
+               d0_HLS,
+               chi2RPhiRed_HLS,
+               chi2RZRed_HLS,
+               bendChi2Red_HLS,
+               hitPattern_HLS,
+               mvaQuality_HLS,
+               mvaOther_HLS);
 }
 
 // A setter for already-digitized values
 void TTTrack_TrackWord::setTrackWord(unsigned int valid,
                                      unsigned int rInv,
-                                     unsigned int localPhi, // relative to centre of phi nonant
+                                     unsigned int localPhi,  // relative to centre of phi nonant
                                      unsigned int tanl,
                                      unsigned int z0,
                                      unsigned int d0,
-                                     unsigned int chi2RPhiRed, // normalized to dof
+                                     unsigned int chi2RPhiRed,  // normalized to dof
                                      unsigned int chi2RZRed,
                                      unsigned int bendChi2Red,
                                      unsigned int hitPattern,
@@ -108,8 +120,18 @@ void TTTrack_TrackWord::setTrackWord(unsigned int valid,
   otherMVA_t mvaOther_HLS = mvaOther;
 
   // pack the track word
-  setTrackWord(
-      valid_HLS, rInv_HLS, localPhi_HLS, tanl_HLS, z0_HLS, d0_HLS, chi2RPhiRed_HLS, chi2RZRed_HLS, bendChi2Red_HLS, hitPattern_HLS, mvaQuality_HLS, mvaOther_HLS);
+  setTrackWord(valid_HLS,
+               rInv_HLS,
+               localPhi_HLS,
+               tanl_HLS,
+               z0_HLS,
+               d0_HLS,
+               chi2RPhiRed_HLS,
+               chi2RZRed_HLS,
+               bendChi2Red_HLS,
+               hitPattern_HLS,
+               mvaQuality_HLS,
+               mvaOther_HLS);
 }
 
 // A setting for already-digitized values in HLS format
@@ -165,11 +187,11 @@ void TTTrack_TrackWord::setTrackWord(ap_uint<TrackBitWidths::kValidSize> valid,
 }
 
 void TTTrack_TrackWord::printTestDigitizationScheme(const unsigned int nBits,
-                                                   const double lsb,
-                                                   const double floatingPointValue,
-                                                   const unsigned int digitizedSignedValue,
-                                                   const double undigitizedSignedValue,
-                                                   const unsigned int redigitizedSignedValue) const {
+                                                    const double lsb,
+                                                    const double floatingPointValue,
+                                                    const unsigned int digitizedSignedValue,
+                                                    const double undigitizedSignedValue,
+                                                    const unsigned int redigitizedSignedValue) const {
   edm::LogInfo("TTTrack_TrackWord") << "testDigitizationScheme: (nBits, lsb) = (" << nBits << ", " << lsb << ")\n"
                                     << "Floating point value = " << floatingPointValue
                                     << "\tDigitized value = " << digitizedSignedValue
@@ -183,7 +205,8 @@ bool TTTrack_TrackWord::singleDigitizationSchemeTest(const double floatingPointV
   unsigned int digitizedSignedValue = digitizeSignedValue(floatingPointValue, nBits, lsb);
   double undigitizedSignedValue = undigitizeSignedValue(digitizedSignedValue, nBits, lsb);
   unsigned int redigitizedSignedValue = digitizeSignedValue(undigitizedSignedValue, nBits, lsb);
-  this->printTestDigitizationScheme(nBits, lsb, floatingPointValue, digitizedSignedValue, undigitizedSignedValue, redigitizedSignedValue);
+  this->printTestDigitizationScheme(
+      nBits, lsb, floatingPointValue, digitizedSignedValue, undigitizedSignedValue, redigitizedSignedValue);
   return (std::abs(floatingPointValue - undigitizedSignedValue) <= (lsb / 2.0)) &&
          (digitizedSignedValue == redigitizedSignedValue);
 }

--- a/DataFormats/L1TrackTrigger/src/classes.h
+++ b/DataFormats/L1TrackTrigger/src/classes.h
@@ -16,5 +16,7 @@
 #include "DataFormats/L1TrackTrigger/interface/TTDTC.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Math/interface/Error.h"
+#include "TMatrixTSym.h"
 
 #endif

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -44,5 +44,8 @@
   <class name="edm::Wrapper<tt::TTTrackRefMap>"/>
   <class name="TTDTC"/>
   <class name="edm::Wrapper<TTDTC>"/>
+  <class name="std::vector<ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<float,5> > >"/>
+  <class name="std::vector<ROOT::Math::SMatrix<float,5u,5u,ROOT::Math::MatRepSym<float,5u> > >"/>
+  <class name="TMatrixTSym<float>"/>
 </lcgdict>
 

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -44,8 +44,8 @@
   <class name="edm::Wrapper<tt::TTTrackRefMap>"/>
   <class name="TTDTC"/>
   <class name="edm::Wrapper<TTDTC>"/>
-  <class name="std::vector<ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<float,5> > >"/>
-  <class name="std::vector<ROOT::Math::SMatrix<float,5u,5u,ROOT::Math::MatRepSym<float,5u> > >"/>
-  <class name="TMatrixTSym<float>"/>
+  <!--class name="std::vector<ROOT::Math::SMatrix<float,5,5,ROOT::Math::MatRepSym<float,5> > >"/-->
+  <!--class name="std::vector<ROOT::Math::SMatrix<float,5u,5u,ROOT::Math::MatRepSym<float,5u> > >"/-->
+  <!--class name="TMatrixTSym<float>"/-->
 </lcgdict>
 

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -27,13 +27,6 @@
   <class name="TTTrack_TrackWord" ClassVersion="4">
    <version ClassVersion="4" checksum="133238749"/>
    <version ClassVersion="3" checksum="4186150061"/>
-   <ioread sourceClass = "TTTrack_TrackWord" version="[-3]" targetClass="TTTrack_TrackWord"
-    source="unsigned int iRinv; unsigned int iphi; unsigned int itanl; unsigned int iz0; unsigned int id0; unsigned int ichi2XY; unsigned int ichi2Z; unsigned int iBendChi2; unsigned int ispare; unsigned int iHitPattern;" target="">
-    <![CDATA[
-      TTTrack_TrackWord tmp(1, onfile.iRinv, onfile.iphi, onfile.itanl, onfile.iz0, onfile.id0, onfile.ichi2XY, onfile.ichi2Z, onfile.iBendChi2, onfile.iHitPattern, 0, 0);
-      *newObj=tmp;
-    ]]>
-   </ioread>
   </class>
   <class name="std::vector<TTTrack_TrackWord>"/>
   <class name="edm::Wrapper<std::vector<TTTrack_TrackWord> >"/>

--- a/L1Trigger/TrackFindingTMTT/interface/KFParamsComb.h
+++ b/L1Trigger/TrackFindingTMTT/interface/KFParamsComb.h
@@ -59,6 +59,8 @@ namespace tmtt {
     // Convert to physical helix params instead of local ones used by KF
     TVectorD trackParams(const KalmanState* state) const override;
     TVectorD trackParams_BeamConstr(const KalmanState* state, double& chi2rphi) const override;
+    // Convert to physical helix covariance matrix instead of local ones used by KF
+    TMatrixD trackParamsCov(const KalmanState* state) const override;
 
     // Does helix state pass cuts?
     bool isGoodState(const KalmanState& state) const override;

--- a/L1Trigger/TrackFindingTMTT/interface/KFTrackletTrack.h
+++ b/L1Trigger/TrackFindingTMTT/interface/KFTrackletTrack.h
@@ -9,6 +9,7 @@
 #include "L1Trigger/TrackFindingTMTT/interface/TP.h"
 #include "L1Trigger/TrackFindingTMTT/interface/Stub.h"
 #include "L1Trigger/TrackFindingTMTT/interface/DigitalTrack.h"
+#include "DataFormats/Math/interface/Error.h"
 
 #include <vector>
 #include <utility>
@@ -26,6 +27,8 @@ namespace tmtt {
 
   class KFTrackletTrack {
   public:
+    typedef math::ErrorF<5>::type CovMat;
+
     // Store a new fitted track, specifying the input Hough transform track, the stubs used for the fit,
     // bit-encoded hit layers,
     // the fitted helix parameters & chi2,
@@ -40,6 +43,7 @@ namespace tmtt {
                     float phi0,
                     float z0,
                     float tanLambda,
+                    const CovMat& helixCovMat,
                     float chi2rphi,
                     float chi2rz,
                     unsigned int nHelixParam,
@@ -59,6 +63,7 @@ namespace tmtt {
           phi0_(phi0),
           z0_(z0),
           tanLambda_(tanLambda),
+          helixCovMat_(helixCovMat),
           chi2rphi_(chi2rphi),
           chi2rz_(chi2rz),
           done_bcon_(done_bcon),
@@ -130,6 +135,9 @@ namespace tmtt {
     float phi0_bcon() const { return phi0_bcon_; }
     float d0_bcon() const { return d0_bcon_; }
 
+    // Helix covariance matrix (always 5x5)
+    const CovMat& helixCovMat() { return helixCovMat_; }
+
     // Phi and z coordinates at which track crosses "chosenR" values used by r-phi HT and rapidity sectors respectively.
     // (Optionally with beam-spot constraint applied).
     float phiAtChosenR(bool beamConstraint) const {
@@ -199,12 +207,17 @@ namespace tmtt {
     //--- Bit-encoded hit pattern (where layer number assigned by increasing distance from origin, according to layers track expected to cross).
     unsigned int hitPattern_;
 
-    //--- The fitted helix parameters and fit chi-squared.
+    //--- The fitted helix parameters.
     float qOverPt_;
     float d0_;
     float phi0_;
     float z0_;
     float tanLambda_;
+
+    //--- Helix covariance matrix (always 5x5)
+    CovMat helixCovMat_;
+
+    //--- Fit chi2
     float chi2rphi_;
     float chi2rz_;
 

--- a/L1Trigger/TrackFindingTMTT/interface/KFbase.h
+++ b/L1Trigger/TrackFindingTMTT/interface/KFbase.h
@@ -141,6 +141,9 @@ namespace tmtt {
     // Ditto after applying beam-spot constraint.
     virtual TVectorD trackParams_BeamConstr(const KalmanState *state, double &chi2rphi_bcon) const = 0;
 
+    // Convert to physical helix covariance matrix instead of local ones used by KF
+    virtual TMatrixD trackParamsCov(const KalmanState *state) const = 0;
+
     // Get phi of centre of sector containing track.
     double sectorPhi() const {
       float phiCentreSec0 = -M_PI / float(settings_->numPhiNonants()) + M_PI / float(settings_->numPhiSectors());

--- a/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
+++ b/L1Trigger/TrackFindingTMTT/interface/L1fittedTrack.h
@@ -13,6 +13,7 @@
 #include "L1Trigger/TrackFindingTMTT/interface/HTrphi.h"
 #include "L1Trigger/TrackFindingTMTT/interface/DigitalTrack.h"
 #include "L1Trigger/TrackFindingTMTT/interface/KFTrackletTrack.h"
+#include "DataFormats/Math/interface/Error.h"
 
 #include <vector>
 #include <set>
@@ -29,6 +30,8 @@ namespace tmtt {
 
   class L1fittedTrack : public L1trackBase {
   public:
+    typedef math::ErrorF<5>::type CovMat;
+
     // Store a new fitted track, specifying the input Hough transform track, the stubs used for the fit,
     // bit-encoded hit layer pattern (numbered by increasing distance from origin),
     // the fitted helix parameters & chi2,
@@ -43,6 +46,7 @@ namespace tmtt {
                   float phi0,
                   float z0,
                   float tanLambda,
+                  const TMatrixD& helCovMat,
                   float chi2rphi,
                   float chi2rz,
                   unsigned int nHelixParam,
@@ -84,6 +88,11 @@ namespace tmtt {
         nLayers_ = Utility::countLayers(settings, stubs_);
         // Find associated truth particle & calculate info about match.
         matchedTP_ = Utility::matchingTP(settings, stubs_, nMatchedLayers_, matchedStubs_);
+        for (unsigned int i = 0; i < nHelixParam; i++) {
+          for (unsigned int j = i; j < nHelixParam; j++) {
+            helixCovMat_[i][j] = helCovMat[i][j];
+          }
+        }
       } else {  // Rejected track
         nLayers_ = 0;
         matchedTP_ = nullptr;
@@ -106,7 +115,8 @@ namespace tmtt {
     }
 
     // Creates track rejected by fitter.
-    L1fittedTrack() : L1fittedTrack(nullptr, nullptr, noStubs_, 0, 0., 0., 0., 0., 0., 0., 0., 0, false) {}
+    L1fittedTrack()
+        : L1fittedTrack(nullptr, nullptr, noStubs_, 0, 0., 0., 0., 0., 0., TMatrixD(5, 5), 0., 0., 0, false) {}
 
     ~L1fittedTrack() override = default;
 
@@ -157,6 +167,7 @@ namespace tmtt {
                            phi0(),
                            z0(),
                            tanLambda(),
+                           helixCovMat(),
                            chi2rphi(),
                            chi2rz(),
                            nHelixParam(),
@@ -254,6 +265,9 @@ namespace tmtt {
     }
     float phi0_bcon() const { return phi0_bcon_; }
     float d0_bcon() const { return d0_bcon_; }
+
+    // Helix covariance matrix (always 5x5) in (1/2R, phi0, tanL, z0, d0).
+    const CovMat& helixCovMat() const { return helixCovMat_; }
 
     // Phi and z coordinates at which track crosses "chosenR" values used by r-phi HT and rapidity sectors respectively.
     // (Optionally with beam-spot constraint applied).
@@ -386,6 +400,9 @@ namespace tmtt {
 
     //--- The number of helix parameters being fitted (=5 if d0 is fitted or =4 if d0 is not fitted).
     unsigned int nHelixParam_;
+
+    //--- Helix covariance matrix (always 5x5)
+    CovMat helixCovMat_;
 
     //--- Phi sector and eta region used track finding code that this track was in.
     unsigned int iPhiSec_;

--- a/L1Trigger/TrackFindingTMTT/src/ChiSquaredFitBase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/ChiSquaredFitBase.cc
@@ -124,6 +124,7 @@ namespace tmtt {
                            x[PHI0],
                            x[Z0],
                            x[T],
+                           TMatrixD(4, 4),  // helix cov matrix not yet calculated
                            chiSq_,
                            chi2rz,
                            nPar_);

--- a/L1Trigger/TrackFindingTMTT/src/ConverterToTTTrack.cc
+++ b/L1Trigger/TrackFindingTMTT/src/ConverterToTTTrack.cc
@@ -1,4 +1,5 @@
 #include "L1Trigger/TrackFindingTMTT/interface/ConverterToTTTrack.h"
+#include "DataFormats/Math/interface/Error.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace std;
@@ -12,6 +13,7 @@ namespace tmtt {
                                                                   unsigned int iEtaReg) const {
     unsigned int nPar, hitPattern;
     double d0, z0, tanL, chi2rphi, chi2rz;
+    L1fittedTrack::CovMat helixCovMat;
 
     const L1fittedTrack* fitTrk = dynamic_cast<const L1fittedTrack*>(trk);
 
@@ -35,6 +37,7 @@ namespace tmtt {
       d0 = fitTrk->d0();
       z0 = fitTrk->z0();
       tanL = fitTrk->tanLambda();
+      helixCovMat = fitTrk->helixCovMat();
       chi2rphi = fitTrk->chi2rphi();
       chi2rz = fitTrk->chi2rz();
     }
@@ -44,18 +47,31 @@ namespace tmtt {
     constexpr double mva = -1.;  // MVA quality flags not yet set.
     const double& magneticField = settings_->magneticField();
 
-    TTTrack<Ref_Phase2TrackerDigi_> track(
-        rinv, phi0, tanL, z0, d0, chi2rphi, chi2rz, mva, mva, mva, hitPattern, nPar, magneticField);
+    constexpr double chi2BendRed = -99;  // Not yet filled.
+    constexpr unsigned int dummy = 99;
+
+    TTTrack<Ref_Phase2TrackerDigi_> track(rinv,
+                                          phi0,
+                                          tanL,
+                                          z0,
+                                          d0,
+                                          chi2rphi,
+                                          chi2rz,
+                                          mva,
+                                          mva,
+                                          mva,
+                                          hitPattern,
+                                          nPar,
+                                          magneticField,
+                                          iPhiSec,
+                                          iEtaReg,
+                                          chi2BendRed,
+                                          dummy,
+                                          helixCovMat);
 
     // Set references to stubs on this track.
     std::vector<TTStubRef> ttstubrefs = this->stubRefs(trk);
     track.setStubRefs(ttstubrefs);
-
-    // Note which (eta,phi) sector this track was reconstructed in.
-    track.setPhiSector(iPhiSec);
-    track.setEtaSector(iEtaReg);
-
-    track.setStubPtConsistency(-1);  // not yet filled.
 
     return track;
   }

--- a/L1Trigger/TrackFindingTMTT/src/KFParamsComb.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFParamsComb.cc
@@ -182,10 +182,10 @@ namespace tmtt {
     return unitMatrix;
   }
 
-  /* Get physical helix params */
+  /* Get physical helix params instead of ones used internally by KF */
 
   TVectorD KFParamsComb::trackParams(const KalmanState* state) const {
-    TVectorD vecX = state->vectorX();
+    const TVectorD& vecX = state->vectorX();
     TVectorD vecY(nHelixPar_);
     vecY[QOVERPT] = 2. * vecX[INV2R] / settings_->invPtToInvR();
     vecY[PHI0] = reco::deltaPhi(vecX[PHI0] + sectorPhi(), 0.);
@@ -220,6 +220,18 @@ namespace tmtt {
     } else {
       return (this->trackParams(state));
     }
+  }
+
+  /*  Convert to physical helix covariance matrix instead of ones used internally by KF */
+  TMatrixD KFParamsComb::trackParamsCov(const KalmanState* state) const {
+    TMatrixD cov = state->matrixC();
+    // Local and external matrix differ only in that local one uses 1/2R and external one
+    // uses 1/R.
+    for (unsigned int i = 0; i < nHelixPar_; i++) {
+      cov[INV2R][i] = 2 * cov[INV2R][i];
+      cov[i][INV2R] = 2 * cov[i][INV2R];
+    }
+    return cov;
   }
 
   /* Check if helix state passes cuts */

--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -89,6 +89,7 @@ namespace tmtt {
                            trackPars[PHI0],
                            trackPars[Z0],
                            trackPars[T],
+                           cand->matrixC(),
                            cand->chi2rphi(),
                            cand->chi2rz(),
                            nHelixPar_);

--- a/L1Trigger/TrackFindingTMTT/src/KFbase.cc
+++ b/L1Trigger/TrackFindingTMTT/src/KFbase.cc
@@ -79,6 +79,7 @@ namespace tmtt {
       // Get track helix params.
       TVectorD trackPars = trackParams(cand);
       double d0 = (nHelixPar_ == 5) ? trackPars[D0] : 0.;
+      TMatrixD trackCov = trackParamsCov(cand);
 
       L1fittedTrack fitTrk(settings_,
                            &l1track3D,
@@ -89,7 +90,7 @@ namespace tmtt {
                            trackPars[PHI0],
                            trackPars[Z0],
                            trackPars[T],
-                           cand->matrixC(),
+                           trackCov,
                            cand->chi2rphi(),
                            cand->chi2rz(),
                            nHelixPar_);

--- a/L1Trigger/TrackFindingTMTT/src/SimpleLR4.cc
+++ b/L1Trigger/TrackFindingTMTT/src/SimpleLR4.cc
@@ -8,6 +8,7 @@
 #include "L1Trigger/TrackFindingTMTT/interface/L1track3D.h"
 #include "L1Trigger/TrackFindingTMTT/interface/PrintL1trk.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
+#include <TMatrixD.h>
 
 #include <vector>
 #include <set>
@@ -443,9 +444,21 @@ namespace tmtt {
 
     if (accepted) {
       // Create the L1fittedTrack object
-      const unsigned int hitPattern = 0;  // FIX: Needs setting
-      L1fittedTrack fitTrk(
-          settings_, &l1track3D, fitStubs, hitPattern, qOverPt, 0., phi0, z0, tanLambda, chi2_phi, chi2_z, nHelixPar);
+      const unsigned int hitPattern = 0;                 // FIX: Needs setting
+      const TMatrixD helixCovMat(nHelixPar, nHelixPar);  // FIX: Needs setting
+      L1fittedTrack fitTrk(settings_,
+                           &l1track3D,
+                           fitStubs,
+                           hitPattern,
+                           qOverPt,
+                           0.,
+                           phi0,
+                           z0,
+                           tanLambda,
+                           helixCovMat,
+                           chi2_phi,
+                           chi2_z,
+                           nHelixPar);
 
       if (settings_->enableDigitize())
         fitTrk.digitizeTrack("SimpleLR4");

--- a/L1Trigger/TrackFindingTracklet/interface/Track.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Track.h
@@ -12,11 +12,14 @@
 #include "L1Trigger/TrackFindingTracklet/interface/Util.h"
 #include "L1Trigger/TrackFindingTracklet/interface/SLHCEvent.h"
 #include "L1Trigger/TrackFindingTracklet/interface/TrackPars.h"
+#include "DataFormats/Math/interface/Error.h"
 
 namespace trklet {
 
   class Track {
   public:
+    typedef math::ErrorF<5>::type CovMat;
+
     // Create track from digitized helix params & stubs
     Track(TrackPars<int> ipars,  // digi helix
           int ichisqrphi,        // digi chi2
@@ -29,6 +32,10 @@ namespace trklet {
           int seed);
 
     ~Track() = default;
+
+    // Optional: set and get helix covariance matrix (not sure if FPGA will output this)
+    void setHelixCovMat(const CovMat& covMat) { covMat_ = covMat; }
+    const CovMat& helixCovMat() const { return covMat_; }
 
     void setDuplicate(bool flag) { duplicate_ = flag; }
     void setSector(int nsec) { sector_ = nsec; }
@@ -85,6 +92,8 @@ namespace trklet {
 
     double chisqrphi_;
     double chisqrz_;
+
+    CovMat covMat_;
 
     int hitpattern_;
 

--- a/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Tracklet.h
@@ -163,6 +163,9 @@ namespace trklet {
       return FPGAWord(ichisqrphifit_.value() + ichisqrzfit_.value(), ichisqrphifit_.nbits());
     }
 
+    // Helix covariance matrix from fit (not sure to be written out by FPGA).
+    const Track::CovMat& helixCovMat() const { return covMat_; }
+
     // Note floating & digitized helix params after track fit.
     void setFitPars(double rinvfit,
                     double phi0fit,
@@ -186,7 +189,8 @@ namespace trklet {
                     int ichisqrphifit,
                     int ichisqrzfit,
                     int hitpattern,
-                    const std::vector<const L1TStub*>& l1stubs = std::vector<const L1TStub*>());
+                    const std::vector<const L1TStub*>& l1stubs = std::vector<const L1TStub*>(),
+                    const Track::CovMat& helixCovMat = Track::CovMat());
 
     const std::string layerstubstr(const unsigned layer) const;
     const std::string diskstubstr(const unsigned disk) const;
@@ -270,6 +274,8 @@ namespace trklet {
     TrackPars<double> fitparsexact_;
     double chisqrphifitexact_;
     double chisqrzfitexact_;
+
+    Track::CovMat covMat_;
 
     int hitpattern_;
 

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -1,5 +1,5 @@
 //////////////////////////
-//  Producer by Anders  //mo
+//  Producer by Anders  //
 //     and Emmanuele    //
 //    july 2012 @ CU    //
 //////////////////////////
@@ -750,6 +750,11 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
     // set track word again to set MVA variable from TTTrack into track word
     aTrack.setTrackWordBits();
+
+    if (!settings_.fakefit()) {
+      if (settings_.debugTracklet())
+        edm::LogVerbatim("Tracklet") << aTrack;  // Print track
+    }
 
     L1TkTracksForOutput->push_back(aTrack);
   }

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -686,6 +686,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     unsigned int trkseed = (unsigned int)abs(track.seed());
     constexpr unsigned int dummy = 99;
     constexpr double dummyf = -99.;
+    const trklet::Track::CovMat& covMat = track.helixCovMat();
 
     TTTrack<Ref_Phase2TrackerDigi_> aTrack(tmp_rinv,
                                            tmp_phi,
@@ -703,7 +704,8 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
                                            trksector,
                                            dummy,
                                            dummyf,
-                                           trkseed);
+                                           trkseed,
+                                           covMat);
 
     const std::vector<trklet::L1TStub>& stubptrs = track.stubs();
     std::vector<trklet::L1TStub> stubs;

--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -584,6 +584,7 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         }
 
         double stubbend = stubRef->bendFE();  //stubRef->rawBend()
+        // Bend has opposite sign in -ve endcap?
         if (ttPos.z() < -120) {
           stubbend = -stubbend;
         }
@@ -681,6 +682,10 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     double tmp_chi2rphi = track.chisqrphi();
     double tmp_chi2rz = track.chisqrz();
     unsigned int tmp_hit = track.hitpattern();
+    unsigned int trksector = track.sector();
+    unsigned int trkseed = (unsigned int)abs(track.seed());
+    constexpr unsigned int dummy = 99;
+    constexpr double dummyf = -99.;
 
     TTTrack<Ref_Phase2TrackerDigi_> aTrack(tmp_rinv,
                                            tmp_phi,
@@ -694,13 +699,11 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
                                            0,
                                            tmp_hit,
                                            settings_.nHelixPar(),
-                                           settings_.bfield());
-
-    unsigned int trksector = track.sector();
-    unsigned int trkseed = (unsigned int)abs(track.seed());
-
-    aTrack.setPhiSector(trksector);
-    aTrack.setTrackSeedType(trkseed);
+                                           settings_.bfield(),
+                                           trksector,
+                                           dummy,
+                                           dummyf,
+                                           trkseed);
 
     const std::vector<trklet::L1TStub>& stubptrs = track.stubs();
     std::vector<trklet::L1TStub> stubs;
@@ -710,24 +713,24 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       stubs.push_back(stubptr);
     }
 
-    int countStubs = 0;
     stubMapType::const_iterator it;
     stubIndexMapType::const_iterator itIndex;
     for (const auto& itstubs : stubs) {
       itIndex = stubIndexMap.find(itstubs.uniqueIndex());
       if (itIndex != stubIndexMap.end()) {
         aTrack.addStubRef(itIndex->second);
-        countStubs = countStubs + 1;
       } else {
-        // could not find stub in stub map
+        // can this ever happen?
+        throw cms::Exception("LogicError") << __FILE__ << "Stub disappeared";
       }
     }
 
-    // pt consistency
-    aTrack.setStubPtConsistency(
-        StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar()));
+    // stub bend pt consistency chi2/ndf
+    float chi2BendRed =
+        StubPtConsistency::getConsistency(aTrack, theTrackerGeom, tTopo, settings_.bfield(), settings_.nHelixPar());
+    aTrack.setChi2BendRed(chi2BendRed);
 
-    // set track word before TQ MVA calculated which uses track word variables
+    // set track word before TQ MVA calculated, since TQ MVA uses track word variables
     aTrack.setTrackWordBits();
 
     // tq
@@ -742,11 +745,6 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     //    if (trackQuality_) {
     //      trackQualityModel_->setBonusFeatures(hph.bonusFeatures());
     //    }
-
-    // set track word again to set MVA variable from TTTrack into track word
-    aTrack.setTrackWordBits();
-    // test track word
-    //aTrack.testTrackWordBits();
 
     // set track word again to set MVA variable from TTTrack into track word
     aTrack.setTrackWordBits();

--- a/L1Trigger/TrackFindingTracklet/src/HitPatternHelper.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HitPatternHelper.cc
@@ -135,7 +135,14 @@ namespace hph {
             edm::LogVerbatim("Tracklet") << "Layer found in hitpattern";
           }
           if (layerEncoding_[i] < 0) {
-            edm::LogError("Tracklet") << "Track's hit-pattern shows stub in non-traversed layer";
+            // TO FIX: This warning occurs because the KF determines which r-z sector each track is
+            // in using the Tracklet helix params, whereas users accessing the TTTrack object
+            // only have access to the KF helix params, which for about 2% of tracks correspond to
+            // a different r-z sector.
+            // -- If get here, LayerEncoding give this warning too, so can disable it here.
+            if (hphDebug_) {
+              edm::LogWarning("Tracklet") << "WARNING: Track's hit-pattern shows stub in non-traversed layer";
+            }
             continue;
           }
           binary_[reducedId(layerEncoding_[i])] = 1;

--- a/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
+++ b/L1Trigger/TrackFindingTracklet/src/HybridFit.cc
@@ -221,6 +221,8 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
       int ichi2rphifit = chi2rphi / 16;
       int ichi2rzfit = trk.chi2rz() / 16;
 
+      const tmtt::KFTrackletTrack::CovMat& covMat = trk.helixCovMat();
+
       const vector<const tmtt::Stub*>& stubsFromFit = trk.stubs();
       vector<const L1TStub*> l1stubsFromFit;
       for (const tmtt::Stub* s : stubsFromFit) {
@@ -251,7 +253,9 @@ void HybridFit::Fit(Tracklet* tracklet, std::vector<const Stub*>& trackstublist)
                            ichi2rphifit,
                            ichi2rzfit,
                            trk.hitPattern(),
-                           l1stubsFromFit);
+                           l1stubsFromFit,
+                           covMat);
+
     } else {
       if (settings_.printDebugKF()) {
         edm::LogVerbatim("L1track") << "FitTrack:KF rejected track";

--- a/L1Trigger/TrackFindingTracklet/src/KalmanFilter.cc
+++ b/L1Trigger/TrackFindingTracklet/src/KalmanFilter.cc
@@ -382,11 +382,11 @@ namespace trklet {
                                ttTrackRef->trkMVA3(),
                                ttTrackRef->hitPattern(),
                                5,
-                               setup_->bField());
-        ttTracks_.back().setPhiSector(ttTrackRef->phiSector());
-        ttTracks_.back().setEtaSector(ttTrackRef->etaSector());
-        ttTracks_.back().setTrackSeedType(ttTrackRef->trackSeedType());
-        ttTracks_.back().setStubPtConsistency(ttTrackRef->stubPtConsistency());
+                               setup_->bField(),
+                               ttTrackRef->phiSector(),
+                               ttTrackRef->etaSector(),
+                               ttTrackRef->chi2BendRed(),
+                               ttTrackRef->trackSeedType());
         ttTracks_.back().setStubRefs(ttTrackRef->getStubRefs());
       }
     }

--- a/L1Trigger/TrackFindingTracklet/src/TrackFindingProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackFindingProcessor.cc
@@ -1,5 +1,6 @@
 #include "L1Trigger/TrackFindingTracklet/interface/TrackFindingProcessor.h"
 #include "L1Trigger/TrackTrigger/interface/StubPtConsistency.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <numeric>
 #include <algorithm>
@@ -269,6 +270,8 @@ namespace trklet {
       ttTrack.setChi2BendRed(StubPtConsistency::getConsistency(
           ttTrack, setup_->trackerGeometry(), setup_->trackerTopology(), bfield_, nPar));
       ttTrack.setTrackWordBits();
+
+      //edm::LogVerbatim("Tracklet") << ttTrack;  // Print track
     }
   }
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackFindingProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackFindingProcessor.cc
@@ -246,6 +246,7 @@ namespace trklet {
       static constexpr double trkMVA3 = 0.;
       const unsigned int aHitpattern = it->hitPattern_.val();
       const unsigned int nPar = ttTrackRef->nFitPars();
+      const float dummy = -99.;
       outputs.emplace_back(aRinv,
                            aphi,
                            aTanLambda,
@@ -258,13 +259,14 @@ namespace trklet {
                            trkMVA3,
                            aHitpattern,
                            nPar,
-                           bfield_);
+                           bfield_,
+                           region,
+                           ttTrackRef->etaSector(),
+                           dummy,
+                           ttTrackRef->trackSeedType());
       TTTrack<Ref_Phase2TrackerDigi_>& ttTrack = outputs.back();
-      ttTrack.setPhiSector(region);
-      ttTrack.setEtaSector(ttTrackRef->etaSector());
-      ttTrack.setTrackSeedType(ttTrackRef->trackSeedType());
       ttTrack.setStubRefs(it->ttStubRefs_);
-      ttTrack.setStubPtConsistency(StubPtConsistency::getConsistency(
+      ttTrack.setChi2BendRed(StubPtConsistency::getConsistency(
           ttTrack, setup_->trackerGeometry(), setup_->trackerTopology(), bfield_, nPar));
       ttTrack.setTrackWordBits();
     }

--- a/L1Trigger/TrackFindingTracklet/src/TrackFindingProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackFindingProcessor.cc
@@ -271,7 +271,9 @@ namespace trklet {
           ttTrack, setup_->trackerGeometry(), setup_->trackerTopology(), bfield_, nPar));
       ttTrack.setTrackWordBits();
 
-      //edm::LogVerbatim("Tracklet") << ttTrack;  // Print track
+      constexpr bool debug = false;
+      if (debug)
+        edm::LogVerbatim("Tracklet") << ttTrack;  // Print track
     }
   }
 

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -545,7 +545,8 @@ void Tracklet::setFitPars(double rinvfit,
                           int ichisqrphifit,
                           int ichisqrzfit,
                           int hitpattern,
-                          const vector<const L1TStub*>& l1stubs) {
+                          const vector<const L1TStub*>& l1stubs,
+                          const Track::CovMat& helixCovMat) {
   fitpars_.init(rinvfit, phi0fit, d0fit, tfit, z0fit);
   chisqrphifit_ = chisqrphifit;
   chisqrzfit_ = chisqrzfit;
@@ -576,6 +577,8 @@ void Tracklet::setFitPars(double rinvfit,
   ichisqrzfit_.set(ichisqrzfit, 8, true, __LINE__, __FILE__);
 
   hitpattern_ = hitpattern;
+
+  covMat_ = helixCovMat;
 
   fpgatrack_ = std::make_unique<Track>(makeTrack(l1stubs));
 }
@@ -792,6 +795,9 @@ Track Tracklet::makeTrack(const vector<const L1TStub*>& l1stubs) {
                  getStubIDs(),
                  tmp2,
                  getISeed());
+
+  // Set helix covariance matrix separately, as not sure FPGA will output that.
+  tmpTrack.setHelixCovMat(covMat_);
 
   return tmpTrack;
 }

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1133,7 +1133,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_chi2 = iterL1Track->chi2();
       float tmp_trk_chi2rphi = iterL1Track->chi2XY();
       float tmp_trk_chi2rz = iterL1Track->chi2Z();
-      float tmp_trk_bendchi2 = iterL1Track->stubPtConsistency();
+      float tmp_trk_bendchi2 = iterL1Track->chi2BendRed();
       float tmp_trk_MVA1 = iterL1Track->trkMVA1();
 
       std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
@@ -1596,7 +1596,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
                                        << " eta = " << matchedTracks.at(it)->momentum().eta()
                                        << " phi = " << matchedTracks.at(it)->momentum().phi()
                                        << " chi2 = " << matchedTracks.at(it)->chi2()
-                                       << " consistency = " << matchedTracks.at(it)->stubPtConsistency()
+                                       << " consistency = " << matchedTracks.at(it)->chi2BendRed()
                                        << " z0 = " << matchedTracks.at(it)->z0()
                                        << " nstub = " << matchedTracks.at(it)->getStubRefs().size();
           if (tmp_trk_genuine)
@@ -1699,7 +1699,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       tmp_matchtrk_chi2 = matchedTracks.at(i_track)->chi2();
       tmp_matchtrk_chi2rphi = matchedTracks.at(i_track)->chi2XY();
       tmp_matchtrk_chi2rz = matchedTracks.at(i_track)->chi2Z();
-      tmp_matchtrk_bendchi2 = matchedTracks.at(i_track)->stubPtConsistency();
+      tmp_matchtrk_bendchi2 = matchedTracks.at(i_track)->chi2BendRed();
       tmp_matchtrk_MVA1 = matchedTracks.at(i_track)->trkMVA1();
       tmp_matchtrk_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
       tmp_matchtrk_seed = (int)matchedTracks.at(i_track)->trackSeedType();

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -977,7 +977,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
   // Conversion factor curvature radius to Pt.
   const float b_field = bFieldHandle.product()->inTesla(GlobalPoint(0, 0, 0)).z();
   const float cLight = CLHEP::c_light / 1.0E5;
-  const float convertRToPt = cLight * b_field;
+  const float convertRtoPt = cLight * b_field;
 
   // ----------------------------------------------------------------------------------------------
   // loop over L1 stubs
@@ -1180,7 +1180,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       const auto& helixCovMat = iterL1Track->helixCovMat();
       // Protect against wierd covariance matrices with negatives.
       auto safeSqrt = [](float q) { return q >= 0 ? sqrt(q) : -sqrt(-q); };
-      float tmp_trk_sigma_qOverPt = 2 * safeSqrt(helixCovMat[0][0]) / convertRToPt;
+      float tmp_trk_sigma_qOverPt = 2 * safeSqrt(helixCovMat[0][0]) / convertRtoPt;
       float tmp_trk_sigma_phi = safeSqrt(helixCovMat[1][1]);
       float tmp_trk_sigma_tanL = safeSqrt(helixCovMat[2][2]);
       float tmp_trk_sigma_z0 = safeSqrt(helixCovMat[3][3]);
@@ -1445,7 +1445,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         float delx = -tmp_matchtp_vx;
         float dely = -tmp_matchtp_vy;
 
-        float r2_inv = my_tp->charge() * convertRToPt / tmp_matchtp_pt / 2.0;
+        float r2_inv = my_tp->charge() * convertRtoPt / tmp_matchtp_pt / 2.0;
 
         float tmp_matchtp_x0p = delx - (1. / (2. * r2_inv) * sin(tmp_matchtp_phi));
         float tmp_matchtp_y0p = dely + (1. / (2. * r2_inv) * cos(tmp_matchtp_phi));
@@ -1553,7 +1553,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float delx = -tmp_tp_vx;
     float dely = -tmp_tp_vy;
 
-    float r2_inv = tmp_tp_charge * convertRToPt / tmp_tp_pt / 2.0;
+    float r2_inv = tmp_tp_charge * convertRtoPt / tmp_tp_pt / 2.0;
 
     float tmp_tp_x0p = delx - (1. / (2. * r2_inv) * sin(tmp_tp_phi));  // centre of track circle (except sign ...)
     float tmp_tp_y0p = dely + (1. / (2. * r2_inv) * cos(tmp_tp_phi));

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -178,6 +178,9 @@ private:
   std::vector<float>* m_trk_sigma_d0;
   std::vector<float>* m_trk_sigma_z0;
   std::vector<float>* m_trk_sigma_tanL;
+  std::vector<float>* m_trk_pt_beamCon;  // Helix params constrained to x=y=0.
+  std::vector<float>* m_trk_phi_beamCon;
+  std::vector<float>* m_trk_chi2rphi_dof_beamCon;
   std::vector<int>* m_trk_nstub;
   std::vector<int>* m_trk_lhits;
   std::vector<int>* m_trk_dhits;
@@ -205,7 +208,7 @@ private:
   // N.B. This TP not required to have stubs in at least 4 layers.
 
   std::vector<int>*
-      m_trk_matchtp_eventtype;  //event type: 0 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
+      m_trk_matchtp_eventtype;  //event type: -999 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
   std::vector<int>* m_trk_matchtp_pdgid;
   // kinematics of matching truth particle
   std::vector<float>* m_trk_matchtp_pt;
@@ -252,6 +255,9 @@ private:
   std::vector<float>* m_matchtrk_chi2rz_dof;
   std::vector<float>* m_matchtrk_bendchi2;
   std::vector<float>* m_matchtrk_MVA1;
+  std::vector<float>* m_matchtrk_pt_beamCon;  // Helix params constrained to x=y=0.
+  std::vector<float>* m_matchtrk_phi_beamCon;
+  std::vector<float>* m_matchtrk_chi2rphi_dof_beamCon;
   std::vector<int>* m_matchtrk_nstub;
   std::vector<int>* m_matchtrk_lhits;
   std::vector<int>* m_matchtrk_dhits;
@@ -375,6 +381,9 @@ void L1TrackNtupleMaker::endJob() {
   delete m_trk_sigma_d0;
   delete m_trk_sigma_z0;
   delete m_trk_sigma_tanL;
+  delete m_trk_pt_beamCon;
+  delete m_trk_phi_beamCon;
+  delete m_trk_chi2rphi_dof_beamCon;
   delete m_trk_nstub;
   delete m_trk_lhits;
   delete m_trk_dhits;
@@ -439,6 +448,9 @@ void L1TrackNtupleMaker::endJob() {
   delete m_matchtrk_chi2rz_dof;
   delete m_matchtrk_bendchi2;
   delete m_matchtrk_MVA1;
+  delete m_matchtrk_pt_beamCon;
+  delete m_matchtrk_phi_beamCon;
+  delete m_matchtrk_chi2rphi_dof_beamCon;
   delete m_matchtrk_nstub;
   delete m_matchtrk_dhits;
   delete m_matchtrk_lhits;
@@ -507,6 +519,9 @@ void L1TrackNtupleMaker::beginJob() {
   m_trk_sigma_d0 = new std::vector<float>;
   m_trk_sigma_z0 = new std::vector<float>;
   m_trk_sigma_tanL = new std::vector<float>;
+  m_trk_pt_beamCon = new std::vector<float>;
+  m_trk_phi_beamCon = new std::vector<float>;
+  m_trk_chi2rphi_dof_beamCon = new std::vector<float>;
   m_trk_nstub = new std::vector<int>;
   m_trk_lhits = new std::vector<int>;
   m_trk_dhits = new std::vector<int>;
@@ -571,6 +586,9 @@ void L1TrackNtupleMaker::beginJob() {
   m_matchtrk_chi2rz_dof = new std::vector<float>;
   m_matchtrk_bendchi2 = new std::vector<float>;
   m_matchtrk_MVA1 = new std::vector<float>;
+  m_matchtrk_pt_beamCon = new std::vector<float>;
+  m_matchtrk_phi_beamCon = new std::vector<float>;
+  m_matchtrk_chi2rphi_dof_beamCon = new std::vector<float>;
   m_matchtrk_nstub = new std::vector<int>;
   m_matchtrk_dhits = new std::vector<int>;
   m_matchtrk_lhits = new std::vector<int>;
@@ -631,6 +649,9 @@ void L1TrackNtupleMaker::beginJob() {
     eventTree->Branch("trk_sigma_d0", &m_trk_sigma_d0);
     eventTree->Branch("trk_sigma_z0", &m_trk_sigma_z0);
     eventTree->Branch("trk_sigma_tanL", &m_trk_sigma_tanL);
+    eventTree->Branch("trk_pt_beamCon", &m_trk_pt_beamCon);
+    eventTree->Branch("trk_phi_beamCon", &m_trk_phi_beamCon);
+    eventTree->Branch("trk_chi2rphi_dof_beamCon", &m_trk_chi2rphi_dof_beamCon);
     eventTree->Branch("trk_nstub", &m_trk_nstub);
     eventTree->Branch("trk_lhits", &m_trk_lhits);
     eventTree->Branch("trk_dhits", &m_trk_dhits);
@@ -700,6 +721,9 @@ void L1TrackNtupleMaker::beginJob() {
   eventTree->Branch("matchtrk_chi2rz_dof", &m_matchtrk_chi2rz_dof);
   eventTree->Branch("matchtrk_bendchi2", &m_matchtrk_bendchi2);
   eventTree->Branch("matchtrk_MVA1", &m_matchtrk_MVA1);
+  eventTree->Branch("matchtrk_pt_beamCon", &m_matchtrk_pt_beamCon);
+  eventTree->Branch("matchtrk_phi_beamCon", &m_matchtrk_phi_beamCon);
+  eventTree->Branch("matchtrk_chi2rphi_dof_beamCon", &m_matchtrk_chi2rphi_dof_beamCon);
   eventTree->Branch("matchtrk_nstub", &m_matchtrk_nstub);
   eventTree->Branch("matchtrk_lhits", &m_matchtrk_lhits);
   eventTree->Branch("matchtrk_dhits", &m_matchtrk_dhits);
@@ -784,6 +808,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_trk_sigma_d0->clear();
     m_trk_sigma_z0->clear();
     m_trk_sigma_tanL->clear();
+    m_trk_pt_beamCon->clear();
+    m_trk_phi_beamCon->clear();
+    m_trk_chi2rphi_dof_beamCon->clear();
     m_trk_nstub->clear();
     m_trk_lhits->clear();
     m_trk_dhits->clear();
@@ -849,6 +876,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
   m_matchtrk_chi2rz_dof->clear();
   m_matchtrk_bendchi2->clear();
   m_matchtrk_MVA1->clear();
+  m_matchtrk_pt_beamCon->clear();
+  m_matchtrk_phi_beamCon->clear();
+  m_matchtrk_chi2rphi_dof_beamCon->clear();
   m_matchtrk_nstub->clear();
   m_matchtrk_lhits->clear();
   m_matchtrk_dhits->clear();
@@ -1128,9 +1158,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         edm::LogVerbatim("Tracklet") << *iterL1Track;
       }
 
-      float tmp_trk_pt = iterL1Track->momentum().perp();
-      float tmp_trk_eta = iterL1Track->momentum().eta();
-      float tmp_trk_phi = iterL1Track->momentum().phi();
+      float tmp_trk_pt = iterL1Track->pt();
+      float tmp_trk_eta = iterL1Track->eta();
+      float tmp_trk_phi = iterL1Track->phi();
       float tmp_trk_z0 = iterL1Track->z0();  //cm
       float tmp_trk_tanL = iterL1Track->tanL();
       float tmp_trk_zT = iterL1Track->z0() + setup->chosenRofZ() * iterL1Track->tanL();
@@ -1182,15 +1212,21 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_bendchi2 = iterL1Track->chi2BendRed();
       float tmp_trk_MVA1 = iterL1Track->trkMVA1();
 
+      // Constrain track to x=y=0
+      float tmp_trk_phi_beamCon, tmp_trk_rInv_beamCon, tmp_trk_pt_beamCon, tmp_trk_chi2rphi_beamCon,
+          tmp_trk_chi2rphi_dof_beamCon;
+      iterL1Track->beamConstraint(tmp_trk_phi_beamCon,
+                                  tmp_trk_rInv_beamCon,
+                                  tmp_trk_pt_beamCon,
+                                  tmp_trk_chi2rphi_beamCon,
+                                  tmp_trk_chi2rphi_dof_beamCon);
+
       std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>>
           stubRefs = iterL1Track->getStubRefs();
       int tmp_trk_nstub = (int)stubRefs.size();
-      int ndof = 2 * tmp_trk_nstub - L1Tk_nPar;
-      int ndofrphi = tmp_trk_nstub - L1Tk_nPar + 2;
-      int ndofrz = tmp_trk_nstub - 2;
-      float tmp_trk_chi2_dof = (float)tmp_trk_chi2 / ndof;
-      float tmp_trk_chi2rphi_dof = (float)tmp_trk_chi2rphi / ndofrphi;
-      float tmp_trk_chi2rz_dof = (float)tmp_trk_chi2rz / ndofrz;
+      float tmp_trk_chi2_dof = iterL1Track->chi2Red();
+      float tmp_trk_chi2rphi_dof = iterL1Track->chi2XYRed();
+      float tmp_trk_chi2rz_dof = iterL1Track->chi2ZRed();
 
       int tmp_trk_seed = 0;
       tmp_trk_seed = (int)iterL1Track->trackSeedType();
@@ -1328,6 +1364,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       m_trk_sigma_d0->push_back(tmp_trk_sigma_d0);
       m_trk_sigma_tanL->push_back(tmp_trk_sigma_tanL);
       m_trk_MVA1->push_back(tmp_trk_MVA1);
+      m_trk_pt_beamCon->push_back(tmp_trk_pt_beamCon);
+      m_trk_phi_beamCon->push_back(tmp_trk_phi_beamCon);
+      m_trk_chi2rphi_dof_beamCon->push_back(tmp_trk_chi2rphi_dof_beamCon);
       m_trk_nstub->push_back(tmp_trk_nstub);
       m_trk_dhits->push_back(tmp_trk_dhits);
       m_trk_lhits->push_back(tmp_trk_lhits);
@@ -1720,6 +1759,11 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float tmp_matchtrk_chi2rz_dof = -999;
     float tmp_matchtrk_bendchi2 = -999;
     float tmp_matchtrk_MVA1 = -999;
+    float tmp_matchtrk_phi_beamCon = -999;
+    float tmp_matchtrk_rInv_beamCon = -999;
+    float tmp_matchtrk_pt_beamCon = -999;
+    float tmp_matchtrk_chi2rphi_beamCon = -999;
+    float tmp_matchtrk_chi2rphi_dof_beamCon = -999;
     int tmp_matchtrk_charge = -999;
     int tmp_matchtrk_nstub = -999;
     int tmp_matchtrk_dhits = -999;
@@ -1731,10 +1775,10 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       edm::LogVerbatim("Tracklet") << "WARNING *** 2 or more matches to genuine L1 tracks ***";
 
     if (nMatch > 0) {  // TP matches at least 1 genuine track
-      tmp_matchtrk_pt = matchedTracks.at(i_track)->momentum().perp();
+      tmp_matchtrk_pt = matchedTracks.at(i_track)->pt();
       tmp_matchtrk_charge = (int)TMath::Sign(1, matchedTracks.at(i_track)->rInv());
-      tmp_matchtrk_eta = matchedTracks.at(i_track)->momentum().eta();
-      tmp_matchtrk_phi = matchedTracks.at(i_track)->momentum().phi();
+      tmp_matchtrk_eta = matchedTracks.at(i_track)->eta();
+      tmp_matchtrk_phi = matchedTracks.at(i_track)->phi();
       tmp_matchtrk_z0 = matchedTracks.at(i_track)->z0();
 
       if (L1Tk_nPar == 5) {
@@ -1751,13 +1795,16 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       tmp_matchtrk_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
       tmp_matchtrk_seed = (int)matchedTracks.at(i_track)->trackSeedType();
       tmp_matchtrk_hitpattern = (int)matchedTracks.at(i_track)->hitPattern();
+      tmp_matchtrk_chi2_dof = matchedTracks.at(i_track)->chi2Red();
+      tmp_matchtrk_chi2rphi_dof = matchedTracks.at(i_track)->chi2XYRed();
+      tmp_matchtrk_chi2rz_dof = matchedTracks.at(i_track)->chi2ZRed();
 
-      int ndof = 2 * tmp_matchtrk_nstub - L1Tk_nPar;
-      int ndofrphi = tmp_matchtrk_nstub - L1Tk_nPar + 2;
-      int ndofrz = tmp_matchtrk_nstub - 2;
-      tmp_matchtrk_chi2_dof = (float)tmp_matchtrk_chi2 / ndof;
-      tmp_matchtrk_chi2rphi_dof = (float)tmp_matchtrk_chi2rphi / ndofrphi;
-      tmp_matchtrk_chi2rz_dof = (float)tmp_matchtrk_chi2rz / ndofrz;
+      // Constrain track to x=y=0
+      matchedTracks.at(i_track)->beamConstraint(tmp_matchtrk_phi_beamCon,
+                                                tmp_matchtrk_rInv_beamCon,
+                                                tmp_matchtrk_pt_beamCon,
+                                                tmp_matchtrk_chi2rphi_beamCon,
+                                                tmp_matchtrk_chi2rphi_dof_beamCon);
 
       // ------------------------------------------------------------------------------------------
 
@@ -1814,6 +1861,9 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_matchtrk_chi2rz->push_back(tmp_matchtrk_chi2rz);
     m_matchtrk_bendchi2->push_back(tmp_matchtrk_bendchi2);
     m_matchtrk_MVA1->push_back(tmp_matchtrk_MVA1);
+    m_matchtrk_pt_beamCon->push_back(tmp_matchtrk_pt_beamCon);
+    m_matchtrk_phi_beamCon->push_back(tmp_matchtrk_phi_beamCon);
+    m_matchtrk_chi2rphi_dof_beamCon->push_back(tmp_matchtrk_chi2rphi_dof_beamCon);
     m_matchtrk_nstub->push_back(tmp_matchtrk_nstub);
     m_matchtrk_dhits->push_back(tmp_matchtrk_dhits);
     m_matchtrk_lhits->push_back(tmp_matchtrk_lhits);

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -180,6 +180,7 @@ private:
   std::vector<float>* m_trk_sigma_tanL;
   std::vector<float>* m_trk_pt_beamCon;  // Helix params constrained to x=y=0.
   std::vector<float>* m_trk_phi_beamCon;
+  std::vector<float>* m_trk_chi2rphi_beamCon;
   std::vector<float>* m_trk_chi2rphi_dof_beamCon;
   std::vector<int>* m_trk_nstub;
   std::vector<int>* m_trk_lhits;
@@ -257,6 +258,7 @@ private:
   std::vector<float>* m_matchtrk_MVA1;
   std::vector<float>* m_matchtrk_pt_beamCon;  // Helix params constrained to x=y=0.
   std::vector<float>* m_matchtrk_phi_beamCon;
+  std::vector<float>* m_matchtrk_chi2rphi_beamCon;
   std::vector<float>* m_matchtrk_chi2rphi_dof_beamCon;
   std::vector<int>* m_matchtrk_nstub;
   std::vector<int>* m_matchtrk_lhits;
@@ -383,6 +385,7 @@ void L1TrackNtupleMaker::endJob() {
   delete m_trk_sigma_tanL;
   delete m_trk_pt_beamCon;
   delete m_trk_phi_beamCon;
+  delete m_trk_chi2rphi_beamCon;
   delete m_trk_chi2rphi_dof_beamCon;
   delete m_trk_nstub;
   delete m_trk_lhits;
@@ -450,6 +453,7 @@ void L1TrackNtupleMaker::endJob() {
   delete m_matchtrk_MVA1;
   delete m_matchtrk_pt_beamCon;
   delete m_matchtrk_phi_beamCon;
+  delete m_matchtrk_chi2rphi_beamCon;
   delete m_matchtrk_chi2rphi_dof_beamCon;
   delete m_matchtrk_nstub;
   delete m_matchtrk_dhits;
@@ -521,6 +525,7 @@ void L1TrackNtupleMaker::beginJob() {
   m_trk_sigma_tanL = new std::vector<float>;
   m_trk_pt_beamCon = new std::vector<float>;
   m_trk_phi_beamCon = new std::vector<float>;
+  m_trk_chi2rphi_beamCon = new std::vector<float>;
   m_trk_chi2rphi_dof_beamCon = new std::vector<float>;
   m_trk_nstub = new std::vector<int>;
   m_trk_lhits = new std::vector<int>;
@@ -588,6 +593,7 @@ void L1TrackNtupleMaker::beginJob() {
   m_matchtrk_MVA1 = new std::vector<float>;
   m_matchtrk_pt_beamCon = new std::vector<float>;
   m_matchtrk_phi_beamCon = new std::vector<float>;
+  m_matchtrk_chi2rphi_beamCon = new std::vector<float>;
   m_matchtrk_chi2rphi_dof_beamCon = new std::vector<float>;
   m_matchtrk_nstub = new std::vector<int>;
   m_matchtrk_dhits = new std::vector<int>;
@@ -651,6 +657,7 @@ void L1TrackNtupleMaker::beginJob() {
     eventTree->Branch("trk_sigma_tanL", &m_trk_sigma_tanL);
     eventTree->Branch("trk_pt_beamCon", &m_trk_pt_beamCon);
     eventTree->Branch("trk_phi_beamCon", &m_trk_phi_beamCon);
+    eventTree->Branch("trk_chi2rphi_beamCon", &m_trk_chi2rphi_beamCon);
     eventTree->Branch("trk_chi2rphi_dof_beamCon", &m_trk_chi2rphi_dof_beamCon);
     eventTree->Branch("trk_nstub", &m_trk_nstub);
     eventTree->Branch("trk_lhits", &m_trk_lhits);
@@ -723,6 +730,7 @@ void L1TrackNtupleMaker::beginJob() {
   eventTree->Branch("matchtrk_MVA1", &m_matchtrk_MVA1);
   eventTree->Branch("matchtrk_pt_beamCon", &m_matchtrk_pt_beamCon);
   eventTree->Branch("matchtrk_phi_beamCon", &m_matchtrk_phi_beamCon);
+  eventTree->Branch("matchtrk_chi2rphi_beamCon", &m_matchtrk_chi2rphi_beamCon);
   eventTree->Branch("matchtrk_chi2rphi_dof_beamCon", &m_matchtrk_chi2rphi_dof_beamCon);
   eventTree->Branch("matchtrk_nstub", &m_matchtrk_nstub);
   eventTree->Branch("matchtrk_lhits", &m_matchtrk_lhits);
@@ -810,6 +818,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_trk_sigma_tanL->clear();
     m_trk_pt_beamCon->clear();
     m_trk_phi_beamCon->clear();
+    m_trk_chi2rphi_beamCon->clear();
     m_trk_chi2rphi_dof_beamCon->clear();
     m_trk_nstub->clear();
     m_trk_lhits->clear();
@@ -878,6 +887,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
   m_matchtrk_MVA1->clear();
   m_matchtrk_pt_beamCon->clear();
   m_matchtrk_phi_beamCon->clear();
+  m_matchtrk_chi2rphi_beamCon->clear();
   m_matchtrk_chi2rphi_dof_beamCon->clear();
   m_matchtrk_nstub->clear();
   m_matchtrk_lhits->clear();
@@ -1366,6 +1376,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       m_trk_MVA1->push_back(tmp_trk_MVA1);
       m_trk_pt_beamCon->push_back(tmp_trk_pt_beamCon);
       m_trk_phi_beamCon->push_back(tmp_trk_phi_beamCon);
+      m_trk_chi2rphi_beamCon->push_back(tmp_trk_chi2rphi_beamCon);
       m_trk_chi2rphi_dof_beamCon->push_back(tmp_trk_chi2rphi_dof_beamCon);
       m_trk_nstub->push_back(tmp_trk_nstub);
       m_trk_dhits->push_back(tmp_trk_dhits);
@@ -1863,6 +1874,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_matchtrk_MVA1->push_back(tmp_matchtrk_MVA1);
     m_matchtrk_pt_beamCon->push_back(tmp_matchtrk_pt_beamCon);
     m_matchtrk_phi_beamCon->push_back(tmp_matchtrk_phi_beamCon);
+    m_matchtrk_chi2rphi_beamCon->push_back(tmp_matchtrk_chi2rphi_beamCon);
     m_matchtrk_chi2rphi_dof_beamCon->push_back(tmp_matchtrk_chi2rphi_dof_beamCon);
     m_matchtrk_nstub->push_back(tmp_matchtrk_nstub);
     m_matchtrk_dhits->push_back(tmp_matchtrk_dhits);

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1123,6 +1123,11 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       edm::Ptr<TTTrack<Ref_Phase2TrackerDigi_>> l1track_ptr(TTTrackHandle, this_l1track);
       this_l1track++;
 
+      if (DebugMode) {
+        // Print L1 track helix params etc.
+        edm::LogVerbatim("Tracklet") << *iterL1Track;
+      }
+
       float tmp_trk_pt = iterL1Track->momentum().perp();
       float tmp_trk_eta = iterL1Track->momentum().eta();
       float tmp_trk_phi = iterL1Track->momentum().phi();
@@ -1131,6 +1136,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_zT = iterL1Track->z0() + setup->chosenRofZ() * iterL1Track->tanL();
       int tmp_trk_charge = (int)TMath::Sign(1, iterL1Track->rInv());
 
+      int nHelixPars = iterL1Track->nFitPars();
       const auto& helixCovMat = iterL1Track->helixCovMat();
       // Protect against wierd covariance matrices with negatives.
       auto safeSqrt = [](float q) { return q >= 0 ? sqrt(q) : -sqrt(-q); };
@@ -1138,7 +1144,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_sigma_phi = safeSqrt(helixCovMat[1][1]);
       float tmp_trk_sigma_tanL = safeSqrt(helixCovMat[2][2]);
       float tmp_trk_sigma_z0 = safeSqrt(helixCovMat[3][3]);
-      float tmp_trk_sigma_d0 = safeSqrt(helixCovMat[4][4]);
+      float tmp_trk_sigma_d0 = (nHelixPars == 5) ? safeSqrt(helixCovMat[4][4]) : 0.;
 
       int tmp_trk_hitpattern = 0;
       tmp_trk_hitpattern = (int)iterL1Track->hitPattern();

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -173,6 +173,11 @@ private:
   std::vector<float>* m_trk_chi2rz;
   std::vector<float>* m_trk_chi2rz_dof;
   std::vector<float>* m_trk_bendchi2;
+  std::vector<float>* m_trk_sigma_qOverPt;  // Uncertainties from fitted helix covariance matrix
+  std::vector<float>* m_trk_sigma_phi;
+  std::vector<float>* m_trk_sigma_d0;
+  std::vector<float>* m_trk_sigma_z0;
+  std::vector<float>* m_trk_sigma_tanL;
   std::vector<int>* m_trk_nstub;
   std::vector<int>* m_trk_lhits;
   std::vector<int>* m_trk_dhits;
@@ -202,6 +207,7 @@ private:
   std::vector<int>*
       m_trk_matchtp_eventtype;  //event type: 0 = fake track (not genuine), 1 = TP from signal pp event, 2 = TP from pileup
   std::vector<int>* m_trk_matchtp_pdgid;
+  // kinematics of matching truth particle
   std::vector<float>* m_trk_matchtp_pt;
   std::vector<float>* m_trk_matchtp_eta;
   std::vector<float>* m_trk_matchtp_phi;
@@ -364,6 +370,11 @@ void L1TrackNtupleMaker::endJob() {
   delete m_trk_chi2rz;
   delete m_trk_chi2rz_dof;
   delete m_trk_bendchi2;
+  delete m_trk_sigma_qOverPt;
+  delete m_trk_sigma_phi;
+  delete m_trk_sigma_d0;
+  delete m_trk_sigma_z0;
+  delete m_trk_sigma_tanL;
   delete m_trk_nstub;
   delete m_trk_lhits;
   delete m_trk_dhits;
@@ -491,6 +502,11 @@ void L1TrackNtupleMaker::beginJob() {
   m_trk_chi2rz = new std::vector<float>;
   m_trk_chi2rz_dof = new std::vector<float>;
   m_trk_bendchi2 = new std::vector<float>;
+  m_trk_sigma_qOverPt = new std::vector<float>;
+  m_trk_sigma_phi = new std::vector<float>;
+  m_trk_sigma_d0 = new std::vector<float>;
+  m_trk_sigma_z0 = new std::vector<float>;
+  m_trk_sigma_tanL = new std::vector<float>;
   m_trk_nstub = new std::vector<int>;
   m_trk_lhits = new std::vector<int>;
   m_trk_dhits = new std::vector<int>;
@@ -610,6 +626,11 @@ void L1TrackNtupleMaker::beginJob() {
     eventTree->Branch("trk_chi2rz", &m_trk_chi2rz);
     eventTree->Branch("trk_chi2rz_dof", &m_trk_chi2rz_dof);
     eventTree->Branch("trk_bendchi2", &m_trk_bendchi2);
+    eventTree->Branch("trk_sigma_qOverPt", &m_trk_sigma_qOverPt);
+    eventTree->Branch("trk_sigma_phi", &m_trk_sigma_phi);
+    eventTree->Branch("trk_sigma_d0", &m_trk_sigma_d0);
+    eventTree->Branch("trk_sigma_z0", &m_trk_sigma_z0);
+    eventTree->Branch("trk_sigma_tanL", &m_trk_sigma_tanL);
     eventTree->Branch("trk_nstub", &m_trk_nstub);
     eventTree->Branch("trk_lhits", &m_trk_lhits);
     eventTree->Branch("trk_dhits", &m_trk_dhits);
@@ -758,6 +779,11 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_trk_chi2rz->clear();
     m_trk_chi2rz_dof->clear();
     m_trk_bendchi2->clear();
+    m_trk_sigma_qOverPt->clear();
+    m_trk_sigma_phi->clear();
+    m_trk_sigma_d0->clear();
+    m_trk_sigma_z0->clear();
+    m_trk_sigma_tanL->clear();
     m_trk_nstub->clear();
     m_trk_lhits->clear();
     m_trk_dhits->clear();
@@ -907,6 +933,11 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
   const hph::Setup* hphSetup = hphHandle.product();
   const tt::Setup* setup = handleSetup.product();
   const trackerTFP::LayerEncoding* layerEncoding = handleLayerEncoding.product();
+
+  // Conversion factor curvature radius to Pt.
+  const float b_field = bFieldHandle.product()->inTesla(GlobalPoint(0, 0, 0)).z();
+  const float cLight = CLHEP::c_light / 1.0E5;
+  const float convertRToPt = cLight * b_field;
 
   // ----------------------------------------------------------------------------------------------
   // loop over L1 stubs
@@ -1100,6 +1131,15 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_zT = iterL1Track->z0() + setup->chosenRofZ() * iterL1Track->tanL();
       int tmp_trk_charge = (int)TMath::Sign(1, iterL1Track->rInv());
 
+      const auto& helixCovMat = iterL1Track->helixCovMat();
+      // Protect against wierd covariance matrices with negatives.
+      auto safeSqrt = [](float q) { return q >= 0 ? sqrt(q) : -sqrt(-q); };
+      float tmp_trk_sigma_qOverPt = 2 * safeSqrt(helixCovMat[0][0]) / convertRToPt;
+      float tmp_trk_sigma_phi = safeSqrt(helixCovMat[1][1]);
+      float tmp_trk_sigma_tanL = safeSqrt(helixCovMat[2][2]);
+      float tmp_trk_sigma_z0 = safeSqrt(helixCovMat[3][3]);
+      float tmp_trk_sigma_d0 = safeSqrt(helixCovMat[4][4]);
+
       int tmp_trk_hitpattern = 0;
       tmp_trk_hitpattern = (int)iterL1Track->hitPattern();
       // TO FIX -- The HitPatternHelper code contains several bugs & design flaws.
@@ -1276,6 +1316,11 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       m_trk_chi2rz->push_back(tmp_trk_chi2rz);
       m_trk_chi2rz_dof->push_back(tmp_trk_chi2rz_dof);
       m_trk_bendchi2->push_back(tmp_trk_bendchi2);
+      m_trk_sigma_qOverPt->push_back(tmp_trk_sigma_qOverPt);
+      m_trk_sigma_phi->push_back(tmp_trk_sigma_phi);
+      m_trk_sigma_z0->push_back(tmp_trk_sigma_z0);
+      m_trk_sigma_d0->push_back(tmp_trk_sigma_d0);
+      m_trk_sigma_tanL->push_back(tmp_trk_sigma_tanL);
       m_trk_MVA1->push_back(tmp_trk_MVA1);
       m_trk_nstub->push_back(tmp_trk_nstub);
       m_trk_dhits->push_back(tmp_trk_dhits);
@@ -1344,9 +1389,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
         float delx = -tmp_matchtp_vx;
         float dely = -tmp_matchtp_vy;
 
-        float b_field = bFieldHandle.product()->inTesla(GlobalPoint(0, 0, 0)).z();
-        float c_converted = CLHEP::c_light / 1.0E5;
-        float r2_inv = my_tp->charge() * c_converted * b_field / tmp_matchtp_pt / 2.0;
+        float r2_inv = my_tp->charge() * convertRToPt / tmp_matchtp_pt / 2.0;
 
         float tmp_matchtp_x0p = delx - (1. / (2. * r2_inv) * sin(tmp_matchtp_phi));
         float tmp_matchtp_y0p = dely + (1. / (2. * r2_inv) * cos(tmp_matchtp_phi));
@@ -1454,9 +1497,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float delx = -tmp_tp_vx;
     float dely = -tmp_tp_vy;
 
-    float b_field = bFieldHandle.product()->inTesla(GlobalPoint(0, 0, 0)).z();
-    float c_converted = CLHEP::c_light / 1.0E5;
-    float r2_inv = tmp_tp_charge * c_converted * b_field / tmp_tp_pt / 2.0;
+    float r2_inv = tmp_tp_charge * convertRToPt / tmp_tp_pt / 2.0;
 
     float tmp_tp_x0p = delx - (1. / (2. * r2_inv) * sin(tmp_tp_phi));  // centre of track circle (except sign ...)
     float tmp_tp_y0p = dely + (1. / (2. * r2_inv) * cos(tmp_tp_phi));

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -1180,11 +1180,12 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       const auto& helixCovMat = iterL1Track->helixCovMat();
       // Protect against wierd covariance matrices with negatives.
       auto safeSqrt = [](float q) { return q >= 0 ? sqrt(q) : -sqrt(-q); };
-      float tmp_trk_sigma_qOverPt = 2 * safeSqrt(helixCovMat[0][0]) / convertRtoPt;
-      float tmp_trk_sigma_phi = safeSqrt(helixCovMat[1][1]);
-      float tmp_trk_sigma_tanL = safeSqrt(helixCovMat[2][2]);
-      float tmp_trk_sigma_z0 = safeSqrt(helixCovMat[3][3]);
-      float tmp_trk_sigma_d0 = (nHelixPars == 5) ? safeSqrt(helixCovMat[4][4]) : 0.;
+      using enum TTTrack<Ref_Phase2TrackerDigi_>::Hpar;
+      float tmp_trk_sigma_qOverPt = 2 * safeSqrt(helixCovMat[INVR][INVR]) / convertRtoPt;
+      float tmp_trk_sigma_phi = safeSqrt(helixCovMat[PHI0][PHI0]);
+      float tmp_trk_sigma_tanL = safeSqrt(helixCovMat[TANL][TANL]);
+      float tmp_trk_sigma_z0 = safeSqrt(helixCovMat[Z0][Z0]);
+      float tmp_trk_sigma_d0 = (nHelixPars == 5) ? safeSqrt(helixCovMat[D0][D0]) : 0.;
 
       int tmp_trk_hitpattern = 0;
       tmp_trk_hitpattern = (int)iterL1Track->hitPattern();

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -38,8 +38,7 @@ void mySmallText(Double_t x, Double_t y, Color_t color, char* text);
 double getIntervalContainingFractionOfEntries(TH1* histogram, double interval, int minEntries = 10);
 void makeResidualIntervalPlot(
     TString type, TString dir, TString variable, TH1F* h_68, TH1F* h_90, TH1F* h_99, double minY, double maxY);
-void makeAllAndTruePDF(TString type, TString dir, TString variable,
-                        TH1F* h_all, TH1F* h_match);
+void makeAllAndTruePDF(TString type, TString dir, TString variable, TH1F* h_all, TH1F* h_match);
 
 // ----------------------------------------------------------------------------------------------------------------
 // Main script
@@ -87,6 +86,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
 
   constexpr bool doGausFit = false;  //do gaussian fit for resolution vs eta/pt plots
 
+  constexpr float convertRtoPt =
+      0.0114257;  // R (cm) * convertRtoPt = Pt (GeV) * q : calculation in L1TrackNtupleMaker.cc
+
   gROOT->SetBatch();
   gErrorIgnoreLevel = kWarning;
 
@@ -132,8 +134,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   tree->Add(inputDir + inputRootFile + ".root");
 
   if (tree->GetEntries() == 0) {
-    cerr << "Input file doesn't exist or is empty, returning..."
-         << endl;  
+    cerr << "Input file doesn't exist or is empty, returning..." << endl;
     return;
   }
 
@@ -193,7 +194,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   vector<float>* trk_chi2rphi_dof;
   vector<float>* trk_chi2rz;
   vector<float>* trk_chi2rz_dof;
-  vector<float>* trk_chi2rphi_dof_beamCon;  
+  vector<float>* trk_chi2rphi_dof_beamCon;
   vector<int>* trk_nstub;
   vector<int>* trk_lhits;
   vector<int>* trk_dhits;
@@ -370,7 +371,8 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   tree->SetBranchAddress("matchtrk_chi2rz_dof", &matchtrk_chi2rz_dof, &b_matchtrk_chi2rz_dof);
   tree->SetBranchAddress("matchtrk_pt_beamCon", &matchtrk_pt_beamCon, &b_matchtrk_pt_beamCon);
   tree->SetBranchAddress("matchtrk_phi_beamCon", &matchtrk_phi_beamCon, &b_matchtrk_phi_beamCon);
-  tree->SetBranchAddress("matchtrk_chi2rphi_dof_beamCon", &matchtrk_chi2rphi_dof_beamCon, &b_matchtrk_chi2rphi_dof_beamCon);
+  tree->SetBranchAddress(
+      "matchtrk_chi2rphi_dof_beamCon", &matchtrk_chi2rphi_dof_beamCon, &b_matchtrk_chi2rphi_dof_beamCon);
   tree->SetBranchAddress("matchtrk_nstub", &matchtrk_nstub, &b_matchtrk_nstub);
   tree->SetBranchAddress("matchtrk_lhits", &matchtrk_lhits, &b_matchtrk_lhits);
   tree->SetBranchAddress("matchtrk_dhits", &matchtrk_dhits, &b_matchtrk_dhits);
@@ -490,7 +492,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   // resolution interval plots.
   // If ranges are too small, warnings will be printed to cerr.
   // (The plots booked here are not output, just used for these calculations).
-  
+
   unsigned int nBinsPtRes = 500;
   double maxPtRes = 30.;
 
@@ -545,36 +547,39 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TH1F* h_absResVsPt_d0_L[nRANGE_L];
 
   for (int i = 0; i < nRANGE; i++) {
-    h_absResVsPt_pt[i] = new TH1F(
-        "absResVsPt_pt_" + ptrange[i], ";p_{T} residual (L1 - sim) [GeV]; L1 tracks", nBinsPtRes, 0, maxPtRes);
+    h_absResVsPt_pt[i] =
+        new TH1F("absResVsPt_pt_" + ptrange[i], ";p_{T} residual (L1 - sim) [GeV]; L1 tracks", nBinsPtRes, 0, maxPtRes);
     h_absResVsPt_ptRel[i] = new TH1F("absResVsPt_ptRel_" + ptrange[i],
                                      ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks",
                                      nBinsPtRelRes,
                                      0,
                                      maxPtRelRes);
-    h_absResVsPt_z0[i] = new TH1F(
-        "absResVsPt_z0_" + ptrange[i], ";z_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
-    h_absResVsPt_phi[i] = new TH1F(
-        "absResVsPt_phi_" + ptrange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
-    h_absResVsPt_eta[i] = new TH1F(
-        "absResVsPt_eta_" + ptrange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
-    h_absResVsPt_d0[i] = new TH1F(
-      "absResVsPt_d0_" + ptrange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsD0Res, 0, maxD0Res);
+    h_absResVsPt_z0[i] =
+        new TH1F("absResVsPt_z0_" + ptrange[i], ";z_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
+    h_absResVsPt_phi[i] =
+        new TH1F("absResVsPt_phi_" + ptrange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
+    h_absResVsPt_eta[i] =
+        new TH1F("absResVsPt_eta_" + ptrange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
+    h_absResVsPt_d0[i] =
+        new TH1F("absResVsPt_d0_" + ptrange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsD0Res, 0, maxD0Res);
   }
 
   for (int i = 0; i < nRANGE_L; i++) {
     h_absResVsPt_pt_L[i] = new TH1F(
         "absResVsPt_L_pt_" + ptrange_L[i], ";p_{T} residual (L1 - sim) [GeV]; L1 tracks", nBinsPtRes, 0, maxPtRes);
-    h_absResVsPt_ptRel_L[i] = new TH1F(
-        "absResVsPt_L_ptRel_" + ptrange_L[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
+    h_absResVsPt_ptRel_L[i] = new TH1F("absResVsPt_L_ptRel_" + ptrange_L[i],
+                                       ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks",
+                                       nBinsPtRelRes,
+                                       0,
+                                       maxPtRelRes);
     h_absResVsPt_z0_L[i] = new TH1F(
         "absResVsPt_L_z0_" + ptrange_L[i], ";z_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
-    h_absResVsPt_phi_L[i] = new TH1F(
-        "absResVsPt_L_phi_" + ptrange_L[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
-    h_absResVsPt_eta_L[i] = new TH1F(
-        "absResVsPt_L_eta_" + ptrange_L[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
-    h_absResVsPt_d0_L[i] =
-        new TH1F("absResVsPt_L_d0_" + ptrange_L[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsZ0Res, 0, maxD0Res);
+    h_absResVsPt_phi_L[i] =
+        new TH1F("absResVsPt_L_phi_" + ptrange_L[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
+    h_absResVsPt_eta_L[i] =
+        new TH1F("absResVsPt_L_eta_" + ptrange_L[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
+    h_absResVsPt_d0_L[i] = new TH1F(
+        "absResVsPt_L_d0_" + ptrange_L[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsZ0Res, 0, maxD0Res);
   }
 
   // resolution vs. eta histograms
@@ -613,44 +618,56 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TH1F* h_absResVsEta_beamCon_ptRel[nETARANGE];
 
   for (int i = 0; i < nETARANGE; i++) {
-    h_absResVsEta_eta[i] = new TH1F(
-        "absResVsEta_eta_" + etarange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
+    h_absResVsEta_eta[i] =
+        new TH1F("absResVsEta_eta_" + etarange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
     h_absResVsEta_z0[i] = new TH1F(
         "absResVsEta_z0_" + etarange[i], ";z_{0} residual (L1 - sim)| [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
-    h_absResVsEta_phi[i] = new TH1F(
-        "absResVsEta_phi_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
-    h_absResVsEta_ptRel[i] = new TH1F(
-        "absResVsEta_ptRel_" + etarange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
+    h_absResVsEta_phi[i] =
+        new TH1F("absResVsEta_phi_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
+    h_absResVsEta_ptRel[i] = new TH1F("absResVsEta_ptRel_" + etarange[i],
+                                      ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks",
+                                      nBinsPtRelRes,
+                                      0,
+                                      maxPtRelRes);
     h_absResVsEta_d0[i] = new TH1F(
         "absResVsEta_d0_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsD0Res, 0, maxD0Res);
 
-    h_absResVsEta_eta_L[i] = new TH1F(
-        "absResVsEta_eta_L_" + etarange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
+    h_absResVsEta_eta_L[i] =
+        new TH1F("absResVsEta_eta_L_" + etarange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
     h_absResVsEta_z0_L[i] = new TH1F(
         "absResVsEta_z0_L_" + etarange[i], ";z_{0} residual (L1 - sim)| [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
-    h_absResVsEta_phi_L[i] = new TH1F(
-        "absResVsEta_phi_L_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
-    h_absResVsEta_ptRel_L[i] = new TH1F(
-        "absResVsEta_ptRel_L_" + etarange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
+    h_absResVsEta_phi_L[i] =
+        new TH1F("absResVsEta_phi_L_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
+    h_absResVsEta_ptRel_L[i] = new TH1F("absResVsEta_ptRel_L_" + etarange[i],
+                                        ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks",
+                                        nBinsPtRelRes,
+                                        0,
+                                        maxPtRelRes);
     h_absResVsEta_d0_L[i] = new TH1F(
         "absResVsEta_d0_L_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsD0Res, 0, maxD0Res);
 
-    h_absResVsEta_eta_H[i] = new TH1F(
-        "absResVsEta_eta_H_" + etarange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
+    h_absResVsEta_eta_H[i] =
+        new TH1F("absResVsEta_eta_H_" + etarange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
     h_absResVsEta_z0_H[i] = new TH1F(
         "absResVsEta_z0_H_" + etarange[i], ";z_{0} residual (L1 - sim)| [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
-    h_absResVsEta_phi_H[i] = new TH1F(
-        "absResVsEta_phi_H_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
-    h_absResVsEta_ptRel_H[i] = new TH1F(
-        "absResVsEta_ptRel_H_" + etarange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
+    h_absResVsEta_phi_H[i] =
+        new TH1F("absResVsEta_phi_H_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
+    h_absResVsEta_ptRel_H[i] = new TH1F("absResVsEta_ptRel_H_" + etarange[i],
+                                        ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks",
+                                        nBinsPtRelRes,
+                                        0,
+                                        maxPtRelRes);
     h_absResVsEta_d0_H[i] = new TH1F(
         "absResVsEta_d0_H_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsD0Res, 0, maxD0Res);
 
     // Beam-spot constrained resolution
     h_absResVsEta_beamCon_phi[i] = new TH1F(
         "absResVsEta_beamCon_phi_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
-    h_absResVsEta_beamCon_ptRel[i] = new TH1F(
-        "absResVsEta_beamCon_ptRel_" + etarange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
+    h_absResVsEta_beamCon_ptRel[i] = new TH1F("absResVsEta_beamCon_ptRel_" + etarange[i],
+                                              ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks",
+                                              nBinsPtRelRes,
+                                              0,
+                                              maxPtRelRes);
   }
 
   // resolution vs phi
@@ -666,8 +683,11 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   for (int i = 0; i < nPHIRANGE; i++) {
     h_absResVsPhi_pt[i] = new TH1F(
         "absResVsPt_pt_" + phirange[i], ";p_{T} residual (L1 - sim) [GeV]; L1 tracks", nBinsPtRes, 0, maxPtRes);
-    h_absResVsPhi_ptRel[i] = new TH1F(
-        "absResVsPt_ptRel_" + phirange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
+    h_absResVsPhi_ptRel[i] = new TH1F("absResVsPt_ptRel_" + phirange[i],
+                                      ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks",
+                                      nBinsPtRelRes,
+                                      0,
+                                      maxPtRelRes);
   }
 
   // ----------------------------------------------------------------------------------------------------------------
@@ -691,10 +711,11 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       new TH1F("match_trk_chi2rz_dof", ";#chi^{2}_{r-z} / D.O.F.; L1 tracks / 0.2", 100, 0, 20);
 
   // Ditto with beam-spot constraint on helix params
-  TH1F* h_trk_chi2rphi_dof_beamCon = new TH1F("trk_chi2rphi_dof_beamCon", ";#chi^{2}_{r-#phi} / D.O.F.; L1 tracks / 0.2", 100, 0, 20);
+  TH1F* h_trk_chi2rphi_dof_beamCon =
+      new TH1F("trk_chi2rphi_dof_beamCon", ";#chi^{2}_{r-#phi} / D.O.F.; L1 tracks / 0.2", 100, 0, 20);
   TH1F* h_match_trk_chi2rphi_dof_beamCon =
       new TH1F("match_trk_chi2rphi_dof_beamCon", ";#chi^{2}_{r-#phi} / D.O.F.; L1 tracks / 0.2", 100, 0, 20);
-  
+
   // ----------------------------------------------------------------------------------------------------------------
   // total track rates
 
@@ -794,18 +815,12 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TH1F* h_res_z0_L = new TH1F("res_z0_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
   TH1F* h_res_z0_H = new TH1F("res_z0_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
 
-  TH1F* h_res_z0_C_L =
-      new TH1F("res_z0_C_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
-  TH1F* h_res_z0_I_L =
-      new TH1F("res_z0_I_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
-  TH1F* h_res_z0_F_L =
-      new TH1F("res_z0_F_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
-  TH1F* h_res_z0_C_H =
-      new TH1F("res_z0_C_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
-  TH1F* h_res_z0_I_H =
-      new TH1F("res_z0_I_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
-  TH1F* h_res_z0_F_H =
-      new TH1F("res_z0_F_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
+  TH1F* h_res_z0_C_L = new TH1F("res_z0_C_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
+  TH1F* h_res_z0_I_L = new TH1F("res_z0_I_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
+  TH1F* h_res_z0_F_L = new TH1F("res_z0_F_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
+  TH1F* h_res_z0_C_H = new TH1F("res_z0_C_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
+  TH1F* h_res_z0_I_H = new TH1F("res_z0_I_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
+  TH1F* h_res_z0_F_H = new TH1F("res_z0_F_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
 
   TH1F* h_res_d0 = new TH1F("res_d0", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
   TH1F* h_res_d0_C = new TH1F("res_d0_C", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
@@ -814,18 +829,12 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TH1F* h_res_d0_L = new TH1F("res_d0_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
   TH1F* h_res_d0_H = new TH1F("res_d0_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
 
-  TH1F* h_res_d0_C_L =
-      new TH1F("res_d0_C_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
-  TH1F* h_res_d0_I_L =
-      new TH1F("res_d0_I_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
-  TH1F* h_res_d0_F_L =
-      new TH1F("res_d0_F_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
-  TH1F* h_res_d0_C_H =
-      new TH1F("res_d0_C_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
-  TH1F* h_res_d0_I_H =
-      new TH1F("res_d0_I_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
-  TH1F* h_res_d0_F_H =
-      new TH1F("res_d0_F_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_C_L = new TH1F("res_d0_C_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_I_L = new TH1F("res_d0_I_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_F_L = new TH1F("res_d0_F_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_C_H = new TH1F("res_d0_C_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_I_H = new TH1F("res_d0_I_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_F_H = new TH1F("res_d0_F_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
 
   // ----------------------------------------------------------------------------------------------------------------
   // more resolution vs pt (FIX: Do we need these, given we have resolution interval plots?)
@@ -951,10 +960,10 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
 
     h_resVsEta_d0[i] =
         new TH1F("resVsEta2_d0_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 100, -0.1, 0.1);
-    h_resVsEta_d0_L[i] = new TH1F(
-        "resVsEta2_d0_L_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 100, -0.1, 0.1);
-    h_resVsEta_d0_H[i] = new TH1F(
-        "resVsEta2_d0_H_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 100, -0.1, 0.1);
+    h_resVsEta_d0_L[i] =
+        new TH1F("resVsEta2_d0_L_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 100, -0.1, 0.1);
+    h_resVsEta_d0_H[i] =
+        new TH1F("resVsEta2_d0_H_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 100, -0.1, 0.1);
   }
   // ----------------------------------------------------------------------------------------------------------------
 
@@ -1190,9 +1199,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       if (trk_genuine->at(it) && trk_matchtp_eventtype->at(it) == 1) {
         std::vector<float>* m_trk_matchtp_z0;
         p_resOverSigmaVsEta_z0->Fill(fabs(trk_eta->at(it)),
-            fabs(trk_z0->at(it) - trk_matchtp_z0->at(it)) / trk_sigma_z0->at(it));
+                                     fabs(trk_z0->at(it) - trk_matchtp_z0->at(it)) / trk_sigma_z0->at(it));
         p_resOverSigmaVsNumPS_z0->Fill(trk_nPS_hitpattern->at(it),
-            fabs(trk_z0->at(it) - trk_matchtp_z0->at(it)) / trk_sigma_z0->at(it));
+                                       fabs(trk_z0->at(it) - trk_matchtp_z0->at(it)) / trk_sigma_z0->at(it));
       }
 
       // ----------------------------------------------------------------------------------------------------------------
@@ -1548,7 +1557,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       h_res_phi->Fill(matchtrk_phi->at(it) - tp_phi->at(it));
       h_res_z0->Fill(matchtrk_z0->at(it) - tp_z0->at(it));
       if (matchtrk_d0->at(it) < 999.)
-        h_res_d0->Fill(matchtrk_d0->at(it) - tp_d0->at(it));      
+        h_res_d0->Fill(matchtrk_d0->at(it) - tp_d0->at(it));
       if (std::abs(tp_eta->at(it)) < 0.8)
         h_res_z0_C->Fill(matchtrk_z0->at(it) - tp_z0->at(it));
       else if (std::abs(tp_eta->at(it)) < 1.6 && std::abs(tp_eta->at(it)) >= 0.8)
@@ -1658,7 +1667,8 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
           h_absResVsEta_phi[im]->Fill(std::abs(matchtrk_phi->at(it) - tp_phi->at(it)));
           h_absResVsEta_z0[im]->Fill(std::abs(matchtrk_z0->at(it) - tp_z0->at(it)));
 
-          h_absResVsEta_beamCon_ptRel[im]->Fill(std::abs((matchtrk_pt_beamCon->at(it) - tp_pt->at(it))) / tp_pt->at(it));
+          h_absResVsEta_beamCon_ptRel[im]->Fill(std::abs((matchtrk_pt_beamCon->at(it) - tp_pt->at(it))) /
+                                                tp_pt->at(it));
           h_absResVsEta_beamCon_phi[im]->Fill(std::abs(matchtrk_phi_beamCon->at(it) - tp_phi->at(it)));
 
           if (tp_pt->at(it) < 8.0) {
@@ -2028,19 +2038,19 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TH1F* h2_resVsEta_z0_99 =
       new TH1F("resVsEta_z0_99", ";Tracking particle |#eta|; z_{0} resolution [cm]", nETARANGE, 0, eta_resmax);
 
-  TH1F* h2_resVsEta_phi_68 = new TH1F(
-    "resVsEta_phi_68", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
-  TH1F* h2_resVsEta_phi_90 = new TH1F(
-    "resVsEta_phi_90", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
-  TH1F* h2_resVsEta_phi_99 = new TH1F(
-    "resVsEta_phi_99", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_68 =
+      new TH1F("resVsEta_phi_68", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_90 =
+      new TH1F("resVsEta_phi_90", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_99 =
+      new TH1F("resVsEta_phi_99", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
 
-  TH1F* h2_resVsEta_ptRel_68 = new TH1F(
-    "resVsEta_ptRel_68", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
-  TH1F* h2_resVsEta_ptRel_90 = new TH1F(
-    "resVsEta_ptRel_90", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
-  TH1F* h2_resVsEta_ptRel_99 = new TH1F(
-    "resVsEta_ptRel_99", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_ptRel_68 =
+      new TH1F("resVsEta_ptRel_68", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_ptRel_90 =
+      new TH1F("resVsEta_ptRel_90", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_ptRel_99 =
+      new TH1F("resVsEta_ptRel_99", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
 
   TH1F* h2_resVsEta_d0_68 =
       new TH1F("resVsEta_d0_68", ";Tracking particle |#eta|; d_{0} resolution [cm]", nETARANGE, 0, eta_resmax);
@@ -2050,20 +2060,20 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       new TH1F("resVsEta_d0_99", ";Tracking particle |#eta|; d_{0} resolution [cm]", nETARANGE, 0, eta_resmax);
 
   // Same,but for helix params with beam-spot constraint
-  TH1F* h2_resVsEta_phi_beamCon_68 = new TH1F(
-    "resVsEta_phi_beamCon_68", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
-  TH1F* h2_resVsEta_phi_beamCon_90 = new TH1F(
-    "resVsEta_phi_beamCon_90", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
-  TH1F* h2_resVsEta_phi_beamCon_99 = new TH1F(
-    "resVsEta_phi_beamCon_99", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_beamCon_68 =
+      new TH1F("resVsEta_phi_beamCon_68", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_beamCon_90 =
+      new TH1F("resVsEta_phi_beamCon_90", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_beamCon_99 =
+      new TH1F("resVsEta_phi_beamCon_99", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
 
   TH1F* h2_resVsEta_ptRel_beamCon_68 = new TH1F(
-    "resVsEta_ptRel_beamCon_68", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+      "resVsEta_ptRel_beamCon_68", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
   TH1F* h2_resVsEta_ptRel_beamCon_90 = new TH1F(
-    "resVsEta_ptRel_beamCon_90", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+      "resVsEta_ptRel_beamCon_90", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
   TH1F* h2_resVsEta_ptRel_beamCon_99 = new TH1F(
-    "resVsEta_ptRel_beamCon_99", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
-  
+      "resVsEta_ptRel_beamCon_99", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+
   // Same, but for low or high Pt ranges
   TH1F* h2_resVsEta_eta_L_68 =
       new TH1F("resVsEta_eta_L_68", ";Tracking particle |#eta|; #eta resolution", nETARANGE, 0, eta_resmax);
@@ -2215,13 +2225,19 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
     h2_resVsEta_d0_90->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_d0[i], 0.90));
     h2_resVsEta_d0_99->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_d0[i], 0.99));
 
-    h2_resVsEta_ptRel_beamCon_68->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_ptRel[i], 0.68));
-    h2_resVsEta_ptRel_beamCon_90->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_ptRel[i], 0.90));
-    h2_resVsEta_ptRel_beamCon_99->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_ptRel[i], 0.99));
+    h2_resVsEta_ptRel_beamCon_68->SetBinContent(
+        i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_ptRel[i], 0.68));
+    h2_resVsEta_ptRel_beamCon_90->SetBinContent(
+        i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_ptRel[i], 0.90));
+    h2_resVsEta_ptRel_beamCon_99->SetBinContent(
+        i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_ptRel[i], 0.99));
 
-    h2_resVsEta_phi_beamCon_68->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_phi[i], 0.68));
-    h2_resVsEta_phi_beamCon_90->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_phi[i], 0.90));
-    h2_resVsEta_phi_beamCon_99->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_phi[i], 0.99));
+    h2_resVsEta_phi_beamCon_68->SetBinContent(
+        i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_phi[i], 0.68));
+    h2_resVsEta_phi_beamCon_90->SetBinContent(
+        i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_phi[i], 0.90));
+    h2_resVsEta_phi_beamCon_99->SetBinContent(
+        i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_phi[i], 0.99));
 
     h2_resVsEta_eta_L_68->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_eta_L[i], 0.68));
     h2_resVsEta_z0_L_68->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_z0_L[i], 0.68));
@@ -2544,13 +2560,13 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   // plots overlaying 68, 90, 99% confidence levels]
 
   // set plotting dislay limit on interval plot resolution
-  float max_eta_ptRel = 0.2; 
+  float max_eta_ptRel = 0.2;
   float max_pt_ptRel = 0.2;
   float max_pt_pt = 20;
   float max_z0 = 2.0;
   float max_phi = 0.01;
   float max_eta = 0.03;
-  float max_d0 = 0.008;
+  float max_d0 = 0.1;
 
   if (type.Contains("El")) {
     max_pt_ptRel = 1.0;
@@ -2561,19 +2577,22 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   // makeResidualIntervalPlot will save the individual plots to the root file
   makeResidualIntervalPlot(
       type, DIR, "resVsPt_ptRel", h2_resVsPt_ptRel_68, h2_resVsPt_ptRel_90, h2_resVsPt_ptRel_99, 0, max_pt_ptRel);
-  makeResidualIntervalPlot(
-      type, DIR, "resVsPt_pt", h2_resVsPt_pt_68, h2_resVsPt_pt_90, h2_resVsPt_pt_99, 0, max_pt_pt);
-  makeResidualIntervalPlot(
-      type, DIR, "resVsPt_z0", h2_resVsPt_z0_68, h2_resVsPt_z0_90, h2_resVsPt_z0_99, 0, max_z0);
+  makeResidualIntervalPlot(type, DIR, "resVsPt_pt", h2_resVsPt_pt_68, h2_resVsPt_pt_90, h2_resVsPt_pt_99, 0, max_pt_pt);
+  makeResidualIntervalPlot(type, DIR, "resVsPt_z0", h2_resVsPt_z0_68, h2_resVsPt_z0_90, h2_resVsPt_z0_99, 0, max_z0);
   makeResidualIntervalPlot(
       type, DIR, "resVsPt_phi", h2_resVsPt_phi_68, h2_resVsPt_phi_90, h2_resVsPt_phi_99, 0, max_phi);
   makeResidualIntervalPlot(
       type, DIR, "resVsPt_eta", h2_resVsPt_eta_68, h2_resVsPt_eta_90, h2_resVsPt_eta_99, 0, max_eta);
-  makeResidualIntervalPlot(
-      type, DIR, "resVsPt_d0", h2_resVsPt_d0_68, h2_resVsPt_d0_90, h2_resVsPt_d0_99, 0, max_d0 );
-  
-  makeResidualIntervalPlot(
-      type, DIR, "resVsPt_L_ptRel", h2_resVsPt_ptRel_L_68, h2_resVsPt_ptRel_L_90, h2_resVsPt_ptRel_L_99, 0, max_pt_ptRel);
+  makeResidualIntervalPlot(type, DIR, "resVsPt_d0", h2_resVsPt_d0_68, h2_resVsPt_d0_90, h2_resVsPt_d0_99, 0, max_d0);
+
+  makeResidualIntervalPlot(type,
+                           DIR,
+                           "resVsPt_L_ptRel",
+                           h2_resVsPt_ptRel_L_68,
+                           h2_resVsPt_ptRel_L_90,
+                           h2_resVsPt_ptRel_L_99,
+                           0,
+                           max_pt_ptRel);
   makeResidualIntervalPlot(type, DIR, "resVsPt_L_pt", h2_resVsPt_pt_L_68, h2_resVsPt_pt_L_90, h2_resVsPt_pt_L_99, 0, 4);
   makeResidualIntervalPlot(
       type, DIR, "resVsPt_L_z0", h2_resVsPt_z0_L_68, h2_resVsPt_z0_L_90, h2_resVsPt_z0_L_99, 0, max_z0);
@@ -2582,7 +2601,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   makeResidualIntervalPlot(
       type, DIR, "resVsPt_L_eta", h2_resVsPt_eta_L_68, h2_resVsPt_eta_L_90, h2_resVsPt_eta_L_99, 0, max_eta);
   makeResidualIntervalPlot(
-      type, DIR, "resVsPt_L_d0", h2_resVsPt_d0_L_68, h2_resVsPt_d0_L_90, h2_resVsPt_d0_L_99, 0, max_d0 );
+      type, DIR, "resVsPt_L_d0", h2_resVsPt_d0_L_68, h2_resVsPt_d0_L_90, h2_resVsPt_d0_L_99, 0, max_d0);
 
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_eta", h2_resVsEta_eta_68, h2_resVsEta_eta_90, h2_resVsEta_eta_99, 0, max_eta);
@@ -2592,22 +2611,42 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       type, DIR, "resVsEta_phi", h2_resVsEta_phi_68, h2_resVsEta_phi_90, h2_resVsEta_phi_99, 0, max_phi);
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_ptRel", h2_resVsEta_ptRel_68, h2_resVsEta_ptRel_90, h2_resVsEta_ptRel_99, 0, max_eta_ptRel);
-  makeResidualIntervalPlot( type, DIR, "resVsEta_d0", h2_resVsEta_d0_68, h2_resVsEta_d0_90, h2_resVsEta_d0_99, 0, max_d0 );
+  makeResidualIntervalPlot(
+      type, DIR, "resVsEta_d0", h2_resVsEta_d0_68, h2_resVsEta_d0_90, h2_resVsEta_d0_99, 0, max_d0);
 
-  makeResidualIntervalPlot(
-      type, DIR, "resVsEta_ptRel_beamCon", h2_resVsEta_ptRel_beamCon_68, h2_resVsEta_ptRel_beamCon_90, h2_resVsEta_ptRel_beamCon_99, 0, max_pt_ptRel);
-  makeResidualIntervalPlot(
-      type, DIR, "resVsEta_phi_beamCon", h2_resVsEta_phi_beamCon_68, h2_resVsEta_phi_beamCon_90, h2_resVsEta_phi_beamCon_99, 0, max_phi);
-  
+  makeResidualIntervalPlot(type,
+                           DIR,
+                           "resVsEta_ptRel_beamCon",
+                           h2_resVsEta_ptRel_beamCon_68,
+                           h2_resVsEta_ptRel_beamCon_90,
+                           h2_resVsEta_ptRel_beamCon_99,
+                           0,
+                           max_pt_ptRel);
+  makeResidualIntervalPlot(type,
+                           DIR,
+                           "resVsEta_phi_beamCon",
+                           h2_resVsEta_phi_beamCon_68,
+                           h2_resVsEta_phi_beamCon_90,
+                           h2_resVsEta_phi_beamCon_99,
+                           0,
+                           max_phi);
+
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_L_eta", h2_resVsEta_eta_L_68, h2_resVsEta_eta_L_90, h2_resVsEta_eta_L_99, 0, max_eta);
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_L_z0", h2_resVsEta_z0_L_68, h2_resVsEta_z0_L_90, h2_resVsEta_z0_L_99, 0, max_z0);
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_L_phi", h2_resVsEta_phi_L_68, h2_resVsEta_phi_L_90, h2_resVsEta_phi_L_99, 0, max_phi);
+  makeResidualIntervalPlot(type,
+                           DIR,
+                           "resVsEta_L_ptRel",
+                           h2_resVsEta_ptRel_L_68,
+                           h2_resVsEta_ptRel_L_90,
+                           h2_resVsEta_ptRel_L_99,
+                           0,
+                           max_eta_ptRel);
   makeResidualIntervalPlot(
-      type, DIR, "resVsEta_L_ptRel", h2_resVsEta_ptRel_L_68, h2_resVsEta_ptRel_L_90, h2_resVsEta_ptRel_L_99, 0, max_eta_ptRel);
-  makeResidualIntervalPlot( type, DIR, "resVsEta_L_d0", h2_resVsEta_d0_L_68, h2_resVsEta_d0_L_90, h2_resVsEta_d0_L_99, 0, max_d0 );
+      type, DIR, "resVsEta_L_d0", h2_resVsEta_d0_L_68, h2_resVsEta_d0_L_90, h2_resVsEta_d0_L_99, 0, max_d0);
 
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_H_eta", h2_resVsEta_eta_H_68, h2_resVsEta_eta_H_90, h2_resVsEta_eta_H_99, 0, max_eta);
@@ -2615,9 +2654,16 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       type, DIR, "resVsEta_H_z0", h2_resVsEta_z0_H_68, h2_resVsEta_z0_H_90, h2_resVsEta_z0_H_99, 0, max_z0);
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_H_phi", h2_resVsEta_phi_H_68, h2_resVsEta_phi_H_90, h2_resVsEta_phi_H_99, 0, max_phi);
+  makeResidualIntervalPlot(type,
+                           DIR,
+                           "resVsEta_H_ptRel",
+                           h2_resVsEta_ptRel_H_68,
+                           h2_resVsEta_ptRel_H_90,
+                           h2_resVsEta_ptRel_H_99,
+                           0,
+                           max_eta_ptRel);
   makeResidualIntervalPlot(
-      type, DIR, "resVsEta_H_ptRel", h2_resVsEta_ptRel_H_68, h2_resVsEta_ptRel_H_90, h2_resVsEta_ptRel_H_99, 0, max_eta_ptRel);
-  makeResidualIntervalPlot( type, DIR, "resVsEta_H_d0", h2_resVsEta_d0_H_68, h2_resVsEta_d0_H_90, h2_resVsEta_d0_H_99, 0, max_d0 );
+      type, DIR, "resVsEta_H_d0", h2_resVsEta_d0_H_68, h2_resVsEta_d0_H_90, h2_resVsEta_d0_H_99, 0, max_d0);
 
   if (doDetailedPlots) {
     makeResidualIntervalPlot(
@@ -2898,14 +2944,15 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
     h_match_trk_nstub_I->Write();
     h_match_trk_nstub_F->Write();
   }
-  
+
   makeAllAndTruePDF(type, DIR, "trk_chi2", h_trk_chi2, h_match_trk_chi2);
   makeAllAndTruePDF(type, DIR, "trk_chi2_dof", h_trk_chi2_dof, h_match_trk_chi2_dof);
   makeAllAndTruePDF(type, DIR, "trk_chi2rphi", h_trk_chi2rphi, h_match_trk_chi2rphi);
   makeAllAndTruePDF(type, DIR, "trk_chi2rphi_dof", h_trk_chi2rphi_dof, h_match_trk_chi2rphi_dof);
   makeAllAndTruePDF(type, DIR, "trk_chi2rz", h_trk_chi2rz, h_match_trk_chi2rz);
   makeAllAndTruePDF(type, DIR, "trk_chi2rz_dof", h_trk_chi2rz_dof, h_match_trk_chi2rz_dof);
-  makeAllAndTruePDF(type, DIR, "trk_chi2rphi_dof_beamCon", h_trk_chi2rphi_dof_beamCon, h_match_trk_chi2rphi_dof_beamCon);
+  makeAllAndTruePDF(
+      type, DIR, "trk_chi2rphi_dof_beamCon", h_trk_chi2rphi_dof_beamCon, h_match_trk_chi2rphi_dof_beamCon);
 
   if (doDetailedPlots) {
     h_match_trk_chi2_C_L->Write();
@@ -3869,20 +3916,22 @@ double getIntervalContainingFractionOfEntries(TH1* absResidualHistogram, double 
   static unsigned int nErr = 0;
   constexpr unsigned int maxErr = 10;
   if (totalIntegral == 0 || numEntries < minEntries) {
-    if (quantileToCalculate < 0.70 && nErr < maxErr) { // Avoid repeat warning for all quantiles
+    if (quantileToCalculate < 0.70 && nErr < maxErr) {  // Avoid repeat warning for all quantiles
       nErr++;
-      cerr << "WARNING: Cannot compute " << quantileToCalculate << " quantile inverval, as too few stats (" << numEntries << ") in histo " << absResidualHistogram->GetName() << endl;
+      cerr << "WARNING: Cannot compute " << quantileToCalculate << " quantile inverval, as too few stats ("
+           << numEntries << ") in histo " << absResidualHistogram->GetName() << endl;
     }
     interval[0] = 999.;
   } else if (nEntriesInOverflow > maxAllowedEntriesInOverflow) {
     // Suppress warning for 99% interval.
     if (quantileToCalculate < 0.98 && nErr < maxErr) {
       nErr++;
-      cerr << "WARNING : Cannot compute " << quantileToCalculate << " quantile interval, as it is in the overflow bin of histo " << absResidualHistogram->GetName() <<" -- please increase its x-axis range. " << nEntriesInOverflow << "/" << numEntries << endl;
+      cerr << "WARNING : Cannot compute " << quantileToCalculate
+           << " quantile interval, as it is in the overflow bin of histo " << absResidualHistogram->GetName()
+           << " -- please increase its x-axis range. " << nEntriesInOverflow << "/" << numEntries << endl;
     }
     interval[0] = 999.;
   } else {
-    
     // Calculate quantile for given interval
     absResidualHistogram->GetQuantiles(1, interval, quantile);
   }
@@ -3928,8 +3977,7 @@ void makeResidualIntervalPlot(
   delete l;
 }
 
-void makeAllAndTruePDF(TString type, TString dir, TString variable,
-                       TH1F* h_all, TH1F* h_match) {
+void makeAllAndTruePDF(TString type, TString dir, TString variable, TH1F* h_all, TH1F* h_match) {
   // Create PDF in which equivalent histograms that show all tracks and only genuine (matched) tracks are superimposed.
   TCanvas c;
 

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -46,7 +46,7 @@ void makeAllAndTruePDF(TString type, TString dir, TString variable, TH1F* h_all,
 
 void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
                        TString inputDir = "./",
-                       bool useDisplacedTrkCuts = true,
+                       bool useDisplacedTrkCuts = false,
                        bool doDetailedPlots = true,
                        // For displaced tracking studies, consider using TP_minPt = 3.0, TP_maxEta = 2.0.
                        float TP_minPt = 2.0,

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -181,6 +181,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   vector<float>* trk_pt;
   vector<float>* trk_eta;
   vector<float>* trk_phi;
+  vector<float>* trk_z0;
   vector<float>* trk_chi2;
   vector<float>* trk_chi2_dof;
   vector<float>* trk_chi2rphi;
@@ -192,10 +193,13 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   vector<int>* trk_dhits;
   vector<int>* trk_seed;
   vector<int>* trk_hitpattern;
+  vector<int>* trk_nPS_hitpattern;
+  vector<float>* trk_sigma_z0;
   vector<unsigned int>* trk_phiSector;
   vector<int>* trk_genuine;
   vector<int>* trk_loose;
   vector<int>* trk_matchtp_eventtype;
+  vector<float>* trk_matchtp_z0;
   vector<int>* trk_injet;
   vector<int>* trk_injet_highpt;
   vector<int>* trk_injet_vhighpt;
@@ -238,6 +242,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TBranch* b_trk_pt;
   TBranch* b_trk_eta;
   TBranch* b_trk_phi;
+  TBranch* b_trk_z0;
   TBranch* b_trk_chi2;
   TBranch* b_trk_chi2_dof;
   TBranch* b_trk_chi2rphi;
@@ -249,10 +254,13 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TBranch* b_trk_dhits;
   TBranch* b_trk_seed;
   TBranch* b_trk_hitpattern;
+  TBranch* b_trk_nPS_hitpattern;
+  TBranch* b_trk_sigma_z0;
   TBranch* b_trk_phiSector;
   TBranch* b_trk_genuine;
   TBranch* b_trk_loose;
   TBranch* b_trk_matchtp_eventtype;
+  TBranch* b_trk_matchtp_z0;
   TBranch* b_trk_injet;
   TBranch* b_trk_injet_highpt;
   TBranch* b_trk_injet_vhighpt;
@@ -295,6 +303,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   trk_pt = 0;
   trk_eta = 0;
   trk_phi = 0;
+  trk_z0 = 0;
   trk_chi2 = 0;
   trk_chi2_dof = 0;
   trk_chi2rphi = 0;
@@ -306,10 +315,13 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   trk_dhits = 0;
   trk_seed = 0;
   trk_hitpattern = 0;
+  trk_nPS_hitpattern = 0;
+  trk_sigma_z0 = 0;
   trk_phiSector = 0;
   trk_genuine = 0;
   trk_loose = 0;
   trk_matchtp_eventtype = 0;
+  trk_matchtp_z0 = 0;
   trk_injet = 0;
   trk_injet_highpt = 0;
   trk_injet_vhighpt = 0;
@@ -356,6 +368,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   tree->SetBranchAddress("trk_pt", &trk_pt, &b_trk_pt);
   tree->SetBranchAddress("trk_eta", &trk_eta, &b_trk_eta);
   tree->SetBranchAddress("trk_phi", &trk_phi, &b_trk_phi);
+  tree->SetBranchAddress("trk_z0", &trk_z0, &b_trk_z0);
   tree->SetBranchAddress("trk_chi2", &trk_chi2, &b_trk_chi2);
   tree->SetBranchAddress("trk_chi2_dof", &trk_chi2_dof, &b_trk_chi2_dof);
   tree->SetBranchAddress("trk_chi2rphi", &trk_chi2rphi, &b_trk_chi2rphi);
@@ -367,10 +380,13 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   tree->SetBranchAddress("trk_dhits", &trk_dhits, &b_trk_dhits);
   tree->SetBranchAddress("trk_seed", &trk_seed, &b_trk_seed);
   tree->SetBranchAddress("trk_hitpattern", &trk_hitpattern, &b_trk_hitpattern);
+  tree->SetBranchAddress("trk_nPSstub_hitpattern", &trk_nPS_hitpattern, &b_trk_nPS_hitpattern);
+  tree->SetBranchAddress("trk_sigma_z0", &trk_sigma_z0, &b_trk_sigma_z0);
   tree->SetBranchAddress("trk_phiSector", &trk_phiSector, &b_trk_phiSector);
   tree->SetBranchAddress("trk_genuine", &trk_genuine, &b_trk_genuine);
   tree->SetBranchAddress("trk_loose", &trk_loose, &b_trk_loose);
   tree->SetBranchAddress("trk_matchtp_eventtype", &trk_matchtp_eventtype, &b_trk_matchtp_eventtype);
+  tree->SetBranchAddress("trk_matchtp_z0", &trk_matchtp_z0, &b_trk_matchtp_z0);
   if (TP_select_injet > 0) {
     tree->SetBranchAddress("trk_injet", &trk_injet, &b_trk_injet);
     tree->SetBranchAddress("trk_injet_highpt", &trk_injet_highpt, &b_trk_injet_highpt);
@@ -942,6 +958,11 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   }
   // ----------------------------------------------------------------------------------------------------------------
 
+  // more resolution relative to uncertainty estimated from helix covariance matrix
+  TProfile* p_resOverSigmaVsEta_z0 =
+      new TProfile("resOverSigmaVsEta_z0", ";#eta; abs(z_{0} residual)/#sigma", 12, 0.0, 2.4, 0.0, 10.);
+  TProfile* p_resOverSigmaVsNumPS_z0 = new TProfile(
+      "resOverSigmaVsNumPS_z0", ";Number PS stub layers; abs(z_{0} residual)/#sigma", 10, -0.5, 9.5, 0.0, 10.);
   // ----------------------------------------------------------------------------------------------------------------
   // additional ones for sum pt in jets
   /*
@@ -1160,6 +1181,14 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
         ntrkevt_pt10++;
         if (trk_genuine->at(it) == 1)
           ntrkevt_genuine_pt10++;
+      }
+
+      if (trk_genuine->at(it) && trk_matchtp_eventtype->at(it) == 1) {
+        std::vector<float>* m_trk_matchtp_z0;
+        p_resOverSigmaVsEta_z0->Fill(fabs(trk_eta->at(it)),
+                                     fabs(trk_z0->at(it) - trk_matchtp_z0->at(it)) / trk_sigma_z0->at(it));
+        p_resOverSigmaVsNumPS_z0->Fill(trk_nPS_hitpattern->at(it),
+                                       fabs(trk_z0->at(it) - trk_matchtp_z0->at(it)) / trk_sigma_z0->at(it));
       }
 
       // ----------------------------------------------------------------------------------------------------------------
@@ -2826,7 +2855,12 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
     c.SaveAs(DIR + type + "_resVsPhi_ptRel_90.pdf");
   }
 
-  // ----------------------------------------------------------------------------------------------------------------
+  // resolution in z0 relative to sigma(z0)
+  p_resOverSigmaVsEta_z0->Draw();
+  c.SaveAs(DIR + type + "_resOverSigmaVsEta_z0.pdf");
+  p_resOverSigmaVsNumPS_z0->Draw();
+  c.SaveAs(DIR + type + "_resOverSigmaVsNumPS_z0.pdf");
+  //----------------------------------------------------------------------------------------------------------------
   // track quality plots
   // ----------------------------------------------------------------------------------------------------------------
 

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -35,9 +35,11 @@ using namespace std;
 void SetPlotStyle();
 void mySmallText(Double_t x, Double_t y, Color_t color, char* text);
 
-double getIntervalContainingFractionOfEntries(TH1* histogram, double interval, int minEntries = 5);
+double getIntervalContainingFractionOfEntries(TH1* histogram, double interval, int minEntries = 10);
 void makeResidualIntervalPlot(
     TString type, TString dir, TString variable, TH1F* h_68, TH1F* h_90, TH1F* h_99, double minY, double maxY);
+void makeAllAndTruePDF(TString type, TString dir, TString variable,
+                        TH1F* h_all, TH1F* h_match);
 
 // ----------------------------------------------------------------------------------------------------------------
 // Main script
@@ -45,7 +47,7 @@ void makeResidualIntervalPlot(
 
 void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
                        TString inputDir = "./",
-                       bool useDisplacedTrkCuts = false,
+                       bool useDisplacedTrkCuts = true,
                        bool doDetailedPlots = true,
                        // For displaced tracking studies, consider using TP_minPt = 3.0, TP_maxEta = 2.0.
                        float TP_minPt = 2.0,
@@ -130,8 +132,8 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   tree->Add(inputDir + inputRootFile + ".root");
 
   if (tree->GetEntries() == 0) {
-    cout << "File doesn't exist or is empty, returning..."
-         << endl;  //cout's kept in this file as it is an example standalone plotting script, not running in central CMSSW
+    cerr << "Input file doesn't exist or is empty, returning..."
+         << endl;  
     return;
   }
 
@@ -168,6 +170,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   vector<float>* matchtrk_chi2rphi_dof;
   vector<float>* matchtrk_chi2rz;
   vector<float>* matchtrk_chi2rz_dof;
+  vector<float>* matchtrk_pt_beamCon;
+  vector<float>* matchtrk_phi_beamCon;
+  vector<float>* matchtrk_chi2rphi_dof_beamCon;
   vector<int>* matchtrk_nstub;
   vector<int>* matchtrk_lhits;
   vector<int>* matchtrk_dhits;
@@ -188,6 +193,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   vector<float>* trk_chi2rphi_dof;
   vector<float>* trk_chi2rz;
   vector<float>* trk_chi2rz_dof;
+  vector<float>* trk_chi2rphi_dof_beamCon;  
   vector<int>* trk_nstub;
   vector<int>* trk_lhits;
   vector<int>* trk_dhits;
@@ -230,6 +236,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TBranch* b_matchtrk_chi2rphi_dof;
   TBranch* b_matchtrk_chi2rz;
   TBranch* b_matchtrk_chi2rz_dof;
+  TBranch* b_matchtrk_pt_beamCon;
+  TBranch* b_matchtrk_phi_beamCon;
+  TBranch* b_matchtrk_chi2rphi_dof_beamCon;
   TBranch* b_matchtrk_nstub;
   TBranch* b_matchtrk_lhits;
   TBranch* b_matchtrk_dhits;
@@ -249,6 +258,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TBranch* b_trk_chi2rphi_dof;
   TBranch* b_trk_chi2rz;
   TBranch* b_trk_chi2rz_dof;
+  TBranch* b_trk_chi2rphi_dof_beamCon;
   TBranch* b_trk_nstub;
   TBranch* b_trk_lhits;
   TBranch* b_trk_dhits;
@@ -291,6 +301,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   matchtrk_chi2rphi_dof = 0;
   matchtrk_chi2rz = 0;
   matchtrk_chi2rz_dof = 0;
+  matchtrk_pt_beamCon = 0;
+  matchtrk_phi_beamCon = 0;
+  matchtrk_chi2rphi_dof_beamCon = 0;
   matchtrk_nstub = 0;
   matchtrk_lhits = 0;
   matchtrk_dhits = 0;
@@ -310,6 +323,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   trk_chi2rphi_dof = 0;
   trk_chi2rz = 0;
   trk_chi2rz_dof = 0;
+  trk_chi2rphi_dof_beamCon = 0;
   trk_nstub = 0;
   trk_lhits = 0;
   trk_dhits = 0;
@@ -354,6 +368,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   tree->SetBranchAddress("matchtrk_chi2rphi_dof", &matchtrk_chi2rphi_dof, &b_matchtrk_chi2rphi_dof);
   tree->SetBranchAddress("matchtrk_chi2rz", &matchtrk_chi2rz, &b_matchtrk_chi2rz);
   tree->SetBranchAddress("matchtrk_chi2rz_dof", &matchtrk_chi2rz_dof, &b_matchtrk_chi2rz_dof);
+  tree->SetBranchAddress("matchtrk_pt_beamCon", &matchtrk_pt_beamCon, &b_matchtrk_pt_beamCon);
+  tree->SetBranchAddress("matchtrk_phi_beamCon", &matchtrk_phi_beamCon, &b_matchtrk_phi_beamCon);
+  tree->SetBranchAddress("matchtrk_chi2rphi_dof_beamCon", &matchtrk_chi2rphi_dof_beamCon, &b_matchtrk_chi2rphi_dof_beamCon);
   tree->SetBranchAddress("matchtrk_nstub", &matchtrk_nstub, &b_matchtrk_nstub);
   tree->SetBranchAddress("matchtrk_lhits", &matchtrk_lhits, &b_matchtrk_lhits);
   tree->SetBranchAddress("matchtrk_dhits", &matchtrk_dhits, &b_matchtrk_dhits);
@@ -375,6 +392,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   tree->SetBranchAddress("trk_chi2rphi_dof", &trk_chi2rphi_dof, &b_trk_chi2rphi_dof);
   tree->SetBranchAddress("trk_chi2rz", &trk_chi2rz, &b_trk_chi2rz);
   tree->SetBranchAddress("trk_chi2rz_dof", &trk_chi2rz_dof, &b_trk_chi2rz_dof);
+  tree->SetBranchAddress("trk_chi2rphi_dof_beamCon", &trk_chi2rphi_dof_beamCon, &b_trk_chi2rphi_dof_beamCon);
   tree->SetBranchAddress("trk_nstub", &trk_nstub, &b_trk_nstub);
   tree->SetBranchAddress("trk_lhits", &trk_lhits, &b_trk_lhits);
   tree->SetBranchAddress("trk_dhits", &trk_dhits, &b_trk_dhits);
@@ -398,7 +416,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   // ----------------------------------------------------------------------------------------------------------------
 
   /////////////////////////////////////////////////
-  // NOTATION:                                   //
+  // HISTOGRAM NOTATION:                         //
   // 'C' - Central eta range, |eta|<0.8          //
   // 'I' - Intermediate eta range, 0.8<|eta|<1.6 //
   // 'F' - Forward eta range, |eta|>1.6          //
@@ -468,7 +486,11 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   // resolution vs. pt histograms
 
   // ----------------------------------------------
-  // for new versions of resolution vs pt/eta plots
+  // The ranges here show where helix residual distributions are truncated when calculating
+  // resolution interval plots.
+  // If ranges are too small, warnings will be printed to cerr.
+  // (The plots booked here are not output, just used for these calculations).
+  
   unsigned int nBinsPtRes = 500;
   double maxPtRes = 30.;
 
@@ -483,6 +505,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
 
   unsigned int nBinsZ0Res = 100;
   double maxZ0Res = 4.0;
+
+  unsigned int nBinsD0Res = 100;
+  double maxD0Res = 0.2;
   // ----------------------------------------------
 
   const int nRANGE = 20;
@@ -521,44 +546,35 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
 
   for (int i = 0; i < nRANGE; i++) {
     h_absResVsPt_pt[i] = new TH1F(
-        "absResVsPt_pt_" + ptrange[i], ";p_{T} residual (L1 - sim) [GeV]; L1 tracks / 0.1", nBinsPtRes, 0, maxPtRes);
+        "absResVsPt_pt_" + ptrange[i], ";p_{T} residual (L1 - sim) [GeV]; L1 tracks", nBinsPtRes, 0, maxPtRes);
     h_absResVsPt_ptRel[i] = new TH1F("absResVsPt_ptRel_" + ptrange[i],
-                                     ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks / 0.02",
+                                     ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks",
                                      nBinsPtRelRes,
                                      0,
                                      maxPtRelRes);
     h_absResVsPt_z0[i] = new TH1F(
-        "absResVsPt_z0_" + ptrange[i], ";z_{0} residual (L1 - sim) [GeV]; L1 tracks / 0.1", nBinsZ0Res, 0, maxZ0Res);
+        "absResVsPt_z0_" + ptrange[i], ";z_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
     h_absResVsPt_phi[i] = new TH1F(
-        "absResVsPt_phi_" + ptrange[i], ";#phi residual (L1 - sim) [GeV]; L1 tracks / 0.1", nBinsPhiRes, 0, maxPhiRes);
+        "absResVsPt_phi_" + ptrange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
     h_absResVsPt_eta[i] = new TH1F(
-        "absResVsPt_eta_" + ptrange[i], ";#eta residual (L1 - sim) [GeV]; L1 tracks / 0.1", nBinsEtaRes, 0, maxEtaRes);
-    h_absResVsPt_d0[i] =
-        new TH1F("absResVsPt_d0_" + ptrange[i], ";d_{0}residual (L1 - sim) [GeV]; L1 tracks / 0.1", 100, 0, 0.02);
+        "absResVsPt_eta_" + ptrange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
+    h_absResVsPt_d0[i] = new TH1F(
+      "absResVsPt_d0_" + ptrange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsD0Res, 0, maxD0Res);
   }
 
   for (int i = 0; i < nRANGE_L; i++) {
     h_absResVsPt_pt_L[i] = new TH1F(
-        "absResVsPt_L_pt_" + ptrange_L[i], ";p_{T} residual (L1 - sim) [GeV]; L1 tracks / 0.1", nBinsPtRes, 0, maxPtRes);
-    h_absResVsPt_ptRel_L[i] = new TH1F("absResVsPt_L_ptRel_" + ptrange_L[i],
-                                       ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks / 0.02",
-                                       nBinsPtRelRes,
-                                       0,
-                                       maxPtRelRes);
+        "absResVsPt_L_pt_" + ptrange_L[i], ";p_{T} residual (L1 - sim) [GeV]; L1 tracks", nBinsPtRes, 0, maxPtRes);
+    h_absResVsPt_ptRel_L[i] = new TH1F(
+        "absResVsPt_L_ptRel_" + ptrange_L[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
     h_absResVsPt_z0_L[i] = new TH1F(
-        "absResVsPt_L_z0_" + ptrange_L[i], ";z_{0} residual (L1 - sim) [GeV]; L1 tracks / 0.1", nBinsZ0Res, 0, maxZ0Res);
-    h_absResVsPt_phi_L[i] = new TH1F("absResVsPt_L_phi_" + ptrange_L[i],
-                                     ";#phi residual (L1 - sim) [GeV]; L1 tracks / 0.1",
-                                     nBinsPhiRes,
-                                     0,
-                                     maxPhiRes);
-    h_absResVsPt_eta_L[i] = new TH1F("absResVsPt_L_eta_" + ptrange_L[i],
-                                     ";#eta residual (L1 - sim) [GeV]; L1 tracks / 0.1",
-                                     nBinsEtaRes,
-                                     0,
-                                     maxEtaRes);
+        "absResVsPt_L_z0_" + ptrange_L[i], ";z_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
+    h_absResVsPt_phi_L[i] = new TH1F(
+        "absResVsPt_L_phi_" + ptrange_L[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
+    h_absResVsPt_eta_L[i] = new TH1F(
+        "absResVsPt_L_eta_" + ptrange_L[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
     h_absResVsPt_d0_L[i] =
-        new TH1F("absResVsPt_L_d0_" + ptrange_L[i], ";d_{0}residual (L1 - sim) [GeV]; L1 tracks / 0.1", 100, 0, 0.02);
+        new TH1F("absResVsPt_L_d0_" + ptrange_L[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsZ0Res, 0, maxD0Res);
   }
 
   // resolution vs. eta histograms
@@ -593,66 +609,48 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TH1F* h_absResVsEta_ptRel_H[nETARANGE];
   TH1F* h_absResVsEta_d0_H[nETARANGE];
 
+  TH1F* h_absResVsEta_beamCon_phi[nETARANGE];
+  TH1F* h_absResVsEta_beamCon_ptRel[nETARANGE];
+
   for (int i = 0; i < nETARANGE; i++) {
     h_absResVsEta_eta[i] = new TH1F(
-        "absResVsEta_eta_" + etarange[i], ";#eta residual (L1 - sim) [GeV]; L1 tracks / 0.1", nBinsEtaRes, 0, maxEtaRes);
+        "absResVsEta_eta_" + etarange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
     h_absResVsEta_z0[i] = new TH1F(
-        "absResVsEta_z0_" + etarange[i], ";|z_{0} residual (L1 - sim)| [cm]; L1 tracks / 0.01", nBinsZ0Res, 0, maxZ0Res);
+        "absResVsEta_z0_" + etarange[i], ";z_{0} residual (L1 - sim)| [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
     h_absResVsEta_phi[i] = new TH1F(
-        "absResVsEta_phi_" + etarange[i], ";#phi residual (L1 - sim) [GeV]; L1 tracks / 0.1", nBinsPhiRes, 0, maxPhiRes);
-    h_absResVsEta_ptRel[i] = new TH1F("absResVsEta_ptRel_" + etarange[i],
-                                      ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks / 0.02",
-                                      nBinsPtRelRes,
-                                      0,
-                                      maxPtRelRes);
-    h_absResVsEta_d0[i] =
-        new TH1F("absResVsEta_d0_" + etarange[i], ";d_{0}residual (L1 - sim) [GeV]; L1 tracks / 0.1", 100, 0, 0.02);
+        "absResVsEta_phi_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
+    h_absResVsEta_ptRel[i] = new TH1F(
+        "absResVsEta_ptRel_" + etarange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
+    h_absResVsEta_d0[i] = new TH1F(
+        "absResVsEta_d0_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsD0Res, 0, maxD0Res);
 
-    h_absResVsEta_eta_L[i] = new TH1F("absResVsEta_eta_L_" + etarange[i],
-                                      ";#eta residual (L1 - sim) [GeV]; L1 tracks / 0.1",
-                                      nBinsEtaRes,
-                                      0,
-                                      maxEtaRes);
-    h_absResVsEta_z0_L[i] = new TH1F("absResVsEta_z0_L_" + etarange[i],
-                                     ";|z_{0} residual (L1 - sim)| [cm]; L1 tracks / 0.01",
-                                     nBinsZ0Res,
-                                     0,
-                                     maxZ0Res);
-    h_absResVsEta_phi_L[i] = new TH1F("absResVsEta_phi_L_" + etarange[i],
-                                      ";#phi residual (L1 - sim) [GeV]; L1 tracks / 0.1",
-                                      nBinsPhiRes,
-                                      0,
-                                      maxPhiRes);
-    h_absResVsEta_ptRel_L[i] = new TH1F("absResVsEta_ptRel_L_" + etarange[i],
-                                        ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks / 0.02",
-                                        nBinsPtRelRes,
-                                        0,
-                                        maxPtRelRes);
-    h_absResVsEta_d0_L[i] =
-        new TH1F("absResVsEta_d0_L_" + etarange[i], ";d_{0}residual (L1 - sim) [GeV]; L1 tracks / 0.1", 100, 0, 0.02);
+    h_absResVsEta_eta_L[i] = new TH1F(
+        "absResVsEta_eta_L_" + etarange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
+    h_absResVsEta_z0_L[i] = new TH1F(
+        "absResVsEta_z0_L_" + etarange[i], ";z_{0} residual (L1 - sim)| [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
+    h_absResVsEta_phi_L[i] = new TH1F(
+        "absResVsEta_phi_L_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
+    h_absResVsEta_ptRel_L[i] = new TH1F(
+        "absResVsEta_ptRel_L_" + etarange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
+    h_absResVsEta_d0_L[i] = new TH1F(
+        "absResVsEta_d0_L_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsD0Res, 0, maxD0Res);
 
-    h_absResVsEta_eta_H[i] = new TH1F("absResVsEta_eta_H_" + etarange[i],
-                                      ";#eta residual (L1 - sim) [GeV]; L1 tracks / 0.1",
-                                      nBinsEtaRes,
-                                      0,
-                                      maxEtaRes);
-    h_absResVsEta_z0_H[i] = new TH1F("absResVsEta_z0_H_" + etarange[i],
-                                     ";|z_{0} residual (L1 - sim)| [cm]; L1 tracks / 0.01",
-                                     nBinsZ0Res,
-                                     0,
-                                     maxZ0Res);
-    h_absResVsEta_phi_H[i] = new TH1F("absResVsEta_phi_H_" + etarange[i],
-                                      ";#phi residual (L1 - sim) [GeV]; L1 tracks / 0.1",
-                                      nBinsPhiRes,
-                                      0,
-                                      maxPhiRes);
-    h_absResVsEta_ptRel_H[i] = new TH1F("absResVsEta_ptRel_H_" + etarange[i],
-                                        ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks / 0.02",
-                                        nBinsPtRelRes,
-                                        0,
-                                        maxPtRelRes);
-    h_absResVsEta_d0_H[i] =
-        new TH1F("absResVsEta_d0_H_" + etarange[i], ";d_{0}residual (L1 - sim) [GeV]; L1 tracks / 0.1", 100, 0, 0.02);
+    h_absResVsEta_eta_H[i] = new TH1F(
+        "absResVsEta_eta_H_" + etarange[i], ";#eta residual (L1 - sim); L1 tracks", nBinsEtaRes, 0, maxEtaRes);
+    h_absResVsEta_z0_H[i] = new TH1F(
+        "absResVsEta_z0_H_" + etarange[i], ";z_{0} residual (L1 - sim)| [cm]; L1 tracks", nBinsZ0Res, 0, maxZ0Res);
+    h_absResVsEta_phi_H[i] = new TH1F(
+        "absResVsEta_phi_H_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
+    h_absResVsEta_ptRel_H[i] = new TH1F(
+        "absResVsEta_ptRel_H_" + etarange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
+    h_absResVsEta_d0_H[i] = new TH1F(
+        "absResVsEta_d0_H_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks", nBinsD0Res, 0, maxD0Res);
+
+    // Beam-spot constrained resolution
+    h_absResVsEta_beamCon_phi[i] = new TH1F(
+        "absResVsEta_beamCon_phi_" + etarange[i], ";#phi residual (L1 - sim); L1 tracks", nBinsPhiRes, 0, maxPhiRes);
+    h_absResVsEta_beamCon_ptRel[i] = new TH1F(
+        "absResVsEta_beamCon_ptRel_" + etarange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
   }
 
   // resolution vs phi
@@ -667,12 +665,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
 
   for (int i = 0; i < nPHIRANGE; i++) {
     h_absResVsPhi_pt[i] = new TH1F(
-        "absResVsPt_pt_" + phirange[i], ";p_{T} residual (L1 - sim) [GeV]; L1 tracks / 0.1", nBinsPtRes, 0, maxPtRes);
-    h_absResVsPhi_ptRel[i] = new TH1F("absResVsPt_ptRel_" + phirange[i],
-                                      ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks / 0.02",
-                                      nBinsPtRelRes,
-                                      0,
-                                      maxPtRelRes);
+        "absResVsPt_pt_" + phirange[i], ";p_{T} residual (L1 - sim) [GeV]; L1 tracks", nBinsPtRes, 0, maxPtRes);
+    h_absResVsPhi_ptRel[i] = new TH1F(
+        "absResVsPt_ptRel_" + phirange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks", nBinsPtRelRes, 0, maxPtRelRes);
   }
 
   // ----------------------------------------------------------------------------------------------------------------
@@ -695,6 +690,11 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TH1F* h_match_trk_chi2rz_dof =
       new TH1F("match_trk_chi2rz_dof", ";#chi^{2}_{r-z} / D.O.F.; L1 tracks / 0.2", 100, 0, 20);
 
+  // Ditto with beam-spot constraint on helix params
+  TH1F* h_trk_chi2rphi_dof_beamCon = new TH1F("trk_chi2rphi_dof_beamCon", ";#chi^{2}_{r-#phi} / D.O.F.; L1 tracks / 0.2", 100, 0, 20);
+  TH1F* h_match_trk_chi2rphi_dof_beamCon =
+      new TH1F("match_trk_chi2rphi_dof_beamCon", ";#chi^{2}_{r-#phi} / D.O.F.; L1 tracks / 0.2", 100, 0, 20);
+  
   // ----------------------------------------------------------------------------------------------------------------
   // total track rates
 
@@ -781,7 +781,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       new TH1F("match_trk_chi2_dof_F_H", ";#chi^{2} / D.O.F.; L1 tracks / 0.2", 100, 0, 20);
 
   // ----------------------------------------------------------------------------------------------------------------
-  // resolution histograms
+  // residual histograms to understand resolution
   TH1F* h_res_pt = new TH1F("res_pt", ";p_{T} residual (L1 - sim) [GeV]; L1 tracks / 0.05", 200, -5.0, 5.0);
   TH1F* h_res_ptRel = new TH1F("res_ptRel", ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks / 0.01", 200, -1.0, 1.0);
   TH1F* h_res_eta = new TH1F("res_eta", ";#eta residual (L1 - sim); L1 tracks / 0.0002", 100, -0.01, 0.01);
@@ -795,40 +795,40 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TH1F* h_res_z0_H = new TH1F("res_z0_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
 
   TH1F* h_res_z0_C_L =
-      new TH1F("res_z0_C_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, (-1) * 1.0, 1.0);
+      new TH1F("res_z0_C_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
   TH1F* h_res_z0_I_L =
-      new TH1F("res_z0_I_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, (-1) * 1.0, 1.0);
+      new TH1F("res_z0_I_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
   TH1F* h_res_z0_F_L =
-      new TH1F("res_z0_F_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, (-1) * 1.0, 1.0);
+      new TH1F("res_z0_F_L", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
   TH1F* h_res_z0_C_H =
-      new TH1F("res_z0_C_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, (-1) * 1.0, 1.0);
+      new TH1F("res_z0_C_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
   TH1F* h_res_z0_I_H =
-      new TH1F("res_z0_I_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, (-1) * 1.0, 1.0);
+      new TH1F("res_z0_I_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
   TH1F* h_res_z0_F_H =
-      new TH1F("res_z0_F_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, (-1) * 1.0, 1.0);
+      new TH1F("res_z0_F_H", ";z_{0} residual (L1 - sim) [cm]; L1 tracks / 0.02", 100, -1.0, 1.0);
 
-  TH1F* h_res_d0 = new TH1F("res_d0", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0002 cm", 200, -0.02, 0.02);
-  TH1F* h_res_d0_C = new TH1F("res_d0_C", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
-  TH1F* h_res_d0_I = new TH1F("res_d0_I", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
-  TH1F* h_res_d0_F = new TH1F("res_d0_F", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
-  TH1F* h_res_d0_L = new TH1F("res_d0_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
-  TH1F* h_res_d0_H = new TH1F("res_d0_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
+  TH1F* h_res_d0 = new TH1F("res_d0", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_C = new TH1F("res_d0_C", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_I = new TH1F("res_d0_I", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_F = new TH1F("res_d0_F", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_L = new TH1F("res_d0_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
+  TH1F* h_res_d0_H = new TH1F("res_d0_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
 
   TH1F* h_res_d0_C_L =
-      new TH1F("res_d0_C_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
+      new TH1F("res_d0_C_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
   TH1F* h_res_d0_I_L =
-      new TH1F("res_d0_I_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
+      new TH1F("res_d0_I_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
   TH1F* h_res_d0_F_L =
-      new TH1F("res_d0_F_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
+      new TH1F("res_d0_F_L", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
   TH1F* h_res_d0_C_H =
-      new TH1F("res_d0_C_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
+      new TH1F("res_d0_C_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
   TH1F* h_res_d0_I_H =
-      new TH1F("res_d0_I_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
+      new TH1F("res_d0_I_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
   TH1F* h_res_d0_F_H =
-      new TH1F("res_d0_F_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0001 cm", 200, -0.05, 0.05);
+      new TH1F("res_d0_F_H", ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 200, -0.2, 0.2);
 
   // ----------------------------------------------------------------------------------------------------------------
-  // more resolution vs pt
+  // more resolution vs pt (FIX: Do we need these, given we have resolution interval plots?)
 
   TH1F* h_resVsPt_pt[nRANGE];
   TH1F* h_resVsPt_pt_C[nRANGE];
@@ -894,11 +894,11 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
         new TH1F("resVsPt_eta_" + ptrange[i], ";#eta residual (L1 - sim); L1 tracks / 0.0002", 100, -0.01, 0.01);
 
     h_resVsPt_d0[i] =
-        new TH1F("resVsPt_d0_" + ptrange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.0004", 100, -0.02, 0.02);
+        new TH1F("resVsPt_d0_" + ptrange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 100, -0.1, 0.1);
   }
 
   // ----------------------------------------------------------------------------------------------------------------
-  // more resolution vs eta
+  // more resolution vs eta (FIX: Do we need these, given we have resolution interval plots?)
 
   TH1F* h_resVsEta_eta[nETARANGE];
   TH1F* h_resVsEta_eta_L[nETARANGE];
@@ -950,11 +950,11 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
         "resVsEta2_ptRel_H_" + etarange[i], ";p_{T} residual (L1 - sim) / p_{T}; L1 tracks / 0.02", 100, -0.25, 0.25);
 
     h_resVsEta_d0[i] =
-        new TH1F("resVsEta2_d0_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.004", 100, -0.02, 0.02);
+        new TH1F("resVsEta2_d0_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 100, -0.1, 0.1);
     h_resVsEta_d0_L[i] = new TH1F(
-        "resVsEta2_d0_L_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.004", 100, -0.02, 0.02);
+        "resVsEta2_d0_L_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 100, -0.1, 0.1);
     h_resVsEta_d0_H[i] = new TH1F(
-        "resVsEta2_d0_H_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.004", 100, -0.02, 0.02);
+        "resVsEta2_d0_H_" + etarange[i], ";d_{0} residual (L1 - sim) [cm]; L1 tracks / 0.002", 100, -0.1, 0.1);
   }
   // ----------------------------------------------------------------------------------------------------------------
 
@@ -1080,6 +1080,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       float chi2rphidof = trk_chi2rphi_dof->at(it);
       float chi2rz = trk_chi2rz->at(it);
       float chi2rzdof = trk_chi2rz_dof->at(it);
+      float chi2rphidof_beamCon = trk_chi2rphi_dof_beamCon->at(it);
 
       // create overflow bins by restricting range of chi2
       int chi2Overflow = 100;
@@ -1098,6 +1099,8 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
         chi2rz = chi2Overflow - buffer;
       if (chi2rzdof > chi2DOFOverflow)
         chi2rzdof = chi2DOFOverflow - buffer;
+      if (chi2rphidof_beamCon > chi2DOFOverflow)
+        chi2rphidof_beamCon = chi2DOFOverflow - buffer;
 
       if (trk_pt->at(it) > TP_minPt) {  //TRK pt > TP_minPt
 
@@ -1110,6 +1113,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
         h_trk_chi2rz->Fill(chi2rz);
         h_trk_chi2rz_dof->Fill(chi2rzdof);
 
+        h_trk_chi2rphi_dof_beamCon->Fill(chi2rphidof_beamCon);
       }  //end TRK pt > TP_minPt
 
       // ----------------------------------------------------------------------------------------------------------------
@@ -1186,9 +1190,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       if (trk_genuine->at(it) && trk_matchtp_eventtype->at(it) == 1) {
         std::vector<float>* m_trk_matchtp_z0;
         p_resOverSigmaVsEta_z0->Fill(fabs(trk_eta->at(it)),
-                                     fabs(trk_z0->at(it) - trk_matchtp_z0->at(it)) / trk_sigma_z0->at(it));
+            fabs(trk_z0->at(it) - trk_matchtp_z0->at(it)) / trk_sigma_z0->at(it));
         p_resOverSigmaVsNumPS_z0->Fill(trk_nPS_hitpattern->at(it),
-                                       fabs(trk_z0->at(it) - trk_matchtp_z0->at(it)) / trk_sigma_z0->at(it));
+            fabs(trk_z0->at(it) - trk_matchtp_z0->at(it)) / trk_sigma_z0->at(it));
       }
 
       // ----------------------------------------------------------------------------------------------------------------
@@ -1384,6 +1388,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       float chi2rphidof = matchtrk_chi2rphi_dof->at(it);
       float chi2rz = matchtrk_chi2rz->at(it);
       float chi2rzdof = matchtrk_chi2rz_dof->at(it);
+      float chi2rphidof_beamCon = matchtrk_chi2rphi_dof_beamCon->at(it);
 
       // create overflow bins by restricting range of chi2
       int chi2Overflow = 100;
@@ -1402,6 +1407,8 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
         chi2rz = chi2Overflow - buffer;
       if (chi2rzdof > chi2DOFOverflow)
         chi2rzdof = chi2DOFOverflow - buffer;
+      if (chi2rphidof_beamCon > chi2DOFOverflow)
+        chi2rphidof_beamCon = chi2DOFOverflow - buffer;
 
       if (tp_pt->at(it) > TP_minPt) {  //TP pt > TP_minPt
 
@@ -1413,6 +1420,8 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
 
         h_match_trk_chi2rz->Fill(chi2rz);
         h_match_trk_chi2rz_dof->Fill(chi2rzdof);
+
+        h_match_trk_chi2rphi_dof_beamCon->Fill(chi2rphidof_beamCon);
 
         // central eta
         if (std::abs(tp_eta->at(it)) < 0.8) {
@@ -1539,8 +1548,7 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       h_res_phi->Fill(matchtrk_phi->at(it) - tp_phi->at(it));
       h_res_z0->Fill(matchtrk_z0->at(it) - tp_z0->at(it));
       if (matchtrk_d0->at(it) < 999.)
-        h_res_d0->Fill(matchtrk_d0->at(it) - tp_d0->at(it));
-
+        h_res_d0->Fill(matchtrk_d0->at(it) - tp_d0->at(it));      
       if (std::abs(tp_eta->at(it)) < 0.8)
         h_res_z0_C->Fill(matchtrk_z0->at(it) - tp_z0->at(it));
       else if (std::abs(tp_eta->at(it)) < 1.6 && std::abs(tp_eta->at(it)) >= 0.8)
@@ -1649,6 +1657,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
           h_absResVsEta_eta[im]->Fill(std::abs(matchtrk_eta->at(it) - tp_eta->at(it)));
           h_absResVsEta_phi[im]->Fill(std::abs(matchtrk_phi->at(it) - tp_phi->at(it)));
           h_absResVsEta_z0[im]->Fill(std::abs(matchtrk_z0->at(it) - tp_z0->at(it)));
+
+          h_absResVsEta_beamCon_ptRel[im]->Fill(std::abs((matchtrk_pt_beamCon->at(it) - tp_pt->at(it))) / tp_pt->at(it));
+          h_absResVsEta_beamCon_phi[im]->Fill(std::abs(matchtrk_phi_beamCon->at(it) - tp_phi->at(it)));
 
           if (tp_pt->at(it) < 8.0) {
             h_resVsEta_ptRel_L[im]->Fill((matchtrk_pt->at(it) - tp_pt->at(it)) / tp_pt->at(it));
@@ -2017,19 +2028,19 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TH1F* h2_resVsEta_z0_99 =
       new TH1F("resVsEta_z0_99", ";Tracking particle |#eta|; z_{0} resolution [cm]", nETARANGE, 0, eta_resmax);
 
-  TH1F* h2_resVsEta_phi_68 =
-      new TH1F("resVsEta_phi_68", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
-  TH1F* h2_resVsEta_phi_90 =
-      new TH1F("resVsEta_phi_90", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
-  TH1F* h2_resVsEta_phi_99 =
-      new TH1F("resVsEta_phi_99", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_68 = new TH1F(
+    "resVsEta_phi_68", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_90 = new TH1F(
+    "resVsEta_phi_90", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_99 = new TH1F(
+    "resVsEta_phi_99", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
 
-  TH1F* h2_resVsEta_ptRel_68 =
-      new TH1F("resVsEta_ptRel_68", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
-  TH1F* h2_resVsEta_ptRel_90 =
-      new TH1F("resVsEta_ptRel_90", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
-  TH1F* h2_resVsEta_ptRel_99 =
-      new TH1F("resVsEta_ptRel_99", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_ptRel_68 = new TH1F(
+    "resVsEta_ptRel_68", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_ptRel_90 = new TH1F(
+    "resVsEta_ptRel_90", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_ptRel_99 = new TH1F(
+    "resVsEta_ptRel_99", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
 
   TH1F* h2_resVsEta_d0_68 =
       new TH1F("resVsEta_d0_68", ";Tracking particle |#eta|; d_{0} resolution [cm]", nETARANGE, 0, eta_resmax);
@@ -2038,6 +2049,22 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   TH1F* h2_resVsEta_d0_99 =
       new TH1F("resVsEta_d0_99", ";Tracking particle |#eta|; d_{0} resolution [cm]", nETARANGE, 0, eta_resmax);
 
+  // Same,but for helix params with beam-spot constraint
+  TH1F* h2_resVsEta_phi_beamCon_68 = new TH1F(
+    "resVsEta_phi_beamCon_68", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_beamCon_90 = new TH1F(
+    "resVsEta_phi_beamCon_90", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_phi_beamCon_99 = new TH1F(
+    "resVsEta_phi_beamCon_99", ";Tracking particle |#eta|; #phi resolution [rad]", nETARANGE, 0, eta_resmax);
+
+  TH1F* h2_resVsEta_ptRel_beamCon_68 = new TH1F(
+    "resVsEta_ptRel_beamCon_68", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_ptRel_beamCon_90 = new TH1F(
+    "resVsEta_ptRel_beamCon_90", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+  TH1F* h2_resVsEta_ptRel_beamCon_99 = new TH1F(
+    "resVsEta_ptRel_beamCon_99", ";Tracking particle |#eta|; p_{T} resolution / p_{T}", nETARANGE, 0, eta_resmax);
+  
+  // Same, but for low or high Pt ranges
   TH1F* h2_resVsEta_eta_L_68 =
       new TH1F("resVsEta_eta_L_68", ";Tracking particle |#eta|; #eta resolution", nETARANGE, 0, eta_resmax);
   TH1F* h2_resVsEta_z0_L_68 =
@@ -2187,6 +2214,14 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
     h2_resVsEta_d0_68->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_d0[i], 0.68));
     h2_resVsEta_d0_90->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_d0[i], 0.90));
     h2_resVsEta_d0_99->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_d0[i], 0.99));
+
+    h2_resVsEta_ptRel_beamCon_68->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_ptRel[i], 0.68));
+    h2_resVsEta_ptRel_beamCon_90->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_ptRel[i], 0.90));
+    h2_resVsEta_ptRel_beamCon_99->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_ptRel[i], 0.99));
+
+    h2_resVsEta_phi_beamCon_68->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_phi[i], 0.68));
+    h2_resVsEta_phi_beamCon_90->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_phi[i], 0.90));
+    h2_resVsEta_phi_beamCon_99->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_beamCon_phi[i], 0.99));
 
     h2_resVsEta_eta_L_68->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_eta_L[i], 0.68));
     h2_resVsEta_z0_L_68->SetBinContent(i + 1, getIntervalContainingFractionOfEntries(h_absResVsEta_z0_L[i], 0.68));
@@ -2508,12 +2543,14 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
 
   // plots overlaying 68, 90, 99% confidence levels]
 
-  float max_eta_ptRel = 0.2;
+  // set plotting dislay limit on interval plot resolution
+  float max_eta_ptRel = 0.2; 
   float max_pt_ptRel = 0.2;
   float max_pt_pt = 20;
   float max_z0 = 2.0;
   float max_phi = 0.01;
   float max_eta = 0.03;
+  float max_d0 = 0.008;
 
   if (type.Contains("El")) {
     max_pt_ptRel = 1.0;
@@ -2524,22 +2561,19 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   // makeResidualIntervalPlot will save the individual plots to the root file
   makeResidualIntervalPlot(
       type, DIR, "resVsPt_ptRel", h2_resVsPt_ptRel_68, h2_resVsPt_ptRel_90, h2_resVsPt_ptRel_99, 0, max_pt_ptRel);
-  makeResidualIntervalPlot(type, DIR, "resVsPt_pt", h2_resVsPt_pt_68, h2_resVsPt_pt_90, h2_resVsPt_pt_99, 0, max_pt_pt);
-  makeResidualIntervalPlot(type, DIR, "resVsPt_z0", h2_resVsPt_z0_68, h2_resVsPt_z0_90, h2_resVsPt_z0_99, 0, max_z0);
+  makeResidualIntervalPlot(
+      type, DIR, "resVsPt_pt", h2_resVsPt_pt_68, h2_resVsPt_pt_90, h2_resVsPt_pt_99, 0, max_pt_pt);
+  makeResidualIntervalPlot(
+      type, DIR, "resVsPt_z0", h2_resVsPt_z0_68, h2_resVsPt_z0_90, h2_resVsPt_z0_99, 0, max_z0);
   makeResidualIntervalPlot(
       type, DIR, "resVsPt_phi", h2_resVsPt_phi_68, h2_resVsPt_phi_90, h2_resVsPt_phi_99, 0, max_phi);
   makeResidualIntervalPlot(
       type, DIR, "resVsPt_eta", h2_resVsPt_eta_68, h2_resVsPt_eta_90, h2_resVsPt_eta_99, 0, max_eta);
-  //makeResidualIntervalPlot( type, DIR, "resVsPt_d0", h2_resVsPt_d0_68, h2_resVsPt_d0_90, h2_resVsPt_d0_99, 0, 0.02 );
-
-  makeResidualIntervalPlot(type,
-                           DIR,
-                           "resVsPt_L_ptRel",
-                           h2_resVsPt_ptRel_L_68,
-                           h2_resVsPt_ptRel_L_90,
-                           h2_resVsPt_ptRel_L_99,
-                           0,
-                           max_pt_ptRel);
+  makeResidualIntervalPlot(
+      type, DIR, "resVsPt_d0", h2_resVsPt_d0_68, h2_resVsPt_d0_90, h2_resVsPt_d0_99, 0, max_d0 );
+  
+  makeResidualIntervalPlot(
+      type, DIR, "resVsPt_L_ptRel", h2_resVsPt_ptRel_L_68, h2_resVsPt_ptRel_L_90, h2_resVsPt_ptRel_L_99, 0, max_pt_ptRel);
   makeResidualIntervalPlot(type, DIR, "resVsPt_L_pt", h2_resVsPt_pt_L_68, h2_resVsPt_pt_L_90, h2_resVsPt_pt_L_99, 0, 4);
   makeResidualIntervalPlot(
       type, DIR, "resVsPt_L_z0", h2_resVsPt_z0_L_68, h2_resVsPt_z0_L_90, h2_resVsPt_z0_L_99, 0, max_z0);
@@ -2547,7 +2581,8 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       type, DIR, "resVsPt_L_phi", h2_resVsPt_phi_L_68, h2_resVsPt_phi_L_90, h2_resVsPt_phi_L_99, 0, max_phi);
   makeResidualIntervalPlot(
       type, DIR, "resVsPt_L_eta", h2_resVsPt_eta_L_68, h2_resVsPt_eta_L_90, h2_resVsPt_eta_L_99, 0, max_eta);
-  //makeResidualIntervalPlot( type, DIR, "resVsPt_L_d0", h2_resVsPt_d0_L_68, h2_resVsPt_d0_L_90, h2_resVsPt_d0_L_99, 0, 0.02 );
+  makeResidualIntervalPlot(
+      type, DIR, "resVsPt_L_d0", h2_resVsPt_d0_L_68, h2_resVsPt_d0_L_90, h2_resVsPt_d0_L_99, 0, max_d0 );
 
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_eta", h2_resVsEta_eta_68, h2_resVsEta_eta_90, h2_resVsEta_eta_99, 0, max_eta);
@@ -2557,23 +2592,22 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       type, DIR, "resVsEta_phi", h2_resVsEta_phi_68, h2_resVsEta_phi_90, h2_resVsEta_phi_99, 0, max_phi);
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_ptRel", h2_resVsEta_ptRel_68, h2_resVsEta_ptRel_90, h2_resVsEta_ptRel_99, 0, max_eta_ptRel);
-  //makeResidualIntervalPlot( type, DIR, "resVsEta_d0", h2_resVsEta_d0_68, h2_resVsEta_d0_90, h2_resVsEta_d0_99, 0, 0.02 );
+  makeResidualIntervalPlot( type, DIR, "resVsEta_d0", h2_resVsEta_d0_68, h2_resVsEta_d0_90, h2_resVsEta_d0_99, 0, max_d0 );
 
+  makeResidualIntervalPlot(
+      type, DIR, "resVsEta_ptRel_beamCon", h2_resVsEta_ptRel_beamCon_68, h2_resVsEta_ptRel_beamCon_90, h2_resVsEta_ptRel_beamCon_99, 0, max_pt_ptRel);
+  makeResidualIntervalPlot(
+      type, DIR, "resVsEta_phi_beamCon", h2_resVsEta_phi_beamCon_68, h2_resVsEta_phi_beamCon_90, h2_resVsEta_phi_beamCon_99, 0, max_phi);
+  
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_L_eta", h2_resVsEta_eta_L_68, h2_resVsEta_eta_L_90, h2_resVsEta_eta_L_99, 0, max_eta);
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_L_z0", h2_resVsEta_z0_L_68, h2_resVsEta_z0_L_90, h2_resVsEta_z0_L_99, 0, max_z0);
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_L_phi", h2_resVsEta_phi_L_68, h2_resVsEta_phi_L_90, h2_resVsEta_phi_L_99, 0, max_phi);
-  makeResidualIntervalPlot(type,
-                           DIR,
-                           "resVsEta_L_ptRel",
-                           h2_resVsEta_ptRel_L_68,
-                           h2_resVsEta_ptRel_L_90,
-                           h2_resVsEta_ptRel_L_99,
-                           0,
-                           max_eta_ptRel);
-  //makeResidualIntervalPlot( type, DIR, "resVsEta_L_d0", h2_resVsEta_d0_L_68, h2_resVsEta_d0_L_90, h2_resVsEta_d0_L_99, 0, 0.02 );
+  makeResidualIntervalPlot(
+      type, DIR, "resVsEta_L_ptRel", h2_resVsEta_ptRel_L_68, h2_resVsEta_ptRel_L_90, h2_resVsEta_ptRel_L_99, 0, max_eta_ptRel);
+  makeResidualIntervalPlot( type, DIR, "resVsEta_L_d0", h2_resVsEta_d0_L_68, h2_resVsEta_d0_L_90, h2_resVsEta_d0_L_99, 0, max_d0 );
 
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_H_eta", h2_resVsEta_eta_H_68, h2_resVsEta_eta_H_90, h2_resVsEta_eta_H_99, 0, max_eta);
@@ -2581,15 +2615,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
       type, DIR, "resVsEta_H_z0", h2_resVsEta_z0_H_68, h2_resVsEta_z0_H_90, h2_resVsEta_z0_H_99, 0, max_z0);
   makeResidualIntervalPlot(
       type, DIR, "resVsEta_H_phi", h2_resVsEta_phi_H_68, h2_resVsEta_phi_H_90, h2_resVsEta_phi_H_99, 0, max_phi);
-  makeResidualIntervalPlot(type,
-                           DIR,
-                           "resVsEta_H_ptRel",
-                           h2_resVsEta_ptRel_H_68,
-                           h2_resVsEta_ptRel_H_90,
-                           h2_resVsEta_ptRel_H_99,
-                           0,
-                           max_eta_ptRel);
-  //makeResidualIntervalPlot( type, DIR, "resVsEta_H_d0", h2_resVsEta_d0_H_68, h2_resVsEta_d0_H_90, h2_resVsEta_d0_H_99, 0, 0.02 );
+  makeResidualIntervalPlot(
+      type, DIR, "resVsEta_H_ptRel", h2_resVsEta_ptRel_H_68, h2_resVsEta_ptRel_H_90, h2_resVsEta_ptRel_H_99, 0, max_eta_ptRel);
+  makeResidualIntervalPlot( type, DIR, "resVsEta_H_d0", h2_resVsEta_d0_H_68, h2_resVsEta_d0_H_90, h2_resVsEta_d0_H_99, 0, max_d0 );
 
   if (doDetailedPlots) {
     makeResidualIntervalPlot(
@@ -2870,43 +2898,14 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
     h_match_trk_nstub_I->Write();
     h_match_trk_nstub_F->Write();
   }
-
-  h_trk_chi2->Draw();
-  sprintf(ctxt, "|eta| < 2.4");
-  mySmallText(0.52, 0.82, 1, ctxt);
-  c.SaveAs(DIR + type + "_trk_chi2.pdf");
-
-  h_trk_chi2_dof->Draw();
-  sprintf(ctxt, "|eta| < 2.4");
-  mySmallText(0.52, 0.82, 1, ctxt);
-  c.SaveAs(DIR + type + "_trk_chi2_dof.pdf");
-
-  h_trk_chi2rphi->Draw();
-  sprintf(ctxt, "|eta| < 2.4");
-  mySmallText(0.52, 0.82, 1, ctxt);
-  c.SaveAs(DIR + type + "_trk_chi2rphi.pdf");
-
-  h_trk_chi2rphi_dof->Draw();
-  sprintf(ctxt, "|eta| < 2.4");
-  mySmallText(0.52, 0.82, 1, ctxt);
-  c.SaveAs(DIR + type + "_trk_chi2rphi_dof.pdf");
-
-  h_trk_chi2rz->Draw();
-  sprintf(ctxt, "|eta| < 2.4");
-  mySmallText(0.52, 0.82, 1, ctxt);
-  c.SaveAs(DIR + type + "_trk_chi2rz.pdf");
-
-  h_trk_chi2rz_dof->Draw();
-  sprintf(ctxt, "|eta| < 2.4");
-  mySmallText(0.52, 0.82, 1, ctxt);
-  c.SaveAs(DIR + type + "_trk_chi2rz_dof.pdf");
-
-  h_trk_chi2->Write();
-  h_trk_chi2rphi->Write();
-  h_trk_chi2rz->Write();
-  h_match_trk_chi2->Write();
-  h_match_trk_chi2rphi->Write();
-  h_match_trk_chi2rz->Write();
+  
+  makeAllAndTruePDF(type, DIR, "trk_chi2", h_trk_chi2, h_match_trk_chi2);
+  makeAllAndTruePDF(type, DIR, "trk_chi2_dof", h_trk_chi2_dof, h_match_trk_chi2_dof);
+  makeAllAndTruePDF(type, DIR, "trk_chi2rphi", h_trk_chi2rphi, h_match_trk_chi2rphi);
+  makeAllAndTruePDF(type, DIR, "trk_chi2rphi_dof", h_trk_chi2rphi_dof, h_match_trk_chi2rphi_dof);
+  makeAllAndTruePDF(type, DIR, "trk_chi2rz", h_trk_chi2rz, h_match_trk_chi2rz);
+  makeAllAndTruePDF(type, DIR, "trk_chi2rz_dof", h_trk_chi2rz_dof, h_match_trk_chi2rz_dof);
+  makeAllAndTruePDF(type, DIR, "trk_chi2rphi_dof_beamCon", h_trk_chi2rphi_dof_beamCon, h_match_trk_chi2rphi_dof_beamCon);
 
   if (doDetailedPlots) {
     h_match_trk_chi2_C_L->Write();
@@ -3863,23 +3862,29 @@ double getIntervalContainingFractionOfEntries(TH1* absResidualHistogram, double 
   double totalIntegral = absResidualHistogram->Integral(0, absResidualHistogram->GetNbinsX() + 1);
   double numEntries = absResidualHistogram->GetEntries();
 
-  // Check that the interval is not somewhere in the overflow bin
   double maxAllowedEntriesInOverflow = totalIntegral * (1 - quantileToCalculate);
   double nEntriesInOverflow = absResidualHistogram->GetBinContent(absResidualHistogram->GetNbinsX() + 1);
-  if (nEntriesInOverflow > maxAllowedEntriesInOverflow) {
-    // cout << "WARNING : Cannot compute range corresponding to interval, as it is in the overflow bin" << endl;
-    return absResidualHistogram->GetXaxis()->GetXmax() * 1.2;
-  }
-
-  // Calculate quantile for given interval
   double interval[1];
   double quantile[1] = {quantileToCalculate};
-  if (totalIntegral > 0 && numEntries >= minEntries) {
-    absResidualHistogram->GetQuantiles(1, interval, quantile);
+  static unsigned int nErr = 0;
+  constexpr unsigned int maxErr = 10;
+  if (totalIntegral == 0 || numEntries < minEntries) {
+    if (quantileToCalculate < 0.70 && nErr < maxErr) { // Avoid repeat warning for all quantiles
+      nErr++;
+      cerr << "WARNING: Cannot compute " << quantileToCalculate << " quantile inverval, as too few stats (" << numEntries << ") in histo " << absResidualHistogram->GetName() << endl;
+    }
+    interval[0] = 999.;
+  } else if (nEntriesInOverflow > maxAllowedEntriesInOverflow) {
+    // Suppress warning for 99% interval.
+    if (quantileToCalculate < 0.98 && nErr < maxErr) {
+      nErr++;
+      cerr << "WARNING : Cannot compute " << quantileToCalculate << " quantile interval, as it is in the overflow bin of histo " << absResidualHistogram->GetName() <<" -- please increase its x-axis range. " << nEntriesInOverflow << "/" << numEntries << endl;
+    }
+    interval[0] = 999.;
   } else {
-    cout << "WARNING: histo " << absResidualHistogram->GetName()
-         << " empty or with too few entries, so can't calc quantiles." << endl;
-    interval[0] = 0.;
+    
+    // Calculate quantile for given interval
+    absResidualHistogram->GetQuantiles(1, interval, quantile);
   }
 
   return interval[0];
@@ -3921,4 +3926,26 @@ void makeResidualIntervalPlot(
   c.SaveAs(dir + type + "_" + variable + "_interval.pdf");
 
   delete l;
+}
+
+void makeAllAndTruePDF(TString type, TString dir, TString variable,
+                       TH1F* h_all, TH1F* h_match) {
+  // Create PDF in which equivalent histograms that show all tracks and only genuine (matched) tracks are superimposed.
+  TCanvas c;
+
+  h_all->Draw("HIST");
+  h_match->SetMarkerStyle(20);
+  h_match->Draw("P SAME");
+  TLegend* l = new TLegend(0.65, 0.65, 0.85, 0.85);
+  l->SetFillStyle(0);
+  l->SetBorderSize(0);
+  l->SetTextSize(0.04);
+  l->AddEntry(h_all, "All tracks", "L");
+  l->AddEntry(h_match, "Genuine tracks", "p");
+  l->SetTextFont(42);
+  l->Draw();
+  c.SaveAs(dir + type + "_" + variable + ".pdf");
+
+  h_all->Write();
+  h_match->Write();
 }

--- a/L1Trigger/TrackerTFP/src/CleanTrackBuilder.cc
+++ b/L1Trigger/TrackerTFP/src/CleanTrackBuilder.cc
@@ -511,9 +511,8 @@ namespace trackerTFP {
     const int hitPattern = hits.val();
     const double bField = setup_->bField();
     TTTrack<Ref_Phase2TrackerDigi_> ttTrack(
-        invR, phi0, cot, z0, d0, chi2phi, chi2z, trkMVA1, trkMVA2, trkMVA3, hitPattern, nPar, bField);
+        invR, phi0, cot, z0, d0, chi2phi, chi2z, trkMVA1, trkMVA2, trkMVA3, hitPattern, nPar, bField, region);
     ttTrack.setStubRefs(ttStubRefs);
-    ttTrack.setPhiSector(region);
     ttTracks.emplace_back(ttTrack);
   }
 

--- a/L1Trigger/TrackerTFP/src/LayerEncoding.cc
+++ b/L1Trigger/TrackerTFP/src/LayerEncoding.cc
@@ -1,5 +1,6 @@
 #include "L1Trigger/TrackerTFP/interface/LayerEncoding.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <vector>
 #include <set>
@@ -159,7 +160,9 @@ namespace trackerTFP {
     return maybePS(binZT);
   }
 
-  // fills binZT (unsigned), numPS, num2S, numMissingPS and numMissingPS for given TTTrack hitPattern and trajectory
+  // fills binZT (unsigned), numPS, num2S, numMissingPS and numMissingPS for given TTTrack hitPattern and trajectory.
+  // (P.S. This assumes that the left-most bits of the hit pattern correspond to the outer layers, which is true for
+  // TTTracks, but not true for internal KF hit patterns, which use the opposite convention).
   void LayerEncoding::analyze(int hitpattern,
                               double cot,
                               double z0,
@@ -193,6 +196,14 @@ namespace trackerTFP {
         // compare with innermost edge of 2S modules to identify PS
         if (r < rLimit)
           ps = true;
+      }
+      if (layerId < 0) {
+        // TO FIX: This warning can occur because the KF determines which r-z sector each track is
+        // in using the Tracklet helix params, whereas users accessing the TTTrack object
+        // only have access to the KF helix params, which for about 2% of tracks correspond to
+        // a different r-z sector.
+        edm::LogWarning("LayerEncoding") << "Track's hit-pattern has stub in non-traversed layer";
+        ps = false;  // Warning happens mainly in 2S layers, so this is best guess.
       }
       if (hp.test(layerIdKF))  // layer is hit
         ps ? numPS++ : num2S++;

--- a/L1Trigger/TrackerTFP/src/TrackFindingProcessor.cc
+++ b/L1Trigger/TrackerTFP/src/TrackFindingProcessor.cc
@@ -228,6 +228,7 @@ namespace trackerTFP {
       static constexpr double trkMVA3 = 0.;
       const unsigned int aHitpattern = it->hitPattern_.val();
       const unsigned int nPar = ttTrackRef->nFitPars();
+      constexpr float dummy = -99.;
       outputs.emplace_back(aRinv,
                            aphi,
                            aTanLambda,
@@ -240,13 +241,14 @@ namespace trackerTFP {
                            trkMVA3,
                            aHitpattern,
                            nPar,
-                           bfield_);
+                           bfield_,
+                           region,
+                           dfZT.toUnsigned(dfZT.integer(it->zT_)),
+                           dummy,
+                           ttTrackRef->trackSeedType());
       TTTrack<Ref_Phase2TrackerDigi_>& ttTrack = outputs.back();
-      ttTrack.setPhiSector(region);
-      ttTrack.setEtaSector(dfZT.toUnsigned(dfZT.integer(it->zT_)));
-      ttTrack.setTrackSeedType(ttTrackRef->trackSeedType());
       ttTrack.setStubRefs(it->ttStubRefs_);
-      ttTrack.setStubPtConsistency(StubPtConsistency::getConsistency(
+      ttTrack.setChi2BendRed(StubPtConsistency::getConsistency(
           ttTrack, setup_->trackerGeometry(), setup_->trackerTopology(), bfield_, nPar));
     }
   }

--- a/L1Trigger/TrackerTFP/src/TrackQuality.cc
+++ b/L1Trigger/TrackerTFP/src/TrackQuality.cc
@@ -139,7 +139,7 @@ namespace trackerTFP {
     TTTrack<Ref_Phase2TrackerDigi_> ttTrack(
         aRinv, aphi, aTanLambda, az0, ad0, aChi2xyfit, aChi2zfit, trkMVA1, trkMVA2, trkMVA3, aHitpattern, nPar, Bfield);
     ttTrack.setStubRefs(ttStubRefs);
-    ttTrack.setStubPtConsistency(
+    ttTrack.setChi2BendRed(
         StubPtConsistency::getConsistency(ttTrack, setup->trackerGeometry(), setup->trackerTopology(), Bfield, nPar));
     const int chi2B = tq->toBinChi2B(ttTrack.chi2Bend());
     const int chi2rphi = tq->toBinchi2rphi(trackchi2rphi);


### PR DESCRIPTION
#### PR description:

Thanks to this PR, the covariance matrix obtained from the HYBRID KF fit is now stored in the TTTrack object, and a couple of histograms "resOverSigma*z0"plotting z0 resolution divided by the uncertainty in the z0 taken from this matrix have been added to L1TrackNtuplePlot.C .

In addition, the TTTrack object has been slightly tidied up. This clean up preserves backwards compatibility, so it should still be possible to read old datasets, but a couple of changes are needed to L1 trigger code.

Since the TTTrack function  stubPtConsistency() was renamed chi2BendRed() some years ago, and this PR deletes the obsolete name, I've made a PR https://github.com/cms-sw/cmssw/pull/49565 to central CMSSW to change the few L1 trigger routines that have not changed to the new name.

A function TTTrack::beamConstraint() has been added to optionally constrain  the helix parameters obtained with displaced tracking to x=y=0. However, correct treatment of the (x,y) offset of the beam-spot is needed in the L1 trigger code before this can be meaningfully used, since historical records show it can be offset from x=y=0 by up to 2mm.

Quantile based resolution plots have been enabled in L1TrackNTuplePlot.C for the d0. And also plots for the beam-constrained Pt and phi0.

All chi2 plots have been modified, so that the output PDF now superimposes chi2 distributions for all tracks and those of genuine tracks. A plot for the beam-constrained chi2/dof has been added.

#### PR validation:

No change in tracking performance.

I've checked that with this PR, we're still capable of reading TTTrack EDProducts from existing MC, so it doesn't break backwards compatibility. (To be expected, as it only adds new TTTrack data members, and doesn't modify existing ones).