### PR TITLE
Implementing seed ranking for displaced tracks

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -162,9 +162,10 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
               // Best Rank:           L1L2 > L3L4 > D3D4 > D1D2 > L2L3 > L2D1 > L5L6 > L1D1
               // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
-              // Best Displaced Rank: L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1   
+              // Best Displaced Rank: L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1
               const unsigned int curSeed = aTrack->seedIndex();
-              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11}; // L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1 
+              static const std::vector<int> ranks{
+                  1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11};  // L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1
               if (curSeed < ranks.size()) {
                 seedRank.push_back(ranks[curSeed]);
               }
@@ -294,7 +295,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               dupMap[seedRankIdx[itrk]][seedRankIdx[jtrk]] = true;
               dupMap[seedRankIdx[jtrk]][seedRankIdx[itrk]] = true;
               if (seedRank[seedRankIdx[itrk]] <= seedRank[seedRankIdx[jtrk]]) {
-                  mergedTrack[seedRankIdx[jtrk]] = true;
+                mergedTrack[seedRankIdx[jtrk]] = true;
               }
             }
           }
@@ -307,12 +308,12 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               int preftrk;
               int rejetrk;
               if (seedRank[seedRankIdx[itrk]] <= seedRank[seedRankIdx[jtrk]]) {
-                  preftrk = itrk;
-                  rejetrk = jtrk;
-                } else {
-                  preftrk = jtrk;
-                  rejetrk = itrk;
-                }
+                preftrk = itrk;
+                rejetrk = jtrk;
+              } else {
+                preftrk = jtrk;
+                rejetrk = itrk;
+              }
 
               // If the preffered track is in more than one bin, but not in the proper rinv or phi bin, then mark as true
               if (((findOverlapRinvBins(sortedinputtracklets[preftrk]).size() > 1) &&

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -158,19 +158,15 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               inputstubidslists_.push_back(stubidslist);
               mergedstubidslists_.push_back(stubidslist);
 
-              // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7
+              // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7, L2L3L4=8, L4L5L6=9, L2L3D1=10, L2D1D2=11
               // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
               // Best Rank:           L1L2 > L3L4 > D3D4 > D1D2 > L2L3 > L2D1 > L5L6 > L1D1
               // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
+              // Best Displaced Rank: L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1   
               const unsigned int curSeed = aTrack->seedIndex();
-              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
+              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11}; // L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1 
               if (curSeed < ranks.size()) {
                 seedRank.push_back(ranks[curSeed]);
-              } else if (settings_.extended()) {
-                seedRank.push_back(9);
-              } else {
-                throw cms::Exception("LogError") << __FILE__ << " " << __LINE__ << " Seed type " << curSeed
-                                                 << " not found in list, and settings->extended() not set.";
               }
 
               if (stublist.size() != stubidslist.size())
@@ -297,15 +293,8 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
             if (nShareLay >= settings_.minIndStubs()) {  // For number of shared stub merge condition
               dupMap[seedRankIdx[itrk]][seedRankIdx[jtrk]] = true;
               dupMap[seedRankIdx[jtrk]][seedRankIdx[itrk]] = true;
-              // Until extended tracking is optimized, we will keep the comparison of the displaced seeds the same which uses < and not <=
-              if ((seedRank[seedRankIdx[itrk]] == 9) && (seedRank[seedRankIdx[jtrk]] == 9)) {
-                if (seedRank[seedRankIdx[itrk]] < seedRank[seedRankIdx[jtrk]]) {
+              if (seedRank[seedRankIdx[itrk]] <= seedRank[seedRankIdx[jtrk]]) {
                   mergedTrack[seedRankIdx[jtrk]] = true;
-                }
-              } else {
-                if (seedRank[seedRankIdx[itrk]] <= seedRank[seedRankIdx[jtrk]]) {
-                  mergedTrack[seedRankIdx[jtrk]] = true;
-                }
               }
             }
           }
@@ -317,18 +306,13 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Set preferred track based on seed rank
               int preftrk;
               int rejetrk;
-              if ((seedRank[seedRankIdx[itrk]] == 9) && (seedRank[seedRankIdx[jtrk]] == 9)) {
-                preftrk = jtrk;
-                rejetrk = itrk;
-              } else {
-                if (seedRank[seedRankIdx[itrk]] <= seedRank[seedRankIdx[jtrk]]) {
+              if (seedRank[seedRankIdx[itrk]] <= seedRank[seedRankIdx[jtrk]]) {
                   preftrk = itrk;
                   rejetrk = jtrk;
                 } else {
                   preftrk = jtrk;
                   rejetrk = itrk;
                 }
-              }
 
               // If the preffered track is in more than one bin, but not in the proper rinv or phi bin, then mark as true
               if (((findOverlapRinvBins(sortedinputtracklets[preftrk]).size() > 1) &&


### PR DESCRIPTION
Implementing optimized seed ranking for displaced tracks:
L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1

The optimization studies were presented on the [BES Offline Software meeting](https://indico.cern.ch/event/1550792/contributions/6530749/attachments/3072721/5436364/UTK_L1_BES.pdf) on 21 May 2025, performance plots for the proposed rankings are presented on slides 13-19.
