### PR TITLE
All-sector test vectors

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/CleanTrackMemory.h
+++ b/L1Trigger/TrackFindingTracklet/interface/CleanTrackMemory.h
@@ -28,6 +28,8 @@ namespace trklet {
     double phimin_;
     double phimax_;
     std::vector<Tracklet*> tracks_;
+
+    std::ofstream outCT_;
   };
 
 };  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/interface/MemoryBase.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MemoryBase.h
@@ -35,6 +35,9 @@ namespace trklet {
     //Used for a hack below due to MAC OS case insensitiviy problem for files
     void findAndReplaceAll(std::string& data, std::string toSearch, std::string replaceStr);
 
+    std::string fnameWithSuffix(const std::string& fname);
+    std::string eventHeader();
+
     void openFile(bool first, std::string dirName, std::string filebase);
 
     static size_t find_nth(const std::string& haystack, size_t pos, const std::string& needle, size_t nth);

--- a/L1Trigger/TrackFindingTracklet/interface/MemoryBase.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MemoryBase.h
@@ -37,6 +37,7 @@ namespace trklet {
 
     std::string fnameWithSuffix(const std::string& fname);
     std::string eventHeader();
+    void incrBXEvent();
 
     void openFile(const bool first, const std::string& dirName, const std::string& filebase);
 

--- a/L1Trigger/TrackFindingTracklet/interface/MemoryBase.h
+++ b/L1Trigger/TrackFindingTracklet/interface/MemoryBase.h
@@ -38,7 +38,7 @@ namespace trklet {
     std::string fnameWithSuffix(const std::string& fname);
     std::string eventHeader();
 
-    void openFile(bool first, std::string dirName, std::string filebase);
+    void openFile(const bool first, const std::string& dirName, const std::string& filebase);
 
     static size_t find_nth(const std::string& haystack, size_t pos, const std::string& needle, size_t nth);
 

--- a/L1Trigger/TrackFindingTracklet/interface/Sector.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Sector.h
@@ -84,6 +84,8 @@ namespace trklet {
     void writeTF(bool first);
     void writeCT(bool first);
 
+    void incrBXEvent();
+
     void clean();
 
     // execute the different tracklet processing modules

--- a/L1Trigger/TrackFindingTracklet/interface/Settings.h
+++ b/L1Trigger/TrackFindingTracklet/interface/Settings.h
@@ -192,7 +192,8 @@ namespace trklet {
     const std::string& memPath() const { return memPath_; }
     const std::string& tablePath() const { return tablePath_; }
 
-    unsigned int writememsect() const { return writememsect_; }
+    int writememsect() const { return writememsect_; }
+    bool splitmembysect() const { return (writememsect_ >= 0 || splitmembysect_); }
 
     bool enableTripletTables() const { return enableTripletTables_; }
     bool writeTripletTables() const { return writeTripletTables_; }
@@ -920,7 +921,9 @@ namespace trklet {
     std::string memPath_{"L1Trigger/TrackFindingTracklet/data/MemPrints/"};  //path for writing memories
     std::string tablePath_{"L1Trigger/TrackFindingTracklet/data/LUTs/"};     //path for writing LUTs
 
-    unsigned int writememsect_{3};  //writemem only for this sector (note that the files will have _4 extension)
+    int writememsect_{3};         //writemem only for this sector (note that the files will have _4 extension);
+                                  //negative values will cause all sectors to be written
+    bool splitmembysect_{false};  //If true will write each sector to separate files when writememsect_ is negative
 
     bool enableTripletTables_{false};  //Enable the application of the TED and
                                        //TRE tables; when this flag is false,

--- a/L1Trigger/TrackFindingTracklet/interface/TrackletProjectionsMemory.h
+++ b/L1Trigger/TrackFindingTracklet/interface/TrackletProjectionsMemory.h
@@ -44,6 +44,8 @@ namespace trklet {
     int layer_;
     int disk_;
     int npage_;
+
+    std::vector<std::ofstream> outTPROJ_;
   };
 
 };  // namespace trklet

--- a/L1Trigger/TrackFindingTracklet/src/CleanTrackMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/CleanTrackMemory.cc
@@ -15,15 +15,9 @@ CleanTrackMemory::CleanTrackMemory(string name, Settings const& settings, double
 
 void CleanTrackMemory::writeCT(bool first, unsigned int iSector) {
   iSector_ = iSector;
+
   const string dirCT = settings_.memPath() + "CleanTrack/";
-
-  std::ostringstream oss;
-  oss << dirCT << "CleanTrack_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirCT, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+  openFile(first, dirCT, "CleanTrack_");
 
   for (unsigned int j = 0; j < tracks_.size(); j++) {
     out_ << hexstr(j) << " " << tracks_[j]->trackfitstr() << " " << trklet::hexFormat(tracks_[j]->trackfitstr());

--- a/L1Trigger/TrackFindingTracklet/src/CleanTrackMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/CleanTrackMemory.cc
@@ -48,9 +48,4 @@ void CleanTrackMemory::writeCT(bool first, unsigned int iSector) {
     outCT_.close();
   }
   // --------------------------------------------------------------
-
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
 }

--- a/L1Trigger/TrackFindingTracklet/src/CleanTrackMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/CleanTrackMemory.cc
@@ -36,22 +36,22 @@ void CleanTrackMemory::writeCT(bool first, unsigned int iSector) {
   if (settings_.writeMonitorData("CT")) {
     std::string fnameAll = "CleanTracksAll.dat";
     if (first && getName() == "CT_L1L2" && iSector_ == 0)
-      out_.open(fnameAll);
+      outCT_.open(fnameAll);
     else
-      out_.open(fnameAll, std::ofstream::app);
+      outCT_.open(fnameAll, std::ofstream::app);
 
     if (!tracks_.empty())
-      out_ << "BX= " << (bitset<3>)bx_ << " event= " << event_ << " seed= " << getName()
-           << " phisector= " << iSector_ + 1 << endl;
+      outCT_ << "BX= " << (bitset<3>)bx_ << " event= " << event_ << " seed= " << getName()
+             << " phisector= " << iSector_ + 1 << endl;
 
     for (unsigned int j = 0; j < tracks_.size(); j++) {
       if (j < 16)
-        out_ << "0";
-      out_ << hex << j << dec << " ";
-      out_ << tracks_[j]->trackfitstr();
-      out_ << "\n";
+        outCT_ << "0";
+      outCT_ << hex << j << dec << " ";
+      outCT_ << tracks_[j]->trackfitstr();
+      outCT_ << "\n";
     }
-    out_.close();
+    outCT_.close();
   }
   // --------------------------------------------------------------
 

--- a/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
@@ -41,15 +41,9 @@ void FullMatchMemory::addMatch(Tracklet* tracklet, const Stub* stub) {
 
 void FullMatchMemory::writeMC(bool first, unsigned int iSector) {
   iSector_ = iSector;
+
   const string dirM = settings_.memPath() + "Matches/";
-
-  std::ostringstream oss;
-  oss << dirM << "FullMatches_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirM, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+  openFile(first, dirM, "FullMatches_");
 
   for (unsigned int j = 0; j < matches_.size(); j++) {
     string match = (layer_ > 0) ? matches_[j].first->fullmatchstr(layer_) : matches_[j].first->fullmatchdiskstr(disk_);

--- a/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/FullMatchMemory.cc
@@ -50,9 +50,4 @@ void FullMatchMemory::writeMC(bool first, unsigned int iSector) {
     out_ << hexstr(j) << " " << match << " " << trklet::hexFormat(match) << endl;
   }
   out_.close();
-
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
 }

--- a/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
@@ -93,6 +93,13 @@ std::string MemoryBase::eventHeader() {
   return ss.str();
 }
 
+void MemoryBase::incrBXEvent() {
+  bx_++;
+  event_++;
+  if (bx_ > 7)
+    bx_ = 0;
+}
+
 void MemoryBase::openFile(const bool first, const std::string& dirName, const std::string& filebase) {
   std::string fname = filebase + getName();
 
@@ -111,11 +118,6 @@ void MemoryBase::openFile(const bool first, const std::string& dirName, const st
   openfile(out_, first, dirName, dirName + fname, __FILE__, __LINE__);
 
   out_ << eventHeader() << endl;
-
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
 }
 
 size_t MemoryBase::find_nth(const string& haystack, size_t pos, const string& needle, size_t nth) {

--- a/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
@@ -93,7 +93,7 @@ std::string MemoryBase::eventHeader() {
   return ss.str();
 }
 
-void MemoryBase::openFile(bool first, std::string dirName, std::string filebase) {
+void MemoryBase::openFile(const bool first, const std::string& dirName, const std::string& filebase) {
   std::string fname = filebase + getName();
 
   findAndReplaceAll(fname, "PHIa", "PHIaa");

--- a/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/MemoryBase.cc
@@ -72,6 +72,27 @@ void MemoryBase::findAndReplaceAll(std::string& data, std::string toSearch, std:
   }
 }
 
+std::string MemoryBase::fnameWithSuffix(const std::string& fname) {
+  std::string newFname(fname);
+
+  if (settings_.splitmembysect()) {
+    newFname += "_";
+    if (iSector_ + 1 < 10)
+      newFname += "0";
+    newFname += std::to_string(iSector_ + 1);
+  }
+  newFname += ".dat";
+
+  return newFname;
+}
+
+std::string MemoryBase::eventHeader() {
+  std::stringstream ss;
+  ss << "BX : " << (bitset<3>)bx_ << " Event : " << event_ << " Sector : " << (iSector_ + 1);
+
+  return ss.str();
+}
+
 void MemoryBase::openFile(bool first, std::string dirName, std::string filebase) {
   std::string fname = filebase + getName();
 
@@ -85,15 +106,11 @@ void MemoryBase::openFile(bool first, std::string dirName, std::string filebase)
   findAndReplaceAll(fname, "PHIz", "PHIzz");
   findAndReplaceAll(fname, "PHIw", "PHIww");
 
-  fname += "_";
-  if (iSector_ + 1 < 10)
-    fname += "0";
-  fname += std::to_string(iSector_ + 1);
-  fname += ".dat";
+  fname = fnameWithSuffix(fname);
 
   openfile(out_, first, dirName, dirName + fname, __FILE__, __LINE__);
 
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+  out_ << eventHeader() << endl;
 
   bx_++;
   event_++;

--- a/L1Trigger/TrackFindingTracklet/src/Sector.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Sector.cc
@@ -256,6 +256,42 @@ void Sector::writeCT(bool first) {
   }
 }
 
+void Sector::incrBXEvent() {
+  for (auto& i : DL_) {
+    i->incrBXEvent();
+  }
+  for (auto& i : IL_) {
+    i->incrBXEvent();
+  }
+  for (auto& i : VMSTE_) {
+    i->incrBXEvent();
+  }
+  for (auto& i : VMSME_) {
+    i->incrBXEvent();
+  }
+  for (auto& i : AS_) {
+    i->incrBXEvent();
+  }
+  for (auto& i : AIS_) {
+    i->incrBXEvent();
+  }
+  for (auto& i : TPAR_) {
+    i->incrBXEvent();
+  }
+  for (auto& i : TPROJ_) {
+    i->incrBXEvent();
+  }
+  for (auto& i : FM_) {
+    i->incrBXEvent();
+  }
+  for (auto& i : TF_) {
+    i->incrBXEvent();
+  }
+  for (auto& i : CT_) {
+    i->incrBXEvent();
+  }
+}
+
 void Sector::clean() {
   for (auto& mem : MemoriesV_) {
     mem->clean();

--- a/L1Trigger/TrackFindingTracklet/src/TrackFitMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackFitMemory.cc
@@ -15,15 +15,9 @@ TrackFitMemory::TrackFitMemory(string name, Settings const& settings, double phi
 
 void TrackFitMemory::writeTF(bool first, unsigned int iSector) {
   iSector_ = iSector;
+
   const string dirFT = settings_.memPath() + "FitTrack/";
-
-  std::ostringstream oss;
-  oss << dirFT << "TrackFit_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirFT, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+  openFile(first, dirFT, "TrackFit_");
 
   for (unsigned int j = 0; j < tracks_.size(); j++) {
     out_ << hexstr(j) << " " << tracks_[j]->trackfitstr() << " " << trklet::hexFormat(tracks_[j]->trackfitstr());

--- a/L1Trigger/TrackFindingTracklet/src/TrackFitMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackFitMemory.cc
@@ -24,9 +24,4 @@ void TrackFitMemory::writeTF(bool first, unsigned int iSector) {
     out_ << "\n";
   }
   out_.close();
-
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -325,6 +325,9 @@ void TrackletEventProcessor::event(SLHCEvent& ev,
     }
     PDTimer_.stop();
   }
+
+  if (settings_->writeMem())
+    sector_->incrBXEvent();
 }
 
 void TrackletEventProcessor::printSummary() {

--- a/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletEventProcessor.cc
@@ -209,18 +209,22 @@ void TrackletEventProcessor::event(SLHCEvent& ev,
     // ----------------------------------------------------------------------------------------
     // Now start the tracklet processing
 
-    // VM router
+    const bool writeSect = (static_cast<int>(k) == settings_->writememsect() || settings_->writememsect() < 0);
+    const bool multiSectFiles = (settings_->writememsect() < 0 && !settings_->splitmembysect());
+
+    // Input router
     InputRouterTimer_.start();
     sector_->executeIR();
-    if (settings_->writeMem() && k == settings_->writememsect()) {
+    if (settings_->writeMem() && writeSect) {
       sector_->writeDTCStubs(first);
       sector_->writeIRStubs(first);
     }
     InputRouterTimer_.stop();
 
+    // VM router
     VMRouterTimer_.start();
     sector_->executeVMR();
-    if (settings_->writeMem() && k == settings_->writememsect()) {
+    if (settings_->writeMem() && writeSect) {
       sector_->writeVMSTE(first);
       sector_->writeAIS(first);
     }
@@ -285,7 +289,7 @@ void TrackletEventProcessor::event(SLHCEvent& ev,
     PCTimer_.start();
     sector_->executePC();
     PCTimer_.stop();
-    if (settings_->writeMem() && k == settings_->writememsect()) {
+    if (settings_->writeMem() && writeSect) {
       sector_->writeTPROJ(first);
       sector_->writeTPAR(first);
     }
@@ -294,7 +298,7 @@ void TrackletEventProcessor::event(SLHCEvent& ev,
     VMSMERTimer_.start();
     sector_->executeVMSMER();
     VMSMERTimer_.stop();
-    if (settings_->writeMem() && k == settings_->writememsect()) {
+    if (settings_->writeMem() && writeSect) {
       sector_->writeVMSME(first);
       sector_->writeAS(first);
     }
@@ -304,14 +308,14 @@ void TrackletEventProcessor::event(SLHCEvent& ev,
     sector_->executeMP();
     MPTimer_.stop();
 
-    if (settings_->writeMem() && k == settings_->writememsect()) {
+    if (settings_->writeMem() && writeSect) {
       sector_->writeMC(first);
     }
 
     // fit track
     FTTimer_.start();
     sector_->executeFT(streamsTrackRaw, streamsStubRaw);
-    if ((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) {
+    if ((settings_->writeMem() || settings_->writeMonitorData("IFit")) && writeSect) {
       sector_->writeTF(first);
     }
     FTTimer_.stop();
@@ -319,11 +323,14 @@ void TrackletEventProcessor::event(SLHCEvent& ev,
     // purge duplicate
     PDTimer_.start();
     sector_->executePD(tracks_);
-    if (((settings_->writeMem() || settings_->writeMonitorData("IFit")) && k == settings_->writememsect()) ||
+    if (((settings_->writeMem() || settings_->writeMonitorData("IFit")) && writeSect) ||
         settings_->writeMonitorData("CT")) {
       sector_->writeCT(first);
     }
     PDTimer_.stop();
+
+    if (multiSectFiles)
+      first = false;
   }
 
   if (settings_->writeMem())

--- a/L1Trigger/TrackFindingTracklet/src/TrackletParametersMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletParametersMemory.cc
@@ -30,16 +30,9 @@ void TrackletParametersMemory::clean() {
 
 void TrackletParametersMemory::writeTPAR(bool first, unsigned int iSector) {
   iSector_ = iSector;
+
   const string dirTP = settings_.memPath() + "TrackletParameters/";
-
-  std::ostringstream oss;
-  oss << dirTP << "TrackletParameters_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1)
-      << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirTP, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+  openFile(first, dirTP, "TrackletParameters_");
 
   for (unsigned int page = 0; page < tracklets_.size(); page++) {
     for (unsigned int j = 0; j < tracklets_[page].size(); j++) {

--- a/L1Trigger/TrackFindingTracklet/src/TrackletParametersMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletParametersMemory.cc
@@ -41,9 +41,4 @@ void TrackletParametersMemory::writeTPAR(bool first, unsigned int iSector) {
     }
   }
   out_.close();
-
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
@@ -57,20 +57,13 @@ void TrackletProjectionsMemory::clean() {
 
 void TrackletProjectionsMemory::writeTPROJ(bool first, unsigned int iSector) {
   iSector_ = iSector;
-  const string dirTP = settings_.memPath() + "TrackletProjections/";
 
   //Hack to suppress writing empty TPROJ memories - only want to write MPROJ memories
   if (getName()[0] == 'T')
     return;
 
-  std::ostringstream oss;
-  oss << dirTP << "TrackletProjections_" << getName() << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1)
-      << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirTP, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+  const string dirTP = settings_.memPath() + "TrackletProjections/";
+  openFile(first, dirTP, "TrackletProjections_");
 
   if (outTPROJ_.size() < tracklets_.size())
     outTPROJ_.resize(tracklets_.size());

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
@@ -89,9 +89,4 @@ void TrackletProjectionsMemory::writeTPROJ(bool first, unsigned int iSector) {
     outTPROJ_[j].close();
   }
   out_.close();
-
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
 }

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
@@ -72,28 +72,29 @@ void TrackletProjectionsMemory::writeTPROJ(bool first, unsigned int iSector) {
 
   out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
 
+  if (outTPROJ_.size() < tracklets_.size())
+    outTPROJ_.resize(tracklets_.size());
   for (unsigned int j = 0; j < tracklets_.size(); j++) {
-    // This is a hack here to write out the TPAR files for backward compatibility
-    std::ofstream out;
+    // This is a hack here to write out the TPROJ files for backward compatibility
     std::string moduleName = getName().substr(0, 10);
-    ;
+
     moduleName[0] = 'T';
-    std::ostringstream oss2;
+    std::ostringstream oss;
     char postfix = getName()[10];
     postfix += j;
-    oss2 << dirTP << "TrackletProjections_" << moduleName << postfix << "_" << getName().substr(getName().size() - 6, 6)
+    oss << dirTP << "TrackletProjections_" << moduleName << postfix << "_" << getName().substr(getName().size() - 6, 6)
          << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-    std::string fnameTPAR = oss2.str();
-    openfile(out, first, dirTP, fnameTPAR, __FILE__, __LINE__);
-    out << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+    std::string fnameTPROJ = oss.str();
+    openfile(outTPROJ_[j], first, dirTP, fnameTPROJ, __FILE__, __LINE__);
+    outTPROJ_[j] << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
     for (unsigned int i = 0; i < tracklets_[j].size(); i++) {
       string proj = (layer_ > 0 && tracklets_[j][i]->validProj(layer_ - 1))
                         ? tracklets_[j][i]->trackletprojstrlayer(layer_)
                         : tracklets_[j][i]->trackletprojstrdisk(disk_);
       out_ << hexstr(j) << " " << hexstr(i) << " " << proj << "  " << trklet::hexFormat(proj) << endl;
-      out << hexstr(i) << " " << proj << "  " << trklet::hexFormat(proj) << endl;
+      outTPROJ_[j] << hexstr(i) << " " << proj << "  " << trklet::hexFormat(proj) << endl;
     }
-    out.close();
+    outTPROJ_[j].close();
   }
   out_.close();
 

--- a/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletProjectionsMemory.cc
@@ -82,11 +82,10 @@ void TrackletProjectionsMemory::writeTPROJ(bool first, unsigned int iSector) {
     std::ostringstream oss;
     char postfix = getName()[10];
     postfix += j;
-    oss << dirTP << "TrackletProjections_" << moduleName << postfix << "_" << getName().substr(getName().size() - 6, 6)
-         << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-    std::string fnameTPROJ = oss.str();
-    openfile(outTPROJ_[j], first, dirTP, fnameTPROJ, __FILE__, __LINE__);
-    outTPROJ_[j] << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+    oss << "TrackletProjections_" << moduleName << postfix << "_" << getName().substr(getName().size() - 6, 6);
+    const std::string fnameTPROJ = fnameWithSuffix(oss.str());
+    openfile(outTPROJ_[j], first, dirTP, dirTP + fnameTPROJ, __FILE__, __LINE__);
+    outTPROJ_[j] << eventHeader() << endl;
     for (unsigned int i = 0; i < tracklets_[j].size(); i++) {
       string proj = (layer_ > 0 && tracklets_[j][i]->validProj(layer_ - 1))
                         ? tracklets_[j][i]->trackletprojstrlayer(layer_)

--- a/L1Trigger/TrackFindingTracklet/src/VMStubsMEMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubsMEMemory.cc
@@ -18,16 +18,9 @@ VMStubsMEMemory::VMStubsMEMemory(string name, Settings const& settings) : Memory
 
 void VMStubsMEMemory::writeStubs(bool first, unsigned int iSector) {
   iSector_ = iSector;
+
   const string dirVM = settings_.memPath() + "VMStubsME/";
-
-  std::ostringstream oss;
-  oss << dirVM << "VMStubs_" << getName();
-  oss << "_" << std::setfill('0') << std::setw(2) << (iSector_ + 1) << ".dat";
-  auto const& fname = oss.str();
-
-  openfile(out_, first, dirVM, fname, __FILE__, __LINE__);
-
-  out_ << "BX = " << (bitset<3>)bx_ << " Event : " << event_ << endl;
+  openFile(first, dirVM, "VMStubs_");
 
   for (unsigned int i = 0; i < binnedstubs_.size(); i++) {
     int nbitsrz = (layerdisk_ < N_LAYER) ? 3 : 4;

--- a/L1Trigger/TrackFindingTracklet/src/VMStubsMEMemory.cc
+++ b/L1Trigger/TrackFindingTracklet/src/VMStubsMEMemory.cc
@@ -38,9 +38,4 @@ void VMStubsMEMemory::writeStubs(bool first, unsigned int iSector) {
     }
   }
   out_.close();
-
-  bx_++;
-  event_++;
-  if (bx_ > 7)
-    bx_ = 0;
 }


### PR DESCRIPTION
#### PR description:

The main goal of this PR is to add parameters to enable writing all sectors to the test vectors for the track-finding FW chain:
- `writememsect_` has been converted to an integer, and now, negative values will cause all sectors to be output, instead of only a single one
- `splitmembysect_` will cause each sector to be output to a dedicated set of files when true; otherwise, all sectors are written to the same set of files

In addition, I tried to rationalize/clean up some of the code for writing test vectors:
- There are now dedicated file handles in `CleanTrackMemory` and `TrackletProjectionsMemory` for "special" output that is separate from the standard memory contents, which always use `MemoryBase::out_`. I think this makes the code clearer, and also makes it easier to leave file handles open across events in the future, if we find this is more optimal.
- I added methods in `MemoryBase` for generating test vector file names and event headers, in order to slightly reduce some code duplication.
- The various methods for writing test vectors now more consistently use `MemoryBase::openFile`, in order to reduce code duplication.
- The BX and event numbers in the memories are now incremented in the `Sector` object in a consistent way.

#### PR validation:

The output test vectors for sector 4 are identical (modulo minor changes in the event headers) in the following three cases:
- before this PR with `writememsect_ = 3`
- after this PR with `writememsect_ = 3`
- after this PR with `writememsect_ = -1` and `splitmembysect_ = true`

And with `writememsect_ = -1` and `splitmembysect_ = false`, the contents of the test vectors corresponding to sector 4 are also identical to these three cases.