### PR TITLE
Fixes for NEWKF Displaced

### DIFF
--- a/L1Trigger/TrackFindingTracklet/plugins/ProducerFakeDR.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/ProducerFakeDR.cc
@@ -130,7 +130,11 @@ namespace trklet {
       for (const TTStubRef& ttStubRef : ttTrackRef->getStubRefs()) {
         // layer encoding
         const int layerId = setup->layerId(ttStubRef);
-        const int iLayer = std::distance(le.begin(), std::find(le.begin(), le.end(), layerId));
+        const auto it = std::find(le.begin(), le.end(), layerId);
+        const int iLayer = static_cast<int>(std::distance(le.begin(), it));
+        // kill stub if not encodable
+        if (iLayer == setup->numLayers())
+          continue;
         if (hitPattern.test(iLayer))
           continue;
         // stub parameter

--- a/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
@@ -47,7 +47,7 @@ def displacedNewKFKillConfig(process):
   process.l1tTTTracksFromExtendedTrackletEmulation.DoMultipleMatches = False
   process.ChannelAssignment.DR.NumComparisonModules = cms.int32(9999) # number of comparison modules used in each DR node
   process.ChannelAssignment.SeedTypes = ( "L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1", "L2L3L4", "L4L5L6", "L2L3D1", "D1D2L2" )
-  process.ChannelAssignment.TM.MuxOrder = ( "L1L2", "L3L4", "D3D4", "D1D2", "L2L3", "L2D1", "L5L6", "L1D1", "L2L3L4",  "L4L5L6", "D1D2L2" , "L2L3D1" )
+  process.ChannelAssignment.TM.MuxOrder = ( "L1L2", "L3L4", "D3D4", "D1D2", "L2L3", "L2D1", "L5L6", "L1D1", "L2L3L4",  "L4L5L6", "D1D2L2" , "L2L3D1" ) # This order has not been optimized for NEWKF yet
   process.ChannelAssignment.SeedTypesSeedLayers = cms.PSet (
       L1L2   = cms.vint32(  1,  2     ),
       L2L3   = cms.vint32(  2,  3     ),

--- a/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
@@ -33,8 +33,8 @@ def reducedConfig(process):
 def displacedNewKFMergeConfig(process):
   process.TrackTriggerSetup.KalmanFilter.Use5ParameterFit = True
   process.TrackTriggerSetup.Firmware.EnableTruncation = False
-  process.l1tTTTracksFromTrackletEmulation.Fakefit = True
-  process.l1tTTTracksFromTrackletEmulation.DoMultipleMatches = False
+  process.l1tTTTracksFromExtendedTrackletEmulation.Fakefit = True
+  process.l1tTTTracksFromExtendedTrackletEmulation.DoMultipleMatches = False
   process.l1tTTTracksFromTrackletEmulation.RemovalType = "merge"
   process.AnalyzerDR.OutputLabelDR = "ProducerFakeDR"
   process.ProducerKF.InputLabelKF = "ProducerFakeDR"
@@ -43,10 +43,10 @@ def displacedNewKFMergeConfig(process):
 def displacedNewKFKillConfig(process):
   process.TrackTriggerSetup.KalmanFilter.Use5ParameterFit = True
   process.TrackTriggerSetup.Firmware.EnableTruncation = False
-  process.l1tTTTracksFromTrackletEmulation.Fakefit = True
-  process.l1tTTTracksFromTrackletEmulation.DoMultipleMatches = False
+  process.l1tTTTracksFromExtendedTrackletEmulation.Fakefit = True
+  process.l1tTTTracksFromExtendedTrackletEmulation.DoMultipleMatches = False
   process.ChannelAssignment.SeedTypes = ( "L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1", "L2L3L4", "L4L5L6", "L2L3D1", "D1D2L2" )
-  process.ChannelAssignment.TM.MuxOrder = ( "L1L2", "L2L3", "L1D1", "D1D2", "D3D4", "L2D1", "L2L3D1", "D1D2L2", "L3L4", "L2L3L4", "L5L6", "L4L5L6" )
+  process.ChannelAssignment.TM.MuxOrder = ( "L1L2", "L3L4", "D3D4", "D1D2", "L2L3", "L2D1", "L5L6", "L1D1", "L2L3L4",  "L4L5L6", "D1D2L2" , "L2L3D1" )
   process.ChannelAssignment.SeedTypesSeedLayers = cms.PSet (
       L1L2   = cms.vint32(  1,  2     ),
       L2L3   = cms.vint32(  2,  3     ),

--- a/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
+++ b/L1Trigger/TrackFindingTracklet/python/Customize_cff.py
@@ -45,6 +45,7 @@ def displacedNewKFKillConfig(process):
   process.TrackTriggerSetup.Firmware.EnableTruncation = False
   process.l1tTTTracksFromExtendedTrackletEmulation.Fakefit = True
   process.l1tTTTracksFromExtendedTrackletEmulation.DoMultipleMatches = False
+  process.ChannelAssignment.DR.NumComparisonModules = cms.int32(9999) # number of comparison modules used in each DR node
   process.ChannelAssignment.SeedTypes = ( "L1L2", "L2L3", "L3L4", "L5L6", "D1D2", "D3D4", "L1D1", "L2D1", "L2L3L4", "L4L5L6", "L2L3D1", "D1D2L2" )
   process.ChannelAssignment.TM.MuxOrder = ( "L1L2", "L3L4", "D3D4", "D1D2", "L2L3", "L2D1", "L5L6", "L1D1", "L2L3L4",  "L4L5L6", "D1D2L2" , "L2L3D1" )
   process.ChannelAssignment.SeedTypesSeedLayers = cms.PSet (


### PR DESCRIPTION
This PR does four things for the  DISPLACED_NEWKF_MERGE and  DISPLACED_NEWKF_KILL:

1) Fixes L36-37 & L46-47 in L1Trigger/TrackFindingTracklet/python/Customize_cff.py
These lines are meant to turn off the oldKF fit for the DISPLACED_NEWKF_* algorithms. However, they turn off the oldKF fit but for the _prompt_ NEWKF _instead_ of **_'DISPLACED_NEWKF_* _**, leaving it on for our NEWKF displaced options. This is fixed now.

2) Adds a guard against non-encodable stubs in L1Trigger/TrackFindingTracklet/plugins/ProducerFakeDR.cc (using the same procedure as the one already used in L1Trigger/TrackFindingTracklet/src/DuplicateRemoval.cc)

3) Sets NumComparisonModules to 9999 (inf) for the DISPLACED_NEWKF_KILL

4) Makes the MuxOrder DISPLACED_NEWKF_KILL consistent with the optimized seed rank for HYBRID_DISPLACED. _This is just to make validation of the DISPLACED_NEWKF_* consistent across the MERGE and KILL options. We will have to optimize this later._