### PR TITLE
Bug fix & CPU optimization for AnalyzerCluster.cc

### DIFF
--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker_cfg.py
@@ -99,19 +99,11 @@ else:
 
 process.source = cms.Source("PoolSource", fileNames = cms.untracked.vstring(*inputMC))
 
-# Drop previously reconstructed L1 tracks + their truth association to avoid risk of analysing them instead of new tracks created by this job.
+# To avoid confusion, drop previously reconstructed L1 tracks + their truth association.
 process.source.dropDescendantsOfDroppedBranches = cms.untracked.bool(False)
 process.source.inputCommands = cms.untracked.vstring()
 process.source.inputCommands.append('keep *_*_*_*')
-process.source.inputCommands.append('drop  *_*_*Level1TTTracks*_*')
-
-#  # If reading old MC dataset, it can help to drop incompatible EDProducts.
-#  process.source.inputCommands.append('drop *_*_*_*')
-#  process.source.inputCommands.append('keep *_*_*Level1TTTracks*_*')
-#  process.source.inputCommands.append('keep *_*_*StubAccepted*_*')
-#  process.source.inputCommands.append('keep *_*_*ClusterAccepted*_*')
-#  process.source.inputCommands.append('keep *_*_*MergedTrackTruth*_*')
-#  process.source.inputCommands.append('keep *_genParticles_*_*')
+process.source.inputCommands.append('drop  *_*TTTrack*_*_*')
 
 # Use skipEvents to select particular single events for test vectors
 #process.source.skipEvents = cms.untracked.uint32(11)
@@ -119,25 +111,21 @@ process.source.inputCommands.append('drop  *_*_*Level1TTTracks*_*')
 process.TFileService = cms.Service("TFileService", fileName = cms.string('L1TrkNtuple.root'), closeFileFast = cms.untracked.bool(True))
 process.Timing = cms.Service("Timing", summaryOnly = cms.untracked.bool(True))
 
-
 ############################################################
 # L1 tracking: stubs / DTC emulation
 ############################################################
 
 process.load('L1Trigger.TrackTrigger.TrackTrigger_cff')
 
-# Load code needed to remake clusters + stubs + their association to truth,
+# Load code to remake clusters + stubs + their truth association,
 # in case user wants to remake them. 
-from L1Trigger.TrackTrigger.TTStubAlgorithmRegister_cfi import *
 process.load("SimTracker.TrackTriggerAssociation.TrackTriggerAssociator_cff")
-
-from SimTracker.TrackTriggerAssociation.TTClusterAssociation_cfi import *
-TTClusterAssociatorFromPixelDigis.digiSimLinks = cms.InputTag("simSiPixelDigis","Tracker")
+process.TTClusterAssociatorFromPixelDigis.digiSimLinks = cms.InputTag("simSiPixelDigis","Tracker")
 
 process.TTClusterStub = cms.Path(process.TrackTriggerClustersStubs)
 process.TTClusterStubTruth = cms.Path(process.TrackTriggerAssociatorClustersStubs)
 
-# load code that associates stubs with mctruth
+# load more code to associate stubs with mctruth
 process.load( 'SimTracker.TrackTriggerAssociation.StubAssociator_cff' )
 # load code that analyzes mc truth
 process.load( 'L1Trigger.TrackTrigger.AnalyzerMC_cff' )
@@ -297,9 +285,12 @@ process.ana = cms.Path(process.L1TrackNtuple)
 # Run tracking + track associator
 process.schedule = cms.Schedule(process.dtc,process.TTTracksEmulationWithTruth,process.ana)
 
-# use this to re-run the cluster+stub making + truth association
-# (Not needed unless their format has changed or you want to change them)
-#process.schedule = cms.Schedule(process.TTClusterStub,process.TTClusterStubTruth,process.dtc,process.TTTracksEmulationWithTruth,process.ana)
+# Use this to re-run the cluster+stub making + truth association
+# (Not needed unless you want to change them)
+# To avoid confusion, drop existing info if you are doing this. 
+#process.source.inputCommands.append('drop  *_*TTCluster*_*_*')
+#process.source.inputCommands.append('drop  *_*TTStub*_*_*')
+#process.schedule = #cms.Schedule(process.TTClusterStub,process.TTClusterStubTruth,process.dtc,process.TTTracksEmulationWithTruth,process.ana)
 
 
 ############################################################

--- a/L1Trigger/TrackTrigger/test/AnalyzerCluster.cc
+++ b/L1Trigger/TrackTrigger/test/AnalyzerCluster.cc
@@ -76,6 +76,7 @@ struct ClusterHistos {
 class AnalyzerCluster : public edm::one::EDAnalyzer<edm::one::SharedResources> {
 public:
   typedef std::map<unsigned int, const SimTrack*> SimTracksMap;
+  typedef std::map<unsigned int, std::vector<const PSimHit*>> SimHitsMap;
 
   explicit AnalyzerCluster(const edm::ParameterSet&);
   ~AnalyzerCluster() override;
@@ -193,14 +194,26 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
      */
 
   // Rearrange the simTracks for ease of use <simTrackID, simTrack>
-  SimTracksMap simTracks;
+  SimTracksMap simTracksMap;
   for (edm::SimTrackContainer::const_iterator simTrackIt(simTracksRaw->begin()); simTrackIt != simTracksRaw->end();
        ++simTrackIt) {
     if (simTrackIt->momentum().pt() > simtrackminpt_) {
-      simTracks.emplace(simTrackIt->trackId(), &(*simTrackIt));
+      simTracksMap.emplace(simTrackIt->trackId(), &(*simTrackIt));
     }
   }
 
+  /*
+   * Rearrange SimHits
+   */
+
+  SimHitsMap simhitsMap;
+  for (int simhitidx = 0; simhitidx < 2; ++simhitidx) {  // loop over both barrel and endcap hits
+    for (edm::PSimHitContainer::const_iterator simhitIt(simHitsRaw[simhitidx]->begin()); simhitIt != simHitsRaw[simhitidx]->end(); simhitIt++) {
+      simhitsMap[simhitIt->detUnitId()].push_back(&(*simhitIt));
+    }
+  }
+  
+  
   /*
      * Validation   
      */
@@ -213,7 +226,8 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
     // Get the detector unit's id
     unsigned int rawid(DSViter->detId());
     DetId detId(rawid);
-    unsigned int layer = (tTopo->side(detId) != 0) * 1000;  // don't split up endcap sides
+    bool barrel = tTopo->side(detId) == 0;
+    unsigned int layer = (not barrel) * 1000;  // don't split up endcap sides
     if (!layer) {
       layer += tTopo->layer(detId);
     } else {
@@ -259,8 +273,8 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
 
       // Get all the simTracks that form the cluster
       std::vector<unsigned int> clusterSimTrackIds;
-      const auto& rows = clustIt->findRows();
-      const auto& cols = clustIt->findCols();
+      const auto& rows = clustIt->getRows();
+      const auto& cols = clustIt->getCols();
       for (unsigned int i = 0; i < rows.size(); ++i) {
         unsigned int channel(Phase2TrackerDigi::pixelToChannel(rows[i], cols[i]));
         std::vector<unsigned int> simTrackIds(getSimTrackId(pixelSimLinks, detId, channel));
@@ -282,16 +296,16 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
       // when there are more than 1 cluster with common simtrackids
       const PSimHit* simhit = nullptr;  // bad naming to avoid changing code below. This is the closest simhit in x
       float minx = 10000;
-      for (unsigned int simhitidx = 0; simhitidx < 2; ++simhitidx) {  // loop over both barrel and endcap hits
-        for (auto& simhitIt : *simHitsRaw[simhitidx]) {
-          if (rawid == simhitIt.detUnitId()) {
-            //std::cout << "=== " << rawid << " " << &simhitIt << " " << simhitIt.trackId() << " " << simhitIt.localPosition().x() << " " << simhitIt.localPosition().y() << std::endl;
-            auto it = std::lower_bound(clusterSimTrackIds.begin(), clusterSimTrackIds.end(), simhitIt.trackId());
-            if (it != clusterSimTrackIds.end() && *it == simhitIt.trackId()) {
-              if (simhit == nullptr || fabs(simhitIt.localPosition().x() - localPosClu.x()) < minx) {
-                minx = fabs(simhitIt.localPosition().x() - localPosClu.x());
-                simhit = &simhitIt;
-              }
+
+      SimHitsMap::const_iterator simhitsInDet = simhitsMap.find(detId.rawId());
+      if (simhitsInDet != simhitsMap.end()) {
+        for (const auto* sh : simhitsInDet->second) {
+          //std::cout << "=== " << rawid << " " << &simhitIt << " " << sh->trackId() << " " << sh->localPosition().x() << " " << sh->localPosition().y() << std::endl;
+          auto it = std::lower_bound(clusterSimTrackIds.begin(), clusterSimTrackIds.end(), sh->trackId());
+          if (it != clusterSimTrackIds.end() && *it == sh->trackId()) {
+            if (simhit == nullptr || fabs(sh->localPosition().x() - localPosClu.x()) < minx) {
+              minx = fabs(sh->localPosition().x() - localPosClu.x());
+              simhit = sh;
             }
           }
         }
@@ -301,8 +315,8 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
         continue;
 
       // only look at simhits from highpT tracks
-      const auto simTrkIt(simTracks.find(simhit->trackId()));
-      if (simTrkIt == simTracks.end())
+      const auto simTrkIt(simTracksMap.find(simhit->trackId()));
+      if (simTrkIt == simTracksMap.end())
         continue;
       const SimTrack* simTrk = simTrkIt->second;
 
@@ -315,7 +329,6 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
 
       // cluster size
       histogramLayer->second.clusterSize[det]->Fill(clustIt->findWidth());
-      histogramLayer->second.clusterSizeRZ[det]->Fill(clustIt->findWidthCols());
 
       // Fill the position histograms
       trackerLayout_->Fill(globalPosClu.z(), globalPosClu.perp());

--- a/L1Trigger/TrackTrigger/test/AnalyzerCluster.cc
+++ b/L1Trigger/TrackTrigger/test/AnalyzerCluster.cc
@@ -208,12 +208,13 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
 
   SimHitsMap simhitsMap;
   for (int simhitidx = 0; simhitidx < 2; ++simhitidx) {  // loop over both barrel and endcap hits
-    for (edm::PSimHitContainer::const_iterator simhitIt(simHitsRaw[simhitidx]->begin()); simhitIt != simHitsRaw[simhitidx]->end(); simhitIt++) {
+    for (edm::PSimHitContainer::const_iterator simhitIt(simHitsRaw[simhitidx]->begin());
+         simhitIt != simHitsRaw[simhitidx]->end();
+         simhitIt++) {
       simhitsMap[simhitIt->detUnitId()].push_back(&(*simhitIt));
     }
   }
-  
-  
+
   /*
      * Validation   
      */

--- a/L1Trigger/TrackTrigger/test/AnalyzerCluster.cc
+++ b/L1Trigger/TrackTrigger/test/AnalyzerCluster.cc
@@ -301,7 +301,6 @@ void AnalyzerCluster::analyze(const edm::Event& event, const edm::EventSetup& ev
       SimHitsMap::const_iterator simhitsInDet = simhitsMap.find(detId.rawId());
       if (simhitsInDet != simhitsMap.end()) {
         for (const auto* sh : simhitsInDet->second) {
-          //std::cout << "=== " << rawid << " " << &simhitIt << " " << sh->trackId() << " " << sh->localPosition().x() << " " << sh->localPosition().y() << std::endl;
           auto it = std::lower_bound(clusterSimTrackIds.begin(), clusterSimTrackIds.end(), sh->trackId());
           if (it != clusterSimTrackIds.end() && *it == sh->trackId()) {
             if (simhit == nullptr || fabs(sh->localPosition().x() - localPosClu.x()) < minx) {


### PR DESCRIPTION
#### PR description:

This fixes L1Trigger/TrackerTrigger/test/AnalyzerCluster.cc

which is an EDAnalyzer used to study TTClusters. The fixes are:

1) Fix incorrect call to determine which are the hit pixel/strip channels inside cluster.
2) Fix excessive CPU caused by looping multiple times over all SimHits.

Results don't change.
