### PR TITLE
Implementing seed ranking for displaced tracks

### DIFF
--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -309,7 +309,8 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
             if (nShareLay >= settings_.minIndStubs()) {  // For number of shared stub merge condition
               sortedDupMap[itrk][jtrk] = true;
               sortedDupMap[jtrk][itrk] = true;
-              // Until extended tracking is optimized, dont set this for extended seeds
+              // Preserve the displaced-track duplicate-rate benefit by allowing
+              // lower-priority displaced tracks to participate in later comparisons.
               if (seedRank[seedRankIdx[itrk]] < 9) {
                 sortedMergedTrack[jtrk] = true;
               }
@@ -323,7 +324,10 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Set preferred track based on seed rank
               int preftrk;
               int rejetrk;
-              if (seedRank[seedRankIdx[itrk]] >= 9) {  // extended track seed
+              const bool identicalDisplacedSeeds =
+                  seedRank[seedRankIdx[itrk]] >= 9 &&
+                  sortedinputtracklets[itrk]->seedIndex() == sortedinputtracklets[jtrk]->seedIndex();
+              if (identicalDisplacedSeeds) {
                 // COMMENT FROM IAN: The swap here reduces the duplicate
                 // rate for extended tracking by 1/4. Why???
                 preftrk = jtrk;

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -163,18 +163,16 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               inputstubidslists_.push_back(stubidslist);
               mergedstubidslists_.push_back(stubidslist);
 
-              // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7, L2L3L4=8, L4L5L6=9, L2L3D1=10, L2D1D2=11
+              // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7
               // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
               // Best Rank:           L1L2 > L3L4 > D3D4 > D1D2 > L2L3 > L2D1 > L5L6 > L1D1
               // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
-              // Best Displaced Rank: L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1
               const unsigned int curSeed = aTrack->seedIndex();
-              static const std::vector<int> ranks{
-                  1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11};  // L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1};
+              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
               if (curSeed < ranks.size()) {
                 seedRank.push_back(ranks[curSeed]);
-                // } else if (settings_.extended()) {
-                // seedRank.push_back(9);
+              } else if (settings_.extended()) {
+                seedRank.push_back(9);
               } else {
                 throw cms::Exception("LogError") << __FILE__ << " " << __LINE__ << " Seed type " << curSeed
                                                  << " not found in list, and settings->extended() not set.";
@@ -310,7 +308,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               sortedDupMap[itrk][jtrk] = true;
               sortedDupMap[jtrk][itrk] = true;
               // Until extended tracking is optimized, dont set this for extended seeds
-              if (seedRank[seedRankIdx[itrk]] < 9) {
+              if (seedRank[seedRankIdx[itrk]] != 9) {
                 sortedMergedTrack[jtrk] = true;
               }
             }
@@ -323,7 +321,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Set preferred track based on seed rank
               int preftrk;
               int rejetrk;
-              if (seedRank[seedRankIdx[itrk]] >= 9) {  // extended track seed
+              if (seedRank[seedRankIdx[itrk]] == 9) {  // extended track seed
                 // COMMENT FROM IAN: The swap here reduces the duplicate
                 // rate for extended tracking by 1/4. Why???
                 preftrk = jtrk;
@@ -700,7 +698,7 @@ std::vector<double> PurgeDuplicate::getInventedCoordsExtended(unsigned int iSect
 
   // TMP: for displaced tracking, exclude one of the 3 seeding stubs
   // to be discussed
-  if ((seed == L2L3L4 && stubLayer == 4) || (seed == L4L5L6 && stubLayer == 5) ||
+  if ((seed == L3L4L2 && stubLayer == 4) || (seed == L5L6L4 && stubLayer == 5) ||
       (seed == L2L3D1 && abs(stubDisk) == 1) || (seed == D1D2L2 && abs(stubDisk) == 1)) {
     stub_phi = st->l1tstub()->phi();
     stub_z = st->l1tstub()->z();

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -310,9 +310,9 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               sortedDupMap[itrk][jtrk] = true;
               sortedDupMap[jtrk][itrk] = true;
               // Until extended tracking is optimized, dont set this for extended seeds
-              // if (seedRank[seedRankIdx[itrk]] != 9) {
-              sortedMergedTrack[jtrk] = true;
-              // }
+              if (seedRank[seedRankIdx[itrk]] != 9) {
+                sortedMergedTrack[jtrk] = true;
+              }
             }
           }
         }
@@ -323,15 +323,15 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Set preferred track based on seed rank
               int preftrk;
               int rejetrk;
-              // if (seedRank[seedRankIdx[itrk]] == 9) {  // extended track seed
-              //  // COMMENT FROM IAN: The swap here reduces the duplicate
-              //  // rate for extended tracking by 1/4. Why???
-              //  preftrk = jtrk;
-              //  rejetrk = itrk;
-              // } else {
-              preftrk = itrk;
-              rejetrk = jtrk;
-              //}
+              if (seedRank[seedRankIdx[itrk]] == 9) {  // extended track seed
+                // COMMENT FROM IAN: The swap here reduces the duplicate
+                // rate for extended tracking by 1/4. Why???
+                preftrk = jtrk;
+                rejetrk = itrk;
+              } else {
+                preftrk = itrk;
+                rejetrk = jtrk;
+              }
 
               // If the preffered track is in more than one bin, but not in the proper rinv or phi bin, then mark as true
               if (((findOverlapRinvBins(sortedinputtracklets[preftrk]).size() > 1) &&

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -170,11 +170,11 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Best Displaced Rank: L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1
               const unsigned int curSeed = aTrack->seedIndex();
               static const std::vector<int> ranks{
-                  1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11};  //   L2L3L4>  L4L5L6   > L2D1D2 > L2L3D1};};
+                  1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11};  // L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1};
               if (curSeed < ranks.size()) {
                 seedRank.push_back(ranks[curSeed]);
                 // } else if (settings_.extended()) {
-                //  seedRank.push_back(9);
+                // seedRank.push_back(9);
               } else {
                 throw cms::Exception("LogError") << __FILE__ << " " << __LINE__ << " Seed type " << curSeed
                                                  << " not found in list, and settings->extended() not set.";
@@ -310,9 +310,9 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               sortedDupMap[itrk][jtrk] = true;
               sortedDupMap[jtrk][itrk] = true;
               // Until extended tracking is optimized, dont set this for extended seeds
-              // if (seedRank[seedRankIdx[itrk]] != 9) {
-              sortedMergedTrack[jtrk] = true;
-              //}
+              if (seedRank[seedRankIdx[itrk]] < 9) {
+                sortedMergedTrack[jtrk] = true;
+              }
             }
           }
         }
@@ -323,15 +323,15 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Set preferred track based on seed rank
               int preftrk;
               int rejetrk;
-              // if (seedRank[seedRankIdx[itrk]] == 9) {  // extended track seed
-              // COMMENT FROM IAN: The swap here reduces the duplicate
-              // rate for extended tracking by 1/4. Why???
-              //  preftrk = jtrk;
-              //  rejetrk = itrk;
-              //} else {
-              preftrk = itrk;
-              rejetrk = jtrk;
-              //}
+              if (seedRank[seedRankIdx[itrk]] >= 9) {  // extended track seed
+                // COMMENT FROM IAN: The swap here reduces the duplicate
+                // rate for extended tracking by 1/4. Why???
+                preftrk = jtrk;
+                rejetrk = itrk;
+              } else {
+                preftrk = itrk;
+                rejetrk = jtrk;
+              }
 
               // If the preffered track is in more than one bin, but not in the proper rinv or phi bin, then mark as true
               if (((findOverlapRinvBins(sortedinputtracklets[preftrk]).size() > 1) &&

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -310,7 +310,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               sortedDupMap[itrk][jtrk] = true;
               sortedDupMap[jtrk][itrk] = true;
               // Until extended tracking is optimized, dont set this for extended seeds
-              if (seedRank[seedRankIdx[itrk]] != 9) {
+              if (seedRank[seedRankIdx[itrk]] < 9) {
                 sortedMergedTrack[jtrk] = true;
               }
             }
@@ -323,7 +323,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Set preferred track based on seed rank
               int preftrk;
               int rejetrk;
-              if (seedRank[seedRankIdx[itrk]] == 9) {  // extended track seed
+              if (seedRank[seedRankIdx[itrk]] >= 9) {  // extended track seed
                 // COMMENT FROM IAN: The swap here reduces the duplicate
                 // rate for extended tracking by 1/4. Why???
                 preftrk = jtrk;

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -169,12 +169,11 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
               // Best Displaced Rank: L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1
               const unsigned int curSeed = aTrack->seedIndex();
-              static const std::vector<int> ranks{
-                  1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11};  // L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1};
+              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6, 10, 9, 12, 11};  //  L4L5L6 >  L2L3L4   > L2D1D2 > L2L3D1};};
               if (curSeed < ranks.size()) {
                 seedRank.push_back(ranks[curSeed]);
-                // } else if (settings_.extended()) {
-                // seedRank.push_back(9);
+              // } else if (settings_.extended()) {
+              //  seedRank.push_back(9);
               } else {
                 throw cms::Exception("LogError") << __FILE__ << " " << __LINE__ << " Seed type " << curSeed
                                                  << " not found in list, and settings->extended() not set.";
@@ -309,11 +308,10 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
             if (nShareLay >= settings_.minIndStubs()) {  // For number of shared stub merge condition
               sortedDupMap[itrk][jtrk] = true;
               sortedDupMap[jtrk][itrk] = true;
-              // Preserve the displaced-track duplicate-rate benefit by allowing
-              // lower-priority displaced tracks to participate in later comparisons.
-              if (seedRank[seedRankIdx[itrk]] < 9) {
+              // Until extended tracking is optimized, dont set this for extended seeds
+              // if (seedRank[seedRankIdx[itrk]] != 9) {
                 sortedMergedTrack[jtrk] = true;
-              }
+              //}
             }
           }
         }
@@ -324,18 +322,15 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Set preferred track based on seed rank
               int preftrk;
               int rejetrk;
-              const bool identicalDisplacedSeeds =
-                  seedRank[seedRankIdx[itrk]] >= 9 &&
-                  sortedinputtracklets[itrk]->seedIndex() == sortedinputtracklets[jtrk]->seedIndex();
-              if (identicalDisplacedSeeds) {
+              // if (seedRank[seedRankIdx[itrk]] == 9) {  // extended track seed
                 // COMMENT FROM IAN: The swap here reduces the duplicate
                 // rate for extended tracking by 1/4. Why???
-                preftrk = jtrk;
-                rejetrk = itrk;
-              } else {
+              //  preftrk = jtrk;
+              //  rejetrk = itrk;
+              //} else {
                 preftrk = itrk;
                 rejetrk = jtrk;
-              }
+              //}
 
               // If the preffered track is in more than one bin, but not in the proper rinv or phi bin, then mark as true
               if (((findOverlapRinvBins(sortedinputtracklets[preftrk]).size() > 1) &&

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -169,7 +169,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
               // Best Displaced Rank: L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1
               const unsigned int curSeed = aTrack->seedIndex();
-              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6, 10, 9, 12, 11};  //  L4L5L6 >  L2L3L4   > L2D1D2 > L2L3D1};};
+              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11};  //   L2L3L4>  L4L5L6   > L2D1D2 > L2L3D1};};
               if (curSeed < ranks.size()) {
                 seedRank.push_back(ranks[curSeed]);
               // } else if (settings_.extended()) {

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -163,16 +163,18 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               inputstubidslists_.push_back(stubidslist);
               mergedstubidslists_.push_back(stubidslist);
 
-              // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7
+              // Encoding: L1L2=0, L2L3=1, L3L4=2, L5L6=3, D1D2=4, D3D4=5, L1D1=6, L2D1=7, L2L3L4=8, L4L5L6=9, L2L3D1=10, L2D1D2=11
               // Best Guess:          L1L2 > L1D1 > L2L3 > L2D1 > D1D2 > L3L4 > L5L6 > D3D4
               // Best Rank:           L1L2 > L3L4 > D3D4 > D1D2 > L2L3 > L2D1 > L5L6 > L1D1
               // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
+              // Best Displaced Rank: L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1
               const unsigned int curSeed = aTrack->seedIndex();
-              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6};
+              static const std::vector<int> ranks{
+                  1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11};  // L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1};
               if (curSeed < ranks.size()) {
                 seedRank.push_back(ranks[curSeed]);
-              } else if (settings_.extended()) {
-                seedRank.push_back(9);
+                // } else if (settings_.extended()) {
+                // seedRank.push_back(9);
               } else {
                 throw cms::Exception("LogError") << __FILE__ << " " << __LINE__ << " Seed type " << curSeed
                                                  << " not found in list, and settings->extended() not set.";
@@ -308,9 +310,9 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               sortedDupMap[itrk][jtrk] = true;
               sortedDupMap[jtrk][itrk] = true;
               // Until extended tracking is optimized, dont set this for extended seeds
-              if (seedRank[seedRankIdx[itrk]] != 9) {
-                sortedMergedTrack[jtrk] = true;
-              }
+              // if (seedRank[seedRankIdx[itrk]] != 9) {
+              sortedMergedTrack[jtrk] = true;
+              // }
             }
           }
         }
@@ -321,15 +323,15 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Set preferred track based on seed rank
               int preftrk;
               int rejetrk;
-              if (seedRank[seedRankIdx[itrk]] == 9) {  // extended track seed
-                // COMMENT FROM IAN: The swap here reduces the duplicate
-                // rate for extended tracking by 1/4. Why???
-                preftrk = jtrk;
-                rejetrk = itrk;
-              } else {
-                preftrk = itrk;
-                rejetrk = jtrk;
-              }
+              // if (seedRank[seedRankIdx[itrk]] == 9) {  // extended track seed
+              //  // COMMENT FROM IAN: The swap here reduces the duplicate
+              //  // rate for extended tracking by 1/4. Why???
+              //  preftrk = jtrk;
+              //  rejetrk = itrk;
+              // } else {
+              preftrk = itrk;
+              rejetrk = jtrk;
+              //}
 
               // If the preffered track is in more than one bin, but not in the proper rinv or phi bin, then mark as true
               if (((findOverlapRinvBins(sortedinputtracklets[preftrk]).size() > 1) &&

--- a/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
+++ b/L1Trigger/TrackFindingTracklet/src/PurgeDuplicate.cc
@@ -169,11 +169,12 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               // Rank-Informed Guess: L1L2 > L3L4 > L1D1 > L2L3 > L2D1 > D1D2 > L5L6 > D3D4
               // Best Displaced Rank: L2L3L4 >  L4L5L6 > L2D1D2 > L2L3D1
               const unsigned int curSeed = aTrack->seedIndex();
-              static const std::vector<int> ranks{1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11};  //   L2L3L4>  L4L5L6   > L2D1D2 > L2L3D1};};
+              static const std::vector<int> ranks{
+                  1, 5, 2, 7, 4, 3, 8, 6, 9, 10, 12, 11};  //   L2L3L4>  L4L5L6   > L2D1D2 > L2L3D1};};
               if (curSeed < ranks.size()) {
                 seedRank.push_back(ranks[curSeed]);
-              // } else if (settings_.extended()) {
-              //  seedRank.push_back(9);
+                // } else if (settings_.extended()) {
+                //  seedRank.push_back(9);
               } else {
                 throw cms::Exception("LogError") << __FILE__ << " " << __LINE__ << " Seed type " << curSeed
                                                  << " not found in list, and settings->extended() not set.";
@@ -310,7 +311,7 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               sortedDupMap[jtrk][itrk] = true;
               // Until extended tracking is optimized, dont set this for extended seeds
               // if (seedRank[seedRankIdx[itrk]] != 9) {
-                sortedMergedTrack[jtrk] = true;
+              sortedMergedTrack[jtrk] = true;
               //}
             }
           }
@@ -323,13 +324,13 @@ void PurgeDuplicate::execute(std::vector<Track>& outputtracks, unsigned int iSec
               int preftrk;
               int rejetrk;
               // if (seedRank[seedRankIdx[itrk]] == 9) {  // extended track seed
-                // COMMENT FROM IAN: The swap here reduces the duplicate
-                // rate for extended tracking by 1/4. Why???
+              // COMMENT FROM IAN: The swap here reduces the duplicate
+              // rate for extended tracking by 1/4. Why???
               //  preftrk = jtrk;
               //  rejetrk = itrk;
               //} else {
-                preftrk = itrk;
-                rejetrk = jtrk;
+              preftrk = itrk;
+              rejetrk = jtrk;
               //}
 
               // If the preffered track is in more than one bin, but not in the proper rinv or phi bin, then mark as true

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -80,9 +80,9 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   const float TP_maxZ0 = useDisplacedTrkCuts ? 30.0 : 15.0;
   // Optionally also tighten Pt and Eta cuts.
   if (useDisplacedTrkCuts) {
-     TP_minPt = 3.0;
-     TP_maxEta = 2.0;
-   }
+    TP_minPt = 3.0;
+    TP_maxEta = 2.0;
+  }
 
   constexpr bool doGausFit = false;  //do gaussian fit for resolution vs eta/pt plots
 

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtuplePlot.C
@@ -79,10 +79,10 @@ void L1TrackNtuplePlot(TString inputRootFile = "L1TrkNtuple",
   const float TP_maxD0 = useDisplacedTrkCuts ? 10.0 : 1.0;
   const float TP_maxZ0 = useDisplacedTrkCuts ? 30.0 : 15.0;
   // Optionally also tighten Pt and Eta cuts.
-  // if (useDisplacedTrkCuts) {
-  //   TP_minPt = 3.0;
-  //   TP_maxEta = 2.0;
-  // }
+  if (useDisplacedTrkCuts) {
+     TP_minPt = 3.0;
+     TP_maxEta = 2.0;
+   }
 
   constexpr bool doGausFit = false;  //do gaussian fit for resolution vs eta/pt plots
 


### PR DESCRIPTION
<h2>Implementing an Optimized Seed Ranking for Displaced Tracks</h2>

<p><strong>Proposed ordering:</strong></p>

<p><code>L2L3L4 &gt; L4L5L6 &gt; L2D1D2 &gt; L2L3D1</code></p>

<p>
The optimization studies were presented at the
<a href="https://indico.cern.ch/event/1550792/contributions/6530749/attachments/3072721/5436364/UTK_L1_BES.pdf">BES Offline Software meeting</a>
on 21 May 2025. Performance plots for the proposed rankings are shown on slides 13–19.
</p>

<p>
This is PR
<a href="https://github.com/cms-L1TK/cmssw/pull/370">#370</a>
applied to
<a href="https://github.com/cms-L1TK/cmssw/tree/L1TK-dev-20_1_0_pre1"><code>L1TK-dev-20_1_0_pre1</code></a>.
</p>

<p>
I used 10,000 events from the following sample to produce all plots and performance results:
</p>

<pre><code>Phase2Spring24DIGIRECOMiniAOD/DisplacedSUSY_stopToBottom_M-800_50mm_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/</code></pre>

<h3>Seed rankings</h3>

<p>I compared two proposed seed rankings:</p>

<ul>
  <li>
    <strong>Optimized:</strong>
    <code>L2L3L4 &gt; L4L5L6 &gt; L2D1D2 &gt; L2L3D1</code>
  </li>
  <li>
    <strong>Alternative:</strong>
    <code>L4L5L6 &gt; L2L3L4 &gt; L2D1D2 &gt; L2L3D1</code>
  </li>
</ul>

<p>
I retained both comparisons because they give nearly the same efficiency improvement relative to the default ordering, with a small tradeoff among efficiency, fake and duplicate fractions, and the central <code>z0</code> tail.
</p>

<h3>Summary printout</h3>

<h4>Efficiency</h4>

<table>
  <thead>
    <tr>
      <th>Configuration</th>
      <th>Combined efficiency, |η| &lt; 2</th>
      <th>3 &lt; pT &lt; 8 GeV</th>
      <th>pT &gt; 8 GeV</th>
      <th>pT &gt; 40 GeV</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Default</td>
      <td>78.83 ± 0.11%</td>
      <td>86.28 ± 0.13%</td>
      <td>71.39 ± 0.17%</td>
      <td>54.89 ± 0.37%</td>
    </tr>
    <tr>
      <td>Optimized</td>
      <td>80.92 ± 0.11%</td>
      <td>87.14 ± 0.13%</td>
      <td>74.71 ± 0.17%</td>
      <td>59.55 ± 0.36%</td>
    </tr>
    <tr>
      <td>Alternative</td>
      <td>80.95 ± 0.11%</td>
      <td>87.17 ± 0.13%</td>
      <td>74.75 ± 0.17%</td>
      <td>59.64 ± 0.36%</td>
    </tr>
  </tbody>
</table>

<p>
Based on the summary printout, both proposed rankings improve the overall efficiency relative to the default ordering. The alternative ranking gives the highest numerical efficiency, but only slightly: 80.95%, compared with 80.92% for the optimized ranking and 78.83% for the default.
</p>

<p>
The efficiency improvement relative to the default is larger at higher pT. For pT &gt; 8 GeV, the efficiency increases from 71.39% for the default to 74.71% for the optimized ranking and 74.75% for the alternative ranking. For pT &gt; 40 GeV, it increases from 54.89% to 59.55% and 59.64%, respectively.
</p>

<p>
The cost is a modest increase in track multiplicity and in the fake and duplicate fractions. The optimized ranking increases the fake fraction from 38.07% to 39.31% and the duplicate fraction from 6.37% to 7.34%. The alternative ranking gives very similar, but slightly higher, values of 39.35% and 7.41%, respectively.
</p>

<h3>Helix-parameter resolution</h3>

<p>
The 68% and 90% <code>z0</code> and <code>d0</code> resolutions are mostly unchanged between the two proposed rankings. The clearest difference is in the central 99% <code>z0</code> tail at |η| = 0.05:
</p>

<table>
  <thead>
    <tr>
      <th>Configuration</th>
      <th>Central 99% <code>z0</code> interval</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Default</td>
      <td>1.62 cm</td>
    </tr>
    <tr>
      <td>Optimized</td>
      <td>0.85 cm</td>
    </tr>
    <tr>
      <td>Alternative</td>
      <td>0.87 cm</td>
    </tr>
  </tbody>
</table>

<p>
The optimized ranking therefore gives slightly better central <code>z0</code>-tail behavior in this comparison, while the alternative gives a marginally higher numerical efficiency.
</p>

<p>
The difference between the optimized and alternative rankings is very small, so I do not want to overstate it. The robust conclusion is that both proposed rankings improve efficiency relative to the default and both improve the central <code>z0</code> tail.
</p>

<p>
The choice between them is a small tradeoff between slightly better central <code>z0</code>-tail resolution and slightly higher numerical efficiency. Since the optimized ranking gives nearly the same efficiency as the alternative while giving a slightly better central 99% <code>z0</code> tail and slightly lower fake and duplicate fractions, I would retain
<code>L2L3L4 &gt; L4L5L6 &gt; L2D1D2 &gt; L2L3D1</code>
as the proposed ordering.
</p>

<h3>Resolution plots</h3>

<p>
The main performance comparison is the full before-and-after tracking comparison summarized above. I have also produced the corresponding seed-ranking resolution plots using both RMS-based and percentile-based resolutions.
</p>

<p>
The resolution plots for the three oldKF displaced configurations are shown
<a href="https://alaa.web.cern.ch/oldKF_seed_ranking_res/">here</a>:
</p>

<ul>
  <li><strong>Default</strong></li>
  <li>
    <strong>Optimized:</strong>
    <code>L2L3L4 &gt; L4L5L6 &gt; L2D1D2 &gt; L2L3D1</code>
  </li>
  <li>
    <strong>Alternative:</strong>
    <code>L4L5L6 &gt; L2L3L4 &gt; L2D1D2 &gt; L2L3D1</code>
  </li>
</ul>

<p>
The page includes the full set of overlaid resolution plots, grouped by variable, with the RMS, 68%, 90%, and 99% interval versions shown together where available.
</p>
