### PR TITLE
Add TTCluster EDAnalyzer

### DIFF
--- a/L1Trigger/TrackTrigger/test/AnalyzerCluster.cc
+++ b/L1Trigger/TrackTrigger/test/AnalyzerCluster.cc
@@ -84,14 +84,14 @@ public:
 
 private:
   std::map<unsigned int, ClusterHistos>::iterator createLayerHistograms(unsigned int);
-  std::vector<unsigned int> getSimTrackId(const edm::Handle<edm::DetSetVector<PixelDigiSimLink> >&,
+  std::vector<unsigned int> getSimTrackId(const edm::Handle<edm::DetSetVector<PixelDigiSimLink>>&,
                                           const DetId&,
                                           unsigned int);
   const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> esTokenGeom_;
   const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> esTokenTopo_;
-  const edm::EDGetTokenT<std::vector<TrackingParticle> > tpToken_;
-  const edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> tokenClusters_;  
-  const edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > tokenLinks_;
+  const edm::EDGetTokenT<std::vector<TrackingParticle>> tpToken_;
+  const edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> tokenClusters_;
+  const edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink>> tokenLinks_;
   const edm::EDGetTokenT<edm::PSimHitContainer> tokenSimHitsB_;
   const edm::EDGetTokenT<edm::PSimHitContainer> tokenSimHitsE_;
   const edm::EDGetTokenT<edm::SimTrackContainer> tokenSimTracks_;
@@ -115,16 +115,17 @@ private:
 AnalyzerCluster::AnalyzerCluster(const edm::ParameterSet& conf)
     : esTokenGeom_(esConsumes()),
       esTokenTopo_(esConsumes()),
-      tpToken_(consumes<std::vector<TrackingParticle> >(conf.getParameter<edm::InputTag>("trackingParticles"))),
-      tokenClusters_(consumes<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>(conf.getParameter<edm::InputTag>("ttclusters"))),
-      tokenLinks_(consumes<edm::DetSetVector<PixelDigiSimLink> >(conf.getParameter<edm::InputTag>("links"))),
+      tpToken_(consumes<std::vector<TrackingParticle>>(conf.getParameter<edm::InputTag>("trackingParticles"))),
+      tokenClusters_(consumes<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>(
+          conf.getParameter<edm::InputTag>("ttclusters"))),
+      tokenLinks_(consumes<edm::DetSetVector<PixelDigiSimLink>>(conf.getParameter<edm::InputTag>("links"))),
       tokenSimHitsB_(consumes<edm::PSimHitContainer>(conf.getParameter<edm::InputTag>("simhitsbarrel"))),
       tokenSimHitsE_(consumes<edm::PSimHitContainer>(conf.getParameter<edm::InputTag>("simhitsendcap"))),
       tokenSimTracks_(consumes<edm::SimTrackContainer>(conf.getParameter<edm::InputTag>("simtracks"))),
       catECasRings_(conf.getParameter<bool>("ECasRings")),
       simtrackminpt_(conf.getParameter<double>("SimTrackMinPt")),
-      tpSel_(minPt_, 9.9e9, -maxEta_, maxEta_, maxVertR_, maxVertZ_, 0, useSignal_, useIntime_, useCharged_, useStable_)
-{
+      tpSel_(
+          minPt_, 9.9e9, -maxEta_, maxEta_, maxVertR_, maxVertZ_, 0, useSignal_, useIntime_, useCharged_, useStable_) {
   usesResource(TFileService::kSharedResource);
 }
 
@@ -142,17 +143,16 @@ void AnalyzerCluster::beginJob() {
 }
 
 void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
-
   // Get tracking particles (truth)
-  edm::Handle<std::vector<TrackingParticle> > tParts;
+  edm::Handle<std::vector<TrackingParticle>> tParts;
   event.getByToken(tpToken_, tParts);
-  
+
   // Get the clusters
   edm::Handle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> clusters;
   event.getByToken(tokenClusters_, clusters);
 
   // Get the PixelDigiSimLinks
-  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > pixelSimLinks;
+  edm::Handle<edm::DetSetVector<PixelDigiSimLink>> pixelSimLinks;
   event.getByToken(tokenLinks_, pixelSimLinks);
 
   // Get the SimHits
@@ -179,7 +179,6 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
 
       // Check if this TP is of particular interest.
       if (tpSel_(*tempTPPtr)) {
-
         /// Loop over SimTracks inside TrackingParticle
         for (const auto& simTrack : tempTPPtr->g4Tracks()) {
           /// Use the unique SimTrack Id (which is SimTrack ID + EncodedEventId)
@@ -210,8 +209,7 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
   std::map<unsigned int, unsigned int> nClusters[3], nClusterMatch[3];
 
   // Loop over modules
-  for (auto DSViter = clusters->begin(); DSViter != clusters->end();
-       ++DSViter) {
+  for (auto DSViter = clusters->begin(); DSViter != clusters->end(); ++DSViter) {
     // Get the detector unit's id
     unsigned int rawid(DSViter->detId());
     DetId detId(rawid);
@@ -228,7 +226,7 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
     } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS) {
       det = 2;
     } else {
-      throw cms::Exception("LogicError") << "Unknown detector type! "<<det;
+      throw cms::Exception("LogicError") << "Unknown detector type! " << det;
     }
 
     // Get the geomdet
@@ -250,9 +248,7 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
       histogramLayer = createLayerHistograms(layer);
 
     // Loop over the clusters in the detector unit
-    for (auto clustIt = DSViter->begin(); clustIt != DSViter->end();
-         ++clustIt) {
-
+    for (auto clustIt = DSViter->begin(); clustIt != DSViter->end(); ++clustIt) {
       // cluster count
       ++(nClusters[det].at(layer));
 
@@ -300,7 +296,7 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
           }
         }
       }
-      
+
       if (simhit == nullptr)
         continue;
 
@@ -356,20 +352,21 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
   for (unsigned int det = 1; det < 3; ++det) {
     for (auto it : nClusters[det]) {
       auto histogramLayer(histograms_.find(it.first));
-      if (histogramLayer == histograms_.end()) throw cms::Exception("LogicError") << "No histo for an existing counter! This should not happen!";
+      if (histogramLayer == histograms_.end())
+        throw cms::Exception("LogicError") << "No histo for an existing counter! This should not happen!";
       histogramLayer->second.numberClusters[det]->Fill(it.second);
     }
     for (auto it : nClusterMatch[det]) {
       auto histogramLayer(histograms_.find(it.first));
-      if (histogramLayer == histograms_.end()) throw cms::Exception("LogicError") << "No histo for an existing counter! This should not happen!";
+      if (histogramLayer == histograms_.end())
+        throw cms::Exception("LogicError") << "No histo for an existing counter! This should not happen!";
       histogramLayer->second.numberClusterMatch[det]->Fill(it.second);
     }
   }
 }
 
 // Create the histograms
-std::map<unsigned int, ClusterHistos>::iterator AnalyzerCluster::createLayerHistograms(
-    unsigned int ival) {
+std::map<unsigned int, ClusterHistos>::iterator AnalyzerCluster::createLayerHistograms(unsigned int ival) {
   std::ostringstream fname1, fname2;
 
   edm::Service<TFileService> fs;
@@ -446,7 +443,7 @@ std::map<unsigned int, ClusterHistos>::iterator AnalyzerCluster::createLayerHist
   histoName.str("");
   histoName << "Cluster_Size_RZ_Strip" << tag.c_str() << id;
   local_histos.clusterSizeRZ[2] = td.make<TH1D>(histoName.str().c_str(), histoName.str().c_str(), 21, -0.5, 20.5);
-  
+
   /*
      * Local and Global positions
      */
@@ -503,7 +500,7 @@ std::map<unsigned int, ClusterHistos>::iterator AnalyzerCluster::createLayerHist
 }
 
 std::vector<unsigned int> AnalyzerCluster::getSimTrackId(
-    const edm::Handle<edm::DetSetVector<PixelDigiSimLink> >& pixelSimLinks, const DetId& detId, unsigned int channel) {
+    const edm::Handle<edm::DetSetVector<PixelDigiSimLink>>& pixelSimLinks, const DetId& detId, unsigned int channel) {
   std::vector<unsigned int> retvec;
   edm::DetSetVector<PixelDigiSimLink>::const_iterator DSViter(pixelSimLinks->find(detId));
   if (DSViter == pixelSimLinks->end())

--- a/L1Trigger/TrackTrigger/test/AnalyzerCluster.cc
+++ b/L1Trigger/TrackTrigger/test/AnalyzerCluster.cc
@@ -1,0 +1,519 @@
+//===========================================================================
+// Author: Ian Tomalin
+// Date: 2026
+//
+// Plots P2 TTClusters (=clusters used for L1 tracking),
+// including comparisons with associated SimHits,
+// e.g. for position resolution plots.
+//
+// N.B. This code is based on that used for offline P2 clusters,
+// RecoLocalTracker/SiPhase2Clusterizer/test/ClustersValidation.cc
+//
+// Can be run from AnalyzerClusterStub_cfg.py
+//===========================================================================
+
+// system includes
+#include <map>
+#include <vector>
+#include <algorithm>
+
+// user includes
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "CommonTools/Utils/interface/TFileDirectory.h"
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
+#include "DataFormats/Phase2TrackerDigi/interface/Phase2TrackerDigi.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CommonDetUnit/interface/PixelGeomDetUnit.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimTracker/Common/interface/TrackingParticleSelector.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+// ROOT includes
+#include <TH2F.h>
+#include <TH1F.h>
+#include <THStack.h>
+
+struct ClusterHistos {
+  // use TH1D instead of TH1F to avoid stauration at 2^31
+  // above this increments with +1 don't work for float, need double
+
+  TH1D* numberClusters[3];
+  TH1D* numberClusterMatch[3];
+  TH1D* clusterSize[3];
+  TH1D* clusterSizeRZ[3];
+
+  TH2F* globalPosXY[3];
+  TH2F* localPosXY[3];
+
+  TH1F* deltaX[3];
+  TH1F* deltaY[3];
+};
+
+class AnalyzerCluster : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  typedef std::map<unsigned int, const SimTrack*> SimTracksMap;
+
+  explicit AnalyzerCluster(const edm::ParameterSet&);
+  ~AnalyzerCluster();
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+private:
+  std::map<unsigned int, ClusterHistos>::iterator createLayerHistograms(unsigned int);
+  std::vector<unsigned int> getSimTrackId(const edm::Handle<edm::DetSetVector<PixelDigiSimLink> >&,
+                                          const DetId&,
+                                          unsigned int);
+  const edm::ESGetToken<TrackerGeometry, TrackerDigiGeometryRecord> esTokenGeom_;
+  const edm::ESGetToken<TrackerTopology, TrackerTopologyRcd> esTokenTopo_;
+  const edm::EDGetTokenT<std::vector<TrackingParticle> > tpToken_;
+  const edm::EDGetTokenT<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> tokenClusters_;  
+  const edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > tokenLinks_;
+  const edm::EDGetTokenT<edm::PSimHitContainer> tokenSimHitsB_;
+  const edm::EDGetTokenT<edm::PSimHitContainer> tokenSimHitsE_;
+  const edm::EDGetTokenT<edm::SimTrackContainer> tokenSimTracks_;
+
+  const bool catECasRings_;
+  const double simtrackminpt_;
+
+  TH2F* trackerLayout_;
+  TH2F* trackerLayoutXY_;
+  TH2F* trackerLayoutXYBar_;
+  TH2F* trackerLayoutXYEC_;
+
+  std::map<unsigned int, ClusterHistos> histograms_;
+
+  // Cuts for TrackingParticles of most interest.
+  const float maxEta_ = 2.5, minPt_ = 2.0, maxVertR_ = 1.0, maxVertZ_ = 15.0;
+  const bool useSignal_ = true, useIntime_ = true, useCharged_ = true, useStable_ = true;
+  TrackingParticleSelector tpSel_;
+};
+
+AnalyzerCluster::AnalyzerCluster(const edm::ParameterSet& conf)
+    : esTokenGeom_(esConsumes()),
+      esTokenTopo_(esConsumes()),
+      tpToken_(consumes<std::vector<TrackingParticle> >(conf.getParameter<edm::InputTag>("trackingParticles"))),
+      tokenClusters_(consumes<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>>(conf.getParameter<edm::InputTag>("ttclusters"))),
+      tokenLinks_(consumes<edm::DetSetVector<PixelDigiSimLink> >(conf.getParameter<edm::InputTag>("links"))),
+      tokenSimHitsB_(consumes<edm::PSimHitContainer>(conf.getParameter<edm::InputTag>("simhitsbarrel"))),
+      tokenSimHitsE_(consumes<edm::PSimHitContainer>(conf.getParameter<edm::InputTag>("simhitsendcap"))),
+      tokenSimTracks_(consumes<edm::SimTrackContainer>(conf.getParameter<edm::InputTag>("simtracks"))),
+      catECasRings_(conf.getParameter<bool>("ECasRings")),
+      simtrackminpt_(conf.getParameter<double>("SimTrackMinPt")),
+      tpSel_(minPt_, 9.9e9, -maxEta_, maxEta_, maxVertR_, maxVertZ_, 0, useSignal_, useIntime_, useCharged_, useStable_)
+{
+  usesResource(TFileService::kSharedResource);
+}
+
+AnalyzerCluster::~AnalyzerCluster() = default;
+
+void AnalyzerCluster::beginJob() {
+  edm::Service<TFileService> fs;
+  fs->file().cd("/");
+  TFileDirectory td = fs->mkdir("Common");
+  // Create common histograms
+  trackerLayout_ = td.make<TH2F>("RVsZ", "R vs. z position", 6000, -300.0, 300.0, 1200, 0.0, 120.0);
+  trackerLayoutXY_ = td.make<TH2F>("XVsY", "x vs. y position", 2400, -120.0, 120.0, 2400, -120.0, 120.0);
+  trackerLayoutXYBar_ = td.make<TH2F>("XVsYBar", "x vs. y position", 2400, -120.0, 120.0, 2400, -120.0, 120.0);
+  trackerLayoutXYEC_ = td.make<TH2F>("XVsYEC", "x vs. y position", 2400, -120.0, 120.0, 2400, -120.0, 120.0);
+}
+
+void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
+
+  // Get tracking particles (truth)
+  edm::Handle<std::vector<TrackingParticle> > tParts;
+  event.getByToken(tpToken_, tParts);
+  
+  // Get the clusters
+  edm::Handle<edmNew::DetSetVector<TTCluster<Ref_Phase2TrackerDigi_>>> clusters;
+  event.getByToken(tokenClusters_, clusters);
+
+  // Get the PixelDigiSimLinks
+  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > pixelSimLinks;
+  event.getByToken(tokenLinks_, pixelSimLinks);
+
+  // Get the SimHits
+  edm::Handle<edm::PSimHitContainer> simHitsRaw[2];
+  event.getByToken(tokenSimHitsB_, simHitsRaw[0]);
+  event.getByToken(tokenSimHitsE_, simHitsRaw[1]);
+
+  // Get the SimTracks
+  edm::Handle<edm::SimTrackContainer> simTracksRaw;
+  event.getByToken(tokenSimTracks_, simTracksRaw);
+
+  // Get the geometry
+  const TrackerGeometry* tkGeom = &eventSetup.getData(esTokenGeom_);
+  const TrackerTopology* tTopo = &eventSetup.getData(esTokenTopo_);
+
+  /// Preliminary task: map SimTracks to TrackingParticles of interest
+  std::map<unsigned int, TrackingParticlePtr> simTrackUniqueToTPMap;
+
+  if (not tParts->empty()) {
+    /// Loop over TrackingParticles
+    for (unsigned int tpCnt = 0; tpCnt < tParts->size(); tpCnt++) {
+      /// Make the pointer to the TrackingParticle
+      TrackingParticlePtr tempTPPtr(tParts, tpCnt);
+
+      // Check if this TP is of particular interest.
+      if (tpSel_(*tempTPPtr)) {
+
+        /// Loop over SimTracks inside TrackingParticle
+        for (const auto& simTrack : tempTPPtr->g4Tracks()) {
+          /// Use the unique SimTrack Id (which is SimTrack ID + EncodedEventId)
+          simTrackUniqueToTPMap.emplace(simTrack.trackId(), tempTPPtr);
+        }
+      }
+    }  /// End of loop over TrackingParticles
+  }
+
+  /*
+     * Rearrange the simTracks
+     */
+
+  // Rearrange the simTracks for ease of use <simTrackID, simTrack>
+  SimTracksMap simTracks;
+  for (edm::SimTrackContainer::const_iterator simTrackIt(simTracksRaw->begin()); simTrackIt != simTracksRaw->end();
+       ++simTrackIt) {
+    if (simTrackIt->momentum().pt() > simtrackminpt_) {
+      simTracks.emplace(simTrackIt->trackId(), &(*simTrackIt));
+    }
+  }
+
+  /*
+     * Validation   
+     */
+
+  // Number of clusters vs layer
+  std::map<unsigned int, unsigned int> nClusters[3], nClusterMatch[3];
+
+  // Loop over modules
+  for (auto DSViter = clusters->begin(); DSViter != clusters->end();
+       ++DSViter) {
+    // Get the detector unit's id
+    unsigned int rawid(DSViter->detId());
+    DetId detId(rawid);
+    unsigned int layer = (tTopo->side(detId) != 0) * 1000;  // don't split up endcap sides
+    if (!layer) {
+      layer += tTopo->layer(detId);
+    } else {
+      layer += (catECasRings_ ? tTopo->tidRing(detId) * 10 : tTopo->layer(detId));
+    }
+    TrackerGeometry::ModuleType mType = tkGeom->getDetectorType(detId);
+    unsigned int det = 0;
+    if (mType == TrackerGeometry::ModuleType::Ph2PSP) {
+      det = 1;
+    } else if (mType == TrackerGeometry::ModuleType::Ph2PSS || mType == TrackerGeometry::ModuleType::Ph2SS) {
+      det = 2;
+    } else {
+      throw cms::Exception("LogicError") << "Unknown detector type! "<<det;
+    }
+
+    // Get the geomdet
+    const GeomDetUnit* geomDetUnit(tkGeom->idToDetUnit(detId));
+    if (!geomDetUnit)
+      continue;
+
+    // initialize the ncluster counters if they don't exist for this layer
+    if (nClusters[det].find(layer) == nClusters[det].end()) {
+      nClusters[det].emplace(layer, 0);
+    }
+    if (nClusterMatch[det].find(layer) == nClusterMatch[det].end()) {
+      nClusterMatch[det].emplace(layer, 0);
+    }
+
+    // Create histograms for the layer if they do not yet exist
+    std::map<unsigned int, ClusterHistos>::iterator histogramLayer(histograms_.find(layer));
+    if (histogramLayer == histograms_.end())
+      histogramLayer = createLayerHistograms(layer);
+
+    // Loop over the clusters in the detector unit
+    for (auto clustIt = DSViter->begin(); clustIt != DSViter->end();
+         ++clustIt) {
+
+      // cluster count
+      ++(nClusters[det].at(layer));
+
+      // determine the position
+      MeasurementPoint mpClu(clustIt->findAverageLocalCoordinatesCentered());
+      Local3DPoint localPosClu = geomDetUnit->topology().localPosition(mpClu);
+      Global3DPoint globalPosClu = geomDetUnit->surface().toGlobal(localPosClu);
+
+      // Get all the simTracks that form the cluster
+      std::vector<unsigned int> clusterSimTrackIds;
+      const auto& rows = clustIt->findRows();
+      const auto& cols = clustIt->findCols();
+      for (unsigned int i = 0; i < rows.size(); ++i) {
+        unsigned int channel(Phase2TrackerDigi::pixelToChannel(rows[i], cols[i]));
+        std::vector<unsigned int> simTrackIds(getSimTrackId(pixelSimLinks, detId, channel));
+        for (auto it : simTrackIds) {
+          bool add = true;
+          for (unsigned int j = 0; j < clusterSimTrackIds.size(); ++j) {
+            // only save simtrackids that are not present yet
+            if (it == clusterSimTrackIds.at(j))
+              add = false;
+          }
+          if (add)
+            clusterSimTrackIds.push_back(it);
+        }
+      }
+      std::sort(clusterSimTrackIds.begin(), clusterSimTrackIds.end());
+
+      // find the closest simhit
+      // this is needed because otherwise you get cases with simhits and clusters being swapped
+      // when there are more than 1 cluster with common simtrackids
+      const PSimHit* simhit = nullptr;  // bad naming to avoid changing code below. This is the closest simhit in x
+      float minx = 10000;
+      for (unsigned int simhitidx = 0; simhitidx < 2; ++simhitidx) {  // loop over both barrel and endcap hits
+        for (auto& simhitIt : *simHitsRaw[simhitidx]) {
+          if (rawid == simhitIt.detUnitId()) {
+            //std::cout << "=== " << rawid << " " << &simhitIt << " " << simhitIt.trackId() << " " << simhitIt.localPosition().x() << " " << simhitIt.localPosition().y() << std::endl;
+            auto it = std::lower_bound(clusterSimTrackIds.begin(), clusterSimTrackIds.end(), simhitIt.trackId());
+            if (it != clusterSimTrackIds.end() && *it == simhitIt.trackId()) {
+              if (simhit == nullptr || fabs(simhitIt.localPosition().x() - localPosClu.x()) < minx) {
+                minx = fabs(simhitIt.localPosition().x() - localPosClu.x());
+                simhit = &simhitIt;
+              }
+            }
+          }
+        }
+      }
+      
+      if (simhit == nullptr)
+        continue;
+
+      // only look at simhits from highpT tracks
+      const auto simTrkIt(simTracks.find(simhit->trackId()));
+      if (simTrkIt == simTracks.end())
+        continue;
+      const SimTrack* simTrk = simTrkIt->second;
+
+      /*
+             * Cluster related variables
+             */
+
+      //  truth-matched cluster count
+      ++(nClusterMatch[det].at(layer));
+
+      // cluster size
+      histogramLayer->second.clusterSize[det]->Fill(clustIt->findWidth());
+      histogramLayer->second.clusterSizeRZ[det]->Fill(clustIt->findWidthCols());
+
+      // Fill the position histograms
+      trackerLayout_->Fill(globalPosClu.z(), globalPosClu.perp());
+      trackerLayoutXY_->Fill(globalPosClu.x(), globalPosClu.y());
+      if (layer < 1000) {
+        trackerLayoutXYBar_->Fill(globalPosClu.x(), globalPosClu.y());
+      } else {
+        trackerLayoutXYEC_->Fill(globalPosClu.x(), globalPosClu.y());
+      }
+
+      histogramLayer->second.localPosXY[det]->Fill(localPosClu.x(), localPosClu.y());
+      if (layer < 1000) {
+        histogramLayer->second.globalPosXY[det]->Fill(globalPosClu.z(), globalPosClu.perp());
+      } else {
+        histogramLayer->second.globalPosXY[det]->Fill(globalPosClu.x(), globalPosClu.y());
+      }
+
+      // now get the position of the closest hit
+      Local3DPoint localPosHit(simhit->localPosition());
+
+      //unsigned int procT(simhit->processType()); // Unreliable source of SimHit?
+
+      // Check if this TP is of interest (high Pt etc.).
+      bool isSelTP = (simTrackUniqueToTPMap.find(simTrk->trackId()) != simTrackUniqueToTPMap.end());
+      if (isSelTP) {
+        // Plot resolution for TP for interest.
+        histogramLayer->second.deltaX[det]->Fill(localPosClu.x() - localPosHit.x());
+        histogramLayer->second.deltaY[det]->Fill(localPosClu.y() - localPosHit.y());
+      }
+    }
+  }
+
+  // fill the counter histos per layer
+  for (unsigned int det = 1; det < 3; ++det) {
+    for (auto it : nClusters[det]) {
+      auto histogramLayer(histograms_.find(it.first));
+      if (histogramLayer == histograms_.end()) throw cms::Exception("LogicError") << "No histo for an existing counter! This should not happen!";
+      histogramLayer->second.numberClusters[det]->Fill(it.second);
+    }
+    for (auto it : nClusterMatch[det]) {
+      auto histogramLayer(histograms_.find(it.first));
+      if (histogramLayer == histograms_.end()) throw cms::Exception("LogicError") << "No histo for an existing counter! This should not happen!";
+      histogramLayer->second.numberClusterMatch[det]->Fill(it.second);
+    }
+  }
+}
+
+// Create the histograms
+std::map<unsigned int, ClusterHistos>::iterator AnalyzerCluster::createLayerHistograms(
+    unsigned int ival) {
+  std::ostringstream fname1, fname2;
+
+  edm::Service<TFileService> fs;
+  fs->file().cd("/");
+
+  std::string tag;
+  unsigned int id;
+  if (ival < 1000) {
+    id = ival;
+    fname1 << "Barrel";
+    fname2 << "Layer_" << id;
+    tag = "_layer_";
+  } else {
+    int side = ival / 1000;
+    id = ival - side * 1000;
+    if (ival > 10) {
+      id /= 10;
+      //        fname1 << "EndCap_Side_" << side;
+      fname1 << "EndCap";
+      fname2 << "Ring_" << id;
+      tag = "_ring_";
+    } else {
+      id = ival;
+      //        fname1 << "EndCap_Side_" << side;
+      fname1 << "EndCap";
+      fname2 << "Disk_" << id;
+      tag = "_disk_";
+    }
+  }
+
+  TFileDirectory td1 = fs->mkdir(fname1.str().c_str());
+  TFileDirectory td = td1.mkdir(fname2.str().c_str());
+
+  ClusterHistos local_histos;
+
+  std::ostringstream histoName;
+
+  /*
+     * Number of clusters
+     */
+
+  histoName.str("");
+  histoName << "Number_Clusters_Pixel" << tag.c_str() << id;
+  local_histos.numberClusters[1] = td.make<TH1D>(histoName.str().c_str(), histoName.str().c_str(), 50, 0., 0.);
+  histoName.str("");
+  histoName << "Number_Clusters_Strip" << tag.c_str() << id;
+  local_histos.numberClusters[2] = td.make<TH1D>(histoName.str().c_str(), histoName.str().c_str(), 50, 0., 0.);
+
+  /*
+     * Number of clusters matching truth 
+     */
+
+  histoName.str("");
+  histoName << "Number_Match_Clusters_Pixel" << tag.c_str() << id;
+  local_histos.numberClusterMatch[1] = td.make<TH1D>(histoName.str().c_str(), histoName.str().c_str(), 50, 0., 0.);
+  histoName.str("");
+  histoName << "Number_Match_Clusters_Strip" << tag.c_str() << id;
+  local_histos.numberClusterMatch[2] = td.make<TH1D>(histoName.str().c_str(), histoName.str().c_str(), 50, 0., 0.);
+
+  /*
+     * Cluster size
+     */
+
+  histoName.str("");
+  histoName << "Cluster_Size_Pixel" << tag.c_str() << id;
+  local_histos.clusterSize[1] = td.make<TH1D>(histoName.str().c_str(), histoName.str().c_str(), 21, -0.5, 20.5);
+  histoName.str("");
+  histoName << "Cluster_Size_Strip" << tag.c_str() << id;
+  local_histos.clusterSize[2] = td.make<TH1D>(histoName.str().c_str(), histoName.str().c_str(), 21, -0.5, 20.5);
+
+  histoName.str("");
+  histoName << "Cluster_Size_RZ_Pixel" << tag.c_str() << id;
+  local_histos.clusterSizeRZ[1] = td.make<TH1D>(histoName.str().c_str(), histoName.str().c_str(), 21, -0.5, 20.5);
+  histoName.str("");
+  histoName << "Cluster_Size_RZ_Strip" << tag.c_str() << id;
+  local_histos.clusterSizeRZ[2] = td.make<TH1D>(histoName.str().c_str(), histoName.str().c_str(), 21, -0.5, 20.5);
+  
+  /*
+     * Local and Global positions
+     */
+
+  histoName.str("");
+  histoName << "Local_Position_XY_Pixel" << tag.c_str() << id;
+  local_histos.localPosXY[1] =
+      td.make<TH2F>(histoName.str().c_str(), histoName.str().c_str(), 500, 0., 0., 500, 0., 0.);
+
+  histoName.str("");
+  histoName << "Local_Position_XY_Strip" << tag.c_str() << id;
+  local_histos.localPosXY[2] =
+      td.make<TH2F>(histoName.str().c_str(), histoName.str().c_str(), 500, 0., 0., 500, 0., 0.);
+
+  histoName.str("");
+  histoName << "Global_Position_XY_Pixel" << tag.c_str() << id;
+  local_histos.globalPosXY[1] =
+      td.make<TH2F>(histoName.str().c_str(), histoName.str().c_str(), 500, -120.0, 120.0, 2400, -120.0, 120.0);
+
+  histoName.str("");
+  histoName << "Global_Position_XY_Strip" << tag.c_str() << id;
+  local_histos.globalPosXY[2] =
+      td.make<TH2F>(histoName.str().c_str(), histoName.str().c_str(), 500, -120.0, 120.0, 2400, -120.0, 120.0);
+
+  /*
+     * Delta positions with SimHits
+     */
+
+  histoName.str("");
+  histoName << "Delta_X_Pixel" << tag.c_str() << id;
+  local_histos.deltaX[1] = td.make<TH1F>(histoName.str().c_str(), histoName.str().c_str(), 100, -0.02, 0.02);
+
+  histoName.str("");
+  histoName << "Delta_X_Strip" << tag.c_str() << id;
+  local_histos.deltaX[2] = td.make<TH1F>(histoName.str().c_str(), histoName.str().c_str(), 100, -0.02, 0.02);
+
+  histoName.str("");
+  histoName << "Delta_Y_Pixel" << tag.c_str() << id;
+  local_histos.deltaY[1] = td.make<TH1F>(histoName.str().c_str(), histoName.str().c_str(), 100, -0.2, 0.2);
+
+  histoName.str("");
+  histoName << "Delta_Y_Strip" << tag.c_str() << id;
+  local_histos.deltaY[2] = td.make<TH1F>(histoName.str().c_str(), histoName.str().c_str(), 100, -3., 3.);
+
+  /*
+     * End
+     */
+
+  std::pair<std::map<unsigned int, ClusterHistos>::iterator, bool> insertedIt(
+      histograms_.insert(std::make_pair(ival, local_histos)));
+  fs->file().cd("/");
+
+  return insertedIt.first;
+}
+
+std::vector<unsigned int> AnalyzerCluster::getSimTrackId(
+    const edm::Handle<edm::DetSetVector<PixelDigiSimLink> >& pixelSimLinks, const DetId& detId, unsigned int channel) {
+  std::vector<unsigned int> retvec;
+  edm::DetSetVector<PixelDigiSimLink>::const_iterator DSViter(pixelSimLinks->find(detId));
+  if (DSViter == pixelSimLinks->end())
+    return retvec;
+  for (edm::DetSet<PixelDigiSimLink>::const_iterator it = DSViter->data.begin(); it != DSViter->data.end(); ++it) {
+    if (channel == it->channel()) {
+      retvec.push_back(it->SimTrackId());
+    }
+  }
+  return retvec;
+}
+
+DEFINE_FWK_MODULE(AnalyzerCluster);

--- a/L1Trigger/TrackTrigger/test/AnalyzerClusterStub_cfg.py
+++ b/L1Trigger/TrackTrigger/test/AnalyzerClusterStub_cfg.py
@@ -1,14 +1,9 @@
 ####################################################
-# SLHCUpgradeSimulations                           #
-# Configuration file for Full Workflow             #
-# Step 2 (again)                                   #
-# Validate the L1 track trigger inputs             #
-# TTCluster & TTStub.                              #
-####################################################
-# Author: Nicola Pozzobon                          #
-# CERN, August 2012                                #
-# Updated: Ian Tomalin                             #
-# RAL, May 2026                                    #
+# Analyze TTClusters & TTStubs                     #
+# (P2 objects used for L1 tracking)                #
+# using either AnalyzerClusterStub.cc,             #
+# or AnalyzerCluster.cc.                           #
+# (Edit this file to decide which to run)          #
 ####################################################
 
 ################################################################################
@@ -44,16 +39,18 @@ process.load('Configuration.StandardSequences.MagneticField_cff')
 process.source = cms.Source("PoolSource",
     #fileNames = cms.untracked.vstring('/store/relval/CMSSW_15_1_0_pre5/RelValDoubleMuFlatPt1p5To8/GEN-SIM-DIGI-RAW/150X_mcRun4_realistic_v1_RV269_Run4D110_noPU-v1/2590000/1172421f-823f-420f-8ec9-3de20dd6dda4.root')
     #fileNames = cms.untracked.vstring('/store/relval/CMSSW_15_1_0_pre5/RelValTTbar_14TeV_TuneCP5/GEN-SIM-DIGI-RAW/150X_mcRun4_realistic_v1_RV269_Run4D110_noPU-v1/2590000/02a7204c-3f1c-4858-9350-2f506d729bbc.root')
-    fileNames = cms.untracked.vstring('/store/relval/CMSSW_15_1_0_pre5/RelValTTbar_14TeV_TuneCP5/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_RV269_Run4D110_PU-v2/2590000/0f0bcfd3-dafe-4dda-8d39-9765f6eae68e.root')
+    #fileNames = cms.untracked.vstring('/store/relval/CMSSW_15_1_0_pre5/RelValTTbar_14TeV_TuneCP5/GEN-SIM-DIGI-RAW/PU_150X_mcRun4_realistic_v1_RV269_Run4D110_PU-v2/2590000/0f0bcfd3-dafe-4dda-8d39-9765f6eae68e.root')
+    fileNames = cms.untracked.vstring('file:/opt/ppd/data/cms/L1TrkMC/MCsamples1510_D110/RelVal/TTbar/PU0/02a7204c-3f1c-4858-9350-2f506d729bbc.root')
 )
 
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(10)
+  input = cms.untracked.int32(100)
 )
 
 ################################################################################
-# load the analyzer
+# load the analyzers
 ################################################################################
+# Old analyzer for clusters & stubs (rates, origin of stubs etc.)
 process.AnalyzerClusterStub = cms.EDAnalyzer("AnalyzerClusterStub",
   DebugMode = cms.bool(True),
   TTClusterInputTag = cms.InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"),
@@ -64,18 +61,38 @@ process.AnalyzerClusterStub = cms.EDAnalyzer("AnalyzerClusterStub",
   TrackingVertexInputTag = cms.InputTag("mix", "MergedTrackTruth"),   
 )
 
+# New analyzer for clusters (position resolution w.r.t. SimHits etc.)
+process.AnalyzerCluster = cms.EDAnalyzer("AnalyzerCluster",
+  trackingParticles= cms.InputTag("mix","MergedTrackTruth"),
+  ttclusters = cms.InputTag("TTClustersFromPhase2TrackerDigis", "ClusterInclusive"),
+  links = cms.InputTag("simSiPixelDigis", "Tracker"),
+  simhitsbarrel = cms.InputTag("g4SimHits", "TrackerHitsPixelBarrelLowTof"),
+  simhitsendcap = cms.InputTag("g4SimHits", "TrackerHitsPixelEndcapLowTof"),
+  simtracks = cms.InputTag("g4SimHits"),
+  ECasRings = cms.bool(True),
+  SimTrackMinPt = cms.double(2.)
+                                        
+)
+
 #################################################################################################
 # define output file and message logger
 #################################################################################################
 process.TFileService = cms.Service("TFileService",
-    fileName = cms.string('file:AnalyzerClusterStub.root'),
+    fileName = cms.string('file:analysis.root'),
     closeFileFast = cms.untracked.bool(True)
 )
 
 #################################################################################################
 # define the final path to be fed to cmsRun
 #################################################################################################
-process.p = cms.Path( process.AnalyzerClusterStub )
+
+#-- Choose which analyzer to run
+
+# This is the old one for both clusters & stubs.
+#process.p = cms.Path( process.AnalyzerClusterStub )
+
+# This is the new one for clusters alone (includes resolution plots unlike old one)
+process.p = cms.Path( process.AnalyzerCluster )
 
 
 


### PR DESCRIPTION
#### PR description:

This adds an EDAnalyzer L1Trigger/TrackTrigger/test/AnalyzerCluster.cc to check TTCluster properties, such as position resolution.

(There is an existing EDAnalyser for both clusters and stubs, but although I updated this in a recent PR, the code structure made it hard to add all the desired histos.  In additon, the new one adopts the same style as the EDAnalyzer for the offline P2 clusters). 

#### PR validation:

Some plots presented in BES SW meeting https://indico.cern.ch/event/1703333/ . Doesn't change tracking performance, as only analyzer.