### PR TITLE
FW synchronization fixes

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/ProjectionCalculator.cc
+++ b/L1Trigger/TrackFindingTracklet/src/ProjectionCalculator.cc
@@ -52,21 +52,21 @@ ProjectionCalculator::ProjectionCalculator(string name, Settings const& settings
 
 // Project to layer (taken from TrackletCalculatorBase.cc)
 void ProjectionCalculator::projLayer(int ir, int irinv, int iphi0, int it, int iz0, int& iz, int& iphi) {
-  int irtilde = ir * phiHG_ / sqrt(6.0) + 0.5;
-  int is = (irtilde * irinv) >> n_s_;
-  int is6 = (1 << n_s6_) + ((is * is) >> (2 + 2 * n_r_ + 2 * n_rinv_ - 2 * n_s_ - n_s6_));
-  int iu = (ir * irinv) >> (n_r_ + n_rinv_ + 1 - n_phi_);
+  long int irtilde = ir * phiHG_ / sqrt(6.0) + 0.5;
+  long int is = (irtilde * irinv) >> n_s_;
+  long int is6 = (1 << n_s6_) + ((is * is) >> (2 + 2 * n_r_ + 2 * n_rinv_ - 2 * n_s_ - n_s6_));
+  long int iu = (ir * irinv) >> (n_r_ + n_rinv_ + 1 - n_phi_);
   iphi = (iphi0 << (n_phi_ - n_phi0_)) - ((iu * is6) >> n_s6_);
-  int iv = (it * ir) >> (n_r_ + n_t_ - n_z_);
+  long int iv = (it * ir) >> (n_r_ + n_t_ - n_z_);
   iz = iz0 + ((iv * is6) >> n_s6_);
 }
 // Project to disk (taken from TrackletCalculatorBase.cc)
 void ProjectionCalculator::projDisk(
     int iz, int irinv, int iphi0, int it, int iz0, int& ir, int& iphi, int& iderphi, int& iderr) {
-  int iz0_sign = (it > 0) ? iz0 : -iz0;
+  long int iz0_sign = (it > 0) ? iz0 : -iz0;
 
   assert(abs(it) < static_cast<int>(LUT_itinv_.size()));
-  int itinv = LUT_itinv_[abs(it)];
+  long int itinv = LUT_itinv_[abs(it)];
 
   iderphi = (-irinv * itinv) >> 17;
   iderr = itinv >> 5;
@@ -76,17 +76,17 @@ void ProjectionCalculator::projDisk(
     iderr = -iderr;
   }
 
-  int iw = (((iz << (n_r_ - n_z_)) - (iz0_sign << (n_r_ - n_z_))) * itinv) >> n_tinv_;
+  long int iw = (((iz << (n_r_ - n_z_)) - (iz0_sign << (n_r_ - n_z_))) * itinv) >> n_tinv_;
 
   iphi = (iphi0 >> (n_phi0_ - n_phidisk_)) - ((iw * irinv) >> (1 + n_r_ + n_rinv_ - n_phidisk_));
 
-  int ifact = (1 << n_y_) * phiHG_ / sqrt(6.0);
+  long int ifact = (1 << n_y_) * phiHG_ / sqrt(6.0);
 
-  int iy = (ifact * irinv) >> n_y_;
+  long int iy = (ifact * irinv) >> n_y_;
 
-  int ix = (iw * iy) >> n_x_;
+  long int ix = (iw * iy) >> n_x_;
 
-  int ix6 = (1 << n_xx6_) - ((ix * ix) >> (2 + 2 * n_r_ + 2 * n_rinv_ - 2 * n_x_ - n_xx6_));
+  long int ix6 = (1 << n_xx6_) - ((ix * ix) >> (2 + 2 * n_r_ + 2 * n_rinv_ - 2 * n_x_ - n_xx6_));
 
   ir = (iw * ix6) >> (n_r_ - n_rdisk_ + n_xx6_);
 }

--- a/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
+++ b/L1Trigger/TrackFindingTracklet/src/Tracklet.cc
@@ -61,7 +61,7 @@ Tracklet::Tracklet(Settings const& settings,
   trackparsapprox_.init(rinvapprox, phi0approx, d0approx, tapprox, z0approx);
 
   fpgapars_.rinv().set(irinv, settings_.nbitsrinv(), false, __LINE__, __FILE__);
-  fpgapars_.phi0().set(iphi0, settings_.nbitsphi0(), false, __LINE__, __FILE__);
+  fpgapars_.phi0().set(iphi0, settings_.nbitsphi0(), true, __LINE__, __FILE__);
   fpgapars_.d0().set(id0, settings_.nbitsd0(), false, __LINE__, __FILE__);
   fpgapars_.z0().set(iz0, settings_.nbitsz0(), false, __LINE__, __FILE__);
   fpgapars_.t().set(it, settings_.nbitst(), false, __LINE__, __FILE__);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
@@ -218,35 +218,36 @@ void TrackletCalculatorBase::calcPars(unsigned int idr,
                                       int& iphi0_new,
                                       int& iz0_new,
                                       int& it_new) {
-  int idz = iz2 - iz1;
+  long int idz = iz2 - iz1;
 
   assert(idr < LUT_idrinv_.size());
-  int invdr = LUT_idrinv_[idr];
+  long int invdr = LUT_idrinv_[idr];
 
-  int idelta0 = ((iphi2 - iphi1) * invdr) >> n_delta0_;
-  int ideltaz = (idz * invdr) >> n_deltaz_;
+  long int idelta0 = ((iphi2 - iphi1) * invdr) >> n_delta0_;
+  long int ideltaz = (idz * invdr) >> n_deltaz_;
 
-  int idelta1 = (ir1 * idelta0) >> n_delta1_;
-  int idelta2 = (ir2 * idelta0) >> n_delta2_;
+  long int idelta1 = (ir1 * idelta0) >> n_delta1_;
+  long int idelta2 = (ir2 * idelta0) >> n_delta2_;
 
-  int idelta12 = (idelta1 * idelta2) >> n_delta12_;
+  long int idelta12 = (idelta1 * idelta2) >> n_delta12_;
 
-  int iHG = phiHG_ * phiHG_ * (1 << n_HG_);
+  long int iHG = phiHG_ * phiHG_ * (1 << n_HG_);
 
-  int ia = ((1 << n_a_) - ((idelta12 * iHG) >> (2 * n_Deltar_ + 2 * n_phi_ + n_HG_ - 2 * n_delta0_ - n_delta1_ -
-                                                n_delta2_ - n_delta12_ + 1 - n_a_)));
+  long int ia = ((1 << n_a_) - ((idelta12 * iHG) >> (2 * n_Deltar_ + 2 * n_phi_ + n_HG_ - 2 * n_delta0_ - n_delta1_ -
+                                                     n_delta2_ - n_delta12_ + 1 - n_a_)));
 
-  int ifact = (1 << n_r6_) * phiHG_ * phiHG_ / 6.0;
+  long int ifact = (1 << n_r6_) * phiHG_ * phiHG_ / 6.0;
 
-  int ir6 = (ir1 + ir2) * ifact;
+  long int ir6 = (ir1 + ir2) * ifact;
 
-  int idelta02 = (idelta0 * idelta2) >> n_delta02_;
+  long int idelta02 = (idelta0 * idelta2) >> n_delta02_;
 
-  int ix6 = (-(1 << n_x6_) + ((ir6 * idelta02) >>
-                              (n_r6_ + 2 * n_Deltar_ + 2 * n_phi_ - n_x6_ - n_delta2_ - n_delta02_ - 2 * n_delta0_)));
+  long int ix6 =
+      (-(1 << n_x6_) +
+       ((ir6 * idelta02) >> (n_r6_ + 2 * n_Deltar_ + 2 * n_phi_ - n_x6_ - n_delta2_ - n_delta02_ - 2 * n_delta0_)));
 
   //Temporary hack here
-  int it1 = (ir1 * ideltaz) >> (n_Deltar_ - n_deltaz_ - 3);
+  long int it1 = (ir1 * ideltaz) >> (n_Deltar_ - n_deltaz_ - 3);
 
   //std::cout << "ifact it1 ix6: " << ifact << " " << it1 << " " << ix6 << std::endl;
 
@@ -255,7 +256,7 @@ void TrackletCalculatorBase::calcPars(unsigned int idr,
   iphi0_new = (iphi1 >> (n_phi_ - n_phi0_)) +
               ((idelta1 * ix6) >> (n_Deltar_ + n_x6_ + n_phi_ - n_delta0_ - n_delta1_ - n_phi0_));
 
-  int shift_tmp = n_Deltar_ + n_a_ + n_z_ - n_t_ - n_deltaz_ - n_r_;
+  long int shift_tmp = n_Deltar_ + n_a_ + n_z_ - n_t_ - n_deltaz_ - n_r_;
   it_new = (((ideltaz * ia) >> (shift_tmp - 1)) + 1) >> 1;
 
   iz0_new = iz1 + ((((it1 * ix6) >> (n_x6_ + 3 - 1)) + 1) >> 1);

--- a/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackletCalculatorBase.cc
@@ -287,8 +287,9 @@ bool TrackletCalculatorBase::inSector(int iphi0, int irinv, double phi0approx, d
   int iphicritmincut = settings_.phicritminmc() / settings_.kphi0pars();
   int iphicritmaxcut = settings_.phicritmaxmc() / settings_.kphi0pars();
 
-  bool keepapprox = (phicritapprox > settings_.phicritminmc()) && (phicritapprox < settings_.phicritmaxmc()),
-       keep = (iphicrit > iphicritmincut) && (iphicrit < iphicritmaxcut);
+  bool keepapprox = (phi0approx >= 0) && (phicritapprox > settings_.phicritminmc()) &&
+                    (phicritapprox < settings_.phicritmaxmc()),
+       keep = (iphi0 >= 0) && (iphicrit > iphicritmincut) && (iphicrit < iphicritmaxcut);
   if (settings_.debugTracklet())
     if (keepapprox && !keep)
       edm::LogVerbatim("Tracklet") << getName()


### PR DESCRIPTION
#### PR description:

This PR includes minor fixes meant to fix rare discrepancies with respect to the TF HLS. In particular:
- Very rarely, φ<sub>0</sub> is calculated as a negative integer in the tracklet code, while it should always be a positive (unsigned) integer. This causes disagreements with the HLS because of differences in how the calculated value is ultimately cast to an unsigned integer. My solution is to to explicitly reject the very few tracklets where φ<sub>0</sub> is negative and to treat φ<sub>0</sub> as a positive integer when it is set in the `Tracklet` class.
- Again very rarely, some of the intermediate values used to calculate the tracklet parameters overflow the 32-bit C++ integers. So I simply changed all of them to `long int`, and just to be safe, I did the same for the intermediate values used to calculate the tracklet projections.

#### PR validation:

With these updates, I was able to generate a large sample of test vectors (4500 sector-events). With similar updates to the HLS, we have full agreement for all modules at the level of the C-simulation.